### PR TITLE
Change kotsadm-tls type from Opaque to kubernetes.io/tls

### DIFF
--- a/addons/kotsadm/1.10.2/install.sh
+++ b/addons/kotsadm/1.10.2/install.sh
@@ -230,8 +230,7 @@ EOF
 
     openssl req -newkey rsa:2048 -nodes -keyout kotsadm.key -config kotsadm.cnf -x509 -days 365 -out kotsadm.crt -extensions v3_ext
 
-    kubectl -n default create secret tls kotsadm-tls --key=kotsadm.key --cert=kotsadm.crt
-    kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1
+    kubectl -n default create secret generic kotsadm-tls --from-file=tls.key=kotsadm.key --from-file=tls.crt=kotsadm.crt --from-literal=acceptAnonymousUploads=1
 
     rm kotsadm.cnf kotsadm.key kotsadm.crt
 }

--- a/addons/kotsadm/1.10.2/install.sh
+++ b/addons/kotsadm/1.10.2/install.sh
@@ -230,7 +230,8 @@ EOF
 
     openssl req -newkey rsa:2048 -nodes -keyout kotsadm.key -config kotsadm.cnf -x509 -days 365 -out kotsadm.crt -extensions v3_ext
 
-    kubectl -n default create secret generic kotsadm-tls --from-file=tls.key=kotsadm.key --from-file=tls.crt=kotsadm.crt --from-literal=acceptAnonymousUploads=1
+    kubectl -n default create secret tls kotsadm-tls --key=kotsadm.key --cert=kotsadm.crt
+    kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1
 
     rm kotsadm.cnf kotsadm.key kotsadm.crt
 }

--- a/addons/kotsadm/1.11.0/install.sh
+++ b/addons/kotsadm/1.11.0/install.sh
@@ -230,7 +230,8 @@ EOF
 
     openssl req -newkey rsa:2048 -nodes -keyout kotsadm.key -config kotsadm.cnf -x509 -days 365 -out kotsadm.crt -extensions v3_ext
 
-    kubectl -n default create secret generic kotsadm-tls --from-file=tls.key=kotsadm.key --from-file=tls.crt=kotsadm.crt --from-literal=acceptAnonymousUploads=1
+    kubectl -n default create secret tls kotsadm-tls --key=kotsadm.key --cert=kotsadm.crt
+    kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1
 
     rm kotsadm.cnf kotsadm.key kotsadm.crt
 }

--- a/cmd/proxy/README.md
+++ b/cmd/proxy/README.md
@@ -3,7 +3,7 @@ The Dockerfiles, skaffold.yaml, Makefile, and kustomize/ subdirectory in this di
 The kotsadm addon has the deployment yaml that will be installed on a kurl cluster.
 
 The proxy requires a secret with a cert and key to start. The kotsadm addon will generate this secret when installed.
-That secret will have the flag `acceptAnonymousUploads` which allows anybody to upload a new cert at /tls.
+That secret will have the annotation `acceptAnonymousUploads` which allows anybody to upload a new cert at /tls.
 After the first upload that flag will be turned off and the cert/key in the secret will be replaced with the uploaded pair.
 Navigating to /tls after that will show a warning rather than an upload form.
 Manually add the flag back to the secret to re-enable uploads.


### PR DESCRIPTION
Background:
https://app.clubhouse.io/replicated/story/22517/standard-type-for-tls-secret

Fixes #132 