### PR TITLE
Include Manifest in built kubernetes packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ dist/kubernetes-%.tar.gz:
 	${MAKE} build/packages/kubernetes/$*/ubuntu-20.04
 	${MAKE} build/packages/kubernetes/$*/rhel-7
 	${MAKE} build/packages/kubernetes/$*/rhel-8
+	cp packages/kubernetes/$*/Manifest build/packages/kubernetes/$*/
 	mkdir -p dist
 	tar cf - -C build packages/kubernetes/$* | gzip > dist/kubernetes-$*.tar.gz
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -448,6 +448,10 @@ function kubernetes_node_images() {
 function list_all_required_images() {
     find packages/kubernetes/$KUBERNETES_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
 
+    if [ -n "$STEP_VERSION" ]; then
+        find packages/kubernetes/$STEP_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+    fi
+
     if [ -n "$DOCKER_VERSION" ]; then
         find packages/docker/$DOCKER_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi


### PR DESCRIPTION
This allows kurl to check if any nodes are missing required images in
airgap mode and prompt the user to run the load-images task.