### PR TITLE
GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,22 +51,6 @@ jobs:
             echo "$DOCKERHUB_DOCKER_PASS" | docker login -u $DOCKERHUB_DOCKER_USER --password-stdin
             make -C kurl_util build-and-push-kurl-util-image
 
-  upload_staging_packages:
-    <<: *defaults
-    parallelism: 8
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 17.06.0-ce
-      - run:
-          name: upload packages
-          command: |
-            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-            export S3_BUCKET=kurl-sh-staging
-            source bin/kurl-util-image-export.sh
-            bin/upload-dist.sh
-
   upload_production_packages:
     <<: *defaults
     parallelism: 8
@@ -82,27 +66,6 @@ jobs:
             export S3_BUCKET=kurl-sh
             source bin/kurl-util-image-export.sh
             bin/upload-dist.sh
-
-  build_staging_docker_image:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 17.06.0-ce
-      - run: make -C web deps build
-      - run: make web
-      - run: |
-          export WORKDIR=`pwd`
-          export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
-          source bin/kurl-util-image-export.sh
-          bin/build-docker.sh
-      - deploy:
-          name: push image
-          command: |
-            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-            export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
-            push-docker
 
   build_production_docker_image:
     <<: *defaults
@@ -127,20 +90,6 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=$PRODUCTION_AWS_SECRET_ACCESS_KEY
             export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
             push-docker
-
-  deploy_staging_eks:
-    <<: *defaults
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-          - "25:51:68:66:6d:12:c7:84:f4:18:97:6a:7c:2e:f8:3d"
-      - deploy:
-          name: Maybe deploy staging to eks
-          command: |
-            export WORKDIR=`pwd`
-            export CIRCLE_PROJECT_REPONAME=$PROJECT_NAME
-            deploy
 
   deploy_production_eks:
     <<: *defaults
@@ -180,20 +129,9 @@ workflows:
               only:
                 - master
                 - beta
-
       - kurl_util_image:
           requires:
             - is_upstream
-      - upload_staging_packages:
-          requires:
-            - kurl_util_image
-      - build_staging_docker_image:
-          requires:
-            - kurl_util_image
-      - deploy_staging_eks:
-          requires:
-            - build_staging_docker_image
-            - upload_staging_packages
 
   tag:
     jobs:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -26,3 +26,5 @@ jobs:
 
       - run: go get golang.org/x/lint/golint
       - run: make -C kurl_util test build
+
+      - run: make -C web test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,7 @@ jobs:
 
   deploy-staging-eks:
     runs-on: ubuntu-18.04
+    needs: staging-docker-image
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,6 @@ jobs:
 
     - run: |
         docker tag kurl:${GITHUB_SHA:0:7} \
-      923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}
+          923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}
 
     - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,3 +36,26 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
         FORCE: 1
+
+  staging-docker-image:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.12.17
+
+    - name: setup env
+      run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
+      shell: bash
+
+    - run: make -C web deps build
+
+    - run: make web
+
+    - run: |
+      docker build -f deploy/Dockerfile-slim \
+        --build-arg version=${GITHUB_SHA:0:7} \
+        -t kurl:${GITHUB_SHA:0:7} \
+        .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
       run: |
         cd ~ && git clone --single-branch -b master git@github.com:replicatedcom/gitops-deploy
         mkdir -p ~/gitops-deploy/kurl
-        mv kustomize/overlays/staging/kurl.yaml gitops-deploy/kurl/kurl.yaml
+        mv ${GITHUB_WORKSPACE}/kustomize/overlays/staging/kurl.yaml gitops-deploy/kurl/kurl.yaml
         cd ~/gitops-deploy
         git config user.email "kurl-github-actions@replicated.com"
         git config user.name "kURL GitHub Actions"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,3 +70,40 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
 
     - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7}
