### PR TITLE
Upgrade Contour to 1.6.0

### DIFF
--- a/addons/contour/1.6.0/Manifest
+++ b/addons/contour/1.6.0/Manifest
@@ -1,0 +1,3 @@
+image contour docker.io/projectcontour/contour:v1.6.0
+image contour docker.io/projectcontour/contour:latest
+image envoy docker.io/envoyproxy/envoy:v1.14.2

--- a/addons/contour/1.6.0/contour.yaml
+++ b/addons/contour/1.6.0/contour.yaml
@@ -1,0 +1,1430 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: projectcontour
+data:
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # Client request timeout to be passed to Envoy
+    # as the connection manager request_timeout.
+    # Defaults to 0, which Envoy interprets as disabled.
+    # Note that this is the timeout for the whole request,
+    # not an idle timeout.
+    # request-timeout: 0s
+    # disable HTTPProxy permitInsecure field
+    disablePermitInsecure: false
+    tls:
+    # minimum TLS version that Contour will negotiate
+    # minimum-protocol-version: "1.1"
+    # Defines the Kubernetes name/namespace matching a secret to use
+    # as the fallback certificate when requests which don't match the
+    # SNI defined for a vhost.
+      fallback-certificate:
+    #   name: fallback-secret-name
+    #   namespace: projectcontour
+    # The following config shows the defaults for the leader election.
+    # leaderelection:
+    #   configmap-name: leader-elect
+    #   configmap-namespace: projectcontour
+    ### Logging options
+    # Default setting
+    accesslog-format: envoy
+    # To enable JSON logging in Envoy
+    # accesslog-format: json
+    # The default fields that will be logged are specified below.
+    # To customise this list, just add or remove entries.
+    # The canonical list is available at
+    # https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
+    # json-fields:
+    #   - "@timestamp"
+    #   - "authority"
+    #   - "bytes_received"
+    #   - "bytes_sent"
+    #   - "downstream_local_address"
+    #   - "downstream_remote_address"
+    #   - "duration"
+    #   - "method"
+    #   - "path"
+    #   - "protocol"
+    #   - "request_id"
+    #   - "requested_server_name"
+    #   - "response_code"
+    #   - "response_flags"
+    #   - "uber_trace_id"
+    #   - "upstream_cluster"
+    #   - "upstream_host"
+    #   - "upstream_local_address"
+    #   - "upstream_service_time"
+    #   - "user_agent"
+    #   - "x_forwarded_for"
+    #
+    # default-http-versions:
+    # - "HTTP/2"
+    # - "HTTP/1.1"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: httpproxies.projectcontour.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.virtualhost.fqdn
+    description: Fully qualified domain name
+    name: FQDN
+    type: string
+  - JSONPath: .spec.virtualhost.tls.secretName
+    description: Secret with TLS credentials
+    name: TLS Secret
+    type: string
+  - JSONPath: .status.currentStatus
+    description: The current status of the HTTPProxy
+    name: Status
+    type: string
+  - JSONPath: .status.description
+    description: Description of the current status
+    name: Status Description
+    type: string
+  group: projectcontour.io
+  names:
+    kind: HTTPProxy
+    listKind: HTTPProxyList
+    plural: httpproxies
+    shortNames:
+    - proxy
+    - proxies
+    singular: httpproxy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: HTTPProxy is an Ingress CRD specification
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HTTPProxySpec defines the spec of the CRD.
+          properties:
+            includes:
+              description: Includes allow for specific routing configuration to be
+                appended to another HTTPProxy in another namespace.
+              items:
+                description: Include describes a set of policies that can be applied
+                  to an HTTPProxy in a namespace.
+                properties:
+                  conditions:
+                    description: Conditions are a set of routing properties that is
+                      applied to an HTTPProxy in a namespace.
+                    items:
+                      description: Condition are policies that are applied on top
+                        of HTTPProxies. One of Prefix or Header must be provided.
+                      properties:
+                        header:
+                          description: Header specifies the header condition to match.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header value.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                value must be equal to.
+                              type: string
+                            name:
+                              description: Name is the name of the header to match
+                                against. Name is required. Header names are case insensitive.
+                              type: string
+                            notcontains:
+                              description: NotContains specifies a substring that
+                                must not be present in the header value.
+                              type: string
+                            notexact:
+                              description: NoExact specifies a string that the header
+                                value must not be equal to. The condition is true
+                                if the header has any other value.
+                              type: string
+                            present:
+                              description: Present specifies that condition is true
+                                when the named header is present, regardless of its
+                                value. Note that setting Present to false does not
+                                make the condition true if the named header is absent.
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        prefix:
+                          description: Prefix defines a prefix match for a request.
+                          type: string
+                      type: object
+                    type: array
+                  name:
+                    description: Name of the HTTPProxy
+                    type: string
+                  namespace:
+                    description: Namespace of the HTTPProxy to include. Defaults to
+                      the current namespace if not supplied.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            routes:
+              description: Routes are the ingress routes. If TCPProxy is present,
+                Routes is ignored.
+              items:
+                description: Route contains the set of routes for a virtual host.
+                properties:
+                  conditions:
+                    description: Conditions are a set of routing properties that is
+                      applied to an HTTPProxy in a namespace.
+                    items:
+                      description: Condition are policies that are applied on top
+                        of HTTPProxies. One of Prefix or Header must be provided.
+                      properties:
+                        header:
+                          description: Header specifies the header condition to match.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header value.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                value must be equal to.
+                              type: string
+                            name:
+                              description: Name is the name of the header to match
+                                against. Name is required. Header names are case insensitive.
+                              type: string
+                            notcontains:
+                              description: NotContains specifies a substring that
+                                must not be present in the header value.
+                              type: string
+                            notexact:
+                              description: NoExact specifies a string that the header
+                                value must not be equal to. The condition is true
+                                if the header has any other value.
+                              type: string
+                            present:
+                              description: Present specifies that condition is true
+                                when the named header is present, regardless of its
+                                value. Note that setting Present to false does not
+                                make the condition true if the named header is absent.
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        prefix:
+                          description: Prefix defines a prefix match for a request.
+                          type: string
+                      type: object
+                    type: array
+                  enableWebsockets:
+                    description: Enables websocket support for the route.
+                    type: boolean
+                  healthCheckPolicy:
+                    description: The health check policy for this route.
+                    properties:
+                      healthyThresholdCount:
+                        description: The number of healthy health checks required
+                          before a host is marked healthy
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      host:
+                        description: The value of the host header in the HTTP health
+                          check request. If left empty (default value), the name "contour-envoy-healthcheck"
+                          will be used.
+                        type: string
+                      intervalSeconds:
+                        description: The interval (seconds) between health checks
+                        format: int64
+                        type: integer
+                      path:
+                        description: HTTP endpoint used to perform health checks on
+                          upstream service
+                        type: string
+                      timeoutSeconds:
+                        description: The time to wait (seconds) for a health check
+                          response
+                        format: int64
+                        type: integer
+                      unhealthyThresholdCount:
+                        description: The number of unhealthy health checks required
+                          before a host is marked unhealthy
+                        format: int64
+                        minimum: 0
+                        type: integer
+                    required:
+                    - path
+                    type: object
+                  loadBalancerPolicy:
+                    description: The load balancing policy for this route.
+                    properties:
+                      strategy:
+                        description: Strategy specifies the policy used to balance
+                          requests across the pool of backend pods. Valid policy names
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+                          and `Cookie`. If an unknown strategy name is specified or
+                          no policy is supplied, the default `RoundRobin` policy is
+                          used.
+                        type: string
+                    type: object
+                  pathRewritePolicy:
+                    description: The policy for rewriting the path of the request
+                      URL after the request has been routed to a Service.
+                    properties:
+                      replacePrefix:
+                        description: ReplacePrefix describes how the path prefix should
+                          be replaced.
+                        items:
+                          description: ReplacePrefix describes a path prefix replacement.
+                          properties:
+                            prefix:
+                              description: "Prefix specifies the URL path prefix to
+                                be replaced. \n If Prefix is specified, it must exactly
+                                match the Condition prefix that is rendered by the
+                                chain of including HTTPProxies and only that path
+                                prefix will be replaced by Replacement. This allows
+                                HTTPProxies that are included through multiple roots
+                                to only replace specific path prefixes, leaving others
+                                unmodified. \n If Prefix is not specified, all routing
+                                prefixes rendered by the include chain will be replaced."
+                              minLength: 1
+                              type: string
+                            replacement:
+                              description: Replacement is the string that the routing
+                                path prefix will be replaced with. This must not be
+                                empty.
+                              minLength: 1
+                              type: string
+                          required:
+                          - replacement
+                          type: object
+                        type: array
+                    type: object
+                  permitInsecure:
+                    description: Allow this path to respond to insecure requests over
+                      HTTP which are normally not permitted when a `virtualhost.tls`
+                      block is present.
+                    type: boolean
+                  requestHeadersPolicy:
+                    description: The policy for managing request headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove.
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  responseHeadersPolicy:
+                    description: The policy for managing response headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove.
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  retryPolicy:
+                    description: The retry policy for this route.
+                    properties:
+                      count:
+                        description: NumRetries is maximum allowed number of retries.
+                          If not supplied, the number of retries is one.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      perTryTimeout:
+                        description: PerTryTimeout specifies the timeout per retry
+                          attempt. Ignored if NumRetries is not supplied.
+                        type: string
+                    type: object
+                  services:
+                    description: Services are the services to proxy traffic.
+                    items:
+                      description: Service defines an Kubernetes Service to proxy
+                        traffic.
+                      properties:
+                        mirror:
+                          description: If Mirror is true the Service will receive
+                            a read only mirror of the traffic for this route.
+                          type: boolean
+                        name:
+                          description: Name is the name of Kubernetes service to proxy
+                            traffic. Names defined here will be used to look up corresponding
+                            endpoints which contain the ips to route.
+                          type: string
+                        port:
+                          description: Port (defined as Integer) to proxy traffic
+                            to since a service can have multiple defined.
+                          exclusiveMaximum: true
+                          maximum: 65536
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: Protocol may be used to specify (or override)
+                            the protocol used to reach this Service. Values may be
+                            tls, h2, h2c. If omitted, protocol-selection falls back
+                            on Service annotations.
+                          enum:
+                          - h2
+                          - h2c
+                          - tls
+                          type: string
+                        requestHeadersPolicy:
+                          description: The policy for managing request headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        responseHeadersPolicy:
+                          description: The policy for managing response headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        validation:
+                          description: UpstreamValidation defines how to verify the
+                            backend service's certificate
+                          properties:
+                            caSecret:
+                              description: Name of the Kubernetes secret be used to
+                                validate the certificate presented by the backend
+                              type: string
+                            subjectName:
+                              description: Key which is expected to be present in
+                                the 'subjectAltName' of the presented certificate
+                              type: string
+                          required:
+                          - caSecret
+                          - subjectName
+                          type: object
+                        weight:
+                          description: Weight defines percentage of traffic to balance
+                            traffic
+                          format: int64
+                          minimum: 0
+                          type: integer
+                      required:
+                      - name
+                      - port
+                      type: object
+                    minItems: 1
+                    type: array
+                  timeoutPolicy:
+                    description: The timeout policy for this route.
+                    properties:
+                      idle:
+                        description: Timeout after which, if there are no active requests
+                          for this route, the connection between Envoy and the backend
+                          or Envoy and the external client will be closed. If not
+                          specified, there is no per-route idle timeout, though a
+                          connection manager-wide stream_idle_timeout default of 5m
+                          still applies.
+                        type: string
+                      response:
+                        description: Timeout for receiving a response from the server
+                          after processing a request from client. If not supplied,
+                          Envoy's default value of 15s applies.
+                        type: string
+                    type: object
+                required:
+                - services
+                type: object
+              type: array
+            tcpproxy:
+              description: TCPProxy holds TCP proxy information.
+              properties:
+                healthCheckPolicy:
+                  description: The health check policy for this tcp proxy
+                  properties:
+                    healthyThresholdCount:
+                      description: The number of healthy health checks required before
+                        a host is marked healthy
+                      format: int32
+                      type: integer
+                    intervalSeconds:
+                      description: The interval (seconds) between health checks
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: The time to wait (seconds) for a health check response
+                      format: int64
+                      type: integer
+                    unhealthyThresholdCount:
+                      description: The number of unhealthy health checks required
+                        before a host is marked unhealthy
+                      format: int32
+                      type: integer
+                  type: object
+                include:
+                  description: Include specifies that this tcpproxy should be delegated
+                    to another HTTPProxy.
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                includes:
+                  description: "IncludesDeprecated allow for specific routing configuration
+                    to be appended to another HTTPProxy in another namespace. \n Exists
+                    due to a mistake when developing HTTPProxy and the field was marked
+                    plural when it should have been singular. This field should stay
+                    to not break backwards compatibility to v1 users."
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                loadBalancerPolicy:
+                  description: The load balancing policy for the backend services.
+                  properties:
+                    strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
+                      type: string
+                  type: object
+                services:
+                  description: Services are the services to proxy traffic
+                  items:
+                    description: Service defines an Kubernetes Service to proxy traffic.
+                    properties:
+                      mirror:
+                        description: If Mirror is true the Service will receive a
+                          read only mirror of the traffic for this route.
+                        type: boolean
+                      name:
+                        description: Name is the name of Kubernetes service to proxy
+                          traffic. Names defined here will be used to look up corresponding
+                          endpoints which contain the ips to route.
+                        type: string
+                      port:
+                        description: Port (defined as Integer) to proxy traffic to
+                          since a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: Protocol may be used to specify (or override)
+                          the protocol used to reach this Service. Values may be tls,
+                          h2, h2c. If omitted, protocol-selection falls back on Service
+                          annotations.
+                        enum:
+                        - h2
+                        - h2c
+                        - tls
+                        type: string
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      validation:
+                        description: UpstreamValidation defines how to verify the
+                          backend service's certificate
+                        properties:
+                          caSecret:
+                            description: Name of the Kubernetes secret be used to
+                              validate the certificate presented by the backend
+                            type: string
+                          subjectName:
+                            description: Key which is expected to be present in the
+                              'subjectAltName' of the presented certificate
+                            type: string
+                        required:
+                        - caSecret
+                        - subjectName
+                        type: object
+                      weight:
+                        description: Weight defines percentage of traffic to balance
+                          traffic
+                        format: int64
+                        minimum: 0
+                        type: integer
+                    required:
+                    - name
+                    - port
+                    type: object
+                  minItems: 1
+                  type: array
+              required:
+              - services
+              type: object
+            virtualhost:
+              description: Virtualhost appears at most once. If it is present, the
+                object is considered to be a "root".
+              properties:
+                fqdn:
+                  description: The fully qualified domain name of the root of the
+                    ingress tree all leaves of the DAG rooted at this object relate
+                    to the fqdn
+                  type: string
+                tls:
+                  description: If present describes tls properties. The SNI names
+                    that will be matched on are described in fqdn, the tls.secretName
+                    secret must contain a matching certificate
+                  properties:
+                    clientValidation:
+                      description: "ClientValidation defines how to verify the client
+                        certificate when an external client establishes a TLS connection
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
+                        validation. 2. Requires clients to present a TLS certificate
+                        (i.e. not optional validation). 3. Specifies how the client
+                        certificate will be validated."
+                      properties:
+                        caSecret:
+                          description: Name of a Kubernetes secret that contains a
+                            CA certificate bundle. The client certificate must validate
+                            against the certificates in the bundle.
+                          minLength: 1
+                          type: string
+                      required:
+                      - caSecret
+                      type: object
+                    enableFallbackCertificate:
+                      description: EnableFallbackCertificate defines if the vhost
+                        should allow a default certificate to be applied which handles
+                        all requests which don't match the SNI defined in this vhost.
+                      type: boolean
+                    minimumProtocolVersion:
+                      description: Minimum TLS version this vhost should negotiate
+                      type: string
+                    passthrough:
+                      description: If Passthrough is set to true, the SecretName will
+                        be ignored and the encrypted handshake will be passed through
+                        to the backing cluster.
+                      type: boolean
+                    secretName:
+                      description: required, the name of a secret in the current namespace
+                      type: string
+                  type: object
+              required:
+              - fqdn
+              type: object
+          type: object
+        status:
+          description: Status reports the current state of the HTTPProxy.
+          properties:
+            currentStatus:
+              type: string
+            description:
+              type: string
+            loadBalancer:
+              description: LoadBalancer contains the current status of the load balancer.
+              properties:
+                ingress:
+                  description: Ingress is a list containing ingress points for the
+                    load-balancer. Traffic intended for the service should be sent
+                    to these ingress points.
+                  items:
+                    description: 'LoadBalancerIngress represents the status of a load-balancer
+                      ingress point: traffic intended for the service should be sent
+                      to an ingress point.'
+                    properties:
+                      hostname:
+                        description: Hostname is set for load-balancer ingress points
+                          that are DNS based (typically AWS load-balancers)
+                        type: string
+                      ip:
+                        description: IP is set for load-balancer ingress points that
+                          are IP based (typically GCE or OpenStack load-balancers)
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      required:
+      - metadata
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: tlscertificatedelegations.projectcontour.io
+spec:
+  group: projectcontour.io
+  names:
+    kind: TLSCertificateDelegation
+    listKind: TLSCertificateDelegationList
+    plural: tlscertificatedelegations
+    shortNames:
+    - tlscerts
+    singular: tlscertificatedelegation
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+        See design/tls-certificate-delegation.md for details.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TLSCertificateDelegationSpec defines the spec of the CRD
+          properties:
+            delegations:
+              items:
+                description: CertificateDelegation maps the authority to reference
+                  a secret in the current namespace to a set of namespaces.
+                properties:
+                  secretName:
+                    description: required, the name of a secret in the current namespace.
+                    type: string
+                  targetNamespaces:
+                    description: required, the namespaces the authority to reference
+                      the the secret will be delegated to. If TargetNamespaces is
+                      nil or empty, the CertificateDelegation' is ignored. If the
+                      TargetNamespace list contains the character, "*" the secret
+                      will be delegated to all namespaces.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - secretName
+                - targetNamespaces
+                type: object
+              type: array
+          required:
+          - delegations
+          type: object
+      required:
+      - metadata
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contour-certgen
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour
+  namespace: projectcontour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-certgen
+subjects:
+- kind: ServiceAccount
+  name: contour-certgen
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-certgen
+  namespace: projectcontour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - update
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: contour-certgen-v1.5.0
+  namespace: projectcontour
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    metadata:
+      labels:
+        app: "contour-certgen"
+    spec:
+      containers:
+      - name: contour
+        # This version is set to latest because Job specs are immutable;
+        # if we change this on each version, you can no longer upgrade
+        # just by applying the deployment YAML.
+        # See #2423, #2395, #2150, and #2030 for earlier questions about this.
+        image: docker.io/projectcontour/contour:latest
+        imagePullPolicy: Always
+        command:
+        - contour
+        - certgen
+        - --kube
+        - --incluster
+        - --overwrite
+        - --secrets-format=compact
+        - --namespace=$(CONTOUR_NAMESPACE)
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      restartPolicy: Never
+      serviceAccountName: contour-certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+  parallelism: 1
+  completions: 1
+  backoffLimit: 1
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contour
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: contour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - "ingresses/status"
+  verbs:
+  - get
+  - list
+  - watch
+  - patch 
+  - post
+  - update
+- apiGroups: ["contour.heptio.com"]
+  resources: ["ingressroutes", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httpproxies", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups:
+  - "projectcontour.io"
+  resources:
+  - "httpproxies/status"
+  verbs:
+  - update
+- apiGroups: ["networking.x.k8s.io"]
+  resources: ["gatewayclasses", "gateways", "httproutes", "tcproutes"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-leaderelection
+  namespace: projectcontour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour-leaderelection
+  namespace: projectcontour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  ports:
+  - port: 8001
+    name: xds
+    protocol: TCP
+    targetPort: 8001
+  selector:
+    app: contour
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+  namespace: projectcontour
+  annotations:
+    # This annotation puts the AWS ELB into "TCP" mode so that it does not
+    # do HTTP negotiation for HTTPS connections at the ELB edge.
+    # The downside of this is the remote IP address of all connections will
+    # appear to be the internal address of the ELB. See docs/proxy-proto.md
+    # for information about enabling the PROXY protocol on the ELB to recover
+    # the original remote IP address.
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - port: 80
+    name: http
+    protocol: TCP
+  - port: 443
+    name: https
+    protocol: TCP
+  selector:
+    app: envoy
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: contour
+  name: contour
+  namespace: projectcontour
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 50%
+  selector:
+    matchLabels:
+      app: contour
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+      labels:
+        app: contour
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: contour
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - serve
+        - --incluster
+        - --xds-address=0.0.0.0
+        - --xds-port=8001
+        - --envoy-service-http-port=80
+        - --envoy-service-https-port=443
+        - --contour-cafile=/certs/ca.crt
+        - --contour-cert-file=/certs/tls.crt
+        - --contour-key-file=/certs/tls.key
+        - --config-path=/config/contour.yaml
+        command: ["contour"]
+        image: docker.io/projectcontour/contour:v1.6.0
+        imagePullPolicy: IfNotPresent
+        name: contour
+        ports:
+        - containerPort: 8001
+          name: xds
+          protocol: TCP
+        - containerPort: 8000
+          name: debug
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        readinessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        volumeMounts:
+          - name: contourcert
+            mountPath: /certs
+            readOnly: true
+          - name: contour-config
+            mountPath: /config
+            readOnly: true
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+      dnsPolicy: ClusterFirst
+      serviceAccountName: contour
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      volumes:
+        - name: contourcert
+          secret:
+            secretName: contourcert
+        - name: contour-config
+          configMap:
+            name: contour
+            defaultMode: 0644
+            items:
+            - key: contour.yaml
+              path: contour.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: envoy
+  name: envoy
+  namespace: projectcontour
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      app: envoy
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8002"
+        prometheus.io/path: "/stats/prometheus"
+      labels:
+        app: envoy
+    spec:
+      containers:
+      - command:
+        - /bin/contour
+        args:
+          - envoy
+          - shutdown-manager
+        image: docker.io/projectcontour/contour:v1.6.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown
+              port: 8090
+              scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        name: shutdown-manager
+      - args:
+        - -c
+        - /config/envoy.json
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
+        - --log-level info
+        command:
+        - envoy
+        image: docker.io/envoyproxy/envoy:v1.14.2
+        imagePullPolicy: IfNotPresent
+        name: envoy
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        ports:
+        - containerPort: 80
+          hostPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          hostPort: 443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8002
+          initialDelaySeconds: 3
+          periodSeconds: 4
+        volumeMounts:
+          - name: envoy-config
+            mountPath: /config
+          - name: envoycert
+            mountPath: /certs
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown
+              port: 8090
+              scheme: HTTP
+      initContainers:
+      - args:
+        - bootstrap
+        - /config/envoy.json
+        - --xds-address=contour
+        - --xds-port=8001
+        - --resources-dir=/config/resources
+        - --envoy-cafile=/certs/ca.crt
+        - --envoy-cert-file=/certs/tls.crt
+        - --envoy-key-file=/certs/tls.key
+        command:
+        - contour
+        image: docker.io/projectcontour/contour:v1.6.0
+        imagePullPolicy: IfNotPresent
+        name: envoy-initconfig
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /config
+        - name: envoycert
+          mountPath: /certs
+          readOnly: true
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      automountServiceAccountToken: false
+      serviceAccountName: envoy
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: envoy-config
+          emptyDir: {}
+        - name: envoycert
+          secret:
+            secretName: envoycert
+      restartPolicy: Always

--- a/addons/contour/1.6.0/install.sh
+++ b/addons/contour/1.6.0/install.sh
@@ -1,0 +1,36 @@
+
+function contour_pre_init() {
+    if [ -z "$CONTOUR_NAMESPACE" ]; then
+        CONTOUR_NAMESPACE=projectcontour
+    fi
+}
+
+function contour() {
+    local src="$DIR/addons/contour/1.6.0"
+    local dst="$DIR/kustomize/contour"
+
+    cp "$src/contour.yaml" "$dst/"
+
+    cp "$src/patches/service-patch.yaml" "$dst/"
+
+    if [ -z "$CONTOUR_TLS_MINIMUM_PROTOCOL_VERSION" ]; then
+        CONTOUR_TLS_MINIMUM_PROTOCOL_VERSION="1.2"
+    fi
+
+    render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
+    render_yaml_file "$src/tmpl-namespace.yaml" > "$dst/namespace.yaml"
+
+    # heptio-contour namespace was used pre 1.x
+    if kubectl get namespace heptio-contour &>/dev/null && [ "$CONTOUR_NAMESPACE" != heptio-contour ]; then
+        kubectl delete namespace heptio-contour
+    fi
+
+    # In post 1.x releases the namespace has been standardized
+    if kubectl get namespace "$CONTOUR_NAMESPACE" &>/dev/null; then
+        kubectl delete namespace "$CONTOUR_NAMESPACE"
+    fi
+
+    kubectl create namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
+
+    kubectl apply -k "$dst/"
+}

--- a/addons/contour/1.6.0/patches/service-patch.yaml
+++ b/addons/contour/1.6.0/patches/service-patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+spec:
+  type: NodePort

--- a/addons/contour/1.6.0/tmpl-kustomization.yaml
+++ b/addons/contour/1.6.0/tmpl-kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: $CONTOUR_NAMESPACE
+
+resources:
+- namespace.yaml
+- contour.yaml
+
+patchesStrategicMerge:
+- service-patch.yaml

--- a/addons/contour/1.6.0/tmpl-namespace.yaml
+++ b/addons/contour/1.6.0/tmpl-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $CONTOUR_NAMESPACE

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -400,6 +400,7 @@ export class Installer {
     ],
     contour: [
       "1.0.1",
+      "1.6.0", // Do not make this default initially.
       "0.14.0",
     ],
     registry: [


### PR DESCRIPTION
@mzaneri @areed 

Hey guys -- got a request to upgrade Contour to 1.6.0 to support `pathRewritePolicy` which was added in `1.1.0` https://projectcontour.io/announcing-contour-1.1/

I tested this with `kubectl apply -k` on a `kURL` cluster manually and it applied fine.

Couple of things:

* This requires 2 different Contour tags `1.6.0` and `latest`, can you please check the `Manifest` file to see if this has been properly defined?

* What is the best way to test this without merging? I made `1.6.0` _not_ the latest but is there a way to check if upgrade from `1.0.1` to `1.6.0` works? https://projectcontour.io/resources/upgrading/