### PR TITLE
ci: add airgap flag to tgrun instance spec

### DIFF
--- a/testgrid/tgrun/hack/test-spec.yaml
+++ b/testgrid/tgrun/hack/test-spec.yaml
@@ -1,30 +1,19 @@
-kubernetes:
-  version: "latest"
-weave:
-  version: "2.6.5"
-rook:
-  version: "latest"
-contour:
-  version: "latest"
-docker:
-  version: "latest"
-prometheus:
-  version: "latest"
-registry:
-  version: "latest"
-velero:
-  version: "latest"
-kotsadm:
-  version: "latest"
-ekco:
-  version: "latest"
-fluentd:
-  version: "latest"
-minio:
-  version: "latest"
-collectd:
-  version: "latest"
-metricsServer:
-  version: "latest"
-certManager:
-  version: "latest"
+- installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    longhorn:
+      version: "latest"
+- runAirGap: true
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    longhorn:
+      version: "latest"

--- a/testgrid/tgrun/pkg/instances/instances.go
+++ b/testgrid/tgrun/pkg/instances/instances.go
@@ -15,9 +15,9 @@ func RegisterAirgapAndOnlineInstance(instance types.Instance) {
 	if instance.UpgradeSpec != nil {
 		duplicateUpgrade := *instance.UpgradeSpec
 		duplicate.UpgradeSpec = &duplicateUpgrade
-		duplicate.UpgradeSpec.RunAirgap = true
+		duplicate.RunAirgap = true
 	}
 
-	duplicate.InstallerSpec.RunAirgap = true
+	duplicate.RunAirgap = true
 	Instances = append(Instances, duplicate)
 }

--- a/testgrid/tgrun/pkg/scheduler/scheduler.go
+++ b/testgrid/tgrun/pkg/scheduler/scheduler.go
@@ -114,7 +114,7 @@ func Run(schedulerOptions types.SchedulerOptions) error {
 			return fmt.Errorf("error getting kurl spec url: %s", errMsg.Error.Message)
 		}
 
-		if instance.InstallerSpec.RunAirgap {
+		if instance.RunAirgap {
 			installerURLString, err := bundleFromURL(string(installerURL))
 			if err != nil {
 				return errors.Wrapf(err, "generate airgap url from installer url %s", installerURL)

--- a/testgrid/tgrun/pkg/scheduler/types/types.go
+++ b/testgrid/tgrun/pkg/scheduler/types/types.go
@@ -36,6 +36,7 @@ type OperatingSystemImage struct {
 
 type Instance struct {
 	InstallerSpec    InstallerSpec  `json:"installerSpec" yaml:"installerSpec"`
+	RunAirgap        bool           `json:"runAirGap,omitempty" yaml:"runAirGap,omitempty"`
 	UpgradeSpec      *InstallerSpec `json:"upgradeSpec,omitempty" yaml:"upgradeSpec,omitempty"`
 	UnsupportedOSIDs []string       `json:"unsupportedOSIDs,omitempty" yaml:"unsupportedOSIDs,omitempty"`
 }
@@ -49,7 +50,6 @@ type Installer struct {
 
 type InstallerSpec struct {
 	IsStaging       bool                         `json:"-" yaml:"-"`
-	RunAirgap       bool                         `json:"-" yaml:"-"`
 	Kubernetes      *kurlv1beta1.Kubernetes      `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 	RKE2            *kurlv1beta1.RKE2            `json:"rke2,omitempty" yaml:"rke2,omitempty"`
 	K3S             *kurlv1beta1.K3S             `json:"k3s,omitempty" yaml:"k3s,omitempty"`


### PR DESCRIPTION
Refactor to allow PR test specs to specific an airgap build without affecting the installer spec.