### PR TITLE
Kotsadm cluster role

### DIFF
--- a/addons/kotsadm/0.9.12/api.yaml
+++ b/addons/kotsadm/0.9.12/api.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: kotsadm-api-role
 rules:
@@ -27,17 +27,19 @@ rules:
   verbs:
   - get
   - delete
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: kotsadm-api-rolebinding
 subjects:
 - kind: ServiceAccount
   name: kotsadm-api
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: kotsadm-api-role
 ---
 apiVersion: v1


### PR DESCRIPTION
kotsadm requires a clusterrole when deployed using kurl because of the cluster management page.