### PR TITLE
Send support bundle and sonobuoy results to api

### DIFF
--- a/testgrid/migrations/tables/testinstance.yaml
+++ b/testgrid/migrations/tables/testinstance.yaml
@@ -25,6 +25,8 @@ spec:
           type: boolean
         - name: output
           type: text
+        - name: sonobuoy_results
+          type: text
         - name: kurl_yaml
           type: text
         - name: kurl_url

--- a/testgrid/tgapi/pkg/cli/api/run.go
+++ b/testgrid/tgapi/pkg/cli/api/run.go
@@ -35,7 +35,7 @@ func RunCmd() *cobra.Command {
 			r.HandleFunc("/v1/instance/{instanceId}/start", handlers.StartInstance).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/logs", handlers.InstanceLogs).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/bundle", handlers.InstanceBundle).Methods("POST")
-			r.HandleFunc("/v1/instance/{instanceId}/sonobuoy", handlers.InstanceSonobouyResults).Methods("POST")
+			r.HandleFunc("/v1/instance/{instanceId}/sonobuoy", handlers.InstanceSonobuoyResults).Methods("POST")
 
 			r.HandleFunc("/v1/dequeue/instance", handlers.DequeueInstance).Methods("GET")
 

--- a/testgrid/tgapi/pkg/cli/api/run.go
+++ b/testgrid/tgapi/pkg/cli/api/run.go
@@ -35,6 +35,7 @@ func RunCmd() *cobra.Command {
 			r.HandleFunc("/v1/instance/{instanceId}/start", handlers.StartInstance).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/logs", handlers.InstanceLogs).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/bundle", handlers.InstanceBundle).Methods("POST")
+			r.HandleFunc("/v1/instance/{instanceId}/sonobuoy", handlers.InstanceSonobouyResults).Methods("POST")
 
 			r.HandleFunc("/v1/dequeue/instance", handlers.DequeueInstance).Methods("GET")
 

--- a/testgrid/tgapi/pkg/handlers/instance_logs.go
+++ b/testgrid/tgapi/pkg/handlers/instance_logs.go
@@ -18,7 +18,7 @@ func InstanceLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	instanceId := mux.Vars(r)["instanceId"]
-	if err := testinstance.FinishWithLogs(instanceId, logs); err != nil {
+	if err := testinstance.SetInstanceLogs(instanceId, logs); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return

--- a/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
+++ b/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/replicatedhq/kurl/testgrid/tgapi/pkg/logger"
+)
+
+func InstanceSonobouyResults(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logger.Error(err)
+		JSON(w, 500, nil)
+		return
+	}
+
+	fmt.Printf("sonobouy results = %s\n", body)
+
+	JSON(w, 200, nil)
+}

--- a/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
+++ b/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
@@ -1,14 +1,18 @@
 package handlers
 
 import (
-	"fmt"
+	"bufio"
+	"bytes"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/replicatedhq/kurl/testgrid/tgapi/pkg/logger"
+	"github.com/replicatedhq/kurl/testgrid/tgapi/pkg/testinstance"
 )
 
-func InstanceSonobouyResults(w http.ResponseWriter, r *http.Request) {
+func InstanceSonobuoyResults(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		logger.Error(err)
@@ -16,7 +20,37 @@ func InstanceSonobouyResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("sonobouy results = %s\n", body)
+	instanceId := mux.Vars(r)["instanceId"]
+	if err := testinstance.SetInstanceSonobuoyResults(instanceId, body); err != nil {
+		logger.Error(err)
+		JSON(w, 500, nil)
+		return
+	}
+
+	/*
+		Plugin: e2e
+		Status: passed
+		Total: 4843
+		Passed: 1
+		Failed: 0
+		Skipped: 4842
+	*/
+
+	isSuccess := false
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Status:") {
+			isSuccess = strings.HasSuffix(line, "passed")
+		}
+
+	}
+
+	if err := testinstance.SetInstanceSuccess(instanceId, isSuccess); err != nil {
+		logger.Error(err)
+		JSON(w, 500, nil)
+		return
+	}
 
 	JSON(w, 200, nil)
 }

