### PR TITLE
Generate new kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ To get a new command to join worker nodes, re-run the install script on the mast
 
 For HA clusters, the install script will print out separate commands for joining workers and joining masters.
 
+## Connecting Remotely
+
+You can generate a kubeconfig to use from your local machine with:
+
+```
+sudo bash install.sh task=generate-admin-user
+```
+
+This will use the load balancer or public address for the Kubernetes API server and generate a new user with full admin privileges.
+Be sure to open TCP port 6443 to allow traffic from your local machine.
+
 ## What It Does
 
 ### Kubeadm Pre-Init

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -189,7 +189,6 @@ discoverPublicIp() {
 
     if [ "$_status" -eq "0" ] && [ -n "$_out" ]; then
         PUBLIC_ADDRESS=$_out
-        printf "The installer will use public address '%s' (discovered from GCE metadata service)\n" "$PUBLIC_ADDRESS"
         return
     fi
 
@@ -200,7 +199,6 @@ discoverPublicIp() {
     set -e
     if [ "$_status" -eq "0" ] && [ -n "$_out" ]; then
         PUBLIC_ADDRESS=$_out
-        printf "The installer will use public address '%s' (discovered from EC2 metadata service)\n" "$PUBLIC_ADDRESS"
         return
     fi
 }

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -11,6 +11,8 @@ function discover() {
     if [ "$NO_PROXY" != "1" ] && [ -z "$PROXY_ADDRESS" ]; then
         discoverProxy
     fi
+
+    discoverPublicIp
 }
  
 LSB_DIST=
@@ -176,5 +178,29 @@ discoverProxy() {
 
     if curl --noproxy "*" --silent --connect-timeout 2 --fail https://api.replicated.com/market/v1/echo/ip > /dev/null ; then
         NO_PROXY=1
+    fi
+}
+
+discoverPublicIp() {
+    set +e
+    _out=$(curl --noproxy "*" --max-time 5 --connect-timeout 2 -qSfs -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip 2>/dev/null)
+    _status=$?
+    set -e
+
+    if [ "$_status" -eq "0" ] && [ -n "$_out" ]; then
+        PUBLIC_ADDRESS=$_out
+        printf "The installer will use public address '%s' (discovered from GCE metadata service)\n" "$PUBLIC_ADDRESS"
+        return
+    fi
+
+    # ec2
+    set +e
+    _out=$(curl --noproxy "*" --max-time 5 --connect-timeout 2 -qSfs http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null)
+    _status=$?
+    set -e
+    if [ "$_status" -eq "0" ] && [ -n "$_out" ]; then
+        PUBLIC_ADDRESS=$_out
+        printf "The installer will use public address '%s' (discovered from EC2 metadata service)\n" "$PUBLIC_ADDRESS"
+        return
     fi
 }

--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -232,6 +232,35 @@ function prompt_airgap_preload_images() {
     done
 }
 
+promptForPublicIp() {
+    if [ -n "$PUBLIC_ADDRESS" ]; then
+        return 0;
+    fi
+
+    while true; do
+        printf "Public IP address: "
+        promptTimeout "-t 120"
+        if [ -n "$PROMPT_RESULT" ]; then
+            if isValidIpv4 "$PROMPT_RESULT"; then
+                PUBLIC_ADDRESS=$PROMPT_RESULT
+                break
+            else
+                printf "%s is not a valid ip address.\n" "$PROMPT_RESULT"
+            fi
+        else
+            break
+        fi
+    done
+}
+
+isValidIpv4() {
+    if echo "$1" | grep -qs '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 promptForPrivateIp() {
     _count=0
     _regex="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+[[:alnum:]]+ ([[:digit:].]+)"

--- a/scripts/common/tasks.sh
+++ b/scripts/common/tasks.sh
@@ -7,6 +7,10 @@ function tasks() {
     case "$TASK" in
         load-images|load_images)
             load_all_images
+            ;;
+        generate-admin-user|generate_admin_user)
+            generate_admin_user
+            ;;
     esac
 
     # terminate the script if a task was run
@@ -15,4 +19,36 @@ function tasks() {
 
 function load_all_images() {
     find addons/ packages/ -type f -wholename '*/images/*.tar.gz' | xargs -I {} bash -c "docker load < {}"
+}
+
+function generate_admin_user() {
+    # get the last IP address from the SANs because that will be load balancer if defined, else public address if defined, else local
+    local ip=$(echo "Q" | openssl s_client -connect=10.128.0.53:6443 | openssl x509 -noout -text | grep DNS | awk '{ print $NF }' | awk -F ':' '{ print $2 }')
+
+    if ! isValidIpv4 "$ip"; then
+        bail "Failed to parse IP from Kubernetes API Server SANs"
+    fi
+
+    local address="https://${ip}:6443"
+    local username="${SUDO_USER}"
+
+    openssl req -newkey rsa:2048 -nodes -keyout "${username}.key" -out "${username}.csr" -subj="/CN=${username}/O=system:masters"
+    openssl x509 -req -days 365 -sha256 -in "${username}.csr" -CA /etc/kubernetes/pki/ca.crt -CAkey /etc/kubernetes/pki/ca.key -set_serial 2 -out "${username}.crt"
+
+    # kubectl will create the conf file
+    kubectl --kubeconfig="${username}.conf" config set-credentials "${username}" --client-certificate="${username}.crt" --client-key="${username}.key" --embed-certs=true
+    rm "${username}.crt" "${username}.csr" "${username}.key"
+
+    kubectl --kubeconfig="${username}.conf" config set-cluster kurl --server="$address" --certificate-authority=/etc/kubernetes/pki/ca.crt --embed-certs=true
+    kubectl --kubeconfig=areed.conf config set-context kurl --cluster=kurl --user=areed
+    kubectl --kubeconfig=areed.conf config use-context kurl
+
+    chown "${username}" "${username}.conf"
+
+    printf "\n"
+    printf "${GREEN}Kubeconfig successfully generated. Example usage:\n"
+    printf "\n"
+    printf "\tkubectl --kubeconfig=${username}.conf get ns${NC}"
+    printf "\n"
+    printf "\n"
 }

--- a/scripts/common/tasks.sh
+++ b/scripts/common/tasks.sh
@@ -33,7 +33,7 @@ function generate_admin_user() {
     local username="${SUDO_USER}"
 
     openssl req -newkey rsa:2048 -nodes -keyout "${username}.key" -out "${username}.csr" -subj="/CN=${username}/O=system:masters"
-    openssl x509 -req -days 365 -sha256 -in "${username}.csr" -CA /etc/kubernetes/pki/ca.crt -CAkey /etc/kubernetes/pki/ca.key -set_serial 2 -out "${username}.crt"
+    openssl x509 -req -days 365 -sha256 -in "${username}.csr" -CA /etc/kubernetes/pki/ca.crt -CAkey /etc/kubernetes/pki/ca.key -set_serial 1 -out "${username}.crt"
 
     # kubectl will create the conf file
     kubectl --kubeconfig="${username}.conf" config set-credentials "${username}" --client-certificate="${username}.crt" --client-key="${username}.key" --embed-certs=true


### PR DESCRIPTION
Fixes #12 

Detect or prompt for the host's public address so it can be included in the Kubernetes API server's SANs list. Add a `generate-admin-user` task that generates a kubeconfig for an admin user that uses the public address.