### PR TITLE
beta is deployed to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,13 +147,14 @@ workflows:
             branches:
               ignore: master
 
-  master:
+  staging:
     jobs:
       - is_upstream:
           filters:
             branches:
               only:
                 - master
+                - beta
 
       - upload_staging_packages:
           requires:


### PR DESCRIPTION
This will allow for verifying hotfixes on staging by checking out the
last released tag, cherry-picking the fix, and force pushing to the beta
branch.