### PR TITLE
serve airgap bundles from Go container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 dist/
 tmp/
 web/templates
+bin/

--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,14 @@ build/templates: build/templates/install.tmpl build/templates/join.tmpl build/te
 .PHONY: code
 code: build/templates build/yaml build/addons
 
+build/bin/server:
+	go build -o build/bin/server cmd/server/main.go
+
 .PHONY: web
-web: build/templates
+web: build/templates build/bin/server
 	mkdir -p web/build
 	cp -r build/templates web
+	cp -r build/bin web
 
 watchrsync:
 	bin/watchrsync.js

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+)
+
+const upstream = "http://localhost:3000"
+
+var distOrigin = fmt.Sprintf("https://%s.s3.amazonaws.com", os.Getenv("KURL_BUCKET"))
+
+func main() {
+	http.Handle("/bundle/", http.HandlerFunc(bundle))
+
+	upstreamURL, err := url.Parse(upstream)
+	if err != nil {
+		log.Panic(err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	http.Handle("/", proxy)
+
+	log.Println("Listening on :3001")
+	err = http.ListenAndServe(":3001", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+type BundleManifest struct {
+	Layers []string          `json:"layers"`
+	Files  map[string]string `json:"files"`
+}
+
+func bundle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	log.Printf("GET %s", r.URL.Path)
+
+	base := path.Base(r.URL.Path)
+	installerID := strings.TrimSuffix(base, ".tar.gz")
+	installerURL := fmt.Sprintf("%s/bundle/%s", upstream, installerID)
+	resp, err := http.Get(installerURL)
+	if err != nil {
+		log.Printf("Error fetching %s: %v", installerURL, err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading response body from %s: %v", installerURL, err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		http.Error(w, string(body), http.StatusNotFound)
+		return
+	}
+	bundle := &BundleManifest{}
+	err = json.Unmarshal(body, bundle)
+	if err != nil {
+		log.Printf("Error unmarshaling installer bundle manifest from %s: %s: %v", installerURL, body, err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "binary/octet-stream")
+	w.Header().Set("Content-Encoding", "gzip")
+
+	wz := gzip.NewWriter(w)
+	archive := tar.NewWriter(wz)
+
+	for _, layerURL := range bundle.Layers {
+		if err := pipe(archive, layerURL); err != nil {
+			log.Printf("Error piping %s to %s bundle: %v", layerURL, installerID, err)
+			return
+		}
+	}
+
+	for filepath, contents := range bundle.Files {
+		archive.WriteHeader(&tar.Header{
+			Name: filepath,
+			Size: int64(len(contents)),
+			Mode: 0644,
+		})
+		_, err := archive.Write([]byte(contents))
+		if err != nil {
+			log.Printf("Error writing file %q: %v", filepath, err)
+			return
+		}
+	}
+
+	if err := archive.Close(); err != nil {
+		log.Printf("Error closing archive for installer %s: %v", installerID, err)
+		return
+	}
+
+	if err := wz.Close(); err != nil {
+		log.Printf("Error closing gzip stream for installer %s: %v", installerID, err)
+	}
+}
+
+func pipe(dst *tar.Writer, srcURL string) error {
+	resp, err := http.Get(srcURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("response code %d", resp.StatusCode)
+	}
+
+	zr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("gunzip response", resp.Body)
+	}
+	defer zr.Close()
+	src := tar.NewReader(zr)
+
+	for {
+		header, err := src.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("next file: %v", err)
+		}
+		dst.WriteHeader(header)
+		_, err = io.Copy(dst, src)
+		if err != nil {
+			return fmt.Errorf("copy file contents: %v", err)
+		}
+	}
+}

--- a/deploy/Dockerfile-slim
+++ b/deploy/Dockerfile-slim
@@ -5,6 +5,7 @@ ENV VERSION=$version
 
 ADD web /src
 ADD build/templates /templates
+ADD build/bin/server /bin
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/replicatedhq/kurl
+
+go 1.13

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -24,6 +24,13 @@ spec:
                   - kurl
               topologyKey: "kubernetes.io/hostname"
       containers:
+      - name: server
+        image: replicated/kurl
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/server"]
+        ports:
+        - name: server
+          containerPort: 3001
       - name: kurl
         image: replicated/kurl
         imagePullPolicy: IfNotPresent

--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -6,6 +6,10 @@ spec:
   template:
     spec:
       containers:
+      - name: server
+        env:
+        - name: KURL_BUCKET
+          value: "kurl-dev"
       - name: kurl
         env:
         - name: KURL_URL

--- a/kustomize/overlays/dev/nodeport.yaml
+++ b/kustomize/overlays/dev/nodeport.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - name: kurl
+    - name: server
       port: 8092
-      targetPort: kurl
+      targetPort: server
       nodePort: 30092
   selector:
     app: kurl

--- a/kustomize/overlays/production/deployment.yaml
+++ b/kustomize/overlays/production/deployment.yaml
@@ -9,6 +9,10 @@ spec:
       nodeSelector:
         replicated/node-pool: privileged
       containers:
+      - name: server
+        env:
+        - name: KURL_BUCKET
+          value: kurl-sh
       - name: kurl
         image: 799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl
         env:

--- a/kustomize/overlays/production/service.yaml
+++ b/kustomize/overlays/production/service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - name: kurl
+    - name: server
       nodePort: 30092
-      port: 3000
-      targetPort: kurl
+      port: 3001
+      targetPort: server
   selector:
     app: kurl

--- a/kustomize/overlays/staging/deployment.yaml
+++ b/kustomize/overlays/staging/deployment.yaml
@@ -9,6 +9,10 @@ spec:
       nodeSelector:
         replicated/node-pool: privileged
       containers:
+      - name: server
+        env:
+        - name: KURL_BUCKET
+          value: kurl-sh-staging
       - name: kurl
         image: 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl
         env:

--- a/kustomize/overlays/staging/service.yaml
+++ b/kustomize/overlays/staging/service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - name: kurl
+  - name: server
     nodePort: 30092
-    port: 3000
-    targetPort: kurl
+    port: 3001
+    targetPort: server
   selector:
     app: kurl

--- a/web/Dockerfile.skaffold
+++ b/web/Dockerfile.skaffold
@@ -9,6 +9,7 @@ RUN make deps
 
 ADD . .
 RUN mv templates /templates
+RUN mv bin/server /bin
 RUN make build
 
 EXPOSE 3000

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
     "cors": "^2.8.1",
     "express": "^4.14.0",
     "express-rate-limit": "^2.11.0",
-    "gunzip-maybe": "^1.4.1",
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.5.1",
     "monkit": "^0.4.0",
@@ -25,7 +24,6 @@
     "sigsci-module-nodejs": "https://dl.signalsciences.net/sigsci-module-nodejs/1.4.8/sigsci-module-nodejs-1.4.8.tgz",
     "statsd-client": "^0.4.2",
     "superagent": "^5.1.0",
-    "tar-stream": "^2.1.0",
     "ts-express-decorators": "^5.24.1"
   },
   "devDependencies": {

--- a/web/src/controllers/Scripts.ts
+++ b/web/src/controllers/Scripts.ts
@@ -34,6 +34,7 @@ export class Installers {
    * @returns string
    */
   @Get("/:installerID")
+  @Get("/:installerID/install.sh")
   @instrumented
   public async getInstaller(
     @Res() response: Express.Response,

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -782,13 +782,6 @@ bl@^1.0.0, bl@^1.2.1:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-3.0.0.tgz#3611ec00579fd18561754360b21e9f784500ff88"
-  integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
-  dependencies:
-    readable-stream "^3.0.1"
-
 bluebird@3.5.5, bluebird@^3.4.7, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@~3.5.1:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
@@ -865,13 +858,6 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
   integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-
-browserify-zlib@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
-  integrity sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=
-  dependencies:
-    pako "~0.2.0"
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
@@ -1749,16 +1735,6 @@ duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-duplexify@^3.5.0, duplexify@^3.6.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
-  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
-  dependencies:
-    end-of-stream "^1.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-    stream-shift "^1.0.0"
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1793,13 +1769,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
-  dependencies:
-    once "^1.4.0"
-
-end-of-stream@^1.4.1:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
@@ -2679,18 +2648,6 @@ growl@1.9.2:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-gunzip-maybe@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz#39c72ed89d1b49ba708e18776500488902a52027"
-  integrity sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==
-  dependencies:
-    browserify-zlib "^0.1.4"
-    is-deflate "^1.0.0"
-    is-gzip "^1.0.0"
-    peek-stream "^1.1.0"
-    pumpify "^1.3.3"
-    through2 "^2.0.3"
-
 handlebars@^4.0.3:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
@@ -2914,7 +2871,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3040,11 +2997,6 @@ is-data-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-deflate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
-  integrity sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=
-
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -3136,11 +3088,6 @@ is-glob@^4.0.0:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-gzip@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
-  integrity sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -4620,11 +4567,6 @@ pad@^1.1.0:
     coffee-script "^1.12.7"
     wcwidth "^1.0.1"
 
-pako@~0.2.0:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
-
 pako@~1.0.2:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
@@ -4756,15 +4698,6 @@ pause-stream@0.0.11:
   integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
   dependencies:
     through "~2.3"
-
-peek-stream@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
-  integrity sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==
-  dependencies:
-    buffer-from "^1.0.0"
-    duplexify "^3.5.0"
-    through2 "^2.0.3"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -4948,14 +4881,6 @@ psl@^1.1.24, psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.3.0.tgz#e1ebf6a3b5564fa8376f3da2275da76d875ca1bd"
   integrity sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==
 
-pump@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
-  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -4963,15 +4888,6 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
-
-pumpify@^1.3.3:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
-  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
-  dependencies:
-    duplexify "^3.6.0"
-    inherits "^2.0.3"
-    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -5108,7 +5024,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@2.3.6, readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@~2.3.6:
+readable-stream@2.3.6, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -5121,7 +5037,7 @@ readable-stream@2.3.6, readable-stream@^2.0.0, readable-stream@^2.0.6, readable-
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@3, readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -6012,11 +5928,6 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
-stream-shift@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
-
 streamroller@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-1.0.6.tgz#8167d8496ed9f19f05ee4b158d9611321b8cacd9"
@@ -6191,17 +6102,6 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar-stream@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.0.tgz#d1aaa3661f05b38b5acc9b7020efdca5179a2cc3"
-  integrity sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==
-  dependencies:
-    bl "^3.0.0"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
-
 tar@4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
@@ -6253,7 +6153,7 @@ then-fs@^2.0.0:
   dependencies:
     promise ">=3.2 <8"
 
-through2@^2.0.2, through2@^2.0.3:
+through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==


### PR DESCRIPTION
The Go container handles /bundles and proxies everything else to the
typescript server. The typescript server /bundles handler now returns a
json manifest with a list of packages to extract and include plus a list
of files with their contents, allowing the Go server to be a dumb
component.