### PR TITLE
Any primary

### DIFF
--- a/addons/weave/2.5.2/install.sh
+++ b/addons/weave/2.5.2/install.sh
@@ -66,7 +66,7 @@ function weave_health_check() {
 }
 
 function weave_ready_spinner() {
-    if ! spinner_until 120 weave_health_check; then
+    if ! spinner_until 180 weave_health_check; then
       kubectl logs -n kube-system -l name=weave-net --all-containers --tail 10
       bail "The weave addon failed to deploy successfully."
     fi

--- a/addons/weave/2.6.4/install.sh
+++ b/addons/weave/2.6.4/install.sh
@@ -66,7 +66,7 @@ function weave_health_check() {
 }
 
 function weave_ready_spinner() {
-    if ! spinner_until 120 weave_health_check; then
+    if ! spinner_until 180 weave_health_check; then
       kubectl logs -n kube-system -l name=weave-net --all-containers --tail 10
       bail "The weave addon failed to deploy successfully."
     fi

--- a/addons/weave/2.6.5/install.sh
+++ b/addons/weave/2.6.5/install.sh
@@ -66,7 +66,7 @@ function weave_health_check() {
 }
 
 function weave_ready_spinner() {
-    if ! spinner_until 120 weave_health_check; then
+    if ! spinner_until 180 weave_health_check; then
       kubectl logs -n kube-system -l name=weave-net --all-containers --tail 10
       bail "The weave addon failed to deploy successfully."
     fi

--- a/addons/weave/2.7.0/install.sh
+++ b/addons/weave/2.7.0/install.sh
@@ -66,7 +66,7 @@ function weave_health_check() {
 }
 
 function weave_ready_spinner() {
-    if ! spinner_until 120 weave_health_check; then
+    if ! spinner_until 180 weave_health_check; then
       kubectl logs -n kube-system -l name=weave-net --all-containers --tail 10
       bail "The weave addon failed to deploy successfully."
     fi

--- a/bundles/helm/Dockerfile
+++ b/bundles/helm/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:18.04
-RUN apt-get update
-RUN apt-get -y install curl
+RUN apt-get update && apt-get -y install curl
 
 RUN mkdir -p /helm
 WORKDIR /helm

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -685,3 +685,10 @@ function job_is_completed() {
   local jobName="$2"
   kubectl get jobs -n "$namespace" "$jobName" | grep -q '1/1'
 }
+
+function maybe() {
+    local cmd="$1"
+    local args=${@:2}
+
+    $cmd $args 2>/dev/null || true
+}

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -354,7 +354,7 @@ function discover_service_subnet() {
         excluded="$excluded,${PRIVATE_ADDRESS}/16"
     fi
 
-    EXISTING_SERVICE_CIDR=$(kubeadm config view 2>/dev/null | grep serviceSubnet | awk '{ print $2 }')
+    EXISTING_SERVICE_CIDR=$(maybe kubeadm_cluster_configuration | grep serviceSubnet | awk '{ print $2 }')
 
     if [ -n "$SERVICE_CIDR" ]; then
         local serviceCidrSize=$(echo $SERVICE_CIDR | awk -F'/' '{ print $2 }')
@@ -539,7 +539,7 @@ function kubernetes_get_secondaries() {
 }
 
 function kubernetes_load_balancer_address() {
-    kubeadm config view 2>/dev/null | grep 'controlPlaneEndpoint:' | sed 's/controlPlaneEndpoint: \|"//g'
+    maybe kubeadm_cluster_configuration | grep 'controlPlaneEndpoint:' | sed 's/controlPlaneEndpoint: \|"//g'
 }
 
 function kubernetes_pod_started() {
@@ -599,4 +599,12 @@ function kubernetes_is_installed() {
         return 0
     fi
     return 1
+}
+
+function kubeadm_cluster_configuration() {
+    kubectl get cm -o yaml -n kube-system kubeadm-config -ojsonpath='{ .data.ClusterConfiguration }'
+}
+
+function kubeadm_cluster_status() {
+    kubectl get cm -o yaml -n kube-system kubeadm-config -ojsonpath='{ .data.ClusterStatus }'
 }

--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -156,8 +156,8 @@ promptForMasterAddress() {
 promptForLoadBalancerAddress() {
     local lastLoadBalancerAddress=
 
-    if kubeadm config view >/dev/null 2>&1; then
-        lastLoadBalancerAddress="$(kubeadm config view | grep 'controlPlaneEndpoint:' | sed 's/controlPlaneEndpoint: \|"//g')"
+    if kubeadm_cluster_configuration >/dev/null 2>&1; then
+        lastLoadBalancerAddress="$(kubeadm_cluster_configuration | grep 'controlPlaneEndpoint:' | sed 's/controlPlaneEndpoint: \|"//g')"
         if [ -n "$lastLoadBalancerAddress" ]; then
             splitHostPort "$lastLoadBalancerAddress"
             if [ "$HOST" = "$lastLoadBalancerAddress" ]; then

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -174,6 +174,8 @@ function upgrade_kubernetes_local_master_minor() {
     printf "${YELLOW}Drain local node and apply upgrade? ${NC}"
     confirmY " "
 
+    kubernetes_drain "$node"
+
     spinner_kubernetes_api_stable
     kubeadm upgrade apply "v$k8sVersion" --yes --force
     upgrade_etcd_image_18 "$k8sVersion"

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -67,8 +67,6 @@ function upgrade_kubernetes_local_master_patch() {
     load_images $DIR/packages/kubernetes/$k8sVersion/images
     upgrade_kubeadm "$k8sVersion"
 
-    kubeadm_config_migrate
-
     kubeadm upgrade plan "v${k8sVersion}"
     printf "${YELLOW}Drain local node and apply upgrade? ${NC}"
     confirmY " "
@@ -76,8 +74,7 @@ function upgrade_kubernetes_local_master_patch() {
     kubernetes_drain "$node"
  
     spinner_kubernetes_api_stable
-    kubeadm upgrade apply "v$k8sVersion" --yes --config /opt/replicated/kubeadm.conf --force
-    sed -i "s/kubernetesVersion:.*/kubernetesVersion: v${k8sVersion}/" /opt/replicated/kubeadm.conf
+    kubeadm upgrade apply "v$k8sVersion" --yes --force
 
     kubernetes_install_host_packages "$k8sVersion"
     systemctl daemon-reload
@@ -173,16 +170,13 @@ function upgrade_kubernetes_local_master_minor() {
     load_images $DIR/packages/kubernetes/$k8sVersion/images
     upgrade_kubeadm "$k8sVersion"
 
-    kubeadm_config_migrate
-
     kubeadm upgrade plan "v${k8sVersion}"
     printf "${YELLOW}Drain local node and apply upgrade? ${NC}"
     confirmY " "
 
     spinner_kubernetes_api_stable
-    kubeadm upgrade apply "v$k8sVersion" --yes --config /opt/replicated/kubeadm.conf --force
+    kubeadm upgrade apply "v$k8sVersion" --yes --force
     upgrade_etcd_image_18 "$k8sVersion"
-    sed -i "s/kubernetesVersion:.*/kubernetesVersion: v${k8sVersion}/" /opt/replicated/kubeadm.conf
 
     kubernetes_install_host_packages "$k8sVersion"
     systemctl daemon-reload
@@ -279,22 +273,4 @@ function upgrade_etcd_image_18() {
     fi
     local etcd_tag=$(kubeadm config images list 2>/dev/null | grep etcd | awk -F':' '{ print $NF }')
     sed -i "s/image: k8s.gcr.io\/etcd:.*/image: k8s.gcr.io\/etcd:$etcd_tag/" /etc/kubernetes/manifests/etcd.yaml
-}
-
-function kubeadm_config_migrate() {
-    # Does not migrate kube-proxy or kubelet configs
-    kubeadm config migrate --old-config $KUBEADM_CONF_FILE --new-config $KUBEADM_CONF_FILE
-
-    cat << EOF >> $KUBEADM_CONF_FILE
----
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-cgroupDriver: systemd
----
-EOF
-
-    kubectl -n kube-system get configmaps kube-proxy -o yaml > /tmp/temp.yaml
-    $DIR/bin/yamlutil -p -fp /tmp/temp.yaml -yp data_config.conf
-    cat /tmp/temp.yaml >> /opt/replicated/kubeadm.conf
-    rm /tmp/temp.yaml
 }


### PR DESCRIPTION
Fixes the bug that requires all kurl upgrades be initiated on the first primary. The problem was that a config file was being passed to `kubeadm upgrade` and the existing file on primaries other than the first contained a JoinConfiguration.

The solution was to stop passing any config file to `kubeadm upgrade`. Kubeadm prints out a warning to not use a config file for upgrades. When no config is passed the existing config is used that is stored in the cluster.