### PR TITLE
Update KUBECONFIG unset to echo into .bash_profile instead of .profile

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -431,7 +431,7 @@ function kubeconfig_setup_outro() {
 
             printf "To access the cluster with kubectl, ensure the KUBECONFIG environment variable is unset:\n"
             printf "\n"
-            printf "${GREEN}    echo unset KUBECONFIG >> ~/.profile${NC}\n"
+            printf "${GREEN}    echo unset KUBECONFIG >> ~/.bash_profile${NC}\n"
             printf "${GREEN}    bash -l${NC}\n"
             return
         fi
@@ -441,7 +441,7 @@ function kubeconfig_setup_outro() {
     printf "\n"
     printf "${GREEN}    cp "$(${K8S_DISTRO}_get_kubeconfig)" ~/.kube/config${NC}\n"
     printf "${GREEN}    chown -R ${owner} ~/.kube${NC}\n"
-    printf "${GREEN}    echo unset KUBECONFIG >> ~/.profile${NC}\n"
+    printf "${GREEN}    echo unset KUBECONFIG >> ~/.bash_profile${NC}\n"
     printf "${GREEN}    bash -l${NC}\n"
     printf "\n"
     printf "You will likely need to use sudo to copy and chown "$(${K8S_DISTRO}_get_kubeconfig)".\n"


### PR DESCRIPTION
Using .profile to unset the KUBECONFIG env var isn't working:
```
[vagrant@hostname ~]$ cat .profile
unset KUBECONFIG
[vagrant@hostname ~]$ bash -l
[vagrant@hostname ~]$ kubectl get nodes
error: error loading config file "/etc/kubernetes/admin.conf": open /etc/kubernetes/admin.conf: permission denied
```

but adding it to .bash_profile instead does work:
```
[vagrant@hostname ~]$ cat .bash_profile | grep KUBECONFIG
unset KUBECONFIG
[vagrant@hostname ~]$ bash -l
[vagrant@hostname ~]$ kubectl get nodes
NAME                                      STATUS   ROLES    AGE    VERSION
nodename   Ready    master   100m   v1.19.3
```

kURL seems to also try to set the permissions of `/etc/kubernetes/admin.conf` but that's not working:
```
[vagrant@ip-10-0-2-15 ~]$ ll /etc/kubernetes/admin.conf
-r--r-----. 1 root root 5565 Mar 12 15:07 /etc/kubernetes/admin.conf
[vagrant@ip-10-0-2-15 ~]$ id vagrant
uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant)
```

Updating this output should help reduce issues with the customer being able to use kubectl after install.