### PR TITLE
Retry airgap builds when not found

### DIFF
--- a/bin/create-bundle-alpine.sh
+++ b/bin/create-bundle-alpine.sh
@@ -12,6 +12,7 @@ cd /tmp/work
 
 cp /scripts/install.sh /tmp/work/install.sh
 cp /scripts/join.sh /tmp/work/join.sh
+cp /scripts/upgrade.sh /tmp/work/upgrade.sh
 
 while [ -n "$1" ]; do
     echo "Downloading and extracting $1"

--- a/bin/upload-latest-bundle.sh
+++ b/bin/upload-latest-bundle.sh
@@ -17,10 +17,11 @@ DIST_ORIGIN=https://${S3_BUCKET}.s3.amazonaws.com
 
 mkdir -p tmp/work
 
-make build/install.sh build/join.sh
+make build/install.sh build/join.sh build/upgrade.sh
 
 cp build/install.sh tmp/work/
 cp build/join.sh tmp/work/
+cp build/upgrade.sh tmp/work/
 
 # get latest versions
 . scripts/Manifest

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - ./deployment.yaml
   - ./namespace.yaml
   - ./rbac.yaml
+  - ./resourcequota.yaml

--- a/kustomize/base/rbac.yaml
+++ b/kustomize/base/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kurl-web-server
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -20,6 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kurl-web-server
+  namespace: kurl
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kustomize/base/resourcequota.yaml
+++ b/kustomize/base/resourcequota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: airgap-builder-pods
+  namespace: kurl
+spec:
+  hard:
+    pods: "4"

--- a/web/src/util/services/s3.ts
+++ b/web/src/util/services/s3.ts
@@ -1,0 +1,32 @@
+import {Service} from "ts-express-decorators";
+import { S3 } from "aws-sdk"
+import  s3 from "../persistence/s3";
+
+@Service()
+export class S3Wrapper {
+
+  public readonly s3: S3;
+
+  constructor() {
+    this.s3 = s3();
+  }
+
+  public async objectExists(key: string): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      this.s3.headObject({
+        Bucket: process.env.KURL_BUCKET || "kurl-sh",
+        Key: key,
+      }, (err, data) => {
+        if (err && err.code === "NotFound") {
+          resolve(false);
+          return;
+        }
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(true);
+      });
+    });
+  }
+}


### PR DESCRIPTION
As before, kurl will always build new airgap bundles if the database
reports that the installer is new or changed. This adds a check on S3 to
see if the bundle exists and also schedules a build there if not.
Also add ResourceQuota for the kurl namespace so no more than 4 build
jobs will run concurrently.
Also add check for currently running job for the installer and skip if
active.