### PR TITLE
set src variable when running velero join

### DIFF
--- a/addons/velero/1.2.0/install.sh
+++ b/addons/velero/1.2.0/install.sh
@@ -39,6 +39,8 @@ function velero() {
 }
 
 function velero_join() {
+    local src="$DIR/addons/velero/1.2.0"
+
     velero_binary
 }
 

--- a/addons/velero/1.2.0/install.sh
+++ b/addons/velero/1.2.0/install.sh
@@ -39,12 +39,12 @@ function velero() {
 }
 
 function velero_join() {
-    local src="$DIR/addons/velero/1.2.0"
-
     velero_binary
 }
 
 function velero_binary() {
+    local src="$DIR/addons/velero/1.2.0"
+
     if [ "$VELERO_DISABLE_CLI" = "1" ]; then
         return 0
     fi


### PR DESCRIPTION
otherwise in online /assets is created, and in airgap it fails

(the normal `velero` function, run on first master, does set `src` - this copies that)
https://github.com/replicatedhq/kURL/pull/661/files#diff-a6784e5b3c7e2994442eeec2f29dbcfeL12