### PR TITLE
Set X-Kurl-Hash header in script response

### DIFF
--- a/web/src/controllers/Scripts.ts
+++ b/web/src/controllers/Scripts.ts
@@ -66,6 +66,7 @@ export class Installers {
       logger.error(`Failed to save saas script event: ${err.message}`);
     }
 
+    response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
     return this.templates.renderInstallScript(installer);
   }
@@ -76,6 +77,7 @@ export class Installers {
   ): Promise<string> {
     const installer = Installer.latest().resolve();
 
+    response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
     return this.templates.renderInstallScript(installer);
   }
@@ -99,6 +101,7 @@ export class Installers {
     }
     installer = installer.resolve();
 
+    response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
     return this.templates.renderJoinScript(installer);
   }
@@ -122,6 +125,7 @@ export class Installers {
     }
     installer = installer.resolve();
 
+    response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
     return this.templates.renderUpgradeScript(installer);
   }
@@ -139,6 +143,7 @@ export class Installers {
     }
     installer = installer.resolve();
 
+    response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
     return this.templates.renderTasksScript();
   }


### PR DESCRIPTION
The hash is of the installer spec after versions are resolved, which
will allow clients to determine when changes have been made to the spec
of a named installer.
This will allow automated update tools to determine when the script
needs to be re-run to receive upgrades.
This is different than Etag since there are often changes to the scripts
that don't need to be run on every installation.