### PR TITLE
Only send Content-Encoding when request isn't from Cloudflare Workers

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -101,8 +101,11 @@ func bundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if request.Header.Get("User-Agent") != "cloudflare-worker" {
+		w.Header().Set("Content-Encoding", "gzip")
+	}
+
 	w.Header().Set("Content-Type", "binary/octet-stream")
-	w.Header().Set("Content-Encoding", "gzip")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Disposition", "attachment")
 	w.Header().Set("Transfer-Encoding", "chunked")


### PR DESCRIPTION
Cloudflare will always inspect the `Content-Encoding` header and decompress if its set to `gzip`. The Cloudflare Worker for kurl-sh is being updated to override the user-agent for terminal requests so we can conditionally not set this header and prevent automatic decompression when sending terminal requests through Cloudflare.

https://github.com/replicatedhq/cloudflare-workers/pull/129