### PR TITLE
fix: clean package/addon dir before load

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -61,6 +61,7 @@ function addon_pre_init() {
         if [ -n "$s3Override" ]; then
             addon_fetch "$s3Override"
         elif [ -n "$DIST_URL" ]; then
+            rm -rf $DIR/addons/$name/$version                   # Cleanup broken/ incompatible addons from failed runs
             addon_fetch "$DIST_URL/$name-$version.tar.gz"
         fi
     fi
@@ -85,6 +86,7 @@ function addon_join() {
         if [ -n "$s3Override" ]; then
             addon_fetch "$s3Override"
         elif [ -n "$DIST_URL" ]; then
+            rm -rf $DIR/addons/$name/$version                   # Cleanup broken/ incompatible addons from failed runs
             addon_fetch "$DIST_URL/$name-$version.tar.gz"
         fi
     fi

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -115,6 +115,7 @@ function docker_get_host_packages_online() {
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         curl -sSLO "$DIST_URL/docker-${version}.tar.gz"
+        rm -rf $DIR/packages/docker/${version}                      # Cleanup broken/ incompatible packages from failed runs
         tar xf docker-${version}.tar.gz
         rm docker-${version}.tar.gz
     fi
@@ -125,6 +126,7 @@ function containerd_get_host_packages_online() {
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         curl -sSLO "$DIST_URL/containerd-${version}.tar.gz"
+        rm -rf $DIR/packages/containerd/${version}                  # Cleanup broken/ incompatible packages from failed runs
         tar xf containerd-${version}.tar.gz
         rm containerd-${version}.tar.gz
     fi

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -128,6 +128,7 @@ function kubernetes_get_host_packages_online() {
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         curl -sSLO "$DIST_URL/kubernetes-${k8sVersion}.tar.gz"
+        rm -rf $DIR/packages/kubernetes/${k8sVersion}               # Cleanup broken/ incompatible packages from failed runs
         tar xf kubernetes-${k8sVersion}.tar.gz
         rm kubernetes-${k8sVersion}.tar.gz
     fi


### PR DESCRIPTION
Clean folders for packages and addons before unarchiving and repopulating them.

Will probably be superseded in the future by checking hashes before we delete + re-download.