### PR TITLE
Tgrun queue airgap flag

### DIFF
--- a/testgrid/tgrun/pkg/cli/run/queue.go
+++ b/testgrid/tgrun/pkg/cli/run/queue.go
@@ -25,6 +25,7 @@ func QueueCmd() *cobra.Command {
 				OverwriteRef: v.GetBool("overwrite-ref"),
 				Ref:          v.GetString("ref"),
 				Staging:      v.GetBool("staging"),
+				Airgap:       v.GetBool("airgap"),
 				LatestOnly:   v.GetBool("latest-only"),
 				Spec:         v.GetString("spec"),
 			}
@@ -40,6 +41,7 @@ func QueueCmd() *cobra.Command {
 	cmd.Flags().String("ref", "", "ref to report to testgrid")
 	cmd.Flags().Bool("overwrite-ref", false, "when set, overwrite the ref on the testgrid")
 	cmd.Flags().Bool("staging", false, "when set, run tests against staging.kurl.sh instead of kurl.sh")
+	cmd.Flags().Bool("airgap", false, "when set, run tests in airgapped mode")
 	cmd.Flags().Bool("latest-only", false, "when set, run tests against the 'latest' kurl installer only instead of the standard suite")
 	cmd.Flags().String("spec", "", "when set, runs test against the provided installer spec yaml")
 

--- a/testgrid/tgrun/pkg/scheduler/scheduler.go
+++ b/testgrid/tgrun/pkg/scheduler/scheduler.go
@@ -128,7 +128,7 @@ func Run(schedulerOptions types.SchedulerOptions) error {
 			return fmt.Errorf("error getting kurl spec url: %s", errMsg.Error.Message)
 		}
 
-		if instance.InstallerSpec.RunAirgap {
+		if instance.InstallerSpec.RunAirgap || schedulerOptions.Airgap {
 			installerURLString, err := bundleFromURL(string(installerURL))
 			if err != nil {
 				return errors.Wrapf(err, "generate airgap url from installer url %s", installerURL)

--- a/testgrid/tgrun/pkg/scheduler/types/types.go
+++ b/testgrid/tgrun/pkg/scheduler/types/types.go
@@ -11,6 +11,7 @@ type SchedulerOptions struct {
 	OverwriteRef bool
 	Ref          string
 	Staging      bool
+	Airgap       bool
 	LatestOnly   bool
 	Spec         string
 }


### PR DESCRIPTION
Added a `--airgap` flag to the tgrun queue command to run tests in airgap mode.