### PR TITLE
Host preflights for port availability

### DIFF
--- a/addons/prometheus/0.33.0/host-preflight.yaml
+++ b/addons/prometheus/0.33.0/host-preflight.yaml
@@ -1,0 +1,34 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: prometheus
+spec:
+  collectors:
+    - tcpPortStatus:
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        port: 9100
+        exclude: '{{ .IsUpgrade }}'
+
+  analyzers:
+    - tcpPortStatus:
+        checkName: "Node Exporter Metrics Server TCP Port Status"
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 9100 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 9100.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 9100. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 9100 is available
+          - warn:
+              message: Unexpected port status

--- a/addons/prometheus/0.33.0/install.sh
+++ b/addons/prometheus/0.33.0/install.sh
@@ -115,3 +115,8 @@ EOF
 EOF
     fi
 }
+
+function prometheus_preflight() {
+    local src="${DIR}/addons/prometheus/${PROMETHEUS_VERSION}"
+    echo "${src}/host-preflight.yaml"
+}

--- a/addons/prometheus/0.44.1/host-preflight.yaml
+++ b/addons/prometheus/0.44.1/host-preflight.yaml
@@ -1,0 +1,34 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: prometheus
+spec:
+  collectors:
+    - tcpPortStatus:
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        port: 9100
+        exclude: '{{ .IsUpgrade }}'
+
+  analyzers:
+    - tcpPortStatus:
+        checkName: "Node Exporter Metrics Server TCP Port Status"
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 9100 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 9100.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 9100. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 9100 is available
+          - warn:
+              message: Unexpected port status

--- a/addons/prometheus/0.44.1/install.sh
+++ b/addons/prometheus/0.44.1/install.sh
@@ -119,3 +119,8 @@ EOF
 EOF
     fi
 }
+
+function prometheus_preflight() {
+    local src="${DIR}/addons/prometheus/${PROMETHEUS_VERSION}"
+    echo "${src}/host-preflight.yaml"
+}

--- a/addons/prometheus/0.46.0/host-preflight.yaml
+++ b/addons/prometheus/0.46.0/host-preflight.yaml
@@ -1,0 +1,34 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: prometheus
+spec:
+  collectors:
+    - tcpPortStatus:
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        port: 9100
+        exclude: '{{ .IsUpgrade }}'
+
+  analyzers:
+    - tcpPortStatus:
+        checkName: "Node Exporter Metrics Server TCP Port Status"
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 9100 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 9100.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 9100. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 9100 is available
+          - warn:
+              message: Unexpected port status

--- a/addons/prometheus/0.46.0/install.sh
+++ b/addons/prometheus/0.46.0/install.sh
@@ -90,3 +90,8 @@ function prometheus_rook_ceph() {
             insert_resources "$dst/kustomization.yaml" rook-ceph-rolebindings.yaml
     fi
 }
+
+function prometheus_preflight() {
+    local src="${DIR}/addons/prometheus/${PROMETHEUS_VERSION}"
+    echo "${src}/host-preflight.yaml"
+}

--- a/addons/prometheus/template/base/host-preflight.yaml
+++ b/addons/prometheus/template/base/host-preflight.yaml
@@ -1,0 +1,34 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: prometheus
+spec:
+  collectors:
+    - tcpPortStatus:
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        port: 9100
+        exclude: '{{ .IsUpgrade }}'
+
+  analyzers:
+    - tcpPortStatus:
+        checkName: "Node Exporter Metrics Server TCP Port Status"
+        collectorName: "Node Exporter Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 9100 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 9100.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 9100. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 9100 is available
+          - warn:
+              message: Unexpected port status

--- a/addons/prometheus/template/base/install.sh
+++ b/addons/prometheus/template/base/install.sh
@@ -90,3 +90,8 @@ function prometheus_rook_ceph() {
             insert_resources "$dst/kustomization.yaml" rook-ceph-rolebindings.yaml
     fi
 }
+
+function prometheus_preflight() {
+    local src="${DIR}/addons/prometheus/${PROMETHEUS_VERSION}"
+    echo "${src}/host-preflight.yaml"
+}

