### PR TITLE
Roll kube-proxy pods after lb address change

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -147,6 +147,9 @@ EOF
         # restart scheduler and controller-manager on this node so they use the new address
         mv /etc/kubernetes/manifests/kube-scheduler.yaml /tmp/ && sleep 1 && mv /tmp/kube-scheduler.yaml /etc/kubernetes/manifests/
         mv /etc/kubernetes/manifests/kube-controller-manager.yaml /tmp/ && sleep 1 && mv /tmp/kube-controller-manager.yaml /etc/kubernetes/manifests/
+        # restart kube-proxies so they use the new address
+        kubectl -n kube-system delete pods --selector=k8s-app=kube-proxy
+
         if kubernetes_has_remotes; then
             local proxyFlag=""
             if [ -n "$PROXY_ADDRESS" ]; then


### PR DESCRIPTION
Kube proxy pods connect to the load balancer endpoint directly (in the kube-proxy configmap), not the cluster IP like other components.