### PR TITLE
Kubernetes version flag strips v

### DIFF
--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -96,7 +96,7 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 		case "kubernetes-master-address":
 			installer.Spec.Kubernetes.MasterAddress = split[1]
 		case "kubernetes-version":
-			installer.Spec.Kubernetes.Version = split[1]
+			installer.Spec.Kubernetes.Version = strings.TrimLeft(split[1], "v")
 		case "installer-spec-file":
 			continue
 		case "preserve-docker-config":

--- a/kurl_util/cmd/bashmerge/main_test.go
+++ b/kurl_util/cmd/bashmerge/main_test.go
@@ -197,6 +197,18 @@ func Test_parseBashFlags(t *testing.T) {
 			bashFlags: "BaD FlAgS",
 			wantError: true,
 		},
+		{
+			name:         "Kubernetes version with v",
+			oldInstaller: &kurlv1beta1.Installer{},
+			bashFlags:    "kubernetes-version=v1.17.3",
+			mergedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.17.3",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/kurl_util/go.mod
+++ b/kurl_util/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/coreos/etcd v3.3.15+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/replicatedhq/kurl v0.0.0-20200430165742-b6df5d5ede7e // indirect
-	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200430165742-b6df5d5ede7e // indirect
+	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200430165742-b6df5d5ede7e
 	github.com/stretchr/testify v1.4.0
 	github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect


### PR DESCRIPTION
Previously this flag was only used to check for the correct Kubernetes version when joining a new node and any leading "v" was stripped out with sed.