### PR TITLE
retry old tests if older than 3h

### DIFF
--- a/testgrid/tgapi/pkg/handlers/dequeue_instance.go
+++ b/testgrid/tgapi/pkg/handlers/dequeue_instance.go
@@ -21,8 +21,11 @@ type DequeueInstanceResponse struct {
 func DequeueInstance(w http.ResponseWriter, r *http.Request) {
 	testInstance, err := testinstance.GetNextEnqueued()
 	if err != nil {
-		JSON(w, 200, []DequeueInstanceResponse{})
-		return
+		testInstance, err = testinstance.GetOldEnqueued()
+		if err != nil {
+			JSON(w, 200, []DequeueInstanceResponse{})
+			return
+		}
 	}
 
 	dequeueInstanceResponse := DequeueInstanceResponse{


### PR DESCRIPTION
If a test takes more than three hours, that means that the test runner probably failed for some reason, and we should retry it