### PR TITLE
Secure openebs installation

### DIFF
--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -22,6 +22,7 @@ function openebs() {
     cp "$src/operator.yaml" "$dst/"
     cp "$src/snapshot-operator.yaml" "$dst/"
 
+    secure_openebs
     # Identify if upgrade batch jobs are needed and apply them.
     openebs_do_upgrade
 
@@ -92,9 +93,16 @@ function openebs() {
 }
 
 function openebs_join() {
+    secure_openebs
+
     if [ "$OPENEBS_CSTOR" = "1" ]; then
         openebs_iscsi
     fi
+}
+
+function secure_openebs() {
+    mkdir -p /var/openebs
+    chmod 700 /var/openebs
 }
 
 function openebs_iscsi() {

--- a/addons/openebs/1.12.0/install.sh
+++ b/addons/openebs/1.12.0/install.sh
@@ -92,7 +92,9 @@ function openebs() {
 }
 
 function openebs_join() {
-    openebs_iscsi
+    if [ "$OPENEBS_CSTOR" = "1" ]; then
+        openebs_iscsi
+    fi
 }
 
 function openebs_iscsi() {

--- a/addons/openebs/1.6.0/install.sh
+++ b/addons/openebs/1.6.0/install.sh
@@ -88,7 +88,9 @@ function openebs() {
 }
 
 function openebs_join() {
-    openebs_iscsi
+    if [ "$OPENEBS_CSTOR" = "1" ]; then
+        openebs_iscsi
+    fi
 }
 
 function openebs_iscsi() {

--- a/addons/openebs/1.6.0/install.sh
+++ b/addons/openebs/1.6.0/install.sh
@@ -21,6 +21,8 @@ function openebs() {
     render_yaml_file "$src/tmpl-namespace.yaml" > "$dst/namespace.yaml"
     cp "$src/operator.yaml" "$dst/"
 
+    secure_openebs
+
     if [ "$OPENEBS_LOCALPV" = "1" ]; then
         cp "$src/localpv-provisioner.yaml" "$dst/"
         insert_resources "$dst/kustomization.yaml" localpv-provisioner.yaml
@@ -88,9 +90,16 @@ function openebs() {
 }
 
 function openebs_join() {
+    secure_openebs
+
     if [ "$OPENEBS_CSTOR" = "1" ]; then
         openebs_iscsi
     fi
+}
+
+function secure_openebs() {
+    mkdir -p /var/openebs
+    chmod 700 /var/openebs
 }
 
 function openebs_iscsi() {

--- a/addons/openebs/2.6.0/install.sh
+++ b/addons/openebs/2.6.0/install.sh
@@ -90,7 +90,9 @@ function openebs() {
 }
 
 function openebs_join() {
-    openebs_iscsi
+    if [ "$OPENEBS_CSTOR" = "1" ]; then
+        openebs_iscsi
+    fi
 }
 
 function openebs_iscsi() {

--- a/addons/openebs/2.6.0/install.sh
+++ b/addons/openebs/2.6.0/install.sh
@@ -21,6 +21,7 @@ function openebs() {
     render_yaml_file "$src/tmpl-namespace.yaml" > "$dst/namespace.yaml"
     cp "$src/operator.yaml" "$dst/"
 
+    secure_openebs
     openebs_spc_cspc_migration
 
     if [ "$OPENEBS_CSTOR" = "1" ]; then
@@ -90,9 +91,16 @@ function openebs() {
 }
 
 function openebs_join() {
+    secure_openebs
+
     if [ "$OPENEBS_CSTOR" = "1" ]; then
         openebs_iscsi
     fi
+}
+
+function secure_openebs() {
+    mkdir -p /var/openebs
+    chmod 700 /var/openebs
 }
 
 function openebs_iscsi() {


### PR DESCRIPTION
`chmod 700 /var/openebs` to ensure that non-root users are unable to access OpenEBS-related mountpoints. This shouldn't impede operation as the container runtime runs as root. Ensures the directory exists before modifying as it's normally created by Kubelet when mounting hostPaths.

On the primary install, iscsi is only setup when using cstor. Do the same for joining new nodes.