### PR TITLE
Feature(velero) Velero 1.6.0 support

### DIFF
--- a/addons/velero/1.6.0/Manifest
+++ b/addons/velero/1.6.0/Manifest
@@ -1,0 +1,7 @@
+image velero velero/velero:v1.6.0
+image restic-restore velero/velero-restic-restore-helper:v1.6.0
+image velero-aws velero/velero-plugin-for-aws:v1.2.0
+image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
+image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
+
+asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.0/velero-v1.6.0-linux-amd64.tar.gz

--- a/addons/velero/1.6.0/install.sh
+++ b/addons/velero/1.6.0/install.sh
@@ -51,7 +51,7 @@ function velero_install() {
     $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install \
         $resticArg \
         $bslArgs \
-        --plugins velero/velero-plugin-for-aws:v1.1.0,velero/velero-plugin-for-gcp:v1.1.0,velero/velero-plugin-for-microsoft-azure:v1.1.0 \
+        --plugins velero/velero-plugin-for-aws:v1.2.0,velero/velero-plugin-for-gcp:v1.2.0,velero/velero-plugin-for-microsoft-azure:v1.2.0 \
         --secret-file velero-credentials \
         --use-volume-snapshots=false \
         --namespace $VELERO_NAMESPACE \

--- a/addons/velero/1.6.0/kustomization.yaml
+++ b/addons/velero/1.6.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - velero.yaml

--- a/addons/velero/1.6.0/restic-daemonset-privileged.yaml
+++ b/addons/velero/1.6.0/restic-daemonset-privileged.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+  namespace: $VELERO_NAMESPACE
+spec:
+  template:
+    spec:
+      containers:
+        - name: restic
+          securityContext:
+            privileged: true

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -1,7 +1,7 @@
 image velero velero/velero:v__VELERO_VERSION__
 image restic-restore velero/velero-restic-restore-helper:v__VELERO_VERSION__
-image velero-aws velero/velero-plugin-for-aws:v1.1.0
-image velero-gcp velero/velero-plugin-for-gcp:v1.1.0
-image velero-azure velero/velero-plugin-for-microsoft-azure:v1.1.0
+image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
+image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
+image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v__VELERO_VERSION__/velero-v__VELERO_VERSION__-linux-amd64.tar.gz

--- a/addons/velero/template/base/install.sh.tmpl
+++ b/addons/velero/template/base/install.sh.tmpl
@@ -1,0 +1,115 @@
+
+function velero_pre_init() {
+    if [ -z "$VELERO_NAMESPACE" ]; then
+        VELERO_NAMESPACE=velero
+    fi
+    if [ -z "$VELERO_LOCAL_BUCKET" ]; then
+        VELERO_LOCAL_BUCKET=velero
+    fi
+}
+
+function velero() {
+    local src="$DIR/addons/velero/$VELERO_VERSION"
+    local dst="$DIR/kustomize/velero"
+
+    cp "$src/kustomization.yaml" "$dst/"
+
+    velero_binary
+
+    velero_install "$src" "$dst"
+
+    velero_patch_restic_privilege "$src" "$dst"
+
+    kubectl apply -k "$dst"
+
+    kubectl label -n default --overwrite service/kubernetes velero.io/exclude-from-backup=true
+}
+
+function velero_join() {
+    velero_binary
+}
+
+function velero_install() {
+    local src="$1"
+    local dst="$2"
+
+    # Pre-apply CRDs since kustomize reorders resources. Grep to strip out sailboat emoji.
+    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
+
+    local resticArg="--use-restic"
+    if [ "$VELERO_DISABLE_RESTIC" = "1" ]; then
+        resticArg=""
+    fi
+
+    local bslArgs="--no-default-backup-location"
+    if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
+        bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
+    fi
+
+    velero_credentials
+
+    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install \
+        $resticArg \
+        $bslArgs \
+        --plugins velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__,velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__,velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__ \
+        --secret-file velero-credentials \
+        --use-volume-snapshots=false \
+        --namespace $VELERO_NAMESPACE \
+        --dry-run -o yaml > "$dst/velero.yaml"
+
+    rm velero-credentials
+}
+
+# The --secret-file flag must always be used so that the generated velero deployment uses the
+# cloud-credentials secret. Use the contents of that secret if it exists to avoid overwriting
+# any changes. Else if a local object store (Ceph/Minio) is configured, use its credentials.
+function velero_credentials() {
+   if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
+       kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
+       return 0
+    fi
+
+    if [ -n "$OBJECT_STORE_CLUSTER_IP" ]; then
+        try_1m object_store_create_bucket "$VELERO_LOCAL_BUCKET"
+    fi
+
+    cat >velero-credentials <<EOF
+[default]
+aws_access_key_id=$OBJECT_STORE_ACCESS_KEY
+aws_secret_access_key=$OBJECT_STORE_SECRET_KEY
+EOF
+}
+
+function velero_patch_restic_privilege() {
+    local src="$1"
+    local dst="$2"
+
+    if [ "${VELERO_DISABLE_RESTIC}" = "1" ]; then
+        return 0
+    fi
+
+    if [ "${K8S_DISTRO}" = "rke2" ] || [ "${VELERO_RESTIC_REQUIRES_PRIVILEGED}" = "1" ]; then
+        render_yaml_file "$src/restic-daemonset-privileged.yaml" > "$dst/restic-daemonset-privileged.yaml"
+        insert_patches_strategic_merge "$dst/kustomization.yaml" restic-daemonset-privileged.yaml
+    fi
+}
+
+function velero_binary() {
+    local src="$DIR/addons/velero/$VELERO_VERSION"
+
+    if ! kubernetes_is_master; then
+        return 0
+    fi
+
+    if [ ! -f "$src/assets/velero.tar.gz" ] && [ "$AIRGAP" != "1" ]; then
+        mkdir -p "$src/assets"
+        curl -L "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" > "$src/assets/velero.tar.gz"
+    fi
+
+    pushd "$src/assets"
+    tar xf "velero.tar.gz"
+    if [ "$VELERO_DISABLE_CLI" != "1" ]; then
+        cp velero-v${VELERO_VERSION}-linux-amd64/velero /usr/local/bin/velero
+    fi
+    popd
+}

--- a/addons/velero/template/generate.sh
+++ b/addons/velero/template/generate.sh
@@ -2,28 +2,50 @@
 
 set -euo pipefail
 
-VERSION=""
 function get_latest_release_version() {
-    VERSION=$(curl -I https://github.com/vmware-tanzu/velero/releases/latest | \
+    VAR_NAME=$1 
+    local url=$2 
+    local version
+
+    version=$(curl -I "$url" | \
         grep -i "^location" | \
         grep -Eo "1\.[0-9]+\.[0-9]+")
+
+    declare -g "$VAR_NAME=$version"
 }
 
 function generate() {
-    mkdir -p "../${VERSION}"
-    cp -r ./base/* "../${VERSION}"
+    mkdir -p "../${VELERO_VERSION}"
+    cp -r ./base/* "../${VELERO_VERSION}"
 
-    sed -i "s/__VELERO_VERSION__/$VERSION/g" "../$VERSION/Manifest"
+    sed -i "s/__VELERO_VERSION__/$VELERO_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
+    sed -i "s/__AWS_PLUGIN_VERSION__/$AWS_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
+    sed -i "s/__AZURE_PLUGIN_VERSION__/$AZURE_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
+    sed -i "s/__GCP_PLUGIN_VERSION__/$GCP_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
+    mv "../$VELERO_VERSION/Manifest.tmpl" "../$VELERO_VERSION/Manifest"
+
+    sed -i "s/__AWS_PLUGIN_VERSION__/$AWS_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
+    sed -i "s/__AZURE_PLUGIN_VERSION__/$AZURE_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
+    sed -i "s/__GCP_PLUGIN_VERSION__/$GCP_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
+    mv "../$VELERO_VERSION/install.sh.tmpl" "../$VELERO_VERSION/install.sh"
 }
 
 function add_as_latest() {
-    sed -i "/cron-velero-update/a\    \"${VERSION}\"\," ../../../web/src/installers/versions.js
+    sed -i "/cron-velero-update/a\    \"${VELERO_VERSION}\"\," ../../../web/src/installers/versions.js
 }
 
+VELERO_VERSION=""
+AWS_PLUGIN_VERSION=""
+AZURE_PLUGIN_VERSION=""
+GCP_PLUGIN_VERSION=""
 function main() {
-    get_latest_release_version
+    get_latest_release_version VELERO_VERSION https://github.com/vmware-tanzu/velero/releases/latest 
 
-    if [ -d "../${VERSION}" ]; then
+    get_latest_release_version AWS_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-aws/releases/latest 
+    get_latest_release_version AZURE_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/latest 
+    get_latest_release_version GCP_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/latest 
+
+    if [ -d "../${VELERO_VERSION}" ]; then
         exit 0
     fi
 
@@ -31,7 +53,7 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=velero_version::$VERSION"
+    echo "::set-output name=velero_version::$VELERO_VERSION"
 }
 
 main "$@"

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -178,6 +178,7 @@ module.exports.InstallerVersions = {
   ],
   velero: [
     // cron-velero-update
+    "1.6.0",
     "1.5.4",
     "1.5.3",
     "1.5.1",


### PR DESCRIPTION
Adds Velero 1.6 support, same as #1455, as well as automation for pulling in the latest Velero plugins.

Tested this out with kots 1.38 and it works well. Full and partial snapshots work, but the Snapshot settings screen needs to be updated as the plugin names have changes.