### PR TITLE
Mv fails for airgap upgrades

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -594,7 +594,10 @@ function move_airgap_assets() {
     # The airgap bundle will extract everything into ./kurl directory.
     # Move all assets except the scripts into the $KURL_INSTALL_DIRECTORY to emulate the online install experience.
     if [ "$(ls -A "${cwd}"/kurl)" ]; then
-        mv "${cwd}"/kurl/* "${KURL_INSTALL_DIRECTORY}"
+        for file in "${cwd}"/kurl/*; do
+            rm -rf "${KURL_INSTALL_DIRECTORY}/$(basename ${file})"
+            mv "${file}" "${KURL_INSTALL_DIRECTORY}/"
+        done
     fi
 }
 


### PR DESCRIPTION
Fixes

```
[ethan@ethan-kurl-airgap-1 ~]$ cat install.sh | sudo bash -s airgap ha
mv: cannot move ‘/home/ethan/kurl/addons’ to ‘/var/lib/kurl/addons’: File exists
mv: cannot move ‘/home/ethan/kurl/bin’ to ‘/var/lib/kurl/bin’: File exists
mv: cannot move ‘/home/ethan/kurl/helm’ to ‘/var/lib/kurl/helm’: File exists
mv: cannot move ‘/home/ethan/kurl/krew’ to ‘/var/lib/kurl/krew’: File exists
mv: cannot move ‘/home/ethan/kurl/kurlkinds’ to ‘/var/lib/kurl/kurlkinds’: File exists
mv: cannot move ‘/home/ethan/kurl/kustomize’ to ‘/var/lib/kurl/kustomize’: File exists
mv: cannot move ‘/home/ethan/kurl/packages’ to ‘/var/lib/kurl/packages’: File exists
mv: cannot move ‘/home/ethan/kurl/shared’ to ‘/var/lib/kurl/shared’: File exists
```