### PR TITLE
mount detected cacerts files in kotsadm

### DIFF
--- a/addons/kotsadm/alpha/tmpl-kotsadm-cacerts.yaml
+++ b/addons/kotsadm/alpha/tmpl-kotsadm-cacerts.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kotsadm
+  labels:
+    kots.io/kotsadm: 'true'
+    kots.io/backup: velero
+spec:
+  template:
+    metadata:
+      labels:
+        kots.io/kotsadm: 'true'
+        kots.io/backup: velero
+    spec:
+      volumes:
+        - name: host-cacerts
+          hostPath:
+            path: "${KOTSADM_TRUSTED_CERT_MOUNT}"
+            type: File
+      containers:
+      - name: kotsadm
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/ca-certificates.crt
+          name: host-cacerts


### PR DESCRIPTION
This currently breaks if the cacerts file is in different locations on different nodes in the kurl cluster.
Hopefully, heterogeneous clusters like that should be rare.

It also doesn't expose the cacerts location in a configmap - I think that further design is required before we can decide how to make the host cacerts available to application pods, and if this is even the correct way of going about that.

(For instance, perhaps we should have kotsadm make a web request, see the SSL failure, and present a dialog box to the user with the observed CA certificate and a "would you like to trust this certificate authority" message. Potentially insecure, but convenient)