### PR TITLE
Feat/tgrun default overrides

### DIFF
--- a/.github/workflows/test-addon-pr.yaml
+++ b/.github/workflows/test-addon-pr.yaml
@@ -1,0 +1,62 @@
+
+name: test-addon-pr.yaml
+
+on:
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+        
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Genetate Installer
+        id: installer
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          S3_BUCKET: "kurl-sh"
+        run: |
+          bin/test-addon-pr.sh
+          MSG="Testgrid Run Executing @ https://testgrid.kurl.sh/run/pr-$(echo $GITHUB_REF | cut -d/ -f3)-${GITHUB_SHA:0:7}"
+          echo "::set-output name=installer_available::$INSTALLER_AVAILABLE"
+          echo "::set-output name=installer_spec::$INSTALLER_SPEC"
+          echo "::set-output name=msg::$MSG"
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        if: ${{ steps.installer.outputs.installer_available == 'true' }}
+        with:
+          go-version: 1.15.1
+
+      - name: Tgrun Build
+        if: ${{ steps.installer.outputs.installer_available == 'true' }}
+        working-directory: ./testgrid/tgrun
+        run: make build
+
+      - name: Tgrun Queue
+        if: ${{ steps.installer.outputs.installer_available == 'true' }}
+        env:
+          INSTALLER_SPEC: ${{ steps.installer.outputs.installer_spec }}
+        working-directory: ./testgrid/tgrun
+        run: |
+          PR_NUMBER=$(echo $GITHUB_REF | cut -d"/" -f3)
+          ./bin/tgrun queue --staging --ref "pr-${PR_NUMBER}-${GITHUB_SHA:0:7}" --spec "${INSTALLER_SPEC}"
+
+      - name: Post TG URL
+        uses: unsplash/comment-on-pr@master
+        if: ${{ steps.installer.outputs.installer_available == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        with:
+          msg: ${{ steps.installer.outputs.msg }}
+          check_for_duplicate_msg: true 
+

--- a/bin/test-addon-pr.sh
+++ b/bin/test-addon-pr.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# assumptions
+# - will only run the latest version of an addon if there are multiple version changes (latest is simple dictionary sort :/ )
+# - will run all addon changes in a single spec if multiple addons were changed.
+
+set -eo pipefail
+
+function require() {
+   if [ -z "$2" ]; then
+       echo "validation failed: $1 unset"
+       exit 1
+   fi
+}
+
+# Defaults from GH Action
+require GITHUB_BASE_REF "${GITHUB_BASE_REF}"
+require GITHUB_REF "${GITHUB_REF}"
+require GITHUB_SHA "${GITHUB_SHA}"
+
+# From GH Action Defition
+require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
+require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
+require S3_BUCKET "${S3_BUCKET}"
+
+PR_NUMBER=$(echo $GITHUB_REF | cut -d"/" -f3)
+
+INSTALLER_SPEC=
+prepare_addon() {
+  local name=$1
+
+  # Get the version that's changed
+  local version=$(git diff --dirstat=files,0 "origin/${GITHUB_BASE_REF}" -- "addons/${name}" "origin/${GITHUB_BASE_REF}" -- "addons/${name}" | sed 's/^[ 0-9.]\+% addons\///g' | grep -v template | cut -f2 -d"/" | uniq |  sort -r | head -n 1)
+
+  echo "Found Modified Addon: $name-$version"
+
+  # Concat Spec
+  INSTALLER_SPEC="${INSTALLER_SPEC}$(snakecase_to_camelcase $name):\n"
+  INSTALLER_SPEC="${INSTALLER_SPEC}  version: ${version}:\n"
+  INSTALLER_SPEC="${INSTALLER_SPEC}  s3Override: s3://${S3_BUCKET}/pr/${PR_NUMBER}-${GITHUB_SHA:0:7}-${name}-${version}:\n"
+
+  # Push to S3
+  echo "Building Package: $name-$version.tag.gz"
+  
+  make "dist/${name}-${version}.tar.gz"
+  aws s3 cp "dist/${name}-${version}.tar.gz" "s3://${S3_BUCKET}/pr/${PR_NUMBER}-${GITHUB_SHA:0:7}-${name}-${version}.tar.gz"
+
+  echo "Package pushed to:  s3://${S3_BUCKET}/pr/${PR_NUMBER}-${GITHUB_SHA:0:7}-${name}-${version}.tar.gz"
+
+}
+
+main() {
+
+  echo "Evaluating PR#${PR_NUMBER}..."
+
+  # Take the base branch and figure out which addons changed. Process Each
+  for addon in $(git diff --dirstat=files,0 "origin/${GITHUB_BASE_REF}" -- addons/ "origin/${GITHUB_BASE_REF}" -- addons/ | sed 's/^[ 0-9.]\+% addons\///g' | grep -v template | cut -f -1 -d"/" | uniq ) 
+  do
+    prepare_addon $addon
+  done
+
+  if [ -n "${INSTALLER_SPEC}" ]; then
+    echo "Installer spec generated."
+    export INSTALLER_AVAILABLE=true
+    export INSTALLER_SPEC=$INSTALLER_SPEC
+  else
+    echo "No changed addons detected."
+  fi
+}
+
+snakecase_to_camelcase() {
+  echo $1 | sed -r 's/-([a-z])/\U\1/gi' | sed -r 's/^([A-Z])/\l\1/'
+}
+
+export -f prepare_addon
+main

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -46,180 +46,180 @@ type InstallerSpec struct {
 }
 
 type Contour struct {
-	S3Override                string `json:"s3Override,omitempty"`
-	Version                   string `json:"version"`
-	TLSMinimumProtocolVersion string `json:"tlsMinimumProtocolVersion,omitempty"`
+	S3Override                string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version                   string `json:"version" yaml:"version"`
+	TLSMinimumProtocolVersion string `json:"tlsMinimumProtocolVersion,omitempty" yaml:"tlsMinimumProtocolVersion,omitempty"`
 	HTTPPort                  int    `json:"httpPort,omitempty" yaml:"httpPort,omitempty"`
 	HTTPSPort                 int    `json:"httpsPort,omitempty" yaml:"httpsPort,omitempty"`
 }
 
 type Docker struct {
-	BypassStorageDriverWarning bool   `json:"bypassStorageDriverWarning,omitempty"`
-	DaemonConfig               string `json:"daemonConfig,omitempty"`
-	DockerRegistryIP           string `json:"dockerRegistryIP,omitempty"`
-	HardFailOnLoopback         bool   `json:"hardFailOnLoopback,omitempty"`
-	NoCEOnEE                   bool   `json:"noCEOnEE,omitempty"`
-	PreserveConfig             bool   `json:"preserveConfig,omitempty"`
-	S3Override                 string `json:"s3Override,omitempty"`
-	Version                    string `json:"version"`
+	BypassStorageDriverWarning bool   `json:"bypassStorageDriverWarning,omitempty" yaml:"bypassStorageDriverWarning,omitempty"`
+	DaemonConfig               string `json:"daemonConfig,omitempty" yaml:"daemonConfig,omitempty"`
+	DockerRegistryIP           string `json:"dockerRegistryIP,omitempty" yaml:"dockerRegistryIP,omitempty"`
+	HardFailOnLoopback         bool   `json:"hardFailOnLoopback,omitempty" yaml:"hardFailOnLoopback,omitempty"`
+	NoCEOnEE                   bool   `json:"noCEOnEE,omitempty" yaml:"noCEOnEE,omitempty"`
+	PreserveConfig             bool   `json:"preserveConfig,omitempty" yaml:"preserveConfig,omitempty"`
+	S3Override                 string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version                    string `json:"version" yaml:"version"`
 }
 
 type Fluentd struct {
-	FullEFKStack    bool   `json:"fullEFKStack,omitempty"`
-	S3Override      string `json:"s3Override,omitempty"`
-	Version         string `json:"version"`
-	FluentdConfPath string `json:"fluentdConfPath,omitempty"`
+	FullEFKStack    bool   `json:"fullEFKStack,omitempty" yaml:"fullEFKStack,omitempty"`
+	S3Override      string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version         string `json:"version" yaml:"version"`
+	FluentdConfPath string `json:"fluentdConfPath,omitempty" yaml:"fluentdConfPath,omitempty"`
 }
 
 type Kotsadm struct {
-	ApplicationNamespace string `json:"applicationNamespace,omitempty"`
-	ApplicationSlug      string `json:"applicationSlug,omitempty"`
-	Hostname             string `json:"hostname,omitempty"`
-	S3Override           string `json:"s3Override,omitempty"`
-	UiBindPort           int    `json:"uiBindPort,omitempty"`
-	Version              string `json:"version"`
+	ApplicationNamespace string `json:"applicationNamespace,omitempty" yaml:"applicationNamespace,omitempty"`
+	ApplicationSlug      string `json:"applicationSlug,omitempty" yaml:"applicationSlug,omitempty"`
+	Hostname             string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+	S3Override           string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	UiBindPort           int    `json:"uiBindPort,omitempty" yaml:"uiBindPort,omitempty"`
+	Version              string `json:"version" yaml:"version"`
 }
 
 type Kubernetes struct {
-	BootstrapToken           string `json:"bootstrapToken,omitempty"`
-	BootstrapTokenTTL        string `json:"bootstrapTokenTTL,omitempty"`
-	CertKey                  string `json:"certKey,omitempty"`
-	ControlPlane             bool   `json:"controlPlane,omitempty"`
-	HACluster                bool   `json:"HACluster,omitempty"`
-	KubeadmToken             string `json:"kubeadmToken,omitempty"`
-	KubeadmTokenCAHash       string `json:"kubeadmTokenCAHash,omitempty"`
-	LoadBalancerAddress      string `json:"loadBalancerAddress,omitempty"`
-	MasterAddress            string `json:"masterAddress,omitempty"`
-	S3Override               string `json:"s3Override,omitempty"`
-	ServiceCIDR              string `json:"serviceCIDR,omitempty"`
-	ServiceCidrRange         string `json:"serviceCidrRange,omitempty"`
-	UseStandardNodePortRange bool   `json:"useStandardNodePortRange,omitempty"`
-	Version                  string `json:"version"`
+	BootstrapToken           string `json:"bootstrapToken,omitempty" yaml:"bootstrapToken,omitempty"`
+	BootstrapTokenTTL        string `json:"bootstrapTokenTTL,omitempty" yaml:"bootstrapTokenTTL,omitempty"`
+	CertKey                  string `json:"certKey,omitempty" yaml:"certKey,omitempty"`
+	ControlPlane             bool   `json:"controlPlane,omitempty" yaml:"controlPlane,omitempty"`
+	HACluster                bool   `json:"HACluster,omitempty" yaml:"HACluster,omitempty"`
+	KubeadmToken             string `json:"kubeadmToken,omitempty" yaml:"kubeadmToken,omitempty"`
+	KubeadmTokenCAHash       string `json:"kubeadmTokenCAHash,omitempty" yaml:"kubeadmTokenCAHash,omitempty"`
+	LoadBalancerAddress      string `json:"loadBalancerAddress,omitempty" yaml:"loadBalancerAddress,omitempty"`
+	MasterAddress            string `json:"masterAddress,omitempty" yaml:"masterAddress,omitempty"`
+	S3Override               string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	ServiceCIDR              string `json:"serviceCIDR,omitempty" yaml:"serviceCIDR,omitempty"`
+	ServiceCidrRange         string `json:"serviceCidrRange,omitempty" yaml:"serviceCidrRange,omitempty"`
+	UseStandardNodePortRange bool   `json:"useStandardNodePortRange,omitempty" yaml:"useStandardNodePortRange,omitempty"`
+	Version                  string `json:"version" yaml:"version"`
 }
 
 type Kurl struct {
-	Airgap                     bool     `json:"airgap,omitempty"`
-	HostnameCheck              string   `json:"hostnameCheck,omitempty"`
-	ProxyAddress               string   `json:"proxyAddress,omitempty"`
-	AdditionalNoProxyAddresses []string `json:"additionalNoProxyAddresses,omitempty"`
-	NoProxy                    bool     `json:"noProxy,omitempty"`
-	PublicAddress              string   `json:"publicAddress,omitempty"`
-	PrivateAddress             string   `json:"privateAddress,omitempty"`
-	Nameserver                 string   `json:"nameserver,omitempty"`
+	Airgap                     bool     `json:"airgap,omitempty" yaml:"airgap,omitempty"`
+	HostnameCheck              string   `json:"hostnameCheck,omitempty" yaml:"hostnameCheck,omitempty"`
+	ProxyAddress               string   `json:"proxyAddress,omitempty" yaml:"proxyAddress,omitempty"`
+	AdditionalNoProxyAddresses []string `json:"additionalNoProxyAddresses,omitempty" yaml:"proxyAddress,omitempty"`
+	NoProxy                    bool     `json:"noProxy,omitempty" yaml:"noProxy,omitempty"`
+	PublicAddress              string   `json:"publicAddress,omitempty" yaml:"publicAddress,omitempty"`
+	PrivateAddress             string   `json:"privateAddress,omitempty" yaml:"privateAddress,omitempty"`
+	Nameserver                 string   `json:"nameserver,omitempty" yaml:"nameserver,omitempty"`
 }
 
 type Minio struct {
-	Namespace  string `json:"namespace,omitempty"`
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	Namespace  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type OpenEBS struct {
-	CstorStorageClassName   string `json:"cstorStorageClassName,omitempty"`
-	IsCstorEnabled          bool   `json:"isCstorEnabled,omitempty"`
-	IsLocalPVEnabled        bool   `json:"isLocalPVEnabled,omitempty"`
-	LocalPVStorageClassName string `json:"localPVStorageClassName,omitempty"`
-	Namespace               string `json:"namespace,omitempty"`
-	S3Override              string `json:"s3Override,omitempty"`
-	Version                 string `json:"version"`
+	CstorStorageClassName   string `json:"cstorStorageClassName,omitempty" yaml:"cstorStorageClassName,omitempty"`
+	IsCstorEnabled          bool   `json:"isCstorEnabled,omitempty" yaml:"isCstorEnabled,omitempty"`
+	IsLocalPVEnabled        bool   `json:"isLocalPVEnabled,omitempty" yaml:"isLocalPVEnabled,omitempty"`
+	LocalPVStorageClassName string `json:"localPVStorageClassName,omitempty" yaml:"localPVStorageClassName,omitempty"`
+	Namespace               string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	S3Override              string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version                 string `json:"version" yaml:"version"`
 }
 
 type Prometheus struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type Registry struct {
-	PublishPort int    `json:"publishPort,omitempty"`
-	S3Override  string `json:"s3Override,omitempty"`
-	Version     string `json:"version"`
+	PublishPort int    `json:"publishPort,omitempty" yaml:"publishPort,omitempty"`
+	S3Override  string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version     string `json:"version" yaml:"version"`
 }
 
 type Rook struct {
-	BlockDeviceFilter     string `json:"blockDeviceFilter,omitempty"`
-	CephReplicaCount      int    `json:"cephReplicaCount,omitempty"`
-	IsBlockStorageEnabled bool   `json:"isBlockStorageEnabled,omitempty"`
-	S3Override            string `json:"s3Override,omitempty"`
-	StorageClassName      string `json:"storageClassName,omitempty"`
-	Version               string `json:"version"`
+	BlockDeviceFilter     string `json:"blockDeviceFilter,omitempty" yaml:"blockDeviceFilter,omitempty"`
+	CephReplicaCount      int    `json:"cephReplicaCount,omitempty" yaml:"cephReplicaCount,omitempty"`
+	IsBlockStorageEnabled bool   `json:"isBlockStorageEnabled,omitempty" yaml:"isBlockStorageEnabled,omitempty"`
+	S3Override            string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	StorageClassName      string `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
+	Version               string `json:"version" yaml:"version"`
 }
 
 type Velero struct {
-	DisableCLI    bool   `json:"disableCLI,omitempty"`
-	DisableRestic bool   `json:"disableRestic,omitempty"`
-	LocalBucket   string `json:"localBucket,omitempty"`
-	Namespace     string `json:"namespace,omitempty"`
-	S3Override    string `json:"s3Override,omitempty"`
-	Version       string `json:"version"`
+	DisableCLI    bool   `json:"disableCLI,omitempty" yaml:"disableCLI,omitempty"`
+	DisableRestic bool   `json:"disableRestic,omitempty" yaml:"disableRestic,omitempty"`
+	LocalBucket   string `json:"localBucket,omitempty" yaml:"localBucket,omitempty"`
+	Namespace     string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	S3Override    string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version       string `json:"version" yaml:"version"`
 }
 
 type Weave struct {
-	IsEncryptionDisabled bool   `json:"isEncryptionDisabled,omitempty"`
-	PodCIDR              string `json:"podCIDR,omitempty"`
-	PodCidrRange         string `json:"podCidrRange,omitempty"`
-	S3Override           string `json:"s3Override,omitempty"`
-	Version              string `json:"version"`
+	IsEncryptionDisabled bool   `json:"isEncryptionDisabled,omitempty" yaml:"isEncryptionDisabled,omitempty"`
+	PodCIDR              string `json:"podCIDR,omitempty" yaml:"podCIDR,omitempty"`
+	PodCidrRange         string `json:"podCidrRange,omitempty" yaml:"podCidrRange,omitempty"`
+	S3Override           string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version              string `json:"version" yaml:"version"`
 }
 
 type SelinuxConfig struct {
-	ChconCmds      [][]string `json:"chconCmds,omitempty"`
-	DisableSelinux bool       `json:"disableSelinux,omitempty"`
-	PreserveConfig bool       `json:"preserveConfig,omitempty"`
-	Selinux        string     `json:"selinux,omitempty"`
-	SemanageCmds   [][]string `json:"semanageCmds,omitempty"`
-	Type           string     `json:"type,omitempty"`
+	ChconCmds      [][]string `json:"chconCmds,omitempty" yaml:"chconCmds,omitempty"`
+	DisableSelinux bool       `json:"disableSelinux,omitempty" yaml:"disableSelinux,omitempty"`
+	PreserveConfig bool       `json:"preserveConfig,omitempty" yaml:"preserveConfig,omitempty"`
+	Selinux        string     `json:"selinux,omitempty" yaml:"selinux,omitempty"`
+	SemanageCmds   [][]string `json:"semanageCmds,omitempty" yaml:"semanageCmds,omitempty"`
+	Type           string     `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
 type IptablesConfig struct {
-	IptablesCmds   [][]string `json:"iptablesCmds,omitempty"`
-	PreserveConfig bool       `json:"preserveConfig,omitempty"`
+	IptablesCmds   [][]string `json:"iptablesCmds,omitempty" yaml:"iptablesCmds,omitempty"`
+	PreserveConfig bool       `json:"preserveConfig,omitempty" yaml:"preserveConfig,omitempty"`
 }
 
 type FirewalldConfig struct {
-	BypassFirewalldWarning bool       `json:"bypassFirewalldWarning,omitempty"`
-	DisableFirewalld       bool       `json:"disableFirewalld,omitempty"`
-	Firewalld              string     `json:"firewalld,omitempty"`
-	FirewalldCmds          [][]string `json:"firewalldCmds,omitempty"`
-	HardFailOnFirewalld    bool       `json:"hardFailOnFirewalld,omitempty"`
-	PreserveConfig         bool       `json:"preserveConfig,omitempty"`
+	BypassFirewalldWarning bool       `json:"bypassFirewalldWarning,omitempty" yaml:"bypassFirewalldWarning,omitempty"`
+	DisableFirewalld       bool       `json:"disableFirewalld,omitempty" yaml:"disableFirewalld,omitempty"`
+	Firewalld              string     `json:"firewalld,omitempty" yaml:"firewalld,omitempty"`
+	FirewalldCmds          [][]string `json:"firewalldCmds,omitempty" yaml:"firewalldCmds,omitempty"`
+	HardFailOnFirewalld    bool       `json:"hardFailOnFirewalld,omitempty" yaml:"hardFailOnFirewalld,omitempty"`
+	PreserveConfig         bool       `json:"preserveConfig,omitempty" yaml:"preserveConfig,omitempty"`
 }
 
 type Ekco struct {
-	MinReadyMasterNodeCount     int    `json:"minReadyMasterNodeCount,omitempty"`
-	MinReadyWorkerNodeCount     int    `json:"minReadyWorkerNodeCount,omitempty"`
-	NodeUnreachableToleration   string `json:"nodeUnreachableToleration,omitempty"`
-	RookShouldUseAllNodes       bool   `json:"rookShouldUseAllNodes,omitempty"`
-	S3Override                  string `json:"s3Override,omitempty"`
-	ShouldDisableRebootServices bool   `json:"shouldDisableRebootServices,omitempty"`
-	ShouldDisableClearNodes     bool   `json:"shouldDisableClearNodes,omitempty"`
-	ShouldEnablePurgeNodes      bool   `json:"shouldEnablePurgeNodes,omitempty"`
-	Version                     string `json:"version"`
-	AutoUpgradeSchedule         string `json:"autoUpgradeSchedule,omitempty"`
+	MinReadyMasterNodeCount     int    `json:"minReadyMasterNodeCount,omitempty" yaml:"minReadyMasterNodeCount,omitempty"`
+	MinReadyWorkerNodeCount     int    `json:"minReadyWorkerNodeCount,omitempty" yaml:"minReadyWorkerNodeCount,omitempty"`
+	NodeUnreachableToleration   string `json:"nodeUnreachableToleration,omitempty" yaml:"nodeUnreachableToleration,omitempty"`
+	RookShouldUseAllNodes       bool   `json:"rookShouldUseAllNodes,omitempty" yaml:"rookShouldUseAllNodes,omitempty"`
+	S3Override                  string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	ShouldDisableRebootServices bool   `json:"shouldDisableRebootServices,omitempty" yaml:"shouldDisableRebootServices,omitempty"`
+	ShouldDisableClearNodes     bool   `json:"shouldDisableClearNodes,omitempty" yaml:"shouldDisableClearNodes,omitempty"`
+	ShouldEnablePurgeNodes      bool   `json:"shouldEnablePurgeNodes,omitempty" yaml:"shouldEnablePurgeNodes,omitempty"`
+	Version                     string `json:"version" yaml:"version"`
+	AutoUpgradeSchedule         string `json:"autoUpgradeSchedule,omitempty" yaml:"autoUpgradeSchedule,omitempty"`
 }
 
 type Calico struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type Containerd struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version" yaml:"version" yaml:"version"`
 }
 
 type Collectd struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type CertManager struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type MetricsServer struct {
-	S3Override string `json:"s3Override,omitempty"`
-	Version    string `json:"version"`
+	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 // InstallerStatus defines the observed state of Installer

--- a/testgrid/tgrun/go.mod
+++ b/testgrid/tgrun/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.13.0
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.0-rc.2
 	k8s.io/apimachinery v0.19.0-rc.2
 	k8s.io/client-go v12.0.0+incompatible
@@ -17,8 +18,6 @@ require (
 )
 
 replace (
-	github.com/replicatedhq/kurl/kurlkinds => ../../kurlkinds
-	github.com/replicatedhq/kurl/testgrid/tgapi => ../tgapi
 
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v11.0.0+incompatible
 	github.com/go-kit/kit => github.com/go-kit/kit v0.3.0
@@ -26,6 +25,8 @@ replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a
 	github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190128024246-5eb7ae5bdb7a
+	github.com/replicatedhq/kurl/kurlkinds => ../../kurlkinds
+	github.com/replicatedhq/kurl/testgrid/tgapi => ../tgapi
 	gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.4
 
 	k8s.io/api => k8s.io/api v0.16.4

--- a/testgrid/tgrun/hack/test-spec.yaml
+++ b/testgrid/tgrun/hack/test-spec.yaml
@@ -1,0 +1,30 @@
+kubernetes:
+  version: "latest"
+weave:
+  version: "2.6.5"
+rook:
+  version: "latest"
+contour:
+  version: "latest"
+docker:
+  version: "latest"
+prometheus:
+  version: "latest"
+registry:
+  version: "latest"
+velero:
+  version: "latest"
+kotsadm:
+  version: "latest"
+ekco:
+  version: "latest"
+fluentd:
+  version: "latest"
+minio:
+  version: "latest"
+collectd:
+  version: "latest"
+metricsServer:
+  version: "latest"
+certManager:
+  version: "latest"

--- a/testgrid/tgrun/pkg/cli/run/queue.go
+++ b/testgrid/tgrun/pkg/cli/run/queue.go
@@ -23,6 +23,8 @@ func QueueCmd() *cobra.Command {
 				OverwriteRef: v.GetBool("overwrite-ref"),
 				Ref:          v.GetString("ref"),
 				Staging:      v.GetBool("staging"),
+				LatestOnly:   v.GetBool("latest-only"),
+				Spec:         v.GetString("spec"),
 			}
 
 			if err := scheduler.Run(schedulerOptions); err != nil {
@@ -37,6 +39,8 @@ func QueueCmd() *cobra.Command {
 	cmd.Flags().String("testgrid-api", "https://api.testgrid.kurl.sh", "set to change the location of the testgrid api")
 	cmd.Flags().Bool("overwrite-ref", false, "when set, overwrite the ref on the testgrid")
 	cmd.Flags().Bool("staging", false, "when set, run tests against staging.kurl.sh instead of kurl.sh")
+	cmd.Flags().Bool("latest-only", false, "when set, run tests against the 'latest' kurl installer only instead of the standard suite")
+	cmd.Flags().String("spec", "", "when set, runs test against the provided installer spec yaml")
 
 	cmd.MarkFlagRequired("ref")
 

--- a/testgrid/tgrun/pkg/instances/latest.go
+++ b/testgrid/tgrun/pkg/instances/latest.go
@@ -1,0 +1,38 @@
+package instances
+
+import (
+	kurlv1beta1 "github.com/replicatedhq/kurl/kurlkinds/pkg/apis/cluster/v1beta1"
+	"github.com/replicatedhq/kurl/testgrid/tgrun/pkg/scheduler/types"
+)
+
+// Latest is the latest version(s) or the curl installer.
+var Latest = []types.Instance{
+	{
+		InstallerSpec: types.InstallerSpec{
+			Kubernetes: kurlv1beta1.Kubernetes{
+				Version: "latest",
+			},
+			Weave: &kurlv1beta1.Weave{
+				Version: "latest",
+			},
+			Rook: &kurlv1beta1.Rook{
+				Version: "latest",
+			},
+			Ekco: &kurlv1beta1.Ekco{
+				Version: "latest",
+			},
+			Contour: &kurlv1beta1.Contour{
+				Version: "latest",
+			},
+			Docker: &kurlv1beta1.Docker{
+				Version: "latest",
+			},
+			Prometheus: &kurlv1beta1.Prometheus{
+				Version: "latest",
+			},
+			Registry: &kurlv1beta1.Registry{
+				Version: "latest",
+			},
+		},
+	},
+}

--- a/testgrid/tgrun/pkg/scheduler/types/types.go
+++ b/testgrid/tgrun/pkg/scheduler/types/types.go
@@ -10,6 +10,8 @@ type SchedulerOptions struct {
 	OverwriteRef bool
 	Ref          string
 	Staging      bool
+	LatestOnly   bool
+	Spec         string
 }
 
 type TestRun struct {
@@ -44,26 +46,26 @@ type Installer struct {
 }
 
 type InstallerSpec struct {
-	IsStaging       bool                         `json:"-"`
-	Kubernetes      kurlv1beta1.Kubernetes       `json:"kubernetes,omitempty"`
-	Docker          *kurlv1beta1.Docker          `json:"docker,omitempty"`
-	Containerd      *kurlv1beta1.Containerd      `json:"containerd,omitempty"`
-	Weave           *kurlv1beta1.Weave           `json:"weave,omitempty"`
-	Calico          *kurlv1beta1.Calico          `json:"calico,omitempty"`
-	Contour         *kurlv1beta1.Contour         `json:"contour,omitempty"`
-	Rook            *kurlv1beta1.Rook            `json:"rook,omitempty"`
-	Registry        *kurlv1beta1.Registry        `json:"registry,omitempty"`
-	Prometheus      *kurlv1beta1.Prometheus      `json:"prometheus,omitempty"`
-	Fluentd         *kurlv1beta1.Fluentd         `json:"fluentd,omitempty"`
-	Kotsadm         *kurlv1beta1.Kotsadm         `json:"kotsadm,omitempty"`
-	Velero          *kurlv1beta1.Velero          `json:"velero,omitempty"`
-	Minio           *kurlv1beta1.Minio           `json:"minio,omitempty"`
-	OpenEBS         *kurlv1beta1.OpenEBS         `json:"openebs,omitempty"`
-	Kurl            *kurlv1beta1.Kurl            `json:"kurl,omitempty"`
-	SelinuxConfig   *kurlv1beta1.SelinuxConfig   `json:"selinuxConfig,omitempty"`
-	IptablesConfig  *kurlv1beta1.IptablesConfig  `json:"iptablesConfig,omitempty"`
-	FirewalldConfig *kurlv1beta1.FirewalldConfig `json:"firewalldConfig,omitempty"`
-	Ekco            *kurlv1beta1.Ekco            `json:"ekco,omitempty"`
-	Collectd        *kurlv1beta1.Collectd        `json:"collectd,omitempty"`
-	CertManager     *kurlv1beta1.CertManager     `json:"certManager,omitempty"`
+	IsStaging       bool                         `json:"-" yaml:"-"`
+	Kubernetes      kurlv1beta1.Kubernetes       `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
+	Docker          *kurlv1beta1.Docker          `json:"docker,omitempty" yaml:"docker,omitempty"`
+	Containerd      *kurlv1beta1.Containerd      `json:"containerd,omitempty" yaml:"containerd,omitempty"`
+	Weave           *kurlv1beta1.Weave           `json:"weave,omitempty" yaml:"weave,omitempty"`
+	Calico          *kurlv1beta1.Calico          `json:"calico,omitempty" yaml:"calico,omitempty"`
+	Contour         *kurlv1beta1.Contour         `json:"contour,omitempty" yaml:"contour,omitempty"`
+	Rook            *kurlv1beta1.Rook            `json:"rook,omitempty" yaml:"rook,omitempty"`
+	Registry        *kurlv1beta1.Registry        `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Prometheus      *kurlv1beta1.Prometheus      `json:"prometheus,omitempty" yaml:"prometheus,omitempty"`
+	Fluentd         *kurlv1beta1.Fluentd         `json:"fluentd,omitempty" yaml:"fluentd,omitempty"`
+	Kotsadm         *kurlv1beta1.Kotsadm         `json:"kotsadm,omitempty" yaml:"kotsadm,omitempty"`
+	Velero          *kurlv1beta1.Velero          `json:"velero,omitempty" yaml:"velero,omitempty"`
+	Minio           *kurlv1beta1.Minio           `json:"minio,omitempty" yaml:"minio,omitempty"`
+	OpenEBS         *kurlv1beta1.OpenEBS         `json:"openebs,omitempty" yaml:"openebs,omitempty"`
+	Kurl            *kurlv1beta1.Kurl            `json:"kurl,omitempty" yaml:"kurl,omitempty"`
+	SelinuxConfig   *kurlv1beta1.SelinuxConfig   `json:"selinuxConfig,omitempty" yaml:"selinuxConfig,omitempty"`
+	IptablesConfig  *kurlv1beta1.IptablesConfig  `json:"iptablesConfig,omitempty" yaml:"iptablesConfig,omitempty"`
+	FirewalldConfig *kurlv1beta1.FirewalldConfig `json:"firewalldConfig,omitempty" yaml:"firewalldConfig,omitempty"`
+	Ekco            *kurlv1beta1.Ekco            `json:"ekco,omitempty" json:"ekco,omitempty"`
+	Collectd        *kurlv1beta1.Collectd        `json:"collectd,omitempty" yaml:"collectd,omitempty"`
+	CertManager     *kurlv1beta1.CertManager     `json:"certManager,omitempty" yaml:"certManager,omitempty"`
 }


### PR DESCRIPTION
Pivoted a little from the original plan to use CLI flags for everything to just using a `--spec` flag at the CLI per @emosbaugh's suggestion. If you want to test the `tgrun` changes:

```bash
./bin/tgrun queue --staging --spec "$(cat ./hack/test-spec.yaml)" --ref user-test
# OR
./bin/tgrun queue --staging --latest-only --ref user-test
```

When this gets merged I have a PR for metrics-server that I will make to test out the action.

Lessons learned:
- [StringToString flag type doesn't play well with Viper AutoEnv](https://github.com/spf13/viper/issues/911) - not worth the effort now IMHO
- As a GH Actions newbie: the checkout action only checks out one commit -> makes it hard to do a diff in this case.