### PR TITLE
install nf_conntrack and not nf_conntrack_ipv4 on OL8.3 like CentOS/RHEL8.3

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -29,7 +29,7 @@ function kubernetes_load_ipvs_modules() {
         return
     fi
 
-    if [ "$KERNEL_MAJOR" -gt "4" ] || ([ "$KERNEL_MAJOR" -eq "4" ] && [ "$KERNEL_MINOR" -ge "19" ]) || ([ "$LSB_DIST" = "rhel" ] && [ "$DIST_VERSION" = "8.3" ]) || ([ "$LSB_DIST" = "centos" ] && [ "$DIST_VERSION" = "8.3" ]); then
+    if [ "$KERNEL_MAJOR" -gt "4" ] || ([ "$KERNEL_MAJOR" -eq "4" ] && [ "$KERNEL_MINOR" -ge "19" ]) || ([ "$LSB_DIST" = "rhel" ] && [ "$DIST_VERSION" = "8.3" ]) || ([ "$LSB_DIST" = "centos" ] && [ "$DIST_VERSION" = "8.3" ]) || ([ "$LSB_DIST" = "ol" ] && [ "$DIST_VERSION" = "8.3" ]); then
         modprobe nf_conntrack
     else
         modprobe nf_conntrack_ipv4


### PR DESCRIPTION
The change from nf_conntrack_ipv4 to nf_conntrack happened in Linux 4.19 - _unless_ you're using a RHEL-based kernel, which backported that change to 4.18. Oracle Linux uses a RHEL-based kernel.