### PR TITLE
Wait for running weave-net pod before declaring weave add-on installed

### DIFF
--- a/addons/weave/2.5.2/install.sh
+++ b/addons/weave/2.5.2/install.sh
@@ -22,6 +22,7 @@ function weave() {
     fi
 
     kubectl apply -k "$DIR/kustomize/weave/"
+    weave_ready_spinner
 }
 
 function weave_resource_secret() {
@@ -54,4 +55,8 @@ function weave_use_existing_network() {
         EXISTING_POD_CIDR=$(echo $weaveDev | awk '{ print $1 }')
         echo "Using existing weave network: $EXISTING_POD_CIDR"
     fi
+}
+
+function weave_ready_spinner() {
+    spinnerPodRunning kube-system weave-net
 }


### PR DESCRIPTION
Fixes #245 in that the installer now hangs during the `weave` add-on install while waiting for `weave-net` pod to come up (as opposed to spuriously hanging during the `rook` install). The discussion is still live as to whether this PR will address the hang itself.

Minor proof:
```
⚙  Addon weave 2.5.2
serviceaccount/weave-net created
role.rbac.authorization.k8s.io/weave-net created
clusterrole.rbac.authorization.k8s.io/weave-net created
rolebinding.rbac.authorization.k8s.io/weave-net created
clusterrolebinding.rbac.authorization.k8s.io/weave-net created
secret/weave-passwd created
daemonset.apps/weave-net created
 [|]  
```