+
+  deploy-staging-eks:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: kustomize
+      run: |
+        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/v2.0.0 | \
+          grep browser_download | \
+          grep linux | \
+          cut -d '"' -f 4 | \
+          xargs sudo curl -O -L && \
+          sudo mv kustomize_*_linux_amd64 /usr/local/bin/kustomize && \
+          sudo chmod +x /usr/local/bin/kustomize
+        pushd kustomize/overlays/staging
+        kustomize edit set image 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7}
+        kustomize build . > kurl.yaml
+        popd
+
+    - name: ssh-key
+      run: |
+        mkdir -p ~/.ssh
+        echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' \
+          >> ~/.ssh/known_hosts
+
+    - name: release
+      run: |
+        cd ~ && git clone --single-branch -b master git@github.com:replicatedcom/gitops-deploy
+        mkdir -p ~/gitops-deploy/kurl
+        mv kustomize/overlays/staging/kurl.yaml gitops-deploy/kurl/kurl.yaml
+        cd ~/gitops-deploy
+        git config user.email "kurl-github-actions@replicated.com"
+        git config user.name "kURL GitHub Actions"
+        git add .
+        git commit --allow-empty -m "https://github.com/replicatedhq/kURL/actions/runs/${GITHUB_RUN_ID}" && \
+          git push origin master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,10 +35,10 @@ jobs:
         S3_BUCKET: kurl-sh-staging
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
-        FORCE: 1
 
   staging-docker-image:
     runs-on: ubuntu-18.04
+    needs: test
     steps:
     - uses: actions/setup-go@v1
       with:
@@ -59,5 +59,15 @@ jobs:
     - run: |
         docker build -f deploy/Dockerfile-slim \
           --build-arg version=${GITHUB_SHA:0:7} \
-          -t kurl:${GITHUB_SHA:0:7} \
-          .
+          -t kurl:${GITHUB_SHA:0:7} .
+
+    - run: $(aws ecr get-login --no-include-email --region us-west-1)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+
+    - run: |
+        docker tag kurl:${GITHUB_SHA:0:7} \
+      923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}
+
+    - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,37 @@
+name: build
+
+on:
+  push:
+    branches:
+    - github-actions
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.12.17
+
+    - name: setup env
+      run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
+      shell: bash
+
+    - uses: actions/checkout@v2
+
+    - run: make -C web test
+
+    - run: make -C kurl_util deps test
+
+  build-upload-packages:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: bin/upload-dist.sh
+      env:
+        S3_BUCKET: kurl-sh-staging
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,8 +91,11 @@ jobs:
         popd
 
     - name: ssh-key
+      env:
+        GITOPS_DEPLOY_KEY: ${{ secrets.GITOPS_DEPLOY_KEY }}
       run: |
         mkdir -p ~/.ssh
+        echo "$GITOPS_DEPLOY_KEY" > ~/.ssh/id_rsa
         echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' \
           >> ~/.ssh/known_hosts
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
     - run: make web
 
     - run: |
-      docker build -f deploy/Dockerfile-slim \
-        --build-arg version=${GITHUB_SHA:0:7} \
-        -t kurl:${GITHUB_SHA:0:7} \
-        .
+        docker build -f deploy/Dockerfile-slim \
+          --build-arg version=${GITHUB_SHA:0:7} \
+          -t kurl:${GITHUB_SHA:0:7} \
+          .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,3 +35,4 @@ jobs:
         S3_BUCKET: kurl-sh-staging
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
+        FORCE: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,15 +59,11 @@ jobs:
     - run: |
         docker build -f deploy/Dockerfile-slim \
           --build-arg version=${GITHUB_SHA:0:7} \
-          -t kurl:${GITHUB_SHA:0:7} .
+          -t 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7} .
 
     - run: $(aws ecr get-login --no-include-email --region us-west-1)
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
 
-    - run: |
-        docker tag kurl:${GITHUB_SHA:0:7} \
-          923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}
-
-    - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com:${GITHUB_SHA:0:7}
+    - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
         echo "::add-path::$(go env GOPATH)/bin"
       shell: bash
 
+    - uses: actions/checkout@v2
+
     - run: make -C web deps build
 
     - run: make web

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,10 @@ jobs:
           --build-arg version=${GITHUB_SHA:0:7} \
           -t 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7} .
 
