### PR TITLE
fix(installer): path to helm binaries on non-debian os

### DIFF
--- a/scripts/common/helm.sh
+++ b/scripts/common/helm.sh
@@ -3,6 +3,8 @@ function install_helm() {
     if [ "$MASTER" = "1" ]; then
         cp -f $DIR/helm/helm /usr/local/bin/
         cp -f $DIR/helm/helmfile /usr/local/bin/
+
+        path_add "/usr/local/bin"
     fi
 }
 


### PR DESCRIPTION
~~https://testgrid.kurl.sh/run/dans-helm-fix~~

Not sure why I thought a testgrid run would work - the script changes won't part of the installer 🤦 