### PR TITLE
Revert "Remove latest kubelet and kubectl from rhel-8 build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,8 +364,6 @@ build/packages/kubernetes/%/rhel-8:
 	docker create --name k8s-rhel8-$* kurl/rhel-8-k8s:$*
 	mkdir -p build/packages/kubernetes/$*/rhel-8
 	docker cp k8s-rhel8-$*:/packages/archives/. build/packages/kubernetes/$*/rhel-8/
-	find build/packages/kubernetes/$*/rhel-8 | grep kubelet | grep -v kubelet-$* | xargs rm
-	find build/packages/kubernetes/$*/rhel-8 | grep kubectl | grep -v kubectl-$* | xargs rm
 	docker rm k8s-rhel8-$*
 
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl


### PR DESCRIPTION
Reverts replicatedhq/kURL#973 due to https://testgrid.kurl.sh/run/41a96f5-onmerge-staging