### PR TITLE
Rendering manifest installer yaml should not strip quotes when only integers

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "cors": "^2.8.1",
     "express": "^4.14.0",
     "express-rate-limit": "^2.11.0",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^4.0.0",
     "jsonwebtoken": "^8.5.1",
     "monkit": "^0.4.0",
     "newrelic": "^5.7.0",

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -739,7 +739,7 @@ export class Installer {
 
   // returned installer must be validated before use
   public static parse(doc: string, teamID?: string): Installer {
-    const parsed = yaml.safeLoad(doc);
+    const parsed = yaml.load(doc);
 
     const i = new Installer(teamID);
     i.id = _.get(parsed, "metadata.name", "");
@@ -978,7 +978,7 @@ export class Installer {
   }
 
   public toYAML(): string {
-    return yaml.safeDump(this.toObject());
+    return yaml.dump(this.toObject());
   }
 
   public toObject(): InstallerObject {

--- a/web/src/test/services/templates.ts
+++ b/web/src/test/services/templates.ts
@@ -51,6 +51,6 @@ spec:
     const installer = Installer.parse(yaml);
 
     const manifest = manifestFromInstaller(installer, "KURL_URL", "APP_URL", "DIST_URL", "UTIL_IMAGE", "BINUTILS_IMAGE");
-    expect(manifest.INSTALLER_YAML).to.equal(yaml);
+    expect(manifest.INSTALLER_YAML).to.contain(`name: '0668700'`);
   });
 });

--- a/web/src/test/services/templates.ts
+++ b/web/src/test/services/templates.ts
@@ -1,7 +1,8 @@
 import {describe, it} from "mocha";
 import {expect} from "chai";
-import { bashStringEscape } from "../../util/services/templates";
+import { bashStringEscape, manifestFromInstaller } from "../../util/services/templates";
 import * as _ from "lodash";
+import { Installer } from "../../installers";
 
 
 describe("Escape Bash Special Characters", () => {
@@ -24,4 +25,32 @@ daemonConfig: |
     expect(out).to.equal(singleQuotes);
   });
 
+});
+
+describe("When rendering installer yaml", () => {
+  it("does not strip double quotes from integers", () => {
+    const yaml = `apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: "0668700"
+spec:
+  kubernetes:
+    version: 1.19.9
+  docker:
+    version: 20.10.5
+  weave:
+    version: 2.6.5
+  rook:
+    isBlockStorageEnabled: true
+    version: 1.4.3
+  prometheus:
+    version: 0.46.0
+  sonobuoy:
+    version: 0.50.0
+`;
+    const installer = Installer.parse(yaml);
+
+    const manifest = manifestFromInstaller(installer, "KURL_URL", "APP_URL", "DIST_URL", "UTIL_IMAGE", "BINUTILS_IMAGE");
+    expect(manifest.INSTALLER_YAML).to.equal(yaml);
+  });
 });

--- a/web/src/util/services/templates.ts
+++ b/web/src/util/services/templates.ts
@@ -79,7 +79,7 @@ export function bashStringEscape( unescaped :string): string {
   return unescaped.replace(/[!"\\]/g, "\\\$&");
 }
 
-function manifestFromInstaller(i: Installer, kurlURL: string, replicatedAppURL: string, distURL: string, kurlUtilImage: string, kurlBinUtils: string): Manifest {
+export function manifestFromInstaller(i: Installer, kurlURL: string, replicatedAppURL: string, distURL: string, kurlUtilImage: string, kurlBinUtils: string): Manifest {
   return {
     KURL_URL: kurlURL,
     DIST_URL: distURL,

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -525,6 +525,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -3606,6 +3611,13 @@ js-yaml@3.13.1, js-yaml@^3.13.1, js-yaml@^3.8.4:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
This highlights the issue