### PR TITLE
Include sonobuoy quick mode images in conformance package

### DIFF
--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -33,6 +33,8 @@ while read -r line; do
     fi
     kind=$(echo $line | awk '{ print $1 }')
 
+    echo "LINE $line"
+
     case "$kind" in
         image)
             filename=$(echo $line | awk '{ print $2 }')

--- a/packages/kubernetes/1.17.13/Manifest
+++ b/packages/kubernetes/1.17.13/Manifest
@@ -1,10 +1,10 @@
 image kube-apiserver k8s.gcr.io/kube-apiserver:v1.17.13
 image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.17.13
-image kubes-cheduler k8s.gcr.io/kube-scheduler:v1.17.13
+image kube-scheduler k8s.gcr.io/kube-scheduler:v1.17.13
 image kube-proxy k8s.gcr.io/kube-proxy:v1.17.13
 image pause k8s.gcr.io/pause:3.1
-image coredns k8s.gcr.io/coredns:1.6.5
 image etcd k8s.gcr.io/etcd:3.4.3-0
+image coredns k8s.gcr.io/coredns:1.6.5
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.17.13/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.17.13/conformance/Manifest
+++ b/packages/kubernetes/1.17.13/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.17.13
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.17.13/conformance/Manifest
+++ b/packages/kubernetes/1.17.13/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.17.13
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.17.3/Manifest
+++ b/packages/kubernetes/1.17.3/Manifest
@@ -1,10 +1,10 @@
 image kube-apiserver k8s.gcr.io/kube-apiserver:v1.17.3
 image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.17.3
-image kubes-cheduler k8s.gcr.io/kube-scheduler:v1.17.3
+image kube-scheduler k8s.gcr.io/kube-scheduler:v1.17.3
 image kube-proxy k8s.gcr.io/kube-proxy:v1.17.3
 image pause k8s.gcr.io/pause:3.1
-image coredns k8s.gcr.io/coredns:1.6.5
 image etcd k8s.gcr.io/etcd:3.4.3-0
+image coredns k8s.gcr.io/coredns:1.6.5
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.17.3/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.17.3/conformance/Manifest
+++ b/packages/kubernetes/1.17.3/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.17.3
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.17.3/conformance/Manifest
+++ b/packages/kubernetes/1.17.3/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.17.3
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.17.7/Manifest
+++ b/packages/kubernetes/1.17.7/Manifest
@@ -1,10 +1,10 @@
 image kube-apiserver k8s.gcr.io/kube-apiserver:v1.17.7
 image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.17.7
-image kubes-cheduler k8s.gcr.io/kube-scheduler:v1.17.7
+image kube-scheduler k8s.gcr.io/kube-scheduler:v1.17.7
 image kube-proxy k8s.gcr.io/kube-proxy:v1.17.7
 image pause k8s.gcr.io/pause:3.1
-image coredns k8s.gcr.io/coredns:1.6.5
 image etcd k8s.gcr.io/etcd:3.4.3-0
+image coredns k8s.gcr.io/coredns:1.6.5
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.17.7/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.17.7/conformance/Manifest
+++ b/packages/kubernetes/1.17.7/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.17.7
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.17.7/conformance/Manifest
+++ b/packages/kubernetes/1.17.7/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.17.7
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.10/conformance/Manifest
+++ b/packages/kubernetes/1.18.10/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.18.10
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.10/conformance/Manifest
+++ b/packages/kubernetes/1.18.10/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.18.10
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.17/conformance/Manifest
+++ b/packages/kubernetes/1.18.17/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.18.17
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.17/conformance/Manifest
+++ b/packages/kubernetes/1.18.17/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.18.17
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.4/Manifest
+++ b/packages/kubernetes/1.18.4/Manifest
@@ -1,10 +1,10 @@
 image kube-apiserver k8s.gcr.io/kube-apiserver:v1.18.4
 image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.18.4
-image kubes-cheduler k8s.gcr.io/kube-scheduler:v1.18.4
+image kube-scheduler k8s.gcr.io/kube-scheduler:v1.18.4
 image kube-proxy k8s.gcr.io/kube-proxy:v1.18.4
 image pause k8s.gcr.io/pause:3.2
-image coredns k8s.gcr.io/coredns:1.6.7
 image etcd k8s.gcr.io/etcd:3.4.3-0
