### PR TITLE
priorityClassName system-node-critical unsupported outside kube-system namespace in older k8s versions

### DIFF
--- a/addons/rook/1.4.3/cluster/ceph-cluster.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-cluster.yaml
@@ -164,8 +164,8 @@ spec:
   #    cleanup:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
-  priorityClassNames:
-    all: system-node-critical
+  # priorityClassNames:
+  #    all: rook-ceph-default-priority-class
   #    mon: rook-ceph-mon-priority-class
   #    osd: rook-ceph-osd-priority-class
   #    mgr: rook-ceph-mgr-priority-class

--- a/addons/rook/1.4.3/cluster/ceph-object-store.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-object-store.yaml
@@ -80,7 +80,7 @@ spec:
       requests:
         cpu: "300m"
         memory: "1024Mi"
-    priorityClassName: system-node-critical
+    # priorityClassName: my-priority-class
     #zone:
     #name: zone-a
   # service endpoint healthcheck

--- a/addons/rook/1.4.3/operator/ceph-operator.yaml
+++ b/addons/rook/1.4.3/operator/ceph-operator.yaml
@@ -306,8 +306,8 @@ spec:
             #       key: node-role.kubernetes.io/etcd
             #       operator: Exists
             # (Optional) Rook Agent priority class name to set on the pod(s)
-            - name: AGENT_PRIORITY_CLASS_NAME
-              value: "system-node-critical"
+            # - name: AGENT_PRIORITY_CLASS_NAME
+            #   value: "<PriorityClassName>"
             # (Optional) Rook Agent NodeAffinity.
             # - name: AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook,ceph"
@@ -344,8 +344,8 @@ spec:
             #       key: node-role.kubernetes.io/etcd
             #       operator: Exists
             # (Optional) Rook Discover priority class name to set on the pod(s)
-            - name: DISCOVER_PRIORITY_CLASS_NAME
-              value: "system-node-critical"
+            # - name: DISCOVER_PRIORITY_CLASS_NAME
+            #   value: "<PriorityClassName>"
             # (Optional) Discover Agent NodeAffinity.
             # - name: DISCOVER_AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook, ceph"


### PR DESCRIPTION
backing out this pr https://github.com/replicatedhq/kURL/commit/0abc2deb88eab75d98f6bda74f244d91e15abf70

`priorityClassName: system-node-critical` unsupported outside kube-system namespace in older k8s versions. breaks 1.16.4 installations.

https://github.com/kubernetes/kubernetes/issues/60596