### PR TITLE
Fix krew update

### DIFF
--- a/bundles/k8s-rhel7/Dockerfile
+++ b/bundles/k8s-rhel7/Dockerfile
@@ -6,7 +6,8 @@ RUN yumdownloader --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubeadm-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \
-	kubernetes-cni
+	kubernetes-cni \
+	git
 
 # First upgrade step requires upgraded kubeadm binary before kubeadm package is upgraded
 # https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-11/

--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION} | awk '{ print $3 }') \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION} | awk '{ print $3 }') \
 	kubernetes-cni \
+	git \	
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 # First upgrade step requires upgraded kubeadm binary before kubeadm package is upgraded

--- a/bundles/k8s-ubuntu1804/Dockerfile
+++ b/bundles/k8s-ubuntu1804/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION} | awk '{ print $3 }') \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION} | awk '{ print $3 }') \
 	kubernetes-cni \
+	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 # First upgrade step requires upgraded kubeadm binary before kubeadm package is upgraded

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -257,7 +257,7 @@ function install_krew() {
 
     # Fixes permission issues with 'kubectl krew'
     chmod -R 0777 /opt/replicated/krew
-	chmod -R 0777 /tmp/krew-downloads
+    chmod -R 0777 /tmp/krew-downloads
 
     if ! grep -q KREW_ROOT /etc/profile; then
         echo "export KREW_ROOT=$KREW_ROOT" >> /etc/profile

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -255,7 +255,9 @@ function install_krew() {
     ./krew-linux_amd64 install --manifest=support-bundle.yaml --archive=support-bundle.tar.gz > /dev/null 2>&1
     popd
 
-    chmod -R 0755 /opt/replicated/krew/store
+    # Fixes permission issues with 'kubectl krew'
+    chmod -R 0777 /opt/replicated/krew
+	chmod -R 0777 /tmp/krew-downloads
 
     if ! grep -q KREW_ROOT /etc/profile; then
         echo "export KREW_ROOT=$KREW_ROOT" >> /etc/profile


### PR DESCRIPTION
Here's the fix I'm proposing to fix the 'kubectl krew' issue in kURL installations.  

Here are some considerations with the change:
1) This patch is not applied during upgrades.  We skip re-installing .deb/.rpm packages since the system already has kubectl, kubeadm, etc...  I could go the extra mile and check if 'git' is installed, but it feels like overkill.  Instead, for existing installations, my thinking is to post a document in our forums to simply:  a) install git and b) fix up permissions in two dirs.  

2) Notice I'm not specifying a git level here.  I'm taking the risk that the latest git level should be fine.   Although I suppose the customer could have pre-installed an older version of git that we're upgrading here.  
