### PR TITLE
Fix envoy node ports

### DIFF
--- a/addons/contour/1.7.0/patches/service-patch.yaml
+++ b/addons/contour/1.7.0/patches/service-patch.yaml
@@ -5,3 +5,8 @@ metadata:
   name: envoy
 spec:
   type: NodePort
+  ports:
+  - port: 80
+    nodePort: 80
+  - port: 443
+    nodePort: 443


### PR DESCRIPTION
It was using a random node port but ingress is expected on 80 and 443.