### PR TITLE
Have script error out if weave deployment fails

### DIFF
--- a/addons/weave/2.5.2/install.sh
+++ b/addons/weave/2.5.2/install.sh
@@ -58,11 +58,10 @@ function weave_use_existing_network() {
 }
 
 function weave_health_check() {
-    if [[ -z $(kubectl get pods -n kube-system -l name=weave-net -o jsonpath="{.items[*].status.conditions[?(@.status!='True')]}") ]]; then
-      return 0
-    else
+    if [[ -n $(kubectl get pods -n kube-system -l name=weave-net -o jsonpath="{range .items[*]}{range .status.conditions[*]}{ .type }={ .status }{'\n'}{end}{end}" | grep Ready=False) ]]; then
       return 1
     fi
+    return 0
 }
 
 function weave_ready_spinner() {


### PR DESCRIPTION
Implements/fixes #247.

Checks all weave pods (as there may be multiple as it is a `DaemonSet`). The check does not pass until all [pod conditions are ready](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate); this check seems to be more revealing than checking if a pod is running. I am open to hearing alternative methods for health checking.

These are the conditions in my test environment:
```json
status": {
        "conditions": [
          {
            "lastProbeTime": null,
            "lastTransitionTime": "2020-02-24T02:23:10Z",
            "status": "True",
            "type": "Initialized"
          },
          {
            "lastProbeTime": null,
            "lastTransitionTime": "2020-02-24T02:48:59Z",
            "message": "containers with unready status: [weave]",
            "reason": "ContainersNotReady",
            "status": "False",
            "type": "Ready"
          },
          {
            "lastProbeTime": null,
            "lastTransitionTime": "2020-02-24T02:48:59Z",
            "message": "containers with unready status: [weave]",
            "reason": "ContainersNotReady",
            "status": "False",
            "type": "ContainersReady"
          },
          {
            "lastProbeTime": null,
            "lastTransitionTime": "2020-02-24T02:23:10Z",
            "status": "True",
            "type": "PodScheduled"
          }
```