### PR TITLE
Workaround for nftables race condition

### DIFF
--- a/addons/weave/2.6.5/daemonset.yaml
+++ b/addons/weave/2.6.5/daemonset.yaml
@@ -21,7 +21,9 @@ spec:
       containers:
         - name: weave
           command:
-            - /home/weave/launch.sh
+            - /bin/sh
+            - -c
+            - sed '/ipset destroy weave-kube-test$/ i sleep 1' /home/weave/launch.sh | /bin/sh
           env:
             - name: HOSTNAME
               valueFrom:

--- a/addons/weave/2.7.0/daemonset.yaml
+++ b/addons/weave/2.7.0/daemonset.yaml
@@ -21,7 +21,9 @@ spec:
       containers:
         - name: weave
           command:
-            - /home/weave/launch.sh
+            - /bin/sh
+            - -c
+            - sed '/ipset destroy weave-kube-test$/ i sleep 1' /home/weave/launch.sh | /bin/sh
           env:
             - name: HOSTNAME
               valueFrom:


### PR DESCRIPTION
I had a CentOS 8 install where weave 2.7.0 was crashlooping with error `ipset v7.2: Set cannot be destroyed: it is in use by a kernel component`

[This workaround](https://github.com/weaveworks/weave/issues/3816#issuecomment-640474405) allowed weave to come up.

An alternative workaround is to configure weave to use legacy iptables instead of nftables.