### PR TITLE
rook should run as critical priority (1.4.3)

### DIFF
--- a/addons/rook/1.4.3/cluster/ceph-cluster.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-cluster.yaml
@@ -164,11 +164,11 @@ spec:
   #    cleanup:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
-  # priorityClassNames:
-  #    all: rook-ceph-default-priority-class
-  #    mon: rook-ceph-mon-priority-class
-  #    osd: rook-ceph-osd-priority-class
-  #    mgr: rook-ceph-mgr-priority-class
+  priorityClassNames:
+    all: system-cluster-critical
+#    mon: rook-ceph-mon-priority-class
+#    osd: rook-ceph-osd-priority-class
+#    mgr: rook-ceph-mgr-priority-class
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true

--- a/addons/rook/1.4.3/cluster/ceph-cluster.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-cluster.yaml
@@ -165,7 +165,7 @@ spec:
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
   priorityClassNames:
-    all: system-cluster-critical
+    all: rook-critical
 #    mon: rook-ceph-mon-priority-class
 #    osd: rook-ceph-osd-priority-class
 #    mgr: rook-ceph-mgr-priority-class

--- a/addons/rook/1.4.3/cluster/ceph-object-store.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-object-store.yaml
@@ -80,7 +80,7 @@ spec:
       requests:
         cpu: "300m"
         memory: "1024Mi"
-    # priorityClassName: my-priority-class
+    priorityClassName: system-cluster-critical
     #zone:
     #name: zone-a
   # service endpoint healthcheck

--- a/addons/rook/1.4.3/cluster/ceph-object-store.yaml
+++ b/addons/rook/1.4.3/cluster/ceph-object-store.yaml
@@ -80,7 +80,7 @@ spec:
       requests:
         cpu: "300m"
         memory: "1024Mi"
-    priorityClassName: system-cluster-critical
+    priorityClassName: rook-critical
     #zone:
     #name: zone-a
   # service endpoint healthcheck

--- a/addons/rook/1.4.3/operator/ceph-operator.yaml
+++ b/addons/rook/1.4.3/operator/ceph-operator.yaml
@@ -55,10 +55,10 @@ data:
   # ROOK_CSI_ATTACHER_IMAGE: "quay.io/k8scsi/csi-attacher:v2.1.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.
-  CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
+  CSI_PLUGIN_PRIORITY_CLASSNAME: "rook-critical"
 
   # (Optional) set user created priorityclassName for csi provisioner pods.
-  CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: "rook-critical"
 
   # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.
@@ -307,7 +307,7 @@ spec:
             #       operator: Exists
             # (Optional) Rook Agent priority class name to set on the pod(s)
             - name: AGENT_PRIORITY_CLASS_NAME
-              value: "system-cluster-critical"
+              value: "rook-critical"
             # (Optional) Rook Agent NodeAffinity.
             # - name: AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook,ceph"

--- a/addons/rook/1.4.3/operator/ceph-operator.yaml
+++ b/addons/rook/1.4.3/operator/ceph-operator.yaml
@@ -55,10 +55,10 @@ data:
   # ROOK_CSI_ATTACHER_IMAGE: "quay.io/k8scsi/csi-attacher:v2.1.0"
 
   # (Optional) set user created priorityclassName for csi plugin pods.
-  # CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
+  CSI_PLUGIN_PRIORITY_CLASSNAME: "system-node-critical"
 
   # (Optional) set user created priorityclassName for csi provisioner pods.
-  # CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
+  CSI_PROVISIONER_PRIORITY_CLASSNAME: "system-cluster-critical"
 
   # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.
@@ -306,8 +306,8 @@ spec:
             #       key: node-role.kubernetes.io/etcd
             #       operator: Exists
             # (Optional) Rook Agent priority class name to set on the pod(s)
-            # - name: AGENT_PRIORITY_CLASS_NAME
-            #   value: "<PriorityClassName>"
+            - name: AGENT_PRIORITY_CLASS_NAME
+              value: "system-cluster-critical"
             # (Optional) Rook Agent NodeAffinity.
             # - name: AGENT_NODE_AFFINITY
             #   value: "role=storage-node; storage=rook,ceph"

--- a/addons/rook/1.4.3/operator/kustomization.yaml
+++ b/addons/rook/1.4.3/operator/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - ceph-operator.yaml
 - ceph-toolbox.yaml
 - config-override.yaml
+- priorityclass.yaml

--- a/addons/rook/1.4.3/operator/priorityclass.yaml
+++ b/addons/rook/1.4.3/operator/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+description: Used for rook-ceph critical pods that must not be moved from their current node.
+kind: PriorityClass
+metadata:
+  name: rook-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000


### PR DESCRIPTION
This runs `csi-cephfsplugin-provisioner`, `csi-rbdplugin-provisioner`, `rook-ceph-mgr`, `rook-ceph-mon`, `rook-ceph-osd`, `rook-ceph-osd-prepare` and `rook-ceph-rgw` as `system-cluster-critical`, as well as `csi-cephfsplugin` and `csi-rbdplugin` as `system-node-critical`.