### PR TITLE
Fix rook install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,6 +526,7 @@ build/packages/k-3-s/%/rhel-8:
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl
 
 build/bin: build/bin/kurl
+	rm -rf kurl_util/bin
 	${MAKE} -C kurl_util build
 	cp -r kurl_util/bin build
 

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -211,25 +211,37 @@ function rook_ceph_healthy() {
 
 # rook_version_deployed check that there is only one rook-version reported across the cluster
 function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 # rook_ceph_version_deployed check that there is only one ceph-version reported across the cluster
 function rook_ceph_version_deployed() {
     local ceph_version="$1"
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 function rook_is_1() {

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -211,25 +211,37 @@ function rook_ceph_healthy() {
 
 # rook_version_deployed check that there is only one rook-version reported across the cluster
 function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 # rook_ceph_version_deployed check that there is only one ceph-version reported across the cluster
 function rook_ceph_version_deployed() {
     local ceph_version="$1"
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 function rook_is_1() {

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -211,25 +211,37 @@ function rook_ceph_healthy() {
 
 # rook_version_deployed check that there is only one rook-version reported across the cluster
 function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 # rook_ceph_version_deployed check that there is only one ceph-version reported across the cluster
 function rook_ceph_version_deployed() {
     local ceph_version="$1"
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
     if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
         return 1
     fi
-    if kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
-        return 0
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | grep -q "${ceph_version}" ; then
+        return 1
     fi
-    return 1
+    return 0
 }
 
 function rook_is_1() {

--- a/kurl_util/cmd/yamltobash/main_test.go
+++ b/kurl_util/cmd/yamltobash/main_test.go
@@ -198,6 +198,15 @@ func Test_convertToBash(t *testing.T) {
 				"SONOBUOY_S3_OVERRIDE": `"https://kurl-sh.s3.amazonaws.com/pr/2000-1111111-sonobuoy-0.50.0.tar.gz"`,
 			},
 		},
+		{
+			name: "Rook.BypassUpgradeWarning sets ROOK_BYPASS_UPGRADE_WARNING",
+			inputMap: map[string]interface{}{
+				"Rook.BypassUpgradeWarning": true,
+			},
+			wantedMap: map[string]string{
+				"ROOK_BYPASS_UPGRADE_WARNING": `1`,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -368,6 +368,8 @@ spec:
                 properties:
                   blockDeviceFilter:
                     type: string
+                  bypassUpgradeWarning:
+                    type: boolean
                   cephReplicaCount:
                     type: integer
                   hostpathRequiresPrivileged:


### PR DESCRIPTION
Rook new installs on 1.4.9 and 1.5.9 are broken as it polls forever for the cluster before deploying the cluster.
Fix race condition on upgrades that causes the cluster to be upgraded before it is ready.