### PR TITLE
Fix collectd install on Amazon Linux 2 and RHEL 8

### DIFF
--- a/addons/collectd/v5/Manifest
+++ b/addons/collectd/v5/Manifest
@@ -1,3 +1,4 @@
 apt collectd
 yum collectd
 yum collectd-rrdtool
+yum8 collectd-disk

--- a/addons/collectd/v5/install.sh
+++ b/addons/collectd/v5/install.sh
@@ -8,8 +8,11 @@ function collectd() {
             export DEBIAN_FRONTEND=noninteractive
             dpkg --install --force-depends-version ${src}/ubuntu-${DIST_VERSION}/archives/*.deb
             ;;
-        centos|rhel|amzn)
+        centos|rhel)
             rpm --upgrade --force --nodeps ${src}/rhel-${DIST_VERSION_MAJOR}/archives/*.rpm
+            ;;
+        amzn)
+            rpm --upgrade --force --nodeps ${src}/rhel-7/archives/*.rpm
             ;;
         *)
             printf"${YELLOW}Unsupported OS for collectd installation${NC}\n"


### PR DESCRIPTION
Amazon Linux 2 installs the rhel-7 archives.

The RHEL 8 package no longer includes collectd-disk. Since our conf file
loads that plugin, collectd was failing to start. Add a new type "yum8"
to Manifests that only builds a package for RHEL 8 and use that to
include the collectd-disk package.