### PR TITLE
Update kurlkinds

### DIFF
--- a/addons/cert-manager/1.0.3/install.sh
+++ b/addons/cert-manager/1.0.3/install.sh
@@ -3,6 +3,7 @@ cert-manager() {
   local dst="$DIR/kustomize/cert-manager"
 
   cp "$src/cert-manager.yaml" "$dst"
+  cp "$src/kustomization.yaml" "$dst"
 
   kubectl apply -k  "$dst"
 }

--- a/addons/cert-manager/1.0.3/kustomization.yaml
+++ b/addons/cert-manager/1.0.3/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- cert-manager.yaml

--- a/addons/metrics-server/0.3.7/install.sh
+++ b/addons/metrics-server/0.3.7/install.sh
@@ -3,6 +3,7 @@ metrics-server() {
   local dst="$DIR/kustomize/metrics-server"
 
   cp "$src/components.yaml" "$dst"
+  cp "$src/kubelet-insecure-tls.yaml" "$dst"
   cp "$src/kustomization.yaml" "$dst"
 
   kubectl apply -k  "$dst"

--- a/addons/metrics-server/0.3.7/install.sh
+++ b/addons/metrics-server/0.3.7/install.sh
@@ -3,6 +3,7 @@ metrics-server() {
   local dst="$DIR/kustomize/metrics-server"
 
   cp "$src/components.yaml" "$dst"
+  cp "$src/kustomization.yaml" "$dst"
 
   kubectl apply -k  "$dst"
 }

--- a/addons/metrics-server/0.3.7/kubelet-insecure-tls.yaml
+++ b/addons/metrics-server/0.3.7/kubelet-insecure-tls.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: metrics-server
+        args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+          - --kubelet-insecure-tls

--- a/addons/metrics-server/0.3.7/kustomization.yaml
+++ b/addons/metrics-server/0.3.7/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - components.yaml
+
+patchesStrategicMerge:
+- kubelet-insecure-tls.yaml

--- a/addons/metrics-server/0.3.7/kustomization.yaml
+++ b/addons/metrics-server/0.3.7/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- components.yaml

--- a/kurl_util/go.mod
+++ b/kurl_util/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c
 	github.com/pkg/errors v0.8.1
 	github.com/replicatedhq/kurl v0.0.0-20200601170456-4d9730fe4307
-	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201030214350-520884458640
+	github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201102234114-f9eee5ce9bb6
 	github.com/stretchr/testify v1.4.0
 	github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect
@@ -23,5 +23,3 @@ require (
 )
 
 replace github.com/replicatedhq/kurl/ => ../
-
-replace github.com/replicatedhq/kurlkinds/ => ../kurlkinds/

--- a/kurl_util/go.sum
+++ b/kurl_util/go.sum
@@ -322,6 +322,8 @@ github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200722190903-b668808530fe h1:YMY
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20200722190903-b668808530fe/go.mod h1:CGQURLyceSGyAAvMk6xWorC4calSpnoygOAf4ASk1T0=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201030214350-520884458640 h1:MCdcif+smM5AC0GhJmhfKQy3CA4V5uQccrG/BDsRifI=
 github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201030214350-520884458640/go.mod h1:CGQURLyceSGyAAvMk6xWorC4calSpnoygOAf4ASk1T0=
+github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201102234114-f9eee5ce9bb6 h1:x4/VNN24FWzpOPybIcLCppKOQTt1aoSADYCyxSXMVTQ=
+github.com/replicatedhq/kurl/kurlkinds v0.0.0-20201102234114-f9eee5ce9bb6/go.mod h1:CGQURLyceSGyAAvMk6xWorC4calSpnoygOAf4ASk1T0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
Also add patch to metrics server to skip validation of kubelet's cert since kubeadm configures kubelet to use a self-signed cert.
Also add kustomization.yaml to cert-manager and metrics-server.