### PR TITLE
Runc 1.0.0-rc92

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
 	${MAKE} build/packages/docker/$*/rhel-7
 	mkdir -p dist
+	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64 > build/packages/docker/$*/runc
+	chmod +x build/packages/docker/runc
 	tar cf - -C build packages/docker/$* | gzip > dist/docker-$*.tar.gz
 
 dist/containerd-%.tar.gz: build/addons

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/rhel-7
 	mkdir -p dist
 	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64 > build/packages/docker/$*/runc
-	chmod +x build/packages/docker/runc
+	chmod +x build/packages/docker/$*/runc
 	tar cf - -C build packages/docker/$* | gzip > dist/docker-$*.tar.gz
 
 dist/containerd-%.tar.gz: build/addons

--- a/addons/kotsadm/1.34.0/install.sh
+++ b/addons/kotsadm/1.34.0/install.sh
@@ -319,7 +319,7 @@ function kotsadm_cli() {
     fi
     if [ ! -f "$src/assets/kots.tar.gz" ] && [ "$AIRGAP" != "1" ]; then
         mkdir -p "$src/assets"
-        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.34.0/linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
+        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.34.0/kots_linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
     fi
 
     pushd "$src/assets"

--- a/addons/kotsadm/1.35.0/install.sh
+++ b/addons/kotsadm/1.35.0/install.sh
@@ -323,7 +323,7 @@ function kotsadm_cli() {
     fi
     if [ ! -f "$src/assets/kots.tar.gz" ] && [ "$AIRGAP" != "1" ]; then
         mkdir -p "$src/assets"
-        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.35.0/linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
+        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.35.0/kots_linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
     fi
 
     pushd "$src/assets"

--- a/addons/kotsadm/alpha/install.sh
+++ b/addons/kotsadm/alpha/install.sh
@@ -323,7 +323,7 @@ function kotsadm_cli() {
     fi
     if [ ! -f "$src/assets/kots.tar.gz" ] && [ "$AIRGAP" != "1" ]; then
         mkdir -p "$src/assets"
-        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.35.0/linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
+        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.35.0/kots_linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
     fi
 
     pushd "$src/assets"

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -49,14 +49,14 @@ docker_install() {
         ubuntu)
             export DEBIAN_FRONTEND=noninteractive
             dpkg --install --force-depends-version $DIR/packages/docker/${DOCKER_VERSION}/ubuntu-${DIST_VERSION}/*.deb
-            cp $DIR/packages/docker/${DOCKER_VERSION}/runc /usr/bin/runc
+            cp $DIR/packages/docker/${DOCKER_VERSION}/runc $(which runc)
             DID_INSTALL_DOCKER=1
             return 0
             ;;
 
         centos|rhel|amzn|ol)
             rpm --upgrade --force --nodeps $DIR/packages/docker/${DOCKER_VERSION}/rhel-7/*.rpm
-            cp $DIR/packages/docker/${DOCKER_VERSION}/runc /usr/bin/runc
+            cp $DIR/packages/docker/${DOCKER_VERSION}/runc $(which runc)
             DID_INSTALL_DOCKER=1
             return 0
             ;;

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -49,19 +49,22 @@ docker_install() {
         ubuntu)
             export DEBIAN_FRONTEND=noninteractive
             dpkg --install --force-depends-version $DIR/packages/docker/${DOCKER_VERSION}/ubuntu-${DIST_VERSION}/*.deb
+            cp $DIR/packages/docker/${DOCKER_VERSION}/runc /usr/bin/runc
             DID_INSTALL_DOCKER=1
             return 0
             ;;
 
         centos|rhel|amzn|ol)
             rpm --upgrade --force --nodeps $DIR/packages/docker/${DOCKER_VERSION}/rhel-7/*.rpm
+            cp $DIR/packages/docker/${DOCKER_VERSION}/runc /usr/bin/runc
             DID_INSTALL_DOCKER=1
             return 0
             ;;
     esac
 
-   printf "Offline Docker install is not supported on ${LSB_DIST} ${DIST_MAJOR}"
-   exit 1
+
+    printf "Offline Docker install is not supported on ${LSB_DIST} ${DIST_MAJOR}"
+    exit 1
 }
 
 check_docker_storage_driver() {


### PR DESCRIPTION
Workaround for Node flapping between Ready and NotReady, caused by runc init sometimes hanging using the version bundled with containerd (1.0.0-rc93).