### PR TITLE
only prompt to load images when missing

### DIFF
--- a/addons/fluentd/1.7.4/Manifest
+++ b/addons/fluentd/1.7.4/Manifest
@@ -1,4 +1,4 @@
 image fluentd fluent/fluentd-kubernetes-daemonset:v1.7.4-debian-elasticsearch7-1.0
 image elasticsearch docker.elastic.co/elasticsearch/elasticsearch:7.5.0
 image kibana docker.elastic.co/kibana/kibana:7.5.0
-image busybox busybox
+image busybox busybox:1.31.1

--- a/addons/fluentd/1.7.4/elasticsearch/elasticsearch-statefulset.yaml
+++ b/addons/fluentd/1.7.4/elasticsearch/elasticsearch-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             value: "-Xms1024m -Xmx1024m"
       initContainers:
       - name: fix-permissions
-        image: busybox
+        image: busybox:1.31.1
         command: ["sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data"]
         securityContext:
           privileged: true
@@ -58,12 +58,12 @@ spec:
         - name: data
           mountPath: /usr/share/elasticsearch/data
       - name: increase-vm-max-map
-        image: busybox
+        image: busybox:1.31.1
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:
           privileged: true
       - name: increase-fd-ulimit
-        image: busybox
+        image: busybox:1.31.1
         command: ["sh", "-c", "ulimit -n 65536"]
         securityContext:
           privileged: true

--- a/addons/fluentd/1.7.4/test-log-generator.yaml
+++ b/addons/fluentd/1.7.4/test-log-generator.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   containers:
   - name: example
-    image: busybox
+    image: busybox:1.31.1
     args: [/bin/sh, -c, 'while true; do echo $(date); sleep 1; done']

--- a/addons/kotsadm/alpha/Manifest
+++ b/addons/kotsadm/alpha/Manifest
@@ -4,6 +4,6 @@ image kotsadm-operator docker.io/kotsadm/kotsadm-operator:alpha
 image kotsadm docker.io/kotsadm/kotsadm:alpha
 image kurl-proxy docker.io/kotsadm/kurl-proxy:alpha
 image postgres postgres:10.7
-image bcrypt docker.io/epicsoft/bcrypt:latest
+image bcrypt docker.io/epicsoft/bcrypt:latest no_remote_load
 
 asset kots.tar.gz https://github.com/replicatedhq/kots/releases/download/v1.13.2/kots_linux_amd64.tar.gz

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -456,47 +456,47 @@ function list_all_required_images() {
     fi
 
     if [ -n "$WEAVE_VERSION" ]; then
-        find addons/weave/$WEAVE_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/weave/$WEAVE_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$ROOK_VERSION" ]; then
-        find addons/rook/$ROOK_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/rook/$ROOK_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$OPENEBS_VERSION" ]; then
-        find addons/openebs/$OPENEBS_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/openebs/$OPENEBS_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$MINIO_VERSION" ]; then
-        find addons/minio/$MINIO_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/minio/$MINIO_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$CONTOUR_VERSION" ]; then
-        find addons/contour/$CONTOUR_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/contour/$CONTOUR_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$REGISTRY_VERSION" ]; then
-        find addons/registry/$REGISTRY_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/registry/$REGISTRY_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$PROMETHEUS_VERSION" ]; then
-        find addons/prometheus/$PROMETHEUS_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/prometheus/$PROMETHEUS_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$KOTSADM_VERSION" ]; then
-        find addons/kotsadm/$KOTSADM_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/kotsadm/$KOTSADM_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$FLUENTD_VERSION" ]; then
-        find addons/fluentd/$FLUENTD_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/fluentd/$FLUENTD_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$VELERO_VERSION" ]; then
-        find addons/velero/$VELERO_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/velero/$VELERO_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 
     if [ -n "$EKCO_VERSION" ]; then
-        find addons/ekco/$EKCO_VERSION packages/ -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+        find addons/ekco/$EKCO_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
 }
 


### PR DESCRIPTION
On cluster airgap installs check the list of images on each node's
status to ensure that all kubernetes, docker, and addon images are
available on that node. If a node is found to be missing an image, only
prompt the user to run the load-images task for that node, then
continue on to checking remaining remote nodes.

Addon manifest lines that declare images now have a 4th column
"no_remote_load". There will be no checks to ensure these images exist
on remote nodes. Currently there is a single image using this column,
the bcrypt image in the kotsadm addon which is never used in a pod.