### PR TITLE
Include docker and kubernetes in generated versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 node_modules/
 .idea
 *DS_Store
+versions.json
 supported-versions-gen.json
 addons-gen.json
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -447,4 +447,5 @@ kurl-util-image:
 
 .PHONY: generate-addons
 generate-addons:
+	make -C web generate-versions
 	node generate-addons.js

--- a/generate-addons.js
+++ b/generate-addons.js
@@ -28,6 +28,7 @@ const uploadFile = (file) => {
   });
 }
 
+const preferredVersions = JSON.parse(fs.readFileSync("./web/versions.json"));
 let addons = [];
 let supportedVersions = new Object();
 const specDir = "./addons";
@@ -68,10 +69,19 @@ fs.readdir(specDir, (err, files) => {
       if (hasAlphaVersion) {
         sv.push("alpha");
       }
+      if (preferredVersions[file]) {
+        sv = preferredVersions[file];
+      }
       sv.unshift("latest");
       supportedVersions[file] = sv
     }
   });
+
+  supportedVersions.kubernetes = preferredVersions.kubernetes;
+  supportedVersions.kubernetes.unshift("latest");
+
+  supportedVersions.docker = preferredVersions.docker;
+  supportedVersions.docker.unshift("latest");
 
   // Build JSON files
   const addonsFile = {

--- a/web/Makefile
+++ b/web/Makefile
@@ -60,3 +60,6 @@ build_and_push:
 	docker build -f deploy/Dockerfile-slim -t ${PROJECT_NAME}:$${CIRCLE_SHA1:0:7} .
 	docker tag ${PROJECT_NAME}:$${CIRCLE_SHA1:0:7} $(REGISTRY)/${PROJECT_NAME}:$${CIRCLE_SHA1:0:7}
 	docker push $(REGISTRY)/${PROJECT_NAME}:$${CIRCLE_SHA1:0:7}
+
+generate-versions:
+	`yarn bin`/ts-node generate-versions.ts

--- a/web/generate-versions.ts
+++ b/web/generate-versions.ts
@@ -1,0 +1,4 @@
+import * as fs from "fs";
+import { Installer } from "./src/installers";
+
+fs.writeFileSync("./versions.json", JSON.stringify(Installer.versions));

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6162,7 +6162,15 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.0, source-map-support@^0.5.11, source-map-support@^0.5.12, source-map-support@^0.5.7:
+source-map-support@^0.5.0:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.11, source-map-support@^0.5.12, source-map-support@^0.5.7:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
@@ -7058,9 +7066,9 @@ uuid@^8.3.1:
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
 v8flags@^3.0.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
-  integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
+  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
   dependencies:
     homedir-polyfill "^1.0.1"
 


### PR DESCRIPTION
Also prefer order defined for add-on versions on the Installer class since
that determines latest. We do not want weave 2.7.0 above 2.6.5, for
example, since 2.6.5 is latest and 2.7.0 has bugs.