### PR TITLE
better error message proposal

### DIFF
--- a/addons/kotsadm/1.11.0/install.sh
+++ b/addons/kotsadm/1.11.0/install.sh
@@ -72,7 +72,7 @@ function kotsadm_outro() {
     if [ -n "$KOTSADM_PASSWORD" ]; then
         printf "Login with password (will not be shown again): ${GREEN}$KOTSADM_PASSWORD${NC}\n"
     else
-        printf "Password not regenerated. Run ${GREEN}bash ${INSTALLER_ID:-install.sh} task=kotsadm-change-password${NC} to reset it\n"
+        printf "Password not regenerated. Run ${GREEN}curl https://kurl.sh/${INSTALLER_ID:-latest} | bash -s task=kotsadm-change-password${NC} to reset it\n"
     fi
     printf "\n"
     printf "\n"


### PR DESCRIPTION
Right now when you re-run the install script, you see this message:

    Run bash SLUG task=kotsadm-reset-password

But this is not correct in most cases, for example, if you installed with https://kurl.sh/sentry-pro

    Run bash sentry-pro task=kotsadm-reset-password

When what you really want is

    Run curl https://kurl.sh/sentry-pro | bash -s task=kotsadm-reset-password

This is just an example and does not fix every edge case (most notably, the command will be different for airgap).