### PR TITLE
fix(scripts): don't pull images for ctrd on airgap reset

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -171,7 +171,6 @@ function weave_reset() {
                     # --pid host
                     local guid=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c16)
                     # TODO(ethan): rke2 containerd.sock path is incorrect
-                    ctr -n=k8s.io image pull docker.io/weaveworks/weaveexec:$WEAVE_TAG
                     ctr -n=k8s.io run --rm --net-host --privileged docker.io/weaveworks/weaveexec:$WEAVE_TAG $guid /usr/bin/weaveutil delete-datapath $NETDEV
                 fi
             fi


### PR DESCRIPTION
I feel weird removing it, but this image is already in the bundle manifest.