### PR TITLE
fix: rke krew order install

### DIFF
--- a/scripts/common/rke2.sh
+++ b/scripts/common/rke2.sh
@@ -201,6 +201,8 @@ rke2_install() {
     systemctl enable rke2-server.service
     systemctl start rke2-server.service
 
+    get_shared
+
     logStep "Installing plugins"
     install_plugins
     logSuccess "Plugins installed"
@@ -389,7 +391,6 @@ function rke2_main() {
 
     rke2_install "${rke2_version}"
 
-    get_shared                          # TODO(dan): Docker or CRI needs to be setup for this.
     # upgrade_kubernetes                # TODO(dan): uses kubectl operator
     
     # kubernetes_host                   # TODO(dan): installs and sets up kubeadm, kubectl

--- a/scripts/distro/rke2/distro.sh
+++ b/scripts/distro/rke2/distro.sh
@@ -31,7 +31,7 @@ function rke2_addon_for_each() {
     local cmd="$1"
 
     if [ -n "$METRICS_SERVER_VERSION" ] && [ -z "$METRICS_SERVER_IGNORE" ]; then
-        logWarn "⚠️ Metrics Server is distributed as part of RKE2; the version specified in the installer will be ignored."
+        logWarn "⚠️  Metrics Server is distributed as part of RKE2; the version specified in the installer will be ignored."
         METRICS_SERVER_IGNORE=true
     fi
 


### PR DESCRIPTION
`install_plugins` needs krew, which is in the common bundle installed by `get_shared`.

Tested on centos 7.9 from staging: https://staging.kurl.sh/1f31afa