### PR TITLE
Apply ipset fix to weave 2.6.4

### DIFF
--- a/addons/weave/2.6.4/daemonset.yaml
+++ b/addons/weave/2.6.4/daemonset.yaml
@@ -21,7 +21,9 @@ spec:
       containers:
         - name: weave
           command:
-            - /home/weave/launch.sh
+            - /bin/sh
+            - -c
+            - sed '/ipset destroy weave-kube-test$/ i sleep 1' /home/weave/launch.sh | /bin/sh
           env:
             - name: HOSTNAME
               valueFrom:


### PR DESCRIPTION
[Previously applied to 2.7.0 and 2.6.5](https://github.com/replicatedhq/kURL/pull/717). The bug has not been seen on 2.5.2.