### PR TITLE
Validate Rook version with Kubernetes

### DIFF
--- a/addons/rook/1.0.4/install.sh
+++ b/addons/rook/1.0.4/install.sh
@@ -1,4 +1,10 @@
 
+function rook_pre_init() {
+    if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+        bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+    fi
+}
+
 function rook() {
     rook_lvm2
 

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -5,8 +5,12 @@ function rook_pre_init() {
     if [ -n "$version" ] && [ "$version" != "1.4.3" ]; then
         printf "Rook $version is already installed, will not upgrade to 1.4.3\n"
         export SKIP_ROOK_INSTALL='true'
+        if [ "$version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+            bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+        fi
     elif [ "$ROOK_BLOCK_STORAGE_ENABLED" != "1" ]; then
         bail "Rook 1.4.3 requires enabling block storage"
+
     fi
 }
 

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -6,11 +6,14 @@ function rook_pre_init() {
         printf "Rook $version is already installed, will not upgrade to 1.4.3\n"
         export SKIP_ROOK_INSTALL='true'
         if [ "$version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
-            bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+            KUBERNETES_UPGRADE="0"
+            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            parse_kubernetes_target_version
+            # There's no guarantee the packages from this version of Kubernetes are still available
+            SKIP_KUBERNETES_HOST=1
         fi
     elif [ "$ROOK_BLOCK_STORAGE_ENABLED" != "1" ]; then
         bail "Rook 1.4.3 requires enabling block storage"
-
     fi
 }
 

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -24,13 +24,16 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
+                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then
             echo "Rook ${current_version} is already installed, will not downgrade to ${ROOK_VERSION}"
             SKIP_ROOK_INSTALL=1
         fi
     fi
-    
+
     if [ -z "${SKIP_ROOK_INSTALL}" ] && [ "${ROOK_BLOCK_STORAGE_ENABLED}" != "1" ]; then
         bail "Rook ${ROOK_VERSION} requires enabling block storage"
     fi

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -24,8 +24,12 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
-                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
-                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    KUBERNETES_UPGRADE="0"
+                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    parse_kubernetes_target_version
+                    # There's no guarantee the packages from this version of Kubernetes are still available
+                    SKIP_KUBERNETES_HOST=1
                 fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -24,13 +24,16 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
+                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then
             echo "Rook ${current_version} is already installed, will not downgrade to ${ROOK_VERSION}"
             SKIP_ROOK_INSTALL=1
         fi
     fi
-    
+
     if [ -z "${SKIP_ROOK_INSTALL}" ] && [ "${ROOK_BLOCK_STORAGE_ENABLED}" != "1" ]; then
         bail "Rook ${ROOK_VERSION} requires enabling block storage"
     fi

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -24,8 +24,12 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
-                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
-                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    KUBERNETES_UPGRADE="0"
+                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    parse_kubernetes_target_version
+                    # There's no guarantee the packages from this version of Kubernetes are still available
+                    SKIP_KUBERNETES_HOST=1
                 fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -24,13 +24,16 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
+                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then
             echo "Rook ${current_version} is already installed, will not downgrade to ${ROOK_VERSION}"
             SKIP_ROOK_INSTALL=1
         fi
     fi
-    
+
     if [ -z "${SKIP_ROOK_INSTALL}" ] && [ "${ROOK_BLOCK_STORAGE_ENABLED}" != "1" ]; then
         bail "Rook ${ROOK_VERSION} requires enabling block storage"
     fi

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -24,8 +24,12 @@ function rook_pre_init() {
             elif [ "${current_version_major}" = "1" ] && [ "${current_version_minor}" = "0" ]; then
                 echo "Rook ${current_version} is already installed, will not upgrade to ${ROOK_VERSION}"
                 SKIP_ROOK_INSTALL=1
-                if [ "$current_version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
-                    bail "Rook 1.0.4 is not compatible with Kubernetes 1.20+"
+                if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
+                    KUBERNETES_UPGRADE="0"
+                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    parse_kubernetes_target_version
+                    # There's no guarantee the packages from this version of Kubernetes are still available
+                    SKIP_KUBERNETES_HOST=1
                 fi
             fi
         elif [ "${current_version_patch}" -gt "${next_version_patch}" ]; then

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -1,5 +1,9 @@
 
 function kubernetes_host() {
+    if [ "$SKIP_KUBERNETES_HOST" = "1" ]; then
+        return 0
+    fi
+
     kubernetes_load_ipvs_modules
 
     kubernetes_sysctl_config

--- a/web/src/client/index_test.ts
+++ b/web/src/client/index_test.ts
@@ -826,8 +826,6 @@ describe("POST /installer/validate", () => {
     });
   });
 
-
-
   describe("pinned minor k8s version", () => {
     let id: string;
 
@@ -841,6 +839,25 @@ describe("POST /installer/validate", () => {
 
       expect(script).to.match(new RegExp(`version: 1.18.\\d+`));
       expect(script).not.to.match(new RegExp(`version: 1.18.x`));
+    });
+  });
+
+  describe("rook 1.0.4 with Kubernetes 1.20.0", () => {
+    it("400", async () => {
+      const spec = `
+      spec:
+        rook:
+          version: 1.0.4
+        kubernetes:
+          version: 1.20.0`;
+      let err;
+
+      try {
+        await client.validateInstaller(spec);
+      } catch (error) {
+        err = error;
+      }
+      expect(err).to.have.property("message", "Rook 1.0.4 is not compatible with Kubernetes 1.20+");
     });
   });
 });

--- a/web/src/controllers/InstallerAPI.ts
+++ b/web/src/controllers/InstallerAPI.ts
@@ -101,7 +101,7 @@ export class Installers {
     }
     i.id = i.hash();
 
-    const err = await i.validate();
+    const err = await i.resolve().validate();
     if (err) {
       response.status(400);
       return err;
@@ -222,7 +222,7 @@ export class Installers {
       return invalidYAMLResponse;
     }
 
-    const err = await i.validate();
+    const err = await i.resolve().validate();
     if (err) {
       response.status(400);
       return err;
@@ -280,7 +280,7 @@ export class Installers {
       }
     }
 
-    const err = await i.validate();
+    const err = await i.resolve().validate();
     if (err) {
       response.status(400);
       return err;

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1146,6 +1146,12 @@ export class Installer {
     if (this.spec.sonobuoy && !Installer.hasVersion("sonobuoy", this.spec.sonobuoy.version) && !this.hasS3Override("sonobuoy")) {
       return { error: { message: `Sonobuoy version "${_.escape(this.spec.sonobuoy.version)}" is not supported` } };
     }
+    // Rook 1.0.4. is incompatible with Kubernetes 1.20+
+    if (this.spec.rook && this.spec.rook.version === "1.0.4") {
+      if (this.spec.kubernetes && semver.gte(this.spec.kubernetes.version, "1.20.0")) {
+        return { error: { message: "Rook 1.0.4 is not compatible with Kubernetes 1.20+" } };
+      }
+    }
   }
 
   public packages(): string[] {


### PR DESCRIPTION
The API returns a validation error if attempting to create a spec with Rook 1.0.4 and Kubernetes 1.20+. The install script bails if it detects an attempt to install Rook 1.0.4 with Kubernetes 1.20+, which should only happen if you edit the spec manually or if you had previously installed Rook 1.0.4 then upgraded to Rook 1.4 in the spec.