### PR TITLE
Cleanup function and cmd

### DIFF
--- a/testgrid/tgrun/pkg/cli/run/clean.go
+++ b/testgrid/tgrun/pkg/cli/run/clean.go
@@ -1,0 +1,17 @@
+package run
+
+import (
+	"github.com/replicatedhq/kurl/testgrid/tgrun/pkg/runner"
+	"github.com/spf13/cobra"
+)
+
+func CleanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "clean",
+		Aliases: []string{"r", "rm"},
+		Short:   "Clean-up tasks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runner.CleanUp()
+		},
+	}
+}

--- a/testgrid/tgrun/pkg/cli/run/root.go
+++ b/testgrid/tgrun/pkg/cli/run/root.go
@@ -25,6 +25,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.AddCommand(QueueCmd())
 	cmd.AddCommand(RunCmd())
+	cmd.AddCommand(CleanCmd())
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	return cmd

--- a/testgrid/tgrun/pkg/runner/loop.go
+++ b/testgrid/tgrun/pkg/runner/loop.go
@@ -172,7 +172,7 @@ func CleanUp() error {
 
 	clientset, err := GetClientset()
 	if err != nil {
-		return errors.Wrap(err, "failed to get clientset during cleanup")
+		return errors.Wrap(err, "failed to get clientset")
 	}
 
 	// PV finalizer kubernetes.io/pv-protection fails to clean up pv/pvc
@@ -183,8 +183,8 @@ func CleanUp() error {
 	}
 
 	for _, pv := range pvs.Items {
-		// selecting persistent volumes marked for deletion over 12 hours ago.
-		if pv.ObjectMeta.DeletionTimestamp != nil && time.Since(pv.ObjectMeta.DeletionTimestamp.Time).Hours() > 12 {
+		// selecting persistent volumes marked for deletion over 1 hour ago.
+		if pv.ObjectMeta.DeletionTimestamp != nil && time.Since(pv.ObjectMeta.DeletionTimestamp.Time).Hours() > 1 {
 			pv.ObjectMeta.SetFinalizers(nil)
 			p, _ := clientset.CoreV1().PersistentVolumes().Update(ctx(), &pv, metav1.UpdateOptions{})
 

--- a/testgrid/tgrun/pkg/runner/loop.go
+++ b/testgrid/tgrun/pkg/runner/loop.go
@@ -24,6 +24,12 @@ var lastScheduledInstance = time.Now().Add(-time.Minute)
 func MainRunLoop(runnerOptions types.RunnerOptions) error {
 	fmt.Println("beginning main run loop")
 
+	fmt.Println("running cleanup tasks")
+	err := CleanUp()
+	if err != nil {
+		fmt.Println("PV clean up ERROR: ", err)
+	}
+
 	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
@@ -157,4 +163,34 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
+}
+
+// CleanUp deletes finalizers on 'stack' in Terminating pvs
+// localPath is cleared as PV completes termination.
+func CleanUp() error {
+	var ctx = context.TODO
+
+	clientset, err := GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset during cleanup")
+	}
+
+	// PV finalizer kubernetes.io/pv-protection fails to clean up pv/pvc
+	// Removing the finalizer on stale pvs
+	pvs, err := clientset.CoreV1().PersistentVolumes().List(ctx(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get pv list")
+	}
+
+	for _, pv := range pvs.Items {
+		// selecting persistent volumes marked for deletion over 12 hours ago.
+		if pv.ObjectMeta.DeletionTimestamp != nil && time.Since(pv.ObjectMeta.DeletionTimestamp.Time).Hours() > 12 {
+			pv.ObjectMeta.SetFinalizers(nil)
+			p, _ := clientset.CoreV1().PersistentVolumes().Update(ctx(), &pv, metav1.UpdateOptions{})
+
+			fmt.Printf("Removed finalizers on %s, loalPath: %s\n", p.Name, p.Spec.Local.Path)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
- identifies PVs in Terminating state, and clears finalizers if the state is older then 12 hours