### PR TITLE
add API_ADVERTISE_ENDPOINT env var to golang api pod

### DIFF
--- a/addons/kotsadm/alpha/kotsadm.yaml
+++ b/addons/kotsadm/alpha/kotsadm.yaml
@@ -123,6 +123,8 @@ spec:
                 key: secret-access-key
           - name: S3_BUCKET_ENDPOINT
             value: "true"
+          - name: API_ADVERTISE_ENDPOINT
+            value: "http://localhost:8800"
         volumeMounts:
           - name: kotsadm-web-scripts
             mountPath: /scripts/start-kotsadm-web.sh


### PR DESCRIPTION
this duplicates SHIP_API_ADVERTISE_ENDPOINT in the nodejs api pod
https://github.com/replicatedhq/kURL/blob/laverya/include-api-endpoint-env-var/addons/kotsadm/alpha/api.yaml#L97-L98