### PR TITLE
k8s 1.18.4 requires coredns 1.6.7, not 1.6.5

### DIFF
--- a/packages/kubernetes/1.18.4/Manifest
+++ b/packages/kubernetes/1.18.4/Manifest
@@ -3,7 +3,7 @@ image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.18.4
 image kubes-cheduler k8s.gcr.io/kube-scheduler:v1.18.4
 image kube-proxy k8s.gcr.io/kube-proxy:v1.18.4
 image pause k8s.gcr.io/pause:3.2
-image coredns k8s.gcr.io/coredns:1.6.5
+image coredns k8s.gcr.io/coredns:1.6.7
 image etcd k8s.gcr.io/etcd:3.4.3-0
 
 asset kustomize-v2.0.3 https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64


### PR DESCRIPTION
see https://testgrid.kurl.sh/run/laverya%202021.02.17%201.18.4%20airgap%20validation?kurlLogsInstanceId=wdoeby#L3519