### PR TITLE
Set default containerd logging to warn

### DIFF
--- a/addons/containerd/1.2.13/install.sh
+++ b/addons/containerd/1.2.13/install.sh
@@ -53,4 +53,5 @@ function containerd_configure() {
     containerd config default > /etc/containerd/config.toml
 
     sed -i 's/systemd_cgroup = false/systemd_cgroup = true/' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
 }

--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -37,6 +37,7 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -37,6 +37,7 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -37,6 +37,7 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -37,6 +37,7 @@ function containerd_configure() {
 
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true


### PR DESCRIPTION
Info logging emits 5 lines for every exec probe, which can get very verbose. Change the default to `warn`.

Resolves #1107.