### PR TITLE
Docker daemon.json options fix

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -9,35 +9,11 @@ function change_cgroup_driver_to_systemd() {
     	return
     fi
 
-    case $LSB_DIST in
-        ubuntu)
             cat > /etc/docker/daemon.json <<EOF
 {
     "exec-opts": ["native.cgroupdriver=systemd"],
-    "log-driver": "json-file",
-    "log-opts": {
-        "max-size": "100m"
-    },
-    "storage-driver": "overlay2"
 }
 EOF
-            ;;
-        rhel|centos)
-            cat > /etc/docker/daemon.json <<EOF
-{
-    "exec-opts": ["native.cgroupdriver=systemd"],
-    "log-driver": "json-file",
-    "log-opts": {
-        "max-size": "100m"
-    },
-    "storage-driver": "overlay2",
-    "storage-opts": [
-        "overlay2.override_kernel_check=true"
-    ]
-}
-EOF
-            ;;
-    esac
 
     mkdir -p /etc/systemd/system/docker.service.d
 

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -11,7 +11,7 @@ function change_cgroup_driver_to_systemd() {
 
             cat > /etc/docker/daemon.json <<EOF
 {
-    "exec-opts": ["native.cgroupdriver=systemd"],
+    "exec-opts": ["native.cgroupdriver=systemd"]
 }
 EOF
 

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -60,6 +60,7 @@ function install_docker() {
             systemctl start docker
         fi
         checkDockerStorageDriver "$HARD_FAIL_ON_LOOPBACK"
+        change_cgroup_driver_to_systemd
     fi
 
     if [ "$NO_PROXY" != "1" ] && [ -n "$PROXY_ADDRESS" ]; then
@@ -73,8 +74,6 @@ function install_docker() {
     if [ "$NO_PROXY" != "1" ] && [ -n "$PROXY_ADDRESS" ]; then
         checkDockerProxyConfig
     fi
-
-    change_cgroup_driver_to_systemd
 }
 
 installDockerOnline() {


### PR DESCRIPTION
Change install script to only change exec opts in /etc/docker/daemon.json file. Also changes so that the change_cgroup_to_systemd function does not run for an existing docker install