### PR TITLE
Handle ubuntu systemctl --version output

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -31,7 +31,7 @@ function containerd_binaries() {
 function containerd_service() {
     local src="$1"
 
-    local systemdVersion=$(systemctl --version | head -1 | awk '{ print $NF }')
+    local systemdVersion=$(systemctl --version | head -1 | awk '{ print $2 }')
     if [ $systemdVersion -ge 226 ]; then
         cp "$src/containerd.service" /etc/systemd/system/containerd.service
     else


### PR DESCRIPTION
Ubuntu output is "systemd 245 (245.4-4ubuntu3.2)" while centos is
"systemd 239"