### PR TITLE
fix(registry): escape var in restore script

### DIFF
--- a/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
+++ b/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   backup.sh: |-
     #!/bin/sh
+    set -euo pipefail
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=$OBJECT_STORE_CLUSTER_IP
@@ -17,11 +18,12 @@ data:
 
   restore.sh: |-
     #!/bin/sh
+    set -euo pipefail
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=$OBJECT_STORE_CLUSTER_IP
 
-    if [ ! -d $S3_DIR ]; then
+    if [ ! -d \$S3_DIR ]; then
         exit 0
     fi
 


### PR DESCRIPTION
Getting this error from the init container `restore` for new pods:
```
ERROR: Parameter problem: Invalid source: '/backup/s3/' is not an existing file or directory
```
