### PR TITLE
ci: add cri-tools to k8s template

### DIFF
--- a/packages/kubernetes/template/Dockerfile
+++ b/packages/kubernetes/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get -y install curl apt-transport-https gnupg
 RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -27,6 +27,12 @@ function generate_version_directory() {
         echo "image ${name} ${image}" >> "../$version/Manifest"
     done < <(/tmp/kubeadm config images list --kubernetes-version=${version})
 
+    local criToolsVersion=$(curl -Ls -m 60 -o /dev/null -w %{url_effective} https://github.com/kubernetes-sigs/cri-tools/releases/latest | xargs basename)
+
+    echo "" >> "../$version/Manifest"
+    echo "asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v$version/bin/linux/amd64/kubeadm" >> "../$version/Manifest"
+    echo "asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/$criToolsVersion/crictl-$criToolsVersion-linux-amd64.tar.gz" >> "../$version/Manifest"
+
     echo "" >> "../$version/Manifest"
     echo "asset kustomize-v2.0.3 https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64" >> "../$version/Manifest"
     echo "asset kustomize-v3.5.4.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz" >> "../$version/Manifest"


### PR DESCRIPTION
CRI-tools update could be a maintenance burden rebuilding packages if back-ported, but kept it to hopefully reduce CVE updates later.

Also, I had trouble running this on my codeserver with ubuntu 18.04. Kept getting 404s and was resolved by moving to 20.04.