### PR TITLE
Revert "don't bail when installing on centos/rhel 8.3"

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -81,7 +81,7 @@ function kubernetes_install_host_packages() {
 
         centos|rhel|amzn)
             case "$LSB_DIST$DIST_VERSION" in
-                rhel8.0|rhel8.1|rhel8.2|rhel8.3|centos8.0|centos8.1|centos8.2|centos8.3)
+                rhel8.0|rhel8.1|rhel8.2|centos8.0|centos8.1|centos8.2)
                     rpm --upgrade --force --nodeps $DIR/packages/kubernetes/${k8sVersion}/rhel-8/*.rpm
                     ;;
 

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -37,7 +37,7 @@ function require64Bit() {
 
 function bailIfUnsupportedOS() {
     case "$LSB_DIST$DIST_VERSION" in
-        ubuntu16.04|ubuntu18.04|ubuntu20.04|rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|rhel8.3|centos7.4|centos7.5|centos7.6|centos7.7|centos7.8|centos7.9|centos8.0|centos8.1|centos8.2|centos8.3|amzn2)
+        ubuntu16.04|ubuntu18.04|ubuntu20.04|rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|centos7.4|centos7.5|centos7.6|centos7.7|centos7.8|centos7.9|centos8.0|centos8.1|centos8.2|amzn2)
             ;;
         *)
             bail "Kubernetes install is not supported on ${LSB_DIST} ${DIST_VERSION}"

--- a/testgrid/tgrun/pkg/scheduler/static.go
+++ b/testgrid/tgrun/pkg/scheduler/static.go
@@ -42,12 +42,6 @@ var operatingSystems = []types.OperatingSystemImage{
 		ID:         "centos-82",
 	},
 	{
-		VMImageURI: "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2",
-		Name:       "CentOS",
-		Version:    "8.3",
-		ID:         "centos-83",
-	},
-	{
 		VMImageURI: "https://cdn.amazonlinux.com/os-images/2.0.20200917.0/kvm/amzn2-kvm-2.0.20200917.0-x86_64.xfs.gpt.qcow2",
 		Name:       "Amazon Linux",
 		Version:    "2.0",


### PR DESCRIPTION
Reverts replicatedhq/kURL#983

There's still packages that don't work properly on 8.3 - see https://testgrid.kurl.sh/run/970e07b-onmerge-staging

