### PR TITLE
Fix antrea pod cidr

### DIFF
--- a/addons/antrea/0.13.1/install.sh
+++ b/addons/antrea/0.13.1/install.sh
@@ -2,6 +2,9 @@
 function antrea_pre_init() {
     local src="$DIR/addons/antrea/$ANTREA_VERSION"
 
+    POD_CIDR="$ANTREA_POD_CIDR"
+    POD_CIDR_RANGE="$ANTREA_POD_CIDR_RANGE"
+
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/antrea.yaml"
 
     if commandExists kubectl; then

--- a/addons/antrea/template/base/install.sh
+++ b/addons/antrea/template/base/install.sh
@@ -2,6 +2,9 @@
 function antrea_pre_init() {
     local src="$DIR/addons/antrea/$ANTREA_VERSION"
 
+    POD_CIDR="$ANTREA_POD_CIDR"
+    POD_CIDR_RANGE="$ANTREA_POD_CIDR_RANGE"
+
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/antrea.yaml"
 
     if commandExists kubectl; then

--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -253,8 +253,8 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 		"Weave.S3Override":                       "WEAVE_S3_OVERRIDE",
 		"Weave.Version":                          "WEAVE_VERSION",
 		"Antrea.IsEncryptionDisabled":            "ANTREA_DISABLE_ENCRYPTION",
-		"Antrea.PodCIDR":                         "POD_CIDR",
-		"Antrea.PodCidrRange":                    "POD_CIDR_RANGE",
+		"Antrea.PodCIDR":                         "ANTREA_POD_CIDR",
+		"Antrea.PodCidrRange":                    "ANTREA_POD_CIDR_RANGE",
 		"Antrea.S3Override":                      "ANTREA_S3_OVERRIDE",
 		"Antrea.Version":                         "ANTREA_VERSION",
 	}


### PR DESCRIPTION
Cannot re-use weave vars because they get overwritten when weave spec is
parsed, but must use the same names. Solution is to parse them as
ANTREA_POD_CIDR and ANTREA_POD_CIDR_RANGE but rename them before the discover_pod_subnet function
runs.