### PR TITLE
Openebs upgrade

### DIFF
--- a/addons/openebs/1.12.0/Manifest
+++ b/addons/openebs/1.12.0/Manifest
@@ -10,6 +10,7 @@ image node-disk-manager openebs/node-disk-manager:0.7.0
 image node-disk-operator openebs/node-disk-operator:0.7.0
 image openebs-k8s-provisioner openebs/openebs-k8s-provisioner:1.12.0
 image provisioner-localpv openebs/provisioner-localpv:1.12.0
+image m-upgrade openebs/m-upgrade:1.12.0
 
 yum iscsi-initiator-utils
 apt open-iscsi

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -284,7 +284,7 @@ function openebs_upgrade() {
         logFail "Applications using OpenEBS-backed persistent volumes may become nonresponsive during this upgrade. This upgrade may also in some failure modes result in data loss - please take a backup of any critical volumes before upgrading."
         printf "Continue? "
         if ! confirmN " "; then
-            bail "Will not upgrade OpenEBS. Modify your spec and re-run instllation."
+            bail "OpenEBS upgrade is aborted."
         fi
 
         openebs_upgrade_pools
@@ -329,7 +329,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         tty: true
-        image: quay.io/openebs/m-upgrade:$OPENEBS_VERSION
+        image: openebs/m-upgrade:$OPENEBS_VERSION
         imagePullPolicy: Always
       restartPolicy: OnFailure
 UPGRADE_POOLS
@@ -375,7 +375,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         tty: true
-        image: quay.io/openebs/m-upgrade:$OPENEBS_VERSION
+        image: openebs/m-upgrade:$OPENEBS_VERSION
         imagePullPolicy: Always
       restartPolicy: OnFailure
 UPGRADE_VOLS

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -330,7 +330,7 @@ spec:
               fieldPath: metadata.namespace
         tty: true
         image: openebs/m-upgrade:$OPENEBS_VERSION
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
       restartPolicy: OnFailure
 UPGRADE_POOLS
 
@@ -376,7 +376,7 @@ spec:
               fieldPath: metadata.namespace
         tty: true
         image: openebs/m-upgrade:$OPENEBS_VERSION
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
       restartPolicy: OnFailure
 UPGRADE_VOLS
         kubectl apply -f $out_file

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -268,7 +268,7 @@ function openebs_upgrade() {
     fi
 
     # RE: https://github.com/openebs/openebs/tree/master/k8s/upgrades/1.x.0-1.12.x
-    # Upgrading a minor version of 1.x.x requires two jobs to update pools a volumes for cStor configurations.
+    # Upgrading a minor version of 1.x.x requires two jobs to update pools and volumes for cStor configurations.
     local runningVer=$(kubectl -n $OPENEBS_NAMESPACE get deploy openebs-provisioner -o jsonpath='{.metadata.labels.openebs\.io/version}')
 
     local semVerRunningList=( ${runningVer//./ } )

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -338,7 +338,7 @@ UPGRADE_POOLS
     done
     logSubstep "OpenEBS batch job(s) to upgrade cStor pools added."
     # TODO: Validation and user feedback of the successful completion of the jobs.
-    # The jobs migth take a while to run however, blocking at this point isn't necesseraly the best aproach.
+    # The jobs might take a while to run however, blocking at this point isn't necessarily the best approach.
 }
 
 function openebs_upgrade_vols() {

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -281,7 +281,7 @@ function openebs_upgrade() {
     logSubstep "Runnig upgrade checks..."
     if [[ ${semVerInstallList[1]} -gt ${semVerRunningList[1]} || openebs_check_pools ]]; then
         logSubstep "As part of the OpenEBS upgrade, pools and volumes need to be upgraded. At least some of the existing pools or volumes require an update to match the OpenEBS control plane."
-        logFail "It is highly recommended to schedule a downtime for the application using the OpenEBS PV while performing this upgrade. Also, make sure you have taken a backup of the data before starting the below upgrade procedure."
+        logFail "Applications using OpenEBS-backed persistent volumes may become nonresponsive during this upgrade. This upgrade may also in some failure modes result in data loss - please take a backup of any critical volumes before upgrading."
         printf "Continue? "
         if ! confirmN " "; then
             bail "Will not upgrade OpenEBS. Modify your spec and re-run instllation."

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -397,7 +397,7 @@ function openebs_check_pools() {
         fi
 
         if [ $spcCurrentVer = $OPENEBS_VERSION ]; then
-            # Controll Plane and Poll versions are matching
+            # Control Plane and Poll versions are matching
             continue
         fi
 

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -14,7 +14,7 @@ function openebs_pre_init() {
 }
 
 function openebs() {
-    local src="$DIR/addons/openebs/1.12.0"
+    local src="$DIR/addons/openebs/$OPENEBS_VERSION"
     local dst="$DIR/kustomize/openebs"
 
     render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
@@ -95,7 +95,7 @@ function openebs_join() {
 }
 
 function openebs_iscsi() {
-    local src="$DIR/addons/openebs/1.12.0"
+    local src="$DIR/addons/openebs/$OPENEBS_VERSION"
 
     if ! systemctl list-units | grep -q iscsid; then
         printf "${YELLOW}Installing iscsid service${NC}\n"
@@ -202,7 +202,7 @@ function openebs_cstor_add_replica() {
     local nodeName=$(kubectl -n "$OPENEBS_NAMESPACE" get cstorpools "$cstorPoolName" -ojsonpath='{ .metadata.labels.kubernetes\.io/hostname }')
     local cstorPoolUID=$(kubectl -n "$OPENEBS_NAMESPACE" get cstorpools "$cstorPoolName" -ojsonpath='{ .metadata.uid }')
     local pvName="pvc-$pvcUID"
-    local openebsVersion=1.12.0
+    local openebsVersion=$OPENEBS_VERSION
     local newReplicaName="${pvName}-${cstorPoolName}"
     local targetIP=$(kubectl -n "$OPENEBS_NAMESPACE" get cstorvolumes "$pvName" -ojsonpath='{ .spec.targetIP }')
     local capacity=$(kubectl -n "$OPENEBS_NAMESPACE" get cstorvolumes "$pvName" -ojsonpath='{ .spec.capacity }')

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -294,7 +294,7 @@ function openebs_upgrade() {
 
 function openebs_upgrade_pools() {
     # NOTE: slightly different arguments to pass for pre and after 1.9.0.
-    # Since we only support 1.6.0 -> 1.12.0 using prefixs for pre 1.9.0.
+    # Since we only support 1.6.0 -> 1.12.0 using prefixes for pre 1.9.0.
     local manifest="/tmp/openebs_pool_job.yaml"
     local pools=$(kubectl get spc --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
     

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -343,7 +343,7 @@ UPGRADE_POOLS
 
 function openebs_upgrade_vols() {
     # NOTE: slightly different arguments to pass for pre and after 1.9.0.
-    # Since we only support 1.6.0 -> 1.12.0 using prefixs for pre 1.9.0.
+    # Since we only support 1.6.0 -> 1.12.0 using prefixes for pre 1.9.0.
     local vols=$(kubectl get pods -l app=cstor-volume-manager -n $OPENEBS_NAMESPACE -o jsonpath='{.items[*].metadata.labels.openebs\.io/persistent-volume}')
 
     # Bulk upgrade only supported for versions >=1.9.0.

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -275,7 +275,7 @@ function openebs_upgrade() {
     local semVerInstallList=( ${OPENEBS_VERSION//./ } )
     
     if [[ ${semVerInstallList[0]} -gt 1 ]]; then
-        bail "Only upgrades upto OpenEBS 1.12.0 are tested and supported."
+        bail "Only upgrades up to OpenEBS 1.12.0 are tested and supported."
     fi
 
     logSubstep "Runnig upgrade checks..."

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -280,7 +280,7 @@ function openebs_upgrade() {
 
     logSubstep "Runnig upgrade checks..."
     if [[ ${semVerInstallList[1]} -gt ${semVerRunningList[1]} || openebs_check_pools ]]; then
-        logSubstep "As part of OpenEBS upgrade pools and volumes need to be upgraded. At least some of the pools and(or) volumes require an update to match OpenEBS controll plane."
+        logSubstep "As part of the OpenEBS upgrade, pools and volumes need to be upgraded. At least some of the existing pools or volumes require an update to match the OpenEBS control plane."
         logFail "It is highly recommended to schedule a downtime for the application using the OpenEBS PV while performing this upgrade. Also, make sure you have taken a backup of the data before starting the below upgrade procedure."
         printf "Continue? "
         if ! confirmN " "; then


### PR DESCRIPTION
RE: https://github.com/openebs/openebs/tree/master/k8s/upgrades/1.x.0-1.12.x

NOTE: *Control plane* upgrade is a simple update on *OpenEBS control plane* resources. For cStor configurations, existing pool claims and persistent volumes would need to be upgraded using a batch job.

The kURL installation process will identify if kURL spec is upgrading OpenEBS from 1.6.0 to 1.12.0. Before applying a _control plane_ upgrade a user is informed of the need to upgrade pools and volumes and that the upgrade can potentially result in downtime or data loss. At this point, a user can choose to abort the execution, in which case _control plane_ or upgrade jobs will not be applied. 

On every run of `install.sh` OpenEBS addon validates if provisioned pool(s) versions are matching the _control plane_ version and whether dependant persistent volumes for that pool need to be upgraded (checking a value of a pool claim object `.versionDetails.status.dependentsUpgraded`). If a discrepancy in versions found (_Expecting two supported pre 2.x versions, e.i. 1.6.0 and 1.12.0_) a user is prompted to proceed with pools and volumes upgrade.

Example script output, the Warning "It is highly.." would appear RED in a shell.:
```bash
⚙  Addon openebs 1.12.0
        - As part of the OpenEBS upgrade, pools and volumes need to be upgraded.
        - Storage pool claims to be upgraded:
        -     cstor-disk
        - Persistent volumes to be upgraded:
        -     pvc-1e41a058-80a1-4e06-b3a1-6dda1c781c0c | 10Gi | monitoring/prometheus-k8s-db-prometheus-k8s-1
        -     pvc-28a9a88f-0457-48a6-80f7-ea1d01d33f5d | 100Gi | kurl/registry-pvc
        -     pvc-723300ef-3a28-4bec-832f-f30a9ac1d7e5 | 10Gi | monitoring/prometheus-k8s-db-prometheus-k8s-0
Applications using OpenEBS-backed persistent volumes may become nonresponsive during this upgrade.
This upgrade may also in some failure modes result in data loss - please take a backup of any critical volumes before upgrading.
Continue? (y/N) y
        - Upgrading cstor-disk from 1.6.0 to 1.12.0
job.batch/cstor-spc-29449 created
        - OpenEBS batch job(s) to upgrade cStor pools added.
job.batch/cstor-vol-29867 created
job.batch/cstor-vol-19787 created
job.batch/cstor-vol-6594 created
        - OpenEBS batch job(s) to upgrade cStor pvs added.
namespace/openebs unchanged
serviceaccount/openebs-maya-operator unchanged
...
```