### PR TITLE
remove k8s 1.20.2 from being 'latest'

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -579,7 +579,6 @@ export class Installer {
   // first version of each is "latest"
   public static versions = {
     kubernetes: [
-      "1.20.2",
       "1.19.7",
       "1.19.3",
       "1.19.2",
@@ -594,6 +593,7 @@ export class Installer {
       "1.15.2",
       "1.15.1",
       "1.15.0",
+      "1.20.2",
     ],
     docker: [
       "19.03.10",


### PR DESCRIPTION
until build problems are fixed