### PR TITLE
Preserve kubelet configuration during upgrades

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -52,10 +52,7 @@ maybe_upgrade() {
             15 | 16 | 17 | 18 | 19)
                 kubeadm upgrade node
 
-                # correctly sets the --resolv-conf flag when systemd-resolver is running (Ubuntu 18)
-                # https://github.com/kubernetes/kubeadm/issues/273
                 if kubernetes_is_master; then
-                    kubeadm init phase kubelet-start
                     upgrade_etcd_image_18
 
                     # scheduler and controller-manager kubeconfigs point to local API server in 1.19


### PR DESCRIPTION
Remote primaries in HA clusters were losing their kubelet configuration during upgrades because we were running `kubeadm init phase kubelet-start` as a workaround for failure to configure systemd resolver. This workaround was copied from our old Kubernetes installer and is not required for the version of Kubernetes we support in kurl (1.15 - 1.19).

With this fix, HA clusters using containerd are still configured to use the systemd cgroup driver after upgrade.