### PR TITLE
Testgrid reporting enhancements

### DIFF
--- a/testgrid/migrations/kustomize/overlays/dev/postgres.yaml
+++ b/testgrid/migrations/kustomize/overlays/dev/postgres.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: testgrid-postgres
   labels:
-    app: postgres
+    app: testgrid-postgres
 spec:
   type: NodePort
   ports:
@@ -12,14 +12,14 @@ spec:
     port: 5432
     targetPort: postgres
   selector:
-    app: postgres
+    app: testgrid-postgres
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: testgrid-postgres
   labels:
-    app: postgres
+    app: testgrid-postgres
 type: Opaque
 data:
   uri: "cG9zdGdyZXM6Ly90ZXN0Z3JpZDpwYXNzd29yZEBwb3N0Z3Jlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsOjU0MzIvdGVzdGdyaWQ/c3NsbW9kZT1kaXNhYmxl"
@@ -27,16 +27,16 @@ data:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: postgres
+  name: testgrid-postgres
 spec:
   selector:
     matchLabels:
-      app: postgres
-  serviceName: postgres
+      app: testgrid-postgres
+  serviceName: testgrid-postgres
   template:
     metadata:
       labels:
-        app: postgres
+        app: testgrid-postgres
     spec:
       containers:
       - name: postgres

--- a/testgrid/migrations/kustomize/overlays/dev/testgrid-postgres.yaml
+++ b/testgrid/migrations/kustomize/overlays/dev/testgrid-postgres.yaml
@@ -7,4 +7,4 @@ spec:
   connection:
     postgres:
       uri:
-        value: postgres://testgrid:password@postgres.default.svc.cluster.local:5432/testgrid?sslmode=disable
+        value: postgres://testgrid:password@testgrid-postgres.default.svc.cluster.local:5432/testgrid?sslmode=disable

--- a/testgrid/migrations/tables/testinstance.yaml
+++ b/testgrid/migrations/tables/testinstance.yaml
@@ -25,7 +25,7 @@ spec:
           type: timestamp without timezone
         - name: is_success
           type: boolean
-        - name: failure
+        - name: failure_reason
           type: varchar(255)
         - name: is_unsupported
           type: boolean

--- a/testgrid/migrations/tables/testinstance.yaml
+++ b/testgrid/migrations/tables/testinstance.yaml
@@ -25,6 +25,8 @@ spec:
           type: timestamp without timezone
         - name: is_success
           type: boolean
+        - name: failure
+          type: varchar(255)
         - name: is_unsupported
           type: boolean
         - name: output

--- a/testgrid/tgapi/kustomize/overlays/dev/deployment.yaml
+++ b/testgrid/tgapi/kustomize/overlays/dev/deployment.yaml
@@ -12,4 +12,4 @@ spec:
                 name: tgapi
           env:
             - name: DATABASE_URL
-              value: postgres://testgrid:password@postgres.default.svc.cluster.local:5432/testgrid?sslmode=disable
+              value: postgres://testgrid:password@testgrid-postgres.default.svc.cluster.local:5432/testgrid?sslmode=disable

--- a/testgrid/tgapi/pkg/handlers/instance_finish.go
+++ b/testgrid/tgapi/pkg/handlers/instance_finish.go
@@ -13,8 +13,8 @@ import (
 )
 
 type FinishInstanceRequest struct {
-	Success bool   `json:"success"`
-	Failure string `json:"failure"`
+	Success       bool   `json:"success"`
+	FailureReason string `json:"failureReason"`
 }
 
 func FinishInstance(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +30,7 @@ func FinishInstance(w http.ResponseWriter, r *http.Request) {
 	logger.Debug("finishInstance",
 		zap.String("instanceId", instanceID))
 
-	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, finishInstanceRequest.Success, finishInstanceRequest.Failure); err != nil {
+	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, finishInstanceRequest.Success, finishInstanceRequest.FailureReason); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return
@@ -45,7 +45,7 @@ func FinishInstance(w http.ResponseWriter, r *http.Request) {
 				[]string{
 					fmt.Sprintf("testid:%s", id),
 					fmt.Sprintf("success:%t", finishInstanceRequest.Success),
-					fmt.Sprintf("failure:%s", finishInstanceRequest.Failure),
+					fmt.Sprintf("failure_reason:%s", finishInstanceRequest.FailureReason),
 				},
 				1.0)
 		}