-    - run: $(aws ecr get-login --no-include-email --region us-west-1)
+    - run: |
+        aws ecr get-login-password --region us-east-1 | docker login \
+          --username AWS \
+          --password-stdin 923411875752.dkr.ecr.us-east-1.amazonaws.com
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,7 @@ jobs:
       run: |
         mkdir -p ~/.ssh
         echo "$GITOPS_DEPLOY_KEY" > ~/.ssh/id_rsa
+        chmod 400 ~/.ssh/id_rsa
         echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' \
           >> ~/.ssh/known_hosts
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,30 +1,11 @@
-name: build
+name: deploy-staging
 
 on:
   push:
     branches:
-    - github-actions
+    - master
 
 jobs:
-  test:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/setup-go@v1
-      with:
-        go-version: 1.12.17
-
-    - name: setup env
-      run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
-
-    - uses: actions/checkout@v2
-
-    - run: make -C web test
-
-    - run: make -C kurl_util deps test
-
   build-upload-packages:
     runs-on: ubuntu-18.04
     steps:
@@ -38,7 +19,6 @@ jobs:
 
   staging-docker-image:
     runs-on: ubuntu-18.04
-    needs: test
     steps:
     - uses: actions/setup-go@v1
       with:

--- a/bin/upload-dist.sh
+++ b/bin/upload-dist.sh
@@ -33,11 +33,11 @@ function docker_pkg() {
 function list_all_packages() {
     pkgs addons
     pkgs packages
-    echo "common.tar.gz"
     docker_pkg
 }
 
-mkdir -p dist/
+# always build the common package
+make dist/common.tar.gz
 
 for package in $(list_all_packages)
 do

--- a/bin/upload-dist.sh
+++ b/bin/upload-dist.sh
@@ -14,8 +14,6 @@ function require() {
 
 require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
 require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
-require CIRCLE_NODE_TOTAL "${CIRCLE_NODE_TOTAL}"
-require CIRCLE_NODE_INDEX "${CIRCLE_NODE_INDEX}"
 require S3_BUCKET "${S3_BUCKET}"
 
 function pkgs() {
@@ -39,10 +37,15 @@ function list_all_packages() {
     docker_pkg
 }
 
-for package in $(list_all_packages | sort | awk "NR % $CIRCLE_NODE_TOTAL == $CIRCLE_NODE_INDEX")
+mkdir -p dist/
+
+for package in $(list_all_packages)
 do
-    echo "Making $package"
-    make dist/$package
+    if ! aws s3api head-object --bucket=$S3_BUCKET --key=staging/$package &>/dev/null; then
+        make dist/$package
+    else
+        echo "s3://$S3_BUCKET/staging/$package already exists"
+    fi
 done
 
-aws s3 cp dist/ s3://$S3_BUCKET/dist --recursive
+aws s3 cp dist/ s3://$S3_BUCKET/staging --recursive

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -61,7 +61,7 @@ function addon_load() {
     fi
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
-        curl -sSLO "$DIST_URL/dist/$name-$version.tar.gz"
+        curl -sSLO "$DIST_URL/$name-$version.tar.gz"
         tar xf $name-$version.tar.gz
         rm $name-$version.tar.gz
     fi

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -253,7 +253,7 @@ function spinner_until() {
 
 function get_shared() {
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
-        curl -sSOL $DIST_URL/dist/common.tar.gz
+        curl -sSOL $DIST_URL/common.tar.gz
         tar xf common.tar.gz
         rm common.tar.gz
     fi

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -122,7 +122,7 @@ function kubernetes_get_host_packages_online() {
     local k8sVersion="$1"
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
-        curl -sSLO "$DIST_URL/dist/kubernetes-${k8sVersion}.tar.gz"
+        curl -sSLO "$DIST_URL/kubernetes-${k8sVersion}.tar.gz"
         tar xf kubernetes-${k8sVersion}.tar.gz
         rm kubernetes-${k8sVersion}.tar.gz
     fi

--- a/web/src/controllers/Bundles.ts
+++ b/web/src/controllers/Bundles.ts
@@ -33,15 +33,20 @@ interface BundleManifest {
 
 @Controller("/bundle")
 export class Bundle {
-  private distOrigin: string;
+  private distURL: string;
   private replicatedAppURL: string;
 
   constructor(
     private readonly templates: Templates,
     private readonly installers: InstallerStore,
   ) {
-    this.distOrigin = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
     this.replicatedAppURL = process.env["REPLICATED_APP_URL"] || "https://replicated.app";
+    this.distURL = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
+    if (process.env["NODE_ENV"] === "production") {
+      this.distURL += "/dist";
+    } else {
+      this.distURL += "/staging";
+    }
   }
 
   /**
@@ -67,7 +72,7 @@ export class Bundle {
     response.type("application/json");
 
     const ret: BundleManifest = {layers: [], files: {}};
-    ret.layers = installer.packages().map((pkg) => `${this.distOrigin}/dist/${pkg}.tar.gz`);
+    ret.layers = installer.packages().map((pkg) => `${this.distURL}/${pkg}.tar.gz`);
 
     const kotsadmApplicationSlug = _.get(installer.spec, "kotsadm.applicationSlug");
     if (kotsadmApplicationSlug) {

--- a/web/src/controllers/Dist.ts
+++ b/web/src/controllers/Dist.ts
@@ -7,10 +7,15 @@ import {
 
 @Controller("/dist")
 export class Dist {
-  private distOrigin: string;
+  private distURL: string;
 
   constructor() {
-    this.distOrigin = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
+    this.distURL = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
+    if (process.env["NODE_ENV"] === "production") {
+      this.distURL += "/dist";
+    } else {
+      this.distURL += "/staging";
+    }
   }
 
   /**
@@ -24,7 +29,7 @@ export class Dist {
     @Res() response: Express.Response,
     @PathParams("pkg") pkg: string,
   ): Promise<void> {
-    const location = `${this.distOrigin}/dist/${pkg}`
+    const location = `${this.distURL}/${pkg}`;
 
     response.redirect(307, location);
   }

--- a/web/src/util/services/templates.ts
+++ b/web/src/util/services/templates.ts
@@ -17,9 +17,15 @@ export class Templates {
 
   constructor() {
     this.kurlURL = process.env["KURL_URL"] || "https://kurl.sh";
-    this.distURL = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
     this.replicatedAppURL = process.env["REPLICATED_APP_URL"] || "https://replicated.app";
     this.kurlUtilImage = process.env["KURL_UTIL_IMAGE"] || "replicated/kurl-util:alpha";
+
+    this.distURL = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
+		if (process.env["NODE_ENV"] === "production") {
+			this.distURL += "/dist";
+		} else {
+			this.distURL += "/staging";
+		}
 
     const tmplDir = path.join(__dirname, "../../../../templates");
     const installTmplPath = path.join(tmplDir, "install.tmpl");

--- a/web/src/util/services/templates.ts
+++ b/web/src/util/services/templates.ts
@@ -21,11 +21,11 @@ export class Templates {
     this.kurlUtilImage = process.env["KURL_UTIL_IMAGE"] || "replicated/kurl-util:alpha";
 
     this.distURL = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
-		if (process.env["NODE_ENV"] === "production") {
-			this.distURL += "/dist";
-		} else {
-			this.distURL += "/staging";
-		}
+    if (process.env["NODE_ENV"] === "production") {
+      this.distURL += "/dist";
+    } else {
+      this.distURL += "/staging";
+    }
 
     const tmplDir = path.join(__dirname, "../../../../templates");
     const installTmplPath = path.join(tmplDir, "install.tmpl");


### PR DESCRIPTION
Move package building, package upload, staging docker image, and staging deploy from CircleCI to Github Actions.

Do not rebuild a package if it already exists on S3, except common package gets built every time.

Packages are uploaded to /staging in an S3 bucket and served from there by the staging API server. In a follow-up PR, the staging packages will be uploaded to the /staging directory of the prod S3 bucket and the prod deployment workflow will copy them from there to /dist rather than building them.