### PR TITLE
Sonobuoy support for rke2 and k3s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,8 @@ dist/sonobuoy-%.tar.gz: build/addons
 	mkdir -p dist
 	tar cf - -C build addons/sonobuoy/$* | gzip > dist/sonobuoy-$*.tar.gz
 
-.PRECIOUS: dist/kubernetes-conformance-%.tar.gz
-dist/kubernetes-%.tar.gz: dist/kubernetes-conformance-%.tar.gz
+dist/kubernetes-%.tar.gz:
+	${MAKE} dist/kubernetes-conformance-$*.tar.gz
 	${MAKE} build/packages/kubernetes/$*/images
 	${MAKE} build/packages/kubernetes/$*/ubuntu-16.04
 	${MAKE} build/packages/kubernetes/$*/ubuntu-18.04
@@ -215,6 +215,7 @@ build/packages/kubernetes-conformance/%/images:
 	bin/save-manifest-assets.sh packages/kubernetes/$*/conformance/Manifest build/packages/kubernetes-conformance/$*
 
 dist/rke-2-%.tar.gz:
+	${MAKE} dist/kubernetes-conformance-$(shell echo "$*" | sed 's/^v\(.*\)-.*$$/\1/').tar.gz
 	${MAKE} build/packages/rke-2/$*/images
 	${MAKE} build/packages/rke-2/$*/rhel-7
 	${MAKE} build/packages/rke-2/$*/rhel-8
@@ -227,6 +228,7 @@ build/packages/rke-2/%/images:
 	bin/save-manifest-assets.sh packages/rke-2/$*/Manifest build/packages/rke-2/$*
 
 dist/k-3-s-%.tar.gz:
+	${MAKE} dist/kubernetes-conformance-$(shell echo "$*" | sed 's/^v\(.*\)-.*$$/\1/').tar.gz
 	${MAKE} build/packages/k-3-s/$*/images
 	${MAKE} build/packages/k-3-s/$*/rhel-7
 	${MAKE} build/packages/k-3-s/$*/rhel-8

--- a/scripts/common/k3s.sh
+++ b/scripts/common/k3s.sh
@@ -177,12 +177,16 @@ function k3s_install() {
     # TODO(ethan): is this still necessary?
     # kubernetes_sysctl_config
 
+    local k8s_semver=
+    k8s_semver="$(echo "${k3s_version}" | sed 's/^v\(.*\)-.*$/\1/')"
+
     # For online always download the k3s.tar.gz bundle.
     # Regardless if host packages are already installed, we always inspect for newer versions
     # and/or re-install any missing or corrupted packages.
     # TODO(ethan): is this comment correct?
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         k3s_get_host_packages_online "${k3s_version}"
+        kubernetes_get_conformance_packages_online "${k8s_semver}"
     fi
 
     k3s_configure
@@ -214,6 +218,10 @@ function k3s_install() {
     while [ ! -f /etc/rancher/k3s/k3s.yaml ]; do
         sleep 2
     done
+
+    if [ -d "$DIR/packages/kubernetes-conformance/${k8s_semver}/images" ]; then
+        load_images "$DIR/packages/kubernetes-conformance/${k8s_semver}/images"
+    fi
 
     logStep "Waiting for Kubernetes"
     # Extending timeout to 5 min based on performance on clean machines.

--- a/scripts/distro/k3s/distro.sh
+++ b/scripts/distro/k3s/distro.sh
@@ -52,6 +52,7 @@ function k3s_addon_for_each() {
     $cmd ekco "$EKCO_VERSION" "$EKCO_S3_OVERRIDE"
     $cmd collectd "$COLLECTD_VERSION" "$COLLECTD_S3_OVERRIDE"
     $cmd cert-manager "$CERT_MANAGER_VERSION" "$CERT_MANAGER_S3_OVERRIDE"
+    $cmd sonobuoy "$SONOBUOY_VERSION" "$SONOBUOY_S3_OVERRIDE"
 }
 
 function k3s_reset() {

--- a/scripts/distro/rke2/distro.sh
+++ b/scripts/distro/rke2/distro.sh
@@ -53,6 +53,7 @@ function rke2_addon_for_each() {
     $cmd ekco "$EKCO_VERSION" "$EKCO_S3_OVERRIDE"
     $cmd collectd "$COLLECTD_VERSION" "$COLLECTD_S3_OVERRIDE"
     $cmd cert-manager "$CERT_MANAGER_VERSION" "$CERT_MANAGER_S3_OVERRIDE"
+    $cmd sonobuoy "$SONOBUOY_VERSION" "$SONOBUOY_S3_OVERRIDE"
 }
 
 function rke2_reset() {

--- a/testgrid/tgrun/pkg/scheduler/scheduler.go
+++ b/testgrid/tgrun/pkg/scheduler/scheduler.go
@@ -91,6 +91,14 @@ func Run(schedulerOptions types.SchedulerOptions) error {
 		var upgradeYAML, upgradeURL []byte
 		if instance.UpgradeSpec != nil {
 			installer.Spec = *instance.UpgradeSpec
+
+			// append sonobuoy for conformance testing
+			if installer.Spec.Sonobuoy == nil {
+				installer.Spec.Sonobuoy = &kurlv1beta1.Sonobuoy{
+					Version: "latest",
+				}
+			}
+
 			upgradeYAML, err = json.Marshal(installer)
 			if err != nil {
 				return errors.Wrap(err, "failed to marshal upgrade json")

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1147,13 +1147,16 @@ export class Installer {
           const prevMinor = semver.minor(version) - 1;
           const step = Installer.latestMinors()[prevMinor];
           pkgs.push(`${config}-${step}`);
+        } else if (config === "rke2") {
+          kubernetesVersion = version;
+        } else if (config === "k3s") {
+          kubernetesVersion = version;
         }
       }
     });
 
     // include conformance package if sonobuoy and kubernetes
     // we only build conformance packages for 1.17.0+
-    // TODO: rke2 and k3s
     if (kubernetesVersion && semver.gte(kubernetesVersion, "1.17.0") && _.get(this.spec, "sonobuoy.version")) {
       pkgs.push(`kubernetes-conformance-${kubernetesVersion.replace(special, '-')}`);
     }


### PR DESCRIPTION
1. Build kubernetes conformance packages when building k3s and rke2 packages
2. Add kubernetes conformance packages to k3s and rke2 bundles when sonobuoy is included.
3. Install sonobuoy add-on when included in spec for both k3s and rke2 installers