### PR TITLE
feat(kurkinds): adding port flags for contour

### DIFF
--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -71,6 +71,10 @@ spec:
               type: object
             contour:
               properties:
+                httpPort:
+                  type: integer
+                httpsPort:
+                  type: integer
                 s3Override:
                   type: string
                 tlsMinimumProtocolVersion:

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -49,6 +49,8 @@ type Contour struct {
 	S3Override                string `json:"s3Override,omitempty"`
 	Version                   string `json:"version"`
 	TLSMinimumProtocolVersion string `json:"tlsMinimumProtocolVersion,omitempty"`
+	HTTPPort                  int    `json:"httpPort,omitempty" yaml:"httpPort,omitempty"`
+	HTTPSPort                 int    `json:"httpsPort,omitempty" yaml:"httpsPort,omitempty"`
 }
 
 type Docker struct {


### PR DESCRIPTION
Updating installer spec to add flags for contour port configuration [CH#28704](https://app.clubhouse.io/replicated/story/28704/contour-addon-option-to-listen-on-alternative-ports)
