### PR TITLE
fix openssl s_client command text formatting

### DIFF
--- a/cmd/proxy/assets/insecure.html
+++ b/cmd/proxy/assets/insecure.html
@@ -53,9 +53,11 @@
                 <div class="CodeSnippet-content">
                   <p>Verifying the certificate's authenticity</p>
                   <pre>
-                    <script>document.write(
-                      '$ echo | openssl s_client -servername local -connect ' + opensslLink + ' 2>/dev/null | openssl x509 -noout -fingerprint'
-                    )</script>
+                    <code>
+                      <script>document.write(
+                        '$ echo | openssl s_client -servername local -connect ' + opensslLink + ' 2>/dev/null | openssl x509 -noout -fingerprint'
+                      )</script>
+                    </code>
                   </pre>
                 </div>
               </div>

--- a/cmd/proxy/assets/insecure.html
+++ b/cmd/proxy/assets/insecure.html
@@ -53,10 +53,7 @@
                 <div class="CodeSnippet-content">
                   <p>Verifying the certificate's authenticity</p>
                   <pre>
-                    <code>
-                      <script>document.write(
-                        '$ echo | openssl s_client -servername local -connect ' + opensslLink + ' 2>/dev/null | openssl x509 -noout -fingerprint'
-                      )</script>
+                    <code id="verify-snippet">
                     </code>
                   </pre>
                 </div>
@@ -89,4 +86,8 @@
         </div>
       </div>
   </body>
+  <script>
+    document.getElementById('verify-snippet').innerHTML =
+      '$ echo | openssl s_client -servername local -connect ' + opensslLink + ' 2>/dev/null | openssl x509 -noout -fingerprint';
+  </script>
 </html>


### PR DESCRIPTION
by including it in a code block like before
followup/fix to https://github.com/replicatedhq/kurl/pull/72