### PR TITLE
Mount the ConfigMap with app metadata in kurl-proxy

### DIFF
--- a/addons/kotsadm/alpha/install.sh
+++ b/addons/kotsadm/alpha/install.sh
@@ -195,9 +195,9 @@ function kotsadm_metadata_configmap() {
         curl $REPLICATED_APP_URL/metadata/$KOTSADM_APPLICATION_SLUG > "$src/application.yaml"
     fi
     if test -s "$src/application.yaml"; then
-        echo "- kotsadm-application-metadata.yaml" >> "$dst/kustomization.yaml"
         cp "$src/application.yaml" "$dst/"
         kubectl create configmap kotsadm-application-metadata --from-file="$dst/application.yaml" --dry-run -oyaml > "$dst/kotsadm-application-metadata.yaml"
+        insert_resources $dst/kustomization.yaml kotsadm-application-metadata.yaml
     fi
 }
 

--- a/addons/kotsadm/alpha/kurl-proxy/tmpl-deployment.yaml
+++ b/addons/kotsadm/alpha/kurl-proxy/tmpl-deployment.yaml
@@ -28,4 +28,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        volumeMounts:
+        - name: kotsadm-config
+          mountPath: /etc/kotsadm
       serviceAccount: kurl-proxy
+      volumes:
+      - name: kotsadm-config
+        configMap:
+          name: kotsadm-application-metadata
+          optional: true

--- a/addons/kotsadm/alpha/kustomization.yaml
+++ b/addons/kotsadm/alpha/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
 - schemahero.yaml
 - kotsadm.yaml
 - kotsadm-web-scripts.yaml
-- kotsadm-application-metadata.yaml


### PR DESCRIPTION
This patch also includes improved handling if the app slug was provided or not.
If not, then we'll create an empty ConfigMap (meaning no branding was provided).
If slug provided, then we'll query replicated.app for metadata.  Again, if no
metadata provided, then we'll leave the ConfigMap empty.  If provided, then
we'll populate the ConfigMap with the app's metadata (including branding).

This patch fixes branding on the TLS certs pages.