### PR TITLE
package_cleanup after outro

### DIFF
--- a/scripts/common/rke2.sh
+++ b/scripts/common/rke2.sh
@@ -400,9 +400,9 @@ function rke2_main() {
     type create_registry_service &> /dev/null && create_registry_service # this function is in an optional addon and may be missing
     ${K8S_DISTRO}_addon_for_each addon_install
     # post_init                          # TODO(dan): more kubeadm token setup
-    package_cleanup
     # outro                              # See next line
     rke2_outro                            # TODO(dan): modified this to remove kubeadm stuff
+    package_cleanup
     # report_install_success # TODO(dan) remove reporting for now.
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -422,8 +422,8 @@ function main() {
     ${K8S_DISTRO}_addon_for_each addon_install
     helmfile_sync
     post_init
-    package_cleanup
     outro
+    package_cleanup
 
     popd_install_directory
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -135,8 +135,8 @@ function main() {
     kubernetes_host
     install_helm
     join
-    package_cleanup
     outro
+    package_cleanup
 
     popd_install_directory
 }

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -121,8 +121,8 @@ function main() {
     maybe_upgrade
     install_host_dependencies
     ${K8S_DISTRO}_addon_for_each addon_join
-    package_cleanup
     outro
+    package_cleanup
 
     popd_install_directory
 }


### PR DESCRIPTION
```
configmap/kurl-config created


		Installation
		  Complete ✔
find: ‘addons/’: No such file or directory

To access the cluster with kubectl, reload your shell:

    bash -l
```