### PR TITLE
Set PriorityClass and resource requests for Rook

### DIFF
--- a/addons/rook/1.4.3/cluster/ceph-cluster.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-cluster.yaml
@@ -144,13 +144,18 @@ spec:
   #   mgr:
   resources:
   # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
-  #    mgr:
-  #      limits:
-  #        cpu: "500m"
-  #        memory: "1024Mi"
-  #      requests:
-  #        cpu: "500m"
-  #        memory: "1024Mi"
+    mgr:
+      requests:
+        cpu: "200m"
+        memory: "512Mi"
+    osd:
+      requests:
+        cpu: "500m"
+        memory: "1024Mi"
+    mon:
+      requests:
+        cpu: "300m"
+        memory: "1024Mi"
   # The above example requests/limits can also be added to the mon and osd components
   #    mon:
   #    osd:
@@ -159,8 +164,8 @@ spec:
   #    cleanup:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
-  #  priorityClassNames:
-  #    all: rook-ceph-default-priority-class
+  priorityClassNames:
+    all: system-node-critical
   #    mon: rook-ceph-mon-priority-class
   #    osd: rook-ceph-osd-priority-class
   #    mgr: rook-ceph-mgr-priority-class

--- a/addons/rook/1.4.3/cluster/ceph-object-store.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-object-store.yaml
@@ -77,14 +77,10 @@ spec:
     annotations:
     #  key: value
     resources:
-    # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
-    #  limits:
-    #    cpu: "500m"
-    #    memory: "1024Mi"
-    #  requests:
-    #    cpu: "500m"
-    #    memory: "1024Mi"
-    # priorityClassName: my-priority-class
+      requests:
+        cpu: "300m"
+        memory: "1024Mi"
+    priorityClassName: system-node-critical
     #zone:
     #name: zone-a
   # service endpoint healthcheck

--- a/addons/rook/1.4.3/operator/ceph-operator.yaml
+++ b/addons/rook/1.4.3/operator/ceph-operator.yaml
@@ -306,8 +306,8 @@ spec:
             #       key: node-role.kubernetes.io/etcd
             #       operator: Exists
             # (Optional) Rook Agent priority class name to set on the pod(s)
-            # - name: AGENT_PRIORITY_CLASS_NAME
-            #   value: "<PriorityClassName>"
+            - name: AGENT_PRIORITY_CLASS_NAME
+              value: "system-node-critical"
             # (Optional) Rook Agent NodeAffinity.
             # - name: AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook,ceph"
@@ -344,8 +344,8 @@ spec:
             #       key: node-role.kubernetes.io/etcd
             #       operator: Exists
             # (Optional) Rook Discover priority class name to set on the pod(s)
-            # - name: DISCOVER_PRIORITY_CLASS_NAME
-            #   value: "<PriorityClassName>"
+            - name: DISCOVER_PRIORITY_CLASS_NAME
+              value: "system-node-critical"
             # (Optional) Discover Agent NodeAffinity.
             # - name: DISCOVER_AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook, ceph"


### PR DESCRIPTION
Setting PriorityClass for Rook components to `system-node-critical` and only requests for resources so that the schedualer would use "Burstable" resource algorithm with the critical priority. 
This way we guarantee some minimal resources and priority in scheduling, leaving limits out helps to support variety of usecases.