### PR TITLE
run on ubuntu 20.04

### DIFF
--- a/testgrid/tgrun/pkg/scheduler/scheduler.go
+++ b/testgrid/tgrun/pkg/scheduler/scheduler.go
@@ -74,8 +74,9 @@ func Run(schedulerOptions types.SchedulerOptions) error {
 
 			plannedInstances = append(plannedInstances, plannedInstance)
 		}
-
 	}
+
+	fmt.Printf("Testing %d configs across %d os images\n", len(instances.Instances), len(operatingSystems))
 
 	if err := reportStarted(schedulerOptions, plannedInstances); err != nil {
 		return errors.Wrap(err, "failed to report ref started")

--- a/testgrid/tgrun/pkg/scheduler/static.go
+++ b/testgrid/tgrun/pkg/scheduler/static.go
@@ -6,6 +6,12 @@ import (
 
 var operatingSystems = []types.OperatingSystemImage{
 	{
+		VMImageURI: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img",
+		Name:       "Ubuntu",
+		Version:    "20.04",
+		PVCPrefix:  "ubuntu-20-",
+	},
+	{
 		VMImageURI: "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img",
 		Name:       "Ubuntu",
 		Version:    "18.04",


### PR DESCRIPTION
for usability, print number of tested configs and images on cli in 'tgrun queue'