### PR TITLE
Remove newer kubelet and kubectl rpms from rhel-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,8 @@ build/packages/kubernetes/%/rhel-8:
 	docker create --name k8s-rhel8-$* kurl/rhel-8-k8s:$*
 	mkdir -p build/packages/kubernetes/$*/rhel-8
 	docker cp k8s-rhel8-$*:/packages/archives/. build/packages/kubernetes/$*/rhel-8/
+	find build/packages/kubernetes/$*/rhel-8 | grep kubelet | grep -v kubelet-$* | xargs rm -v
+	find build/packages/kubernetes/$*/rhel-8 | grep kubectl | grep -v kubectl-$* | xargs rm -v
 	docker rm k8s-rhel8-$*
 
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl


### PR DESCRIPTION
Same as PR #973 but with -v flag added to rm.