--- a/addons/weave/2.5.2/host-preflight.yaml
+++ b/addons/weave/2.5.2/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/addons/weave/2.6.4/host-preflight.yaml
+++ b/addons/weave/2.6.4/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/addons/weave/2.6.5/host-preflight.yaml
+++ b/addons/weave/2.6.5/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/addons/weave/2.7.0/host-preflight.yaml
+++ b/addons/weave/2.7.0/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/addons/weave/2.8.1/host-preflight.yaml
+++ b/addons/weave/2.8.1/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/addons/weave/template/base/host-preflight.yaml
+++ b/addons/weave/template/base/host-preflight.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   collectors:
     - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{ .IsUpgrade }}'
+    - tcpPortStatus:
         collectorName: "Weave Net Control TCP Port Status"
         port: 6783
         exclude: '{{ .IsUpgrade }}'
@@ -18,6 +26,50 @@ spec:
 {{- end}}
 
   analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6781. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{ .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6782. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+          - warn:
+              message: Unexpected port status
     - tcpPortStatus:
         checkName: "Weave Net Control TCP Port Status"
         collectorName: "Weave Net Control TCP Port Status"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -34,9 +34,29 @@ spec:
         port: 2380
         exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
     - tcpPortStatus:
+        collectorName: "ETCD Health Server TCP Port Status"
+        port: 2381
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        interface: lo
+    - tcpPortStatus:
+        collectorName: "Kubelet Health Server TCP Port Status"
+        port: 10248
+        exclude: '{{ and (not .IsUpgrade) | not }}'
+        interface: lo
+    - tcpPortStatus:
         collectorName: "Kubelet API TCP Port Status"
         port: 10250
         exclude: '{{ and (not .IsUpgrade) | not }}'
+    - tcpPortStatus:
+        collectorName: "Kube Controller Manager Health Server TCP Port Status"
+        port: 10257
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        interface: lo
+    - tcpPortStatus:
+        collectorName: "Kube Scheduler Health Server TCP Port Status"
+        port: 10259
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        interface: lo
     - tcpConnect:
         collectorName: "Kubernetes API TCP Connection Status"
         address: '{{ .Installer.Spec.Kubernetes.MasterAddress }}'
@@ -185,6 +205,50 @@ spec:
           - warn:
               message: Unexpected port status
     - tcpPortStatus:
+        checkName: "ETCD Health Server TCP Port Status"
+        collectorName: "ETCD Health Server TCP Port Status"
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 2381 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 2381.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 2381. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 2381 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Kubelet Health Server TCP Port Status"
+        collectorName: "Kubelet Health Server TCP Port Status"
+        exclude: '{{ and (not .IsUpgrade) | not }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 10248 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 10248.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 10248. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 10248 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
         checkName: "Kubelet API TCP Port Status"
         collectorName: "Kubelet API TCP Port Status"
         exclude: '{{ and (not .IsUpgrade) | not }}'
@@ -204,6 +268,50 @@ spec:
           - pass:
               when: "connected"
               message: Port 10250 is open
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Kube Controller Manager Health Server TCP Port Status"
+        collectorName: "Kube Controller Manager Health Server TCP Port Status"
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 10257 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 10257.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 10257. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 10257 is available
+          - warn:
+              message: Unexpected port status
+    - tcpPortStatus:
+        checkName: "Kube Scheduler Health Server TCP Port Status"
+        collectorName: "Kube Scheduler Health Server TCP Port Status"
+        exclude: '{{ and .IsPrimary (not .IsUpgrade) | not }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 10259 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 10259.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 10259. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 10259 is available
           - warn:
               message: Unexpected port status
     - tcpConnect:


### PR DESCRIPTION
Add host preflights for ports 2381, 10248, 10257 and 10259 since cluster
components have healthz endpoints on those ports.

Add host preflight for 6781 abd 6782 since Weave crashes when
unavailable.

Add host preflight for 9100 since node exporter in Prometheus crashes
when unavailable.

No host preflight added for 10249 because kube-proxy continues to
function when unavailable.