### PR TITLE
add centos 7.4 to testgrid

### DIFF
--- a/testgrid/tgrun/pkg/scheduler/static.go
+++ b/testgrid/tgrun/pkg/scheduler/static.go
@@ -18,6 +18,12 @@ var operatingSystems = []types.OperatingSystemImage{
 		ID:         "ubuntu-1604",
 	},
 	{
+		VMImageURI: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1708.qcow2",
+		Name:       "CentOS",
+		Version:    "7.4",
+		ID:         "centos-74",
+	},
+	{
 		VMImageURI: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2003.qcow2",
 		Name:       "CentOS",
 		Version:    "7.8",


### PR DESCRIPTION
it's the earliest centos version listed as supported

Tested [here](https://testgrid.kurl.sh/run/laverya%20centos%207.4) as the PR was made - 1708 was the first ISO to register as "centos 7.4" and not "7.3"