--- a/testgrid/tgapi/pkg/handlers/instance_finish.go
+++ b/testgrid/tgapi/pkg/handlers/instance_finish.go
@@ -13,7 +13,8 @@ import (
 )
 
 type FinishInstanceRequest struct {
-	Success bool `json:"success"`
+	Success bool   `json:"success"`
+	Failure string `json:"failure"`
 }
 
 func FinishInstance(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +30,7 @@ func FinishInstance(w http.ResponseWriter, r *http.Request) {
 	logger.Debug("finishInstance",
 		zap.String("instanceId", instanceID))
 
-	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, finishInstanceRequest.Success); err != nil {
+	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, finishInstanceRequest.Success, finishInstanceRequest.Failure); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return
@@ -44,6 +45,7 @@ func FinishInstance(w http.ResponseWriter, r *http.Request) {
 				[]string{
 					fmt.Sprintf("testid:%s", id),
 					fmt.Sprintf("success:%t", finishInstanceRequest.Success),
+					fmt.Sprintf("failure:%s", finishInstanceRequest.Failure),
 				},
 				1.0)
 		}

--- a/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
+++ b/testgrid/tgapi/pkg/handlers/instance_sonobouy.go
@@ -41,7 +41,7 @@ func InstanceSonobuoyResults(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, isSuccess); err != nil {
+	if err := testinstance.SetInstanceFinishedAndSuccess(instanceID, isSuccess, "sonobuoy_results"); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return

--- a/testgrid/tgapi/pkg/testinstance/types/types.go
+++ b/testgrid/tgapi/pkg/testinstance/types/types.go
@@ -10,6 +10,7 @@ type TestInstance struct {
 	StartedAt     *time.Time `json:"startedAt"`
 	FinishedAt    *time.Time `json:"finishedAt"`
 	IsSuccess     bool       `json:"isSuccess"`
+	Failure       string     `json:"failure"`
 	IsUnsupported bool       `json:"isUnsupported"`
 
 	KurlYAML string `json:"kurlYaml"`

--- a/testgrid/tgapi/pkg/testinstance/types/types.go
+++ b/testgrid/tgapi/pkg/testinstance/types/types.go
@@ -10,7 +10,7 @@ type TestInstance struct {
 	StartedAt     *time.Time `json:"startedAt"`
 	FinishedAt    *time.Time `json:"finishedAt"`
 	IsSuccess     bool       `json:"isSuccess"`
-	Failure       string     `json:"failure"`
+	FailureReason string     `json:"failureReason"`
 	IsUnsupported bool       `json:"isUnsupported"`
 
 	KurlYAML string `json:"kurlYaml"`

--- a/testgrid/tgrun/pkg/runner/cleanup.go
+++ b/testgrid/tgrun/pkg/runner/cleanup.go
@@ -42,7 +42,7 @@ func CleanUpVMIs() error {
 		if vmi.Status.Phase == kubevirtv1.Running && time.Since(vmi.CreationTimestamp.Time).Minutes() > 60 {
 			if apiEndpoint := vmi.Annotations["testgrid.kurl.sh/apiendpoint"]; apiEndpoint != "" {
 				url := fmt.Sprintf("%s/v1/instance/%s/finish", apiEndpoint, vmi.Name)
-				data := `{"success": false, "failure": "timeout"}`
+				data := `{"success": false, "failureReason": "timeout"}`
 				resp, err := http.Post(url, "application/json", strings.NewReader(data))
 				if err != nil {
 					fmt.Printf("Failed to post timeout failure to testgrid api for vmi %s: %v\n", vmi.Name, err)

--- a/testgrid/tgrun/pkg/runner/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/embed/runcmd.sh
@@ -5,7 +5,7 @@ function command_exists() {
 }
 
 function setup_runner() {
-    setenforce 0 || : # rhel variants
+    setenforce 0 || true # rhel variants
 
     echo "$TEST_ID" > /tmp/testgrid-id
 
@@ -81,7 +81,7 @@ function run_install() {
         echo "failed kurl install with exit status $KURL_EXIT_STATUS"
     fi
 
-    collect_debug_info_after_kurl || :
+    collect_debug_info_after_kurl || true
 }
 
 function run_upgrade() {
@@ -129,7 +129,7 @@ function run_upgrade() {
         echo "failed kurl upgrade with exit status $KURL_EXIT_STATUS"
     fi
 
-    collect_debug_info_after_kurl || :
+    collect_debug_info_after_kurl || true
 }
 
 function collect_debug_info_after_kurl() {
@@ -150,7 +150,7 @@ function collect_debug_info_after_kurl() {
 
     echo "";
     echo "running pods after completion:";
-    kubectl get pods -A || :
+    kubectl get pods -A || true
     echo "";
 }
 
@@ -259,8 +259,8 @@ function run_sonobuoy() {
 
 function collect_debug_info_sonobuoy() {
     kubectl -n sonobuoy get pods
-    kubectl -n sonobuoy describe pod sonobuoy || :
-    kubectl -n sonobuoy logs sonobuoy || :
+    kubectl -n sonobuoy describe pod sonobuoy || true
+    kubectl -n sonobuoy logs sonobuoy || true
 }
 
 function collect_support_bundle() {

--- a/testgrid/tgrun/pkg/runner/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/embed/runcmd.sh
@@ -282,7 +282,7 @@ function report_success() {
 
 function report_failure() {
     local failure="$1"
-    curl -X POST -d "{\"success\": false, \"failure\": \"${failure}\"}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
+    curl -X POST -d "{\"success\": false, \"failureReason\": \"${failure}\"}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
 }
 
 function send_logs() {

--- a/testgrid/tgrun/pkg/runner/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/embed/runcmd.sh
@@ -4,6 +4,20 @@ function command_exists() {
     command -v "$@" > /dev/null 2>&1
 }
 
+function setup_runner() {
+    setenforce 0 || : # rhel variants
+
+    echo "$TEST_ID" > /tmp/testgrid-id
+
+    if [ ! -c /dev/urandom ]; then
+        /bin/mknod -m 0666 /dev/urandom c 1 9 && /bin/chown root:root /dev/urandom
+    fi
+
+    echo "OS INFO:"
+    cat /etc/*-release
+    echo ""
+}
+
 function run_install() {
     AIRGAP=
     if echo "$KURL_URL" | grep -q "\.tar\.gz$" ; then
@@ -17,66 +31,15 @@ function run_install() {
         # get the install bundle
         curl -L -o install.tar.gz "$KURL_URL"
 
-        # get the list of testgrid API IPs
-        command -v dig >/dev/null 2>&1 || { yum -y install bind-utils; }
-        command -v iptables >/dev/null 2>&1 || { yum -y install iptables; }
-        TESTGRID_DOMAIN=$(echo "$TESTGRID_APIENDPOINT" | sed -e "s.^https://..")
-        echo "testgrid API endpoint: $TESTGRID_APIENDPOINT domain: $TESTGRID_DOMAIN"
-        APIENDPOINT_IPS=$(dig "$TESTGRID_DOMAIN" | grep 'IN A' | awk '{ print $5 }')
-        # and allow access to them
-        for i in $APIENDPOINT_IPS; do
-            echo "allowing access to $i"
-            iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
-        done
-
-        # allow access to the local IP(s)
-        _count=0
-        _regex="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+[[:alnum:]]+ ([[:digit:].]+)"
-        while read -r _line; do
-            [[ $_line =~ $_regex ]]
-            if [ "${BASH_REMATCH[1]}" != "lo" ] && [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && [ "${BASH_REMATCH[1]}" != "docker0" ] && [ "${BASH_REMATCH[1]}" != "weave" ]; then
-                _iface_names[$((_count))]=${BASH_REMATCH[1]}
-                _iface_addrs[$((_count))]=${BASH_REMATCH[2]}
-                let "_count += 1"
-            fi
-        done <<< "$(ip -4 -o addr)"
-        for i in $_iface_addrs; do
-            echo "allowing access to local address $i"
-            iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
-        done
-
-        # disable internet by adding restrictive iptables rules
-        iptables -A OUTPUT -p tcp -d 50.19.197.213 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 54.236.144.143 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 162.159.135.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 162.159.136.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 127.0.0.1 -j ACCEPT # accept comms to localhost
-        iptables -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -j REJECT # reject comms to other IPs
-
-        iptables -L
-
-        # test the lack of internet access
-        echo "testing disabled internet"
-        curl -v --connect-timeout 5 --max-time 5 "http://www.google.com"
-        CURL_EXIT_STATUS=$?
-        if [ $CURL_EXIT_STATUS -eq 0 ]; then
-            echo "successfully curled an external endpoint in airgap"
-            traceroute www.google.com
-            curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-            curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
-            exit 1
-        fi
+        disable_internet
 
         # run the installer
         tar -xzvf install.tar.gz
-        TAR_EXIT_STATUS=$?
-        if [ $TAR_EXIT_STATUS -ne 0 ]; then
-            echo "failed to unpack airgap file with status $TAR_EXIT_STATUS"
-            curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-            curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
+        local tar_exit_status="$?"
+        if [ $tar_exit_status -ne 0 ]; then
+            echo "failed to unpack airgap file with status $tar_exit_status"
+            report_failure "airgap_download"
+            send_logs
             exit 1
         fi
     else
@@ -116,33 +79,13 @@ function run_install() {
     else
         echo ""
         echo "failed kurl install with exit status $KURL_EXIT_STATUS"
-        curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-
-        echo "kubelet status"
-        systemctl status kubelet
-
-        echo "kubelet journalctl"
-        journalctl -xeu kubelet
-
-        echo "docker containers"
-        if command_exists "docker" ; then
-            docker ps -a
-        elif command_exists "crictl" ; then
-            crictl ps -a
-        fi
+        report_failure "kurl_install"
     fi
 
-    echo "";
-    echo "running pods after completion:";
-    kubectl get pods -A
-    echo "";
+    collect_debug_info_after_kurl || :
 }
 
 function run_upgrade() {
-    if [ "$KURL_UPGRADE_URL" = "" ]; then
-        return
-    fi
-
     echo "upgrading installation"
 
     AIRGAP_UPGRADE=
@@ -157,66 +100,15 @@ function run_upgrade() {
         # get the upgrade bundle
         curl -L -o upgrade.tar.gz "$KURL_UPGRADE_URL"
 
-        # get the list of testgrid API IPs
-        command -v dig >/dev/null 2>&1 || { yum -y install bind-utils; }
-        command -v iptables >/dev/null 2>&1 || { yum -y install iptables; }
-        TESTGRID_DOMAIN=$(echo "$TESTGRID_APIENDPOINT" | sed -e "s.^https://..")
-        echo "testgrid API endpoint: $TESTGRID_APIENDPOINT domain: $TESTGRID_DOMAIN"
-        APIENDPOINT_IPS=$(dig "$TESTGRID_DOMAIN" | grep 'IN A' | awk '{ print $5 }')
-        # and allow access to them
-        for i in $APIENDPOINT_IPS; do
-            echo "allowing access to $i"
-            iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
-        done
-
-        # allow access to the local IP(s)
-        _count=0
-        _regex="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+[[:alnum:]]+ ([[:digit:].]+)"
-        while read -r _line; do
-            [[ $_line =~ $_regex ]]
-            if [ "${BASH_REMATCH[1]}" != "lo" ] && [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && [ "${BASH_REMATCH[1]}" != "docker0" ] && [ "${BASH_REMATCH[1]}" != "weave" ]; then
-                _iface_names[$((_count))]=${BASH_REMATCH[1]}
-                _iface_addrs[$((_count))]=${BASH_REMATCH[2]}
-                let "_count += 1"
-            fi
-        done <<< "$(ip -4 -o addr)"
-        for i in $_iface_addrs; do
-            echo "allowing access to local address $i"
-            iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
-        done
-
-        # disable internet by adding restrictive iptables rules
-        iptables -A OUTPUT -p tcp -d 50.19.197.213 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 54.236.144.143 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 162.159.135.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 162.159.136.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
-        iptables -A OUTPUT -p tcp -d 127.0.0.1 -j ACCEPT # accept comms to localhost
-        iptables -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT # accept comms to internal IPs
-        iptables -A OUTPUT -p tcp -j REJECT # reject comms to other IPs
-
-        iptables -L
-
-        # test the lack of internet access
-        echo "testing disabled internet"
-        curl -v --connect-timeout 5 --max-time 5 "http://www.google.com"
-        CURL_EXIT_STATUS=$?
-        if [ $CURL_EXIT_STATUS -eq 0 ]; then
-            echo "successfully curled an external endpoint in airgap"
-            traceroute www.google.com
-            curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-            curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
-            exit 1
-        fi
+        disable_internet
 
         # run the upgrade
         tar -xzvf upgrade.tar.gz
-        TAR_EXIT_STATUS=$?
-        if [ $TAR_EXIT_STATUS -ne 0 ]; then
-            echo "failed to unpack airgap file with status $TAR_EXIT_STATUS"
-            curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-            curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
+        local tar_exit_status="$?"
+        if [ $tar_exit_status -ne 0 ]; then
+            echo "failed to unpack airgap file with status $tar_exit_status"
+            report_failure "airgap_download"
+            send_logs
             exit 1
         fi
     else
@@ -236,8 +128,14 @@ function run_upgrade() {
     else
         echo ""
         echo "failed kurl upgrade with exit status $KURL_EXIT_STATUS"
-        curl -s -X POST -d "{\"success\": false}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
+        report_failure "kurl_upgrade"
+    fi
 
+    collect_debug_info_after_kurl || :
+}
+
+function collect_debug_info_after_kurl() {
+    if [ "$KURL_EXIT_STATUS" -ne 0 ]; then
         echo "kubelet status"
         systemctl status kubelet
 
@@ -254,7 +152,7 @@ function run_upgrade() {
 
     echo "";
     echo "running pods after completion:";
-    kubectl get pods -A
+    kubectl get pods -A || :
     echo "";
 }
 
@@ -268,7 +166,67 @@ function run_tasks_join_token() {
     fi
 }
 
+function disable_internet() {
+    echo "disabling internet"
+
+    # get the list of testgrid API IPs
+    command -v dig >/dev/null 2>&1 || { yum -y install bind-utils; }
+    command -v iptables >/dev/null 2>&1 || { yum -y install iptables; }
+    TESTGRID_DOMAIN=$(echo "$TESTGRID_APIENDPOINT" | sed -e "s.^https://..")
+    echo "testgrid API endpoint: $TESTGRID_APIENDPOINT domain: $TESTGRID_DOMAIN"
+    APIENDPOINT_IPS=$(dig "$TESTGRID_DOMAIN" | grep 'IN A' | awk '{ print $5 }')
+    # and allow access to them
+    for i in $APIENDPOINT_IPS; do
+        echo "allowing access to $i"
+        iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
+    done
+
+    # allow access to the local IP(s)
+    _count=0
+    _regex="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+[[:alnum:]]+ ([[:digit:].]+)"
+    while read -r _line; do
+        [[ $_line =~ $_regex ]]
+        if [ "${BASH_REMATCH[1]}" != "lo" ] && [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && [ "${BASH_REMATCH[1]}" != "docker0" ] && [ "${BASH_REMATCH[1]}" != "weave" ]; then
+            _iface_names[$((_count))]=${BASH_REMATCH[1]}
+            _iface_addrs[$((_count))]=${BASH_REMATCH[2]}
+            let "_count += 1"
+        fi
+    done <<< "$(ip -4 -o addr)"
+    for i in $_iface_addrs; do
+        echo "allowing access to local address $i"
+        iptables -A OUTPUT -p tcp -d $i -j ACCEPT # accept comms to testgrid API IPs
+    done
+
+    # disable internet by adding restrictive iptables rules
+    iptables -A OUTPUT -p tcp -d 50.19.197.213 -j ACCEPT # accept comms to k8s.kurl.sh IPs
+    iptables -A OUTPUT -p tcp -d 54.236.144.143 -j ACCEPT # accept comms to k8s.kurl.sh IPs
+    iptables -A OUTPUT -p tcp -d 162.159.135.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
+    iptables -A OUTPUT -p tcp -d 162.159.136.41 -j ACCEPT # accept comms to k8s.kurl.sh IPs
+    iptables -A OUTPUT -p tcp -d 127.0.0.1 -j ACCEPT # accept comms to localhost
+    iptables -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT # accept comms to internal IPs
+    iptables -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT # accept comms to internal IPs
+    iptables -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT # accept comms to internal IPs
+    iptables -A OUTPUT -p tcp -j REJECT # reject comms to other IPs
+
+    iptables -L
+
+    echo "testing disabled internet"
+    curl -v --connect-timeout 5 --max-time 5 "http://www.google.com"
+    local exit_status="$?"
+    if [ $exit_status -eq 0 ]; then
+        echo "successfully curled an external endpoint in airgap"
+        traceroute www.google.com
+        report_failure "airgap_instance"
+        send_logs
+        exit 1
+    fi
+
+    echo "internet disabled"
+}
+
 function run_sonobuoy() {
+    echo "running sonobuoy"
+
     # wait for 10 minutes for sonobuoy run to complete
     # skip preflights for now cause we pre-create the namespace and preflights will fail if it exists
     /usr/local/bin/sonobuoy run \
@@ -279,6 +237,8 @@ function run_sonobuoy() {
     SONOBUOY_EXIT_STATUS=$?
     if [ $SONOBUOY_EXIT_STATUS -ne 0 ]; then
         echo "failed sonobuoy run"
+        collect_debug_info_sonobuoy
+        report_failure "sonobuoy_run"
         return 1
     fi
 
@@ -289,36 +249,20 @@ function run_sonobuoy() {
         curl -X POST --data-binary "@./sonobuoy-results.txt" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/sonobuoy"
         return 0
     else
-        echo "failed sonobuoy run"
+        echo "failed sonobuoy retrieve"
+        collect_debug_info_sonobuoy
+        report_failure "sonobuoy_retrieve"
         return 1
     fi
 }
 
-function main() {
-    setenforce 0 || true # rhel variants
+function collect_debug_info_sonobuoy() {
+    kubectl -n sonobuoy get pods
+    kubectl -n sonobuoy describe pod sonobuoy || :
+    kubectl -n sonobuoy logs sonobuoy || :
+}
 
-    curl -X POST "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/running"
-
-    echo "running kurl installer"
-
-    echo "$TEST_ID" > /tmp/testgrid-id
-
-    if [ ! -c /dev/urandom ]; then
-        /bin/mknod -m 0666 /dev/urandom c 1 9 && /bin/chown root:root /dev/urandom
-    fi
-
-    echo "OS INFO:"
-    cat /etc/*-release
-    echo ""
-
-    run_install
-
-    run_tasks_join_token
-
-    run_upgrade
-
-    curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
-
+function collect_support_bundle() {
     echo "collecting support bundle"
 
     /usr/local/bin/kubectl-support_bundle https://kots.io
@@ -329,18 +273,56 @@ function main() {
     else
         echo "failed support bundle collection"
     fi
+}
 
+function report_success() {
+    curl -X POST -d '{"success": true}' "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
+}
+
+function report_failure() {
+    local failure="$1"
+    curl -X POST -d "{\"success\": false, \"failure\": \"${failure}\"}" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
+}
+
+function send_logs() {
+    curl -X POST --data-binary "@/var/log/cloud-init-output.log" "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/logs"
+}
+
+function main() {
+    curl -X POST "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/running"
+
+    echo "running kurl installer"
+
+    setup_runner
+
+    run_install
+
+    # if install succeeded, maybe upgrade
+    if [ $KURL_EXIT_STATUS -eq 0 ]; then
+        run_tasks_join_token
+
+        if [ "$KURL_UPGRADE_URL" != "" ]; then
+            run_upgrade
+        fi
+    fi
+
+    send_logs
+
+    collect_support_bundle
+
+    # if install failed no need to 
     if [ $KURL_EXIT_STATUS -ne 0 ]; then
-        exit 1
+        send_logs
+        return 1
     fi
 
-    echo "running sonobuoy"
-
-    if run_sonobuoy ; then
-        curl -X POST -d '{"success": true}' "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
-    else
-        curl -X POST -d '{"success": false}' "$TESTGRID_APIENDPOINT/v1/instance/$TEST_ID/finish"
+    if ! run_sonobuoy ; then
+        send_logs
+        return 1
     fi
+
+    send_logs
+    report_success
 }
 
 ###############################################################################

--- a/testgrid/tgrun/pkg/runner/runner.go
+++ b/testgrid/tgrun/pkg/runner/runner.go
@@ -151,10 +151,11 @@ func execute(singleTest types.SingleRun, uploadProxyURL, tempDir string) error {
 				"kubevirt.io/domain": singleTest.ID,
 			},
 			Annotations: map[string]string{
-				"testgrid.kurl.sh/osname":    singleTest.OperatingSystemName,
-				"testgrid.kurl.sh/osversion": singleTest.OperatingSystemVersion,
-				"testgrid.kurl.sh/osimage":   singleTest.OperatingSystemImage,
-				"testgrid.kurl.sh/kurlurl":   singleTest.KurlURL,
+				"testgrid.kurl.sh/osname":      singleTest.OperatingSystemName,
+				"testgrid.kurl.sh/osversion":   singleTest.OperatingSystemVersion,
+				"testgrid.kurl.sh/osimage":     singleTest.OperatingSystemImage,
+				"testgrid.kurl.sh/kurlurl":     singleTest.KurlURL,
+				"testgrid.kurl.sh/apiendpoint": singleTest.TestGridAPIEndpoint,
 			},
 		},
 		Spec: kubevirtv1.VirtualMachineInstanceSpec{

--- a/testgrid/web/src/components/views/InstanceTable.jsx
+++ b/testgrid/web/src/components/views/InstanceTable.jsx
@@ -193,11 +193,11 @@ export default class InstanceTable extends React.Component {
     }
   }
 
-  getInstanceFailure = instance => {
-    if (!instance || !instance.failure) {
+  getInstanceFailureReason = instance => {
+    if (!instance || !instance.failureReason) {
       return "";
     }
-    return startCase(instance.failure);
+    return startCase(instance.failureReason);
   }
 
   goToLineInEditor = (editorRef, line) => {
@@ -247,14 +247,14 @@ export default class InstanceTable extends React.Component {
             const instance = find(this.props.instancesMap[kurlURL], i => (osKey == `${i.osName}-${i.osVersion}`));
             if (instance) {
               const status = this.getInstanceStatus(instance);
-              const failure = this.getInstanceFailure(instance);
+              const failureReason = this.getInstanceFailureReason(instance);
               return (
                 <td
                   key={`${kurlURL}-${osKey}-${instance.id}`}
                   className={status}
                 >
                   <div className="flex flex1 alignItems--center">
-                    <span className={`status-text ${status} flex1`}>{status}<br/><small>{failure}</small></span>
+                    <span className={`status-text ${status} flex1`}>{status}<br/><small>{failureReason}</small></span>
                     {(instance.finishedAt && !instance.isUnsupported) && 
                       <div className="flex-column flex1 alignItems--flexEnd">
                         <button type="button" className="btn xsmall primary u-width--full u-marginBottom--5" onClick={() => this.viewInstanceLogs(instance)}>kURL Logs</button>

--- a/testgrid/web/src/components/views/InstanceTable.jsx
+++ b/testgrid/web/src/components/views/InstanceTable.jsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import * as Modal from "react-modal";
 import * as find from "lodash/find";
+import * as startCase from "lodash/startCase";
 import * as parseAnsi from "parse-ansi";
 import * as queryString from "query-string";
 
@@ -192,6 +193,13 @@ export default class InstanceTable extends React.Component {
     }
   }
 
+  getInstanceFailure = instance => {
+    if (!instance || !instance.failure) {
+      return "";
+    }
+    return startCase(instance.failure);
+  }
+
   goToLineInEditor = (editorRef, line) => {
     editorRef?.editor?.gotoLine(line);
     this.setState({ activeMarkers: [{
@@ -239,13 +247,14 @@ export default class InstanceTable extends React.Component {
             const instance = find(this.props.instancesMap[kurlURL], i => (osKey == `${i.osName}-${i.osVersion}`));
             if (instance) {
               const status = this.getInstanceStatus(instance);
+              const failure = this.getInstanceFailure(instance);
               return (
                 <td
                   key={`${kurlURL}-${osKey}-${instance.id}`}
                   className={status}
                 >
                   <div className="flex flex1 alignItems--center">
-                    <span className={`status-text ${status} flex1`}>{status}</span>
+                    <span className={`status-text ${status} flex1`}>{status}<br/><small>{failure}</small></span>
                     {(instance.finishedAt && !instance.isUnsupported) && 
                       <div className="flex-column flex1 alignItems--flexEnd">
                         <button type="button" className="btn xsmall primary u-width--full u-marginBottom--5" onClick={() => this.viewInstanceLogs(instance)}>kURL Logs</button>


### PR DESCRIPTION
1. Changed dev environment postgres labels from app=postgres to app=testgrid-postgres to avoid collisions.
2. Added failure reason to testgrid instance run reporting.
3. The cleanup routine will now report run as failed/timeout.
4. The runner script will now always report and send logs before exiting and always exit after reporting.