### PR TITLE
Always configure IPVS

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -23,9 +23,6 @@ function kubernetes_host() {
 }
 
 function kubernetes_load_ipvs_modules() {
-    if [ "$IPVS" != "1" ]; then
-        return
-    fi
     if lsmod | grep -q ip_vs ; then
         return
     fi


### PR DESCRIPTION
The platform installer used this to disable IPVS on Kubernetes 1.9, but
that's not relevant for kURL.