### PR TITLE
Do not include step version for upgrade on 1.16.4

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1146,7 +1146,9 @@ export class Installer {
           kubernetesVersion = version;
           const prevMinor = semver.minor(version) - 1;
           const step = Installer.latestMinors()[prevMinor];
-          pkgs.push(`${config}-${step}`);
+          if (step !== "0.0.0") {
+            pkgs.push(`${config}-${step}`);
+          }
         } else if (config === "rke2") {
           kubernetesVersion = version;
         } else if (config === "k3s") {

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -1058,6 +1058,21 @@ spec:
       });
       expect(hasConformance).to.equal(false);
     });
+
+    it("should not include removed Kubernetes versions", () => {
+      const i = Installer.parse(noConformance);
+      const pkgs = i.packages();
+
+      const hasKubernetes16 = _.some(pkgs, (pkg) => {
+        return pkg === "kubernetes-1.16.4";
+      });
+      expect(hasKubernetes16).to.equal(true);
+
+      const hasKubernetes000 = _.some(pkgs, (pkg) => {
+        return pkg === "kubernetes-0.0.0";
+      });
+      expect(hasKubernetes000).to.equal(false);
+    });
   });
 
   describe("kurl.nameserver", () => {


### PR DESCRIPTION
Airgap downloads were broken for specs with Kubernetes 1.16 because kurl
was attempting to include the package kubernetes-0.0.0 as the step
version for upgrading.