### PR TITLE
Hostname with server makes kurl install hang

### DIFF
--- a/addons/ekco/0.1.0/reboot/startup.sh
+++ b/addons/ekco/0.1.0/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.2.0/reboot/startup.sh
+++ b/addons/ekco/0.2.0/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.2.1/reboot/startup.sh
+++ b/addons/ekco/0.2.1/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.2.3/reboot/startup.sh
+++ b/addons/ekco/0.2.3/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.2.4/reboot/startup.sh
+++ b/addons/ekco/0.2.4/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.3.0/reboot/startup.sh
+++ b/addons/ekco/0.3.0/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.4.0/reboot/startup.sh
+++ b/addons/ekco/0.4.0/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.4.1/reboot/startup.sh
+++ b/addons/ekco/0.4.1/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done

--- a/addons/ekco/0.4.2/reboot/startup.sh
+++ b/addons/ekco/0.4.2/reboot/startup.sh
@@ -8,7 +8,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
 # wait for Kubernets API
-master=$(cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }')
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
 while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
         sleep 1
 done


### PR DESCRIPTION
```
[ethan@ethan-server-1 kurl]$ sudo cat /etc/kubernetes/kubelet.conf | grep server | awk '{ print $2 }'
https://10.138.0.16:6443
system:node:ethan-server-1
system:node:ethan-server-1@kubernetes
system:node:ethan-server-1@kubernetes
name:
```