### PR TITLE
Ensure transfer-encoding header is included in response

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -89,7 +89,8 @@ func bundle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "binary/octet-stream")
 	w.Header().Set("Content-Encoding", "gzip")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Disposition", "attachment")
+	w.Header().Set("Transfer-Encoding", "chunked")
 
 	if r.Method == "HEAD" {
 		return


### PR DESCRIPTION
Go sets the transfer-encoding header automatically when writing a
response without a content-length header, but I believe the explicit
call to w.WriteHeader was causing it not to be included.

Currently the airgap bundle downloaded through CloudFlare is only about 100kb.