### PR TITLE
fix(collectd): fix install prompt on debian

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -538,7 +538,7 @@ function install_host_archives() {
     case "$LSB_DIST" in
         ubuntu)
             if test -n "$(shopt -s nullglob; echo ${dir}/ubuntu-${DIST_VERSION}/archives/*.deb )" ; then
-                DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version ${dir}/ubuntu-${DIST_VERSION}/archives/*.deb
+                DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version --force-confold ${dir}/ubuntu-${DIST_VERSION}/archives/*.deb
             fi
             ;;
 


### PR DESCRIPTION
Collectd consistently fails TestGrid on debian due to a prompt asking to keep the conf file we write: https://testgrid.kurl.sh/run/PROD-daily-2021-03-18T08:25:32Z?kurlLogsInstanceId=hneagd. Also repro locally using the same installer.

I could see where we might want to pass this as an `opt` to `install_host_archives` in collectd. Seems safe globally though.