### PR TITLE
Testgrid - send logs more often

### DIFF
--- a/testgrid/tgrun/pkg/runner/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/embed/runcmd.sh
@@ -297,6 +297,7 @@ function main() {
     setup_runner
 
     run_install
+    send_logs
 
     if [ $KURL_EXIT_STATUS -ne 0 ]; then
         send_logs
@@ -309,6 +310,7 @@ function main() {
 
     if [ "$KURL_UPGRADE_URL" != "" ]; then
         run_upgrade
+        send_logs
     fi
 
     if [ $KURL_EXIT_STATUS -ne 0 ]; then

--- a/testgrid/web/src/components/views/InstanceTable.jsx
+++ b/testgrid/web/src/components/views/InstanceTable.jsx
@@ -255,10 +255,12 @@ export default class InstanceTable extends React.Component {
                 >
                   <div className="flex flex1 alignItems--center">
                     <span className={`status-text ${status} flex1`}>{status}<br/><small>{failureReason}</small></span>
-                    {(instance.finishedAt && !instance.isUnsupported) && 
+                    {(instance.startedAt && !instance.isUnsupported) &&
                       <div className="flex-column flex1 alignItems--flexEnd">
                         <button type="button" className="btn xsmall primary u-width--full u-marginBottom--5" onClick={() => this.viewInstanceLogs(instance)}>kURL Logs</button>
-                        <button type="button" className="btn xsmall secondary blue u-width--full" onClick={() => this.viewInstanceSonobuoyResults(instance)}>Sonobuoy</button>
+                        {instance.finishedAt &&
+                          <button type="button" className="btn xsmall secondary blue u-width--full" onClick={() => this.viewInstanceSonobuoyResults(instance)}>Sonobuoy</button>
+                        }
                       </div>
                     }
                   </div>


### PR DESCRIPTION
This will send the logs more often and allow the user to view them while the test run instance is still running.