### PR TITLE
Don't fail kurl install if missing k8s assets

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -280,6 +280,11 @@ function install_kustomize() {
         return 0
     fi
 
+    if [ ! -d $DIR/packages/kubernetes/${k8sVersion}/assets ];then
+        echo "Missing required assets to install kustomize"
+        return 0
+    fi
+
     kustomize_dir=/usr/local/bin
 
     pushd "$DIR/packages/kubernetes/${k8sVersion}/assets"


### PR DESCRIPTION
Kustomize is packaged under an assets folder.  If that folder is missing, skip
installing kustomize and don't fail the kurl installation.