### PR TITLE
Add nameserver field to kurl installer spec

### DIFF
--- a/kurlkinds/README.md
+++ b/kurlkinds/README.md
@@ -1,0 +1,9 @@
+To make a change to the Installer type.
+
+1. Edit ./pkg/apis/cluster/v1beta1/installer_types.go
+1. Run `make generate`
+1. Make a PR and merge.
+1. cd to ../kurl_util
+1. Run `go get github.com/replicatedhq/kurl/kurlkinds`
+1. Define a new bash variable in kurl_util/cmd/yamltobash/main.go to hold the value of the new field.
+1. Use the new bash variable in kurl install scripts.

--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -207,6 +207,8 @@ spec:
                   type: boolean
                 hostnameCheck:
                   type: string
+                nameserver:
+                  type: string
                 noProxy:
                   type: boolean
                 privateAddress:

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -98,6 +98,7 @@ type Kurl struct {
 	NoProxy                    bool     `json:"noProxy,omitempty"`
 	PublicAddress              string   `json:"publicAddress,omitempty"`
 	PrivateAddress             string   `json:"privateAddress,omitempty"`
+	Nameserver                 string   `json:"nameserver,omitempty"`
 }
 
 type Minio struct {


### PR DESCRIPTION
This will be used in CoreDNS for outbound requests instead of what's
found in resolv.conf.