### PR TITLE
ci: update TG rook version for RKE2

### DIFF
--- a/testgrid/tgrun/pkg/instances/rke2.go
+++ b/testgrid/tgrun/pkg/instances/rke2.go
@@ -13,7 +13,7 @@ func init() {
 					Version: "latest",
 				},
 				Rook: &kurlv1beta1.Rook{
-					Version:                    "1.0.4",
+					Version:                    "1.4.3",
 					HostpathRequiresPrivileged: true,
 					StorageClassName:           "default",
 				},


### PR DESCRIPTION
Only Rook 1.4.3 was tested with RKE2.