### PR TITLE
Remove latest kubelet and kubectl from rhel-8 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,8 @@ build/packages/kubernetes/%/rhel-8:
 	docker create --name k8s-rhel8-$* kurl/rhel-8-k8s:$*
 	mkdir -p build/packages/kubernetes/$*/rhel-8
 	docker cp k8s-rhel8-$*:/packages/archives/. build/packages/kubernetes/$*/rhel-8/
+	find build/packages/kubernetes/$*/rhel-8 | grep kubelet | grep -v kubelet-$* | xargs rm
+	find build/packages/kubernetes/$*/rhel-8 | grep kubectl | grep -v kubectl-$* | xargs rm
 	docker rm k8s-rhel8-$*
 
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl


### PR DESCRIPTION
The rhel-8 kubernetes repos include the latest version of kubectl and
kubelet as dependencies of the kubeadm and kubernetes-cni packages. This
causes the kubernetes 1.19.3 build, for example, to include both kubelet
1.19.3 and 1.20.0, which can break the cluster.

This fix removes the extra kubelet and kubectl rpms that are not the
target version.