+image coredns k8s.gcr.io/coredns:1.6.7
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.18.4/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.18.4/conformance/Manifest
+++ b/packages/kubernetes/1.18.4/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.18.4
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.4/conformance/Manifest
+++ b/packages/kubernetes/1.18.4/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.18.4
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.9/conformance/Manifest
+++ b/packages/kubernetes/1.18.9/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.18.9
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.18.9/conformance/Manifest
+++ b/packages/kubernetes/1.18.9/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.18.9
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.2/Manifest
+++ b/packages/kubernetes/1.19.2/Manifest
@@ -3,8 +3,8 @@ image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.19.2
 image kube-scheduler k8s.gcr.io/kube-scheduler:v1.19.2
 image kube-proxy k8s.gcr.io/kube-proxy:v1.19.2
 image pause k8s.gcr.io/pause:3.2
-image coredns k8s.gcr.io/etcd:3.4.13-0
-image etcd k8s.gcr.io/coredns:1.7.0
+image etcd k8s.gcr.io/etcd:3.4.13-0
+image coredns k8s.gcr.io/coredns:1.7.0
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.19.2/conformance/Manifest
+++ b/packages/kubernetes/1.19.2/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.19.2
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.2/conformance/Manifest
+++ b/packages/kubernetes/1.19.2/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.19.2
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.3/Manifest
+++ b/packages/kubernetes/1.19.3/Manifest
@@ -3,8 +3,8 @@ image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.19.3
 image kube-scheduler k8s.gcr.io/kube-scheduler:v1.19.3
 image kube-proxy k8s.gcr.io/kube-proxy:v1.19.3
 image pause k8s.gcr.io/pause:3.2
-image coredns k8s.gcr.io/etcd:3.4.13-0
-image etcd k8s.gcr.io/coredns:1.7.0
+image etcd k8s.gcr.io/etcd:3.4.13-0
+image coredns k8s.gcr.io/coredns:1.7.0
 
 asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubeadm
 asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz

--- a/packages/kubernetes/1.19.3/conformance/Manifest
+++ b/packages/kubernetes/1.19.3/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.19.3
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.3/conformance/Manifest
+++ b/packages/kubernetes/1.19.3/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.19.3
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.7/conformance/Manifest
+++ b/packages/kubernetes/1.19.7/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.19.7
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.7/conformance/Manifest
+++ b/packages/kubernetes/1.19.7/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.19.7
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.9/conformance/Manifest
+++ b/packages/kubernetes/1.19.9/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.19.9
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.19.9/conformance/Manifest
+++ b/packages/kubernetes/1.19.9/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.19.9
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.0/conformance/Manifest
+++ b/packages/kubernetes/1.20.0/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.20.0
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.0/conformance/Manifest
+++ b/packages/kubernetes/1.20.0/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.20.0
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.1/conformance/Manifest
+++ b/packages/kubernetes/1.20.1/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.20.1
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.1/conformance/Manifest
+++ b/packages/kubernetes/1.20.1/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.20.1
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.2/conformance/Manifest
+++ b/packages/kubernetes/1.20.2/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.20.2
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.2/conformance/Manifest
+++ b/packages/kubernetes/1.20.2/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.20.2
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.4/conformance/Manifest
+++ b/packages/kubernetes/1.20.4/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.20.4
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.4/conformance/Manifest
+++ b/packages/kubernetes/1.20.4/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.20.4
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.5/conformance/Manifest
+++ b/packages/kubernetes/1.20.5/conformance/Manifest
@@ -1,1 +1,1 @@
-image conformance k8s.gcr.io/conformance:v1.20.5
+image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/1.20.5/conformance/Manifest
+++ b/packages/kubernetes/1.20.5/conformance/Manifest
@@ -1,1 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.20.5
 image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -65,7 +65,7 @@ function generate_conformance_package() {
     echo "image conformance k8s.gcr.io/conformance:v${version}" > "../$version/conformance/Manifest"
 
     # image required for sonobuoy --mode=quick
-    echo "image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine" > "../$version/conformance/Manifest"
+    echo "image nginx-1.14-alpine docker.io/library/nginx:1.14-alpine" >> "../$version/conformance/Manifest"
 
     # NOTE: full conformance suite images are not yet included in this package
     # local tmpdir=


### PR DESCRIPTION
This will add conformance images for running sonobuoy e2e tests in quick mode. This will not include all images as this adds about 4GB to the conformance package. All kubernetes conformance packages 1.17+ have been regenerated.