### PR TITLE
Kubectl plugins in /usr/local/bin

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -1,5 +1,4 @@
-export KREW_ROOT=/opt/replicated/krew
-export KUBECTL_PLUGINS_PATH=${KREW_ROOT}/bin
+export KUBECTL_PLUGINS_PATH=/usr/local/bin
 
 function kubernetes_host() {
     kubernetes_load_ipvs_modules


### PR DESCRIPTION
The [kots add-on](https://github.com/replicatedhq/kURL/blob/master/addons/kotsadm/alpha/install.sh#L339) was relying on KUBECTL_PLUGINS_PATH being on the path.