### PR TITLE
Fixing kubectl command syntax used in ekco-purge-node script

### DIFF
--- a/addons/ekco/0.2.0/ekco-purge-node.sh
+++ b/addons/ekco/0.2.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.2.1/ekco-purge-node.sh
+++ b/addons/ekco/0.2.1/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.2.3/ekco-purge-node.sh
+++ b/addons/ekco/0.2.3/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.2.4/ekco-purge-node.sh
+++ b/addons/ekco/0.2.4/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.3.0/ekco-purge-node.sh
+++ b/addons/ekco/0.3.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.4.0/ekco-purge-node.sh
+++ b/addons/ekco/0.4.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.4.1/ekco-purge-node.sh
+++ b/addons/ekco/0.4.1/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.4.2/ekco-purge-node.sh
+++ b/addons/ekco/0.4.2/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.5.0/ekco-purge-node.sh
+++ b/addons/ekco/0.5.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.6.0/ekco-purge-node.sh
+++ b/addons/ekco/0.6.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.7.0/ekco-purge-node.sh
+++ b/addons/ekco/0.7.0/ekco-purge-node.sh
@@ -13,4 +13,4 @@ if [ -z "$pod" ]; then
     exit 1
 fi
 
-kubectl exec -n "$namespace" -it "$pod" ekco -- purge-node $@
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@


### PR DESCRIPTION
## Summary
 - Updated kubectl command syntax used in `ekco-purge-node.sh` script to fix issue with `ekco purge-node` execution. 

**Error:**
```
[root@ip-10-1-0-221 ~]# bash -x /usr/local/bin/ekco-purge-node
+ set -e
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ namespace=kurl
++ kubectl get pods -n kurl -l app=ekc-operator --field-selector=status.phase=Running --no-headers
++ awk 'NR == 1 {print $1}'
+ pod=ekc-operator-5bc9c98b96-m4q65
+ '[' -z ekc-operator-5bc9c98b96-m4q65 ']'
+ kubectl exec -n kurl -it ekc-operator-5bc9c98b96-m4q65 ekco -- purge-node
OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"purge-node\": executable file not found in $PATH": unknown
command terminated with exit code 126
```

**Correct syntax per docs:**

`kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]`

https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#exec

```
[root@ip-10-1-0-221 ~]# kubectl exec -n kurl -it ekc-operator-5bc9c98b96-m4q65 -- ekco purge-node -h
Manually purge a Kurl cluster node

Usage:
  ekco purge-node [name] [flags]

Flags:
      --certificates_dir string       Kubernetes certificates directory (default "/etc/kubernetes/pki")
  -h, --help                          help for purge-node
      --maintain_rook_storage_nodes   Add and remove nodes to the ceph cluster and scale replication of pools
      --min_ready_master_nodes int    Minimum number of ready master nodes required for auto-purge (default 2)
      --min_ready_worker_nodes int    Minimum number of ready worker nodes required for auto-purge
      --rook_version string           Version of Rook to manage (default "1.4.3")

Global Flags:
      --config string      Config file (default is /etc/ekco/config.yaml)
      --log_level string   Log level (default "info")
```

**Environment:**
 - CentOS 7
 - Kubernetes 1.19.3
 - EKCO 0.6.0