### PR TITLE
fix(containerd): configure registry ca on joined nodes

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -1,4 +1,5 @@
 
+CONTAINERD_NEEDS_RESTART=0
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -6,6 +7,7 @@ function containerd_install() {
         install_host_archives "$src"
         install_host_packages "$src"
         containerd_configure
+        systemctl daemon-reload
     fi
 
     systemctl enable containerd
@@ -19,9 +21,11 @@ function containerd_install() {
 
     if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
         registry_containerd_configure "$DOCKER_REGISTRY_IP"
-        if [ "$REGISTRY_CONTAINERD_CA_ADDED" = "1" ]; then
-            restart_containerd
-        fi
+    fi
+
+    if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
+        restart_systemd_and_wait containerd
+        CONTAINERD_NEEDS_RESTART=0
     fi
 
     load_images $src/images
@@ -38,13 +42,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
 
-    # Always set for joining nodes since it's passed as a flag in the generated join script, but not
-    # usually set for the initial install. For initial installs the registry will be configured from
-    # registry_containerd_init.
-    if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
-        registry_containerd_configure "$DOCKER_REGISTRY_IP"
-    fi
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function containerd_configure_ctl() {
@@ -76,10 +74,5 @@ containerd_configure_proxy() {
         echo "Environment=\"HTTP_PROXY=${PROXY_ADDRESS}\" \"NO_PROXY=${NO_PROXY_ADDRESSES}\"" >> $file
     fi
 
-    restart_containerd
-}
-
-function restart_containerd() {
-    systemctl daemon-reload
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -1,4 +1,5 @@
 
+CONTAINERD_NEEDS_RESTART=0
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -6,6 +7,7 @@ function containerd_install() {
         install_host_archives "$src"
         install_host_packages "$src"
         containerd_configure
+        systemctl daemon-reload
     fi
 
     systemctl enable containerd
@@ -19,9 +21,11 @@ function containerd_install() {
 
     if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
         registry_containerd_configure "$DOCKER_REGISTRY_IP"
-        if [ "$REGISTRY_CONTAINERD_CA_ADDED" = "1" ]; then
-            restart_containerd
-        fi
+    fi
+
+    if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
+        restart_systemd_and_wait containerd
+        CONTAINERD_NEEDS_RESTART=0
     fi
 
     load_images $src/images
@@ -38,13 +42,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
 
-    # Always set for joining nodes since it's passed as a flag in the generated join script, but not
-    # usually set for the initial install. For initial installs the registry will be configured from
-    # registry_containerd_init.
-    if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
-        registry_containerd_configure "$DOCKER_REGISTRY_IP"
-    fi
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function containerd_configure_ctl() {
@@ -76,10 +74,5 @@ containerd_configure_proxy() {
         echo "Environment=\"HTTP_PROXY=${PROXY_ADDRESS}\" \"NO_PROXY=${NO_PROXY_ADDRESSES}\"" >> $file
     fi
 
-    restart_containerd
-}
-
-function restart_containerd() {
-    systemctl daemon-reload
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -1,4 +1,5 @@
 
+CONTAINERD_NEEDS_RESTART=0
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -6,6 +7,7 @@ function containerd_install() {
         install_host_archives "$src"
         install_host_packages "$src"
         containerd_configure
+        systemctl daemon-reload
     fi
 
     systemctl enable containerd
@@ -19,9 +21,11 @@ function containerd_install() {
 
     if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
         registry_containerd_configure "$DOCKER_REGISTRY_IP"
-        if [ "$REGISTRY_CONTAINERD_CA_ADDED" = "1" ]; then
-            restart_containerd
-        fi
+    fi
+
+    if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
+        restart_systemd_and_wait containerd
+        CONTAINERD_NEEDS_RESTART=0
     fi
 
     load_images $src/images
@@ -38,13 +42,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
 
-    # Always set for joining nodes since it's passed as a flag in the generated join script, but not
-    # usually set for the initial install. For initial installs the registry will be configured from
-    # registry_containerd_init.
-    if commandExists registry_containerd_configure && [ -n "$DOCKER_REGISTRY_IP" ]; then
-        registry_containerd_configure "$DOCKER_REGISTRY_IP"
-    fi
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function containerd_configure_ctl() {
@@ -76,10 +74,5 @@ containerd_configure_proxy() {
         echo "Environment=\"HTTP_PROXY=${PROXY_ADDRESS}\" \"NO_PROXY=${NO_PROXY_ADDRESSES}\"" >> $file
     fi
 
-    restart_containerd
-}
-
-function restart_containerd() {
-    systemctl daemon-reload
-    systemctl restart containerd
+    CONTAINERD_NEEDS_RESTART=1
 }

--- a/addons/registry/2.7.1/install.sh
+++ b/addons/registry/2.7.1/install.sh
@@ -122,7 +122,6 @@ function registry_containerd_init() {
     spinner_kubernetes_api_healthy
 }
 
-REGISTRY_CONTAINERD_CA_ADDED=0
 function registry_containerd_configure() {
     local registry_ip="$1"
     ${K8S_DISTRO}_registry_containerd_configure "${registry_ip}"

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -53,7 +53,7 @@ function addon_pre_init() {
     fi
 }
 
-function addon_join() {
+function addon_pre_join() {
     local name=$1
     local version=$2
     local s3Override=$3
@@ -72,9 +72,14 @@ function addon_join() {
         fi
     fi
 
-    addon_load "$name" "$version"
-
     . $DIR/addons/$name/$version/install.sh
+}
+
+function addon_join() {
+    local name=$1
+    local version=$2
+
+    addon_load "$name" "$version"
 
     if commandExists ${name}_join; then
         logStep "Addon $name $version"

--- a/scripts/distro/k3s/distro.sh
+++ b/scripts/distro/k3s/distro.sh
@@ -82,7 +82,7 @@ function k3s_registry_containerd_configure() {
       ca_file: "$(k3s_get_server_ca)"
 EOF
 
-    REGISTRY_CONTAINERD_CA_ADDED=1
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function k3s_api_is_healthy() {

--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -87,7 +87,7 @@ function kubeadm_registry_containerd_configure() {
   ca_file = "/etc/kubernetes/pki/ca.crt"
 EOF
 
-    REGISTRY_CONTAINERD_CA_ADDED=1
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function kubeadm_api_is_healthy() {

--- a/scripts/distro/rke2/distro.sh
+++ b/scripts/distro/rke2/distro.sh
@@ -83,7 +83,7 @@ function rke2_registry_containerd_configure() {
       ca_file: "$(rke2_get_server_ca)"
 EOF
 
-    REGISTRY_CONTAINERD_CA_ADDED=1
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function rke2_api_is_healthy() {

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -128,6 +128,7 @@ function main() {
     configure_proxy
     configure_no_proxy
     host_preflights "${MASTER:-0}" "1" "0"
+    ${K8S_DISTRO}_addon_for_each addon_pre_join
     install_cri
     get_shared
     setup_kubeadm_kustomize


### PR DESCRIPTION
Problem is that the `registry_containerd_configure` command isn't sourced before the CRI is installed.

This PR:
1. Refactors addons to download and source before installs and loading images
2. Cleanups up CRI configuration and minimizes restarts.