### PR TITLE
Upgrade add-ons on remote nodes

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -1,5 +1,4 @@
 
-
 function containerd_install() {
     local src="$DIR/addons/containerd/1.3.7"
 
@@ -14,6 +13,13 @@ function containerd_install() {
     # NOTE: this will not remove the proxy
     if [ -n "$PROXY_ADDRESS" ]; then
         containerd_configure_proxy
+    fi
+
+    if [ -n "$DOCKER_REGISTRY_IP" ]; then
+        containerd_configure_registry "$DOCKER_REGISTRY_IP"
+        if [ "$CONTAINERD_REGISTRY_CA_ADDED" = "1" ]; then
+            restart_containerd
+        fi
     fi
 }
 
@@ -94,6 +100,7 @@ function containerd_registry_init() {
     systemctl restart containerd
 }
 
+CONTAINERD_REGISTRY_CA_ADDED=0
 function containerd_configure_registry() {
     local registryIP="$1"
 
@@ -106,6 +113,8 @@ function containerd_configure_registry() {
 [plugins."io.containerd.grpc.v1.cri".registry.configs."${registryIP}".tls]
   ca_file = "/etc/kubernetes/pki/ca.crt"
 EOF
+
+    CONTAINERD_REGISTRY_CA_ADDED=1
 }
 
 containerd_configure_proxy() {

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -21,6 +21,7 @@ function addon_for_each() {
     $cmd metrics-server "$METRICS_SERVER_VERSION"
 }
 
+ADDONS_HAVE_HOST_COMPONENTS=0
 function addon_install() {
     local name=$1
     local version=$2
@@ -37,6 +38,10 @@ function addon_install() {
     . $DIR/addons/$name/$version/install.sh
 
     $name
+
+    if commandExists ${name}_join; then
+        ADDONS_HAVE_HOST_COMPONENTS=1
+    fi
 }
 
 function addon_pre_init() {
@@ -97,6 +102,35 @@ function addon_load() {
 }
 
 function addon_outro() {
+    if [ -n "$PROXY_ADDRESS" ]; then
+        ADDONS_HAVE_HOST_COMPONENTS=1
+    fi
+
+    if [ "$ADDONS_HAVE_HOST_COMPONENTS" = "1" ] && kubernetes_has_remotes; then
+        local dockerRegistryIP=""
+        if [ -n "$DOCKER_REGISTRY_IP" ]; then
+            dockerRegistryIP=" docker-registry-ip=$DOCKER_REGISTRY_IP"
+        fi
+
+        local proxyFlag=""
+        local noProxyAddrs=""
+        if [ -n "$PROXY_ADDRESS" ]; then
+            proxyFlag=" -x $PROXY_ADDRESS"
+            noProxyAddrs=" additional-no-proxy-addresses=${SERVICE_CIDR},${POD_CIDR}"
+        fi
+
+        local prefix="curl -sSL${proxyFlag} $KURL_URL/$INSTALLER_ID/"
+        if [ -z "$KURL_URL" ]; then
+            prefix="cat "
+        fi
+
+        printf "\n${YELLOW}Run this script on all remote nodes to apply changes${NC}\n"
+        printf "\n\t${GREEN}${prefix}upgrade.sh | sudo bash -s${dockerRegistryIP}${noProxyAddrs}${NC}\n\n"
+        printf "Press enter to proceed\n"
+        prompt
+
+    fi
+
     while read -r name; do
         if commandExists ${name}_outro; then
             ${name}_outro

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -500,6 +500,14 @@ function list_all_required_images() {
     if [ -n "$EKCO_VERSION" ]; then
         find addons/ekco/$EKCO_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
     fi
+
+    if [ -n "$CERT_MANAGER_VERSION" ]; then
+        find addons/cert-manager/$CERT_MANAGER_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+    fi
+
+    if [ -n "$METRICS_SERVER_VERSION" ]; then
+        find addons/metrics-server/$METRICS_SERVER_VERSION -type f -name Manifest 2>/dev/null | xargs cat | grep -E '^image' | grep -v no_remote_load | awk '{ print $3 }'
+    fi
 }
 
 function kubernetes_node_has_all_images() {

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -109,9 +109,10 @@ function main() {
     journald_persistent
     configure_proxy
     configure_no_proxy
-    apply_docker_config
+    install_cri
     get_shared
     maybe_upgrade
+    addon_for_each addon_join
     outro
 }
 


### PR DESCRIPTION
This ensures that remote nodes are kept up to date with the installer when run on the first primary by prompting the user to run the `upgrade.sh` script on all remotes nodes when there may be changes. Any add-on that defines a `_join` function has will cause the prompt for the upgrade script to be shown. Additionally, a proxy will trigger the upgrade prompt since docker or containerd may need to be reconfigured.

The upgrade script now runs all `_join` functions from add-ons and ensures docker and containerd are configured to use a proxy and to push/pull images from the in-cluster registry.