### PR TITLE
Tighten permissions on krew files; do not set execute on all

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -256,8 +256,9 @@ function install_krew() {
     popd
 
     # Fixes permission issues with 'kubectl krew'
-    chmod -R 0777 /opt/replicated/krew
-    chmod -R 0777 /tmp/krew-downloads
+    chmod -R 0777 /opt/replicated/krew/store
+    chmod -R a+rw /opt/replicated/krew
+    chmod -R a+rw /tmp/krew-downloads
 
     if ! grep -q KREW_ROOT /etc/profile; then
         echo "export KREW_ROOT=$KREW_ROOT" >> /etc/profile


### PR DESCRIPTION
Put back the original line (exec perms are require on 'store'):
chmod -R 0777 /opt/replicated/krew/store

But tighten permissions to just rw on everything else under krew and krew-downloads.