### PR TITLE
fix check for 'rhel/centos 8.3+' by replacing 'gt' with equality

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -26,7 +26,7 @@ function kubernetes_load_ipvs_modules() {
         return
     fi
 
-    if [ "$KERNEL_MAJOR" -gt "4" ] || ([ "$KERNEL_MAJOR" -eq "4" ] && [ "$KERNEL_MINOR" -ge "19" ]) || ( ( [ "$LSB_DIST" -eq "rhel"] || [ "$LSB_DIST" -eq "centos" ] ) && [ "$DIST_VERSION" -ge "8.3" ] ); then
+    if [ "$KERNEL_MAJOR" -gt "4" ] || ([ "$KERNEL_MAJOR" -eq "4" ] && [ "$KERNEL_MINOR" -ge "19" ]) || ([ "$LSB_DIST" = "rhel" ] && [ "$DIST_VERSION" = "8.3" ]) || ([ "$LSB_DIST" = "centos" ] && [ "$DIST_VERSION" = "8.3" ]); then
         modprobe nf_conntrack
     else
         modprobe nf_conntrack_ipv4


### PR DESCRIPTION
instead of checking for 8.3+, just check for =8.3 for now