### PR TITLE
Rook 1.4.3 updates and Ekco 0.4.0

### DIFF
--- a/addons/ekco/0.4.0/Manifest
+++ b/addons/ekco/0.4.0/Manifest
@@ -1,0 +1,1 @@
+image ekco docker.io/replicated/ekco:v0.4.0

--- a/addons/ekco/0.4.0/README.md
+++ b/addons/ekco/0.4.0/README.md
@@ -1,0 +1,18 @@
+
+[Embedded Kurl cluster operator (EKCO)](https://github.com/replicatedhq/ekco) is responsible for performing various operations to maintain the health of a Kurl cluster. For more information see the documentation [here](https://github.com/replicatedhq/ekco).
+
+This addon deploys it to the `kurl` namespace.
+
+## Options
+
+- `ekco-node-unreachable-toleration-duration`: How long a Node must be unreachable before considered dead (default 5m).
+- `ekco-should-enable-purge-nodes`: Watch the cluster for dead nodes and remove them
+- `ekco-min-ready-master-node-count`: Don't purge the node if it will result in less than this many ready masters.
+   Only applicable if node purging is enabled.
+- `ekco-min-ready-worker-node-count`: Don't purge the node if it will result in less than this many ready workers
+   Only applicable if node purging is enabled.
+- `ekco-should-disable-clear-nodes`: Don't force delete pods on unreachable stuck in the terminating state
+- `ekco-disable-should-maintain-rook-storage-nodes`: Whether to maintain the list of nodes to use in the CephCluster config.
+   This also enables control of the replication factor of ceph pools, scaling up and down with the number of nodes in the cluster.
+- `ekco-disable-should-install-reboot-service`: Whether to disable the reboot service, responsible for graceful node termination.
+- `rook-version`: Version of Rook to manage

--- a/addons/ekco/0.4.0/deployment.yaml
+++ b/addons/ekco/0.4.0/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ekc-operator
+spec:
+  selector:
+    matchLabels:
+      app: ekc-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ekc-operator
+    spec:
+      serviceAccountName: ekco
+      restartPolicy: Always
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: ekc-operator
+          image: replicated/ekco:v0.4.0
+          imagePullPolicy: IfNotPresent
+          command: [ /usr/bin/ekco, operator ]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: ekco-config
+              mountPath: /etc/ekco
+              readOnly: true
+            - name: certificates-dir
+              mountPath: /etc/kubernetes/pki
+              readOnly: true
+      volumes:
+        - name: ekco-config
+          configMap:
+            name: ekco-config
+        - name: certificates-dir
+          hostPath:
+            path: /etc/kubernetes/pki
+            type: Directory

--- a/addons/ekco/0.4.0/ekco-purge-node.sh
+++ b/addons/ekco/0.4.0/ekco-purge-node.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+export KUBECONFIG="${KUBECONFIG:-/etc/kubernetes/admin.conf}"
+
+namespace=kurl
+pod="$(kubectl get pods -n "$namespace" -l app=ekc-operator --field-selector=status.phase=Running --no-headers 2>/dev/null | awk 'NR == 1 {print $1}')"
+
+if [ -z "$pod" ]; then
+    printf "[error] no running EKCO pods found\n\n" 1>&2
+    (set -x; kubectl get pods -n "$namespace" -l app=ekc-operator 1>&2)
+    exit 1
+fi
+
+kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@

--- a/addons/ekco/0.4.0/install.sh
+++ b/addons/ekco/0.4.0/install.sh
@@ -1,0 +1,111 @@
+
+function ekco_pre_init() {
+    if [ -z "$EKCO_NODE_UNREACHABLE_TOLERATION_DURATION" ]; then
+        EKCO_NODE_UNREACHABLE_TOLERATION_DURATION=5m
+    fi
+    if [ -z "$EKCO_MIN_READY_MASTER_NODE_COUNT" ]; then
+        EKCO_MIN_READY_MASTER_NODE_COUNT=2
+    fi
+    if [ -z "$EKCO_MIN_READY_WORKER_NODE_COUNT" ]; then
+        EKCO_MIN_READY_WORKER_NODE_COUNT=0
+    fi
+    EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=true
+    if [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ]; then
+        EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
+    fi
+    EKCO_SHOULD_INSTALL_REBOOT_SERVICE=1
+    if [ "$EKCO_SHOULD_DISABLE_REBOOT_SERVICE" = "1" ]; then
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+    EKCO_PURGE_DEAD_NODES=false
+    if [ "$EKCO_SHOULD_ENABLE_PURGE_NODES" = "1" ]; then
+        EKCO_PURGE_DEAD_NODES=true
+    fi
+    EKCO_CLEAR_DEAD_NODES=true
+    if [ "$EKCO_SHOULD_DISABLE_CLEAR_NODES" = "1" ]; then
+        EKCO_CLEAR_DEAD_NODES=false
+    fi
+}
+
+function ekco() {
+    local src="$DIR/addons/ekco/0.4.0"
+    local dst="$DIR/kustomize/ekco"
+
+    cp "$src/kustomization.yaml" "$dst/kustomization.yaml"
+    cp "$src/namespace.yaml" "$dst/namespace.yaml"
+    cp "$src/rbac.yaml" "$dst/rbac.yaml"
+    cp "$src/rolebinding.yaml" "$dst/rolebinding.yaml"
+    cp "$src/deployment.yaml" "$dst/deployment.yaml"
+
+    # is rook enabled
+    if kubectl get ns | grep -q rook-ceph; then
+        cp "$src/rbac-rook.yaml" "$dst/rbac-rook.yaml"
+        insert_resources "$dst/kustomization.yaml" rbac-rook.yaml
+        cat "$src/rolebinding-rook.yaml" >> "$dst/rolebinding.yaml"
+    else
+        EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
+        # disable reboot service for now as it only serves rook-ceph clusters
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+
+    render_yaml_file "$src/tmpl-configmap.yaml" > "$dst/configmap.yaml"
+    insert_resources "$dst/kustomization.yaml" configmap.yaml
+
+    kubectl apply -k "$dst"
+    # apply rolebindings separately so as not to override the namespace
+    kubectl apply -f "$dst/rolebinding.yaml"
+
+    # delete pod to re-read the config map
+    kubectl -n kurl delete pod -l app=ekc-operator 2>/dev/null || true
+
+    if [ "$EKCO_SHOULD_INSTALL_REBOOT_SERVICE" = "1" ]; then
+        ekco_install_reboot_service "$src"
+    fi
+
+    ekco_install_purge_node_command "$src"
+}
+
+function ekco_join() {
+    local src="$DIR/addons/ekco/0.4.0"
+
+    EKCO_SHOULD_INSTALL_REBOOT_SERVICE=1
+    if [ "$EKCO_SHOULD_DISABLE_REBOOT_SERVICE" = "1" ]; then
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+
+    # is rook disabled
+    if [ -z "$ROOK_VERSION" ]; then
+        # disable reboot service for now as it only serves rook-ceph clusters
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+
+    if [ "$EKCO_SHOULD_INSTALL_REBOOT_SERVICE" = "1" ]; then
+        ekco_install_reboot_service "$src"
+    fi
+
+    if kubernetes_is_master; then
+        ekco_install_purge_node_command "$src"
+    fi
+}
+
+function ekco_install_reboot_service() {
+    local src="$1"
+
+    mkdir -p /opt/ekco
+    cp "$src/reboot/startup.sh" /opt/ekco/startup.sh
+    cp "$src/reboot/shutdown.sh" /opt/ekco/shutdown.sh
+    cp "$src/reboot/ekco-reboot.service" /etc/systemd/system/ekco-reboot.service
+    chmod u+x /opt/ekco/startup.sh
+    chmod u+x /opt/ekco/shutdown.sh
+
+    systemctl daemon-reload
+    systemctl enable ekco-reboot.service
+    systemctl start ekco-reboot.service
+}
+
+function ekco_install_purge_node_command() {
+    local src="$1"
+
+    cp "$src/ekco-purge-node.sh" /usr/local/bin/ekco-purge-node
+    chmod u+x /usr/local/bin/ekco-purge-node
+}

--- a/addons/ekco/0.4.0/kustomization.yaml
+++ b/addons/ekco/0.4.0/kustomization.yaml
@@ -1,0 +1,6 @@
+namespace: kurl
+
+resources:
+- namespace.yaml
+- rbac.yaml
+- deployment.yaml

--- a/addons/ekco/0.4.0/namespace.yaml
+++ b/addons/ekco/0.4.0/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kurl

--- a/addons/ekco/0.4.0/rbac-rook.yaml
+++ b/addons/ekco/0.4.0/rbac-rook.yaml
@@ -1,0 +1,31 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-rook-ceph
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+    verbs:
+      - list
+      - delete
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephclusters
+      - cephblockpools
+      - cephfilesystems
+      - cephobjectstores
+    verbs:
+      - get
+      - update

--- a/addons/ekco/0.4.0/rbac.yaml
+++ b/addons/ekco/0.4.0/rbac.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ekco
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-cluster
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ekco-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-cluster
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update

--- a/addons/ekco/0.4.0/reboot/ekco-reboot.service
+++ b/addons/ekco/0.4.0/reboot/ekco-reboot.service
@@ -1,0 +1,12 @@
+[Unit]
+After=kubelet.service
+After=docker.service
+
+[Service]
+ExecStart=/opt/ekco/startup.sh
+ExecStop=/opt/ekco/shutdown.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/addons/ekco/0.4.0/reboot/shutdown.sh
+++ b/addons/ekco/0.4.0/reboot/shutdown.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+export KUBECONFIG=/etc/kubernetes/kubelet.conf
+
+kubectl cordon $(hostname | tr '[:upper:]' '[:lower:]')
+
+# delete local pods with PVCs
+while read -r uid; do
+        pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep $uid )
+        kubectl delete pod $(echo $pod | awk '{ print $1 }') --namespace=$(echo $pod | awk '{ print $3 }') --wait=false
+done < <(lsblk | grep '^rbd[0-9]' | awk '{ print $7 }' | awk -F '/' '{ print $6 }')
+
+# delete local pods using the Ceph filesystem
+while read -r uid; do
+        pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep $uid )
+        kubectl delete pod $(echo $pod | awk '{ print $1 }') --namespace=$(echo $pod | awk '{ print $3 }') --wait=false
+done < <(cat /proc/mounts | grep ':6789:/' | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
+
+while $(lsblk | grep -q '^rbd[0-9]'); do
+        echo "Waiting for Ceph block devices to unmount"
+        sleep 1
+done
+
+while $(cat /proc/mounts | grep -q ':6789:/'); do
+        echo "Waiting for Ceph shared filesystems to unmount"
+        sleep 1
+done
+
+# remove ceph-operator and mds pods from this node so they can continue to service the cluster
+thisHost=$(hostname | tr '[:upper:]' '[:lower:]')
+while read -r row; do
+    podName=$(echo $row | awk '{ print $1 }')
+    ns=$(echo $row | awk '{ print $2 }')
+
+    if echo $podName | grep -q "rook-ceph-operator"; then
+        kubectl -n $ns delete pod $podName
+    fi
+    if echo $podName | grep -q "rook-ceph-mds-rook-shared-fs"; then
+        kubectl -n $ns delete pod $podName
+    fi
+done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")

--- a/addons/ekco/0.4.0/reboot/startup.sh
+++ b/addons/ekco/0.4.0/reboot/startup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# On first install on additional nodes the node is not yet joined to the cluster
+if [ ! -e /etc/kubernetes/kubelet.conf ]; then
+    exit 0
+fi
+
+export KUBECONFIG=/etc/kubernetes/kubelet.conf
+
+# wait for Kubernets API
+master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
+        sleep 1
+done
+
+kubectl uncordon $(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/ekco/0.4.0/rolebinding-rook.yaml
+++ b/addons/ekco/0.4.0/rolebinding-rook.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ekco-rook-ceph
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-rook-ceph
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl

--- a/addons/ekco/0.4.0/rolebinding.yaml
+++ b/addons/ekco/0.4.0/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ekco-kube-system
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-kube-system
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl

--- a/addons/ekco/0.4.0/tmpl-configmap.yaml
+++ b/addons/ekco/0.4.0/tmpl-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ekco-config
+data:
+  config.yaml: |
+    node_unreachable_toleration: $EKCO_NODE_UNREACHABLE_TOLERATION_DURATION
+    clear_dead_nodes: $EKCO_CLEAR_DEAD_NODES
+    purge_dead_nodes: $EKCO_PURGE_DEAD_NODES
+    min_ready_master_nodes: $EKCO_MIN_READY_MASTER_NODE_COUNT
+    min_ready_worker_nodes: $EKCO_MIN_READY_WORKER_NODE_COUNT
+    maintain_rook_storage_nodes: $EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES
+    ceph_block_pool: replicapool
+    ceph_filesystem: rook-shared-fs
+    ceph_object_store: rook-ceph-store
+    min_ceph_pool_replication: 1
+    max_ceph_pool_replication: 3
+    certificates_dir: /etc/kubernetes/pki
+    reconcile_interval: 1m
+    rook_version: $ROOK_VERSION

--- a/addons/rook/1.4.3/cluster/kustomization.yaml
+++ b/addons/rook/1.4.3/cluster/kustomization.yaml
@@ -3,9 +3,9 @@ resources:
 - ceph-block-pool.yaml
 - ceph-storage-class.yaml
 - ceph-object-store.yaml
+- shared-fs.yaml
 
 patchesStrategicMerge:
-- ceph-cluster-mons.yaml
 - ceph-cluster-image.yaml
 - ceph-cluster-storage.yaml
 - ceph-block-pool-replicas.yaml

--- a/addons/rook/1.4.3/cluster/kustomization.yaml
+++ b/addons/rook/1.4.3/cluster/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - shared-fs.yaml
 
 patchesStrategicMerge:
+- ceph-cluster-mons.yaml
 - ceph-cluster-image.yaml
 - ceph-cluster-storage.yaml
 - ceph-block-pool-replicas.yaml

--- a/addons/rook/1.4.3/cluster/patches/ceph-cluster-mons.yaml
+++ b/addons/rook/1.4.3/cluster/patches/ceph-cluster-mons.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: rook-ceph
 spec:
   mon:
-    allowMultiplePerNode: true
+    count: 1

--- a/addons/rook/1.4.3/cluster/shared-fs.yaml
+++ b/addons/rook/1.4.3/cluster/shared-fs.yaml
@@ -1,0 +1,57 @@
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: rook-shared-fs
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 1
+  dataPools:
+    - failureDomain: host
+      replicated:
+        size: 1
+  preservePoolsOnDelete: true
+  metadataServer:
+    activeCount: 1
+    activeStandby: true
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "1024Mi"
+      requests:
+        cpu: "500m"
+        memory: "1024Mi"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-cephfs
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+provisioner: rook-ceph.cephfs.csi.ceph.com
+parameters:
+  # clusterID is the namespace where operator is deployed.
+  clusterID: rook-ceph
+
+  # CephFS filesystem name into which the volume shall be created
+  fsName: rook-shared-fs
+
+  # Ceph pool into which the volume shall be created
+  # Required for provisionVolume: "true"
+  pool: rook-shared-fs-data0
+
+  # Root path of an existing CephFS volume
+  # Required for provisionVolume: "false"
+  # rootPath: /absolute/path
+
+  # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+  # in the same namespace as the cluster.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+
+reclaimPolicy: Delete

--- a/addons/rook/1.4.3/cluster/tmpl-ceph-storage-class.yaml
+++ b/addons/rook/1.4.3/cluster/tmpl-ceph-storage-class.yaml
@@ -23,7 +23,7 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
   csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, csi-provisioner
-  # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+  # will set default as ext4. Note that xfs is not recommended due to potential deadlock
   # in hyperconverged settings where the volume is mounted on the same node as the osds.
   csi.storage.k8s.io/fstype: ext4
 

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -46,6 +46,12 @@ function rook_cluster_deploy() {
     local src="$DIR/addons/rook/1.4.3/cluster"
     local dst="$DIR/kustomize/rook/cluster"
 
+    # Don't redeploy cluster - ekco may have made changes based on num of nodes in cluster
+    if kubectl -n rook-ceph get cephcluster rook-ceph 2>/dev/null 1>/dev/null; then
+        echo "Cluster rook-ceph already deployed"
+        return 0
+    fi
+
     mkdir -p "$dst"
     cp "$src/kustomization.yaml" "$dst/"
 
@@ -53,6 +59,7 @@ function rook_cluster_deploy() {
     cp "$src/ceph-cluster.yaml" "$dst/"
     cp "$src/ceph-block-pool.yaml" "$dst/"
     cp "$src/ceph-object-store.yaml" "$dst/"
+    cp "$src/shared-fs.yaml" "$dst/"
     render_yaml_file "$src/tmpl-ceph-storage-class.yaml" > "$dst/ceph-storage-class.yaml"
 
     # patches

--- a/addons/rook/1.4.3/operator/config-override.yaml
+++ b/addons/rook/1.4.3/operator/config-override.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   config: |
     [global]
-    osd pool default size = 2
+    osd pool default size = 1

--- a/addons/rook/1.4.3/operator/config-override.yaml
+++ b/addons/rook/1.4.3/operator/config-override.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-config-override
+  namespace: rook-ceph
+data:
+  config: |
+    [global]
+    osd pool default size = 2

--- a/addons/rook/1.4.3/operator/kustomization.yaml
+++ b/addons/rook/1.4.3/operator/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - ceph-common.yaml
 - ceph-operator.yaml
 - ceph-toolbox.yaml
+- config-override.yaml


### PR DESCRIPTION
- Ekco 0.4.0 with no major changes besides image that will support Rook 1.4
- Enable shared fs in rook
- Do not redeploy ceph cluster when re-running kurl install script
- Start mon count at 1. Ekco will scale it up as nodes join.
- Change default osd pool size to 1 in global config map