### PR TITLE
Print kubectl help if sudo groups was not found

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,9 +200,7 @@ function outro() {
     printf "\t\t${GREEN}  Complete ✔${NC}\n"
     addon_outro
     printf "\n"
-    printf "To access the cluster with kubectl, reload your shell:\n"
-    printf "\n"
-    printf "${GREEN}    bash -l${NC}\n"
+    kubeconfig_setup_outro
     printf "\n"
     if [ "$OUTRO_NOTIFIY_TO_RESTART_DOCKER" = "1" ]; then
         printf "\n"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -83,9 +83,7 @@ outro() {
     printf "\t\t${GREEN}  Complete ✔${NC}\n"
     if [ "$MASTER" = "1" ]; then
         printf "\n"
-        printf "To access the cluster with kubectl, reload your shell:\n"
-        printf "\n"
-        printf "${GREEN}    bash -l${NC}\n"
+        kubeconfig_setup_outro
     fi
     printf "\n"
 }


### PR DESCRIPTION
Keep track of whether the sudo group was found. If not print an enhanced
help message for setting up kubectl to work with kubeconfig in the
default location.