### PR TITLE
Automated Containerd version update 1.4.4

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -37,7 +37,6 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
-    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -37,7 +37,6 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
-    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -37,7 +37,6 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
-    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -37,7 +37,6 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
-    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -33,7 +33,7 @@ module.exports.InstallerVersions = {
     "19.03.4",
     "18.09.8",
   ],
-  containerd: ["1.4.4", "1.4.3", "1.3.9", "1.3.7", "1.2.13"], // cron-containerd-update
+    containerd: ["1.4.4", "1.4.3", "1.3.9", "1.3.7", "1.2.13"], // cron-containerd-update
   weave: [
     "2.6.5",
     "2.6.4",


### PR DESCRIPTION
Automated changes by the [cron-containerd-update](https://github.com/replicatedhq/kURL/blob/master/.github/workflows/update-containerd.yaml) GitHub action