--- a/testgrid/tgapi/pkg/testinstance/testinstance.go
+++ b/testgrid/tgapi/pkg/testinstance/testinstance.go
@@ -74,13 +74,36 @@ func Start(id string) error {
 	return nil
 }
 
-func FinishWithLogs(id string, logs []byte) error {
+func SetInstanceLogs(id string, logs []byte) error {
 	db := persistence.MustGetPGSession()
 
-	query := `update testinstance set finished_at = now(), output = $1 
-where id = $2`
+	query := `update testinstance set output = $1 where id = $2`
 
 	if _, err := db.Exec(query, logs, id); err != nil {
+		return errors.Wrap(err, "failed to update")
+	}
+
+	return nil
+}
+
+func SetInstanceSonobuoyResults(id string, results []byte) error {
+	db := persistence.MustGetPGSession()
+
+	query := `update testinstance set sonobuoy_results = $1 where id = $2`
+
+	if _, err := db.Exec(query, results, id); err != nil {
+		return errors.Wrap(err, "failed to update")
+	}
+
+	return nil
+}
+
+func SetInstanceSuccess(id string, isSuccess bool) error {
+	db := persistence.MustGetPGSession()
+
+	query := `update testinstance set is_success = $1, finished_at = now() where id = $2`
+
+	if _, err := db.Exec(query, isSuccess, id); err != nil {
 		return errors.Wrap(err, "failed to update")
 	}
 

--- a/testgrid/tgrun/go.mod
+++ b/testgrid/tgrun/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/pkg/errors v0.8.1
-	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200603224716-d4526b9c8ad0
+	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200616210543-a7ac91c8c90b
 	github.com/replicatedhq/kurl/testgrid/tgapi v0.0.0-20200609141000-22fb64716037
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.2

--- a/testgrid/tgrun/go.sum
+++ b/testgrid/tgrun/go.sum
@@ -345,6 +345,8 @@ github.com/replicatedhq/kurl v0.0.0-20200514170003-b9e4bf917dd9 h1:RQvXCkkLW71/0
 github.com/replicatedhq/kurl v0.0.0-20200514170003-b9e4bf917dd9/go.mod h1:ORM8QYmmMuylJCxWXnclSOKO+N4kx7eLIw5593awx9Y=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200603224716-d4526b9c8ad0 h1:R2v+aaGhNepDk+rntF4pLtwdo02VyTQIFaPB/DoDLpA=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200603224716-d4526b9c8ad0/go.mod h1:swtN+H2q4iFze0pXAOhx0ZgX/Eej1lk9iI4cx13HcBU=
+github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200616210543-a7ac91c8c90b h1:F59nl9KLyAbvY9wgWNIe9yc/O5O+mrNRrtU35GFpH2Q=
+github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200616210543-a7ac91c8c90b/go.mod h1:swtN+H2q4iFze0pXAOhx0ZgX/Eej1lk9iI4cx13HcBU=
 github.com/replicatedhq/kurl/testgrid/tgapi v0.0.0-20200609141000-22fb64716037 h1:fPfmHsNTzOMtfmK9cxrFicfyhsFLYHmx5Ut4pceEPWU=
 github.com/replicatedhq/kurl/testgrid/tgapi v0.0.0-20200609141000-22fb64716037/go.mod h1:bUcIAf2qoQo18mXvZV4I6BoHNuMJ3O6MRmW9OdbxoOc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/testgrid/tgrun/pkg/runner/runner.go
+++ b/testgrid/tgrun/pkg/runner/runner.go
@@ -175,14 +175,19 @@ chpasswd: { expire: False }
 runcmd:
   - [ bash, -c, "curl %s | sudo bash" ]
   - [ bash, -c, 'curl -X POST --data-binary "@/var/log/cloud-init-output.log" %s/v1/instance/%s/logs']
-  - [ bash, -c, 'kubectl support-bundle https://kots.io' ]
-  - [ bash, -c, 'curl -X POST --data-binary "@~/support-bundle.tar.gz" %s/v1/instance/%s/bundle' ]
+  - [ bash, -c, '/opt/replicated/krew/bin/kubectl-support_bundle --kubeconfig /etc/kubernetes/admin.conf https://kots.io' ]
+  - [ bash, -c, 'curl -X POST --data-binary "@/support-bundle.tar.gz" %s/v1/instance/%s/bundle' ]
+  - [ bash, -c, 'mkdir -p /run/sonobuoy && curl -L --output /run/sonobuoy/sonobuoy.tar.gz https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.18.3/sonobuoy_0.18.3_linux_amd64.tar.gz']
+  - [ bash, -c, 'cd /usr/local/bin && tar xzvf /run/sonobuoy/sonobuoy.tar.gz']
+  - [ bash, -c, 'sonobuoy --kubeconfig /etc/kubernetes/admin.conf run --wait --mode quick']
+  - [ bash, -c, 'results=$(sonobuoy retrieve --kubeconfig /etc/kubernetes/admin.conf) && sonobuoy results $results > /tmp/sonobuoy-results.txt && curl -X POST --data-binary "@/tmp/sonobuoy-results.txt" %s/v1/instance/%s/sonobuoy' ]
 power_state:
   mode: poweroff
   timeout: 1
   condition: True
 `,
 								singleTest.KurlURL,
+								singleTest.TestGridAPIEndpoint, singleTest.ID,
 								singleTest.TestGridAPIEndpoint, singleTest.ID,
 								singleTest.TestGridAPIEndpoint, singleTest.ID),
 						},

--- a/testgrid/tgrun/pkg/scheduler/static.go
+++ b/testgrid/tgrun/pkg/scheduler/static.go
@@ -15,11 +15,11 @@ var operatingSystems = []types.OperatingSystemImage{
 }
 
 var testSpecs = []types.InstallerSpec{
-	latestRecommendedRook,
-	latestRecommendedOpenEBS,
+	latestRecommendedRookDocker,
+	latestRecommendedRookContainerd,
 }
 
-var latestRecommendedRook = types.InstallerSpec{
+var latestRecommendedRookDocker = types.InstallerSpec{
 	Kubernetes: kurlv1beta1.Kubernetes{
 		Version: "1.17.3",
 	},
@@ -49,21 +49,21 @@ var latestRecommendedRook = types.InstallerSpec{
 	},
 }
 
-var latestRecommendedOpenEBS = types.InstallerSpec{
+var latestRecommendedRookContainerd = types.InstallerSpec{
 	Kubernetes: kurlv1beta1.Kubernetes{
 		Version: "1.17.3",
 	},
 	Weave: &kurlv1beta1.Weave{
 		Version: "2.6.4",
 	},
-	OpenEBS: &kurlv1beta1.OpenEBS{
-		Version: "1.6.0",
+	Rook: &kurlv1beta1.Rook{
+		Version: "1.0.4",
 	},
 	Contour: &kurlv1beta1.Contour{
 		Version: "1.0.1",
 	},
-	Docker: &kurlv1beta1.Docker{
-		Version: "19.03.4",
+	Containerd: &kurlv1beta1.Containerd{
+		Version: "beta",
 	},
 	Prometheus: &kurlv1beta1.Prometheus{
 		Version: "0.33.0",

--- a/testgrid/tgrun/pkg/scheduler/types/types.go
+++ b/testgrid/tgrun/pkg/scheduler/types/types.go
@@ -40,6 +40,7 @@ type Installer struct {
 type InstallerSpec struct {
 	Kubernetes      kurlv1beta1.Kubernetes       `json:"kubernetes,omitempty"`
 	Docker          *kurlv1beta1.Docker          `json:"docker,omitempty"`
+	Containerd      *kurlv1beta1.Containerd      `json:"containerd,omitempty"`
 	Weave           *kurlv1beta1.Weave           `json:"weave,omitempty"`
 	Calico          *kurlv1beta1.Calico          `json:"calico,omitempty"`
 	Contour         *kurlv1beta1.Contour         `json:"contour,omitempty"`


### PR DESCRIPTION
This does a few things:

1. fix the support bundle collection
2. adds a quick sonobuoy conformance test to the output
3. removes the broken openebs spec and adds containerd with ubuntu (also broken)
