### PR TITLE
allow for conformance packages to be built for rke2 and k3s for versi…

### DIFF
--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -18,7 +18,10 @@ function pkgs() {
         if [ "$version" = "template" ] || [ "$version" = "build-images" ]; then
             continue
         fi
-        echo "${name}-${version}.tar.gz"
+        # HACK: allow for conformance packages to be built for rke2 and k3s for versions we do not support of kubeadm.
+        if [ -f "$dir/Manifest" ]; then
+            echo "${name}-${version}.tar.gz"
+        fi
         if [ "${name}" = "kubernetes" ] || [ "${name}" = "k-3-s" ] || [ "${name}" = "rke-2" ]; then
             local minor="$(echo "${version}" | sed -E 's/^v?[0-9]+\.([0-9]+).[0-9]+.*$/\1/')"
             if [ "${minor}" -ge 17 ]; then


### PR DESCRIPTION
allow for conformance packages to be built for rke2 and k3s for versions we do not support of kubeadm.

Fixes build

```
packages/kubernetes/1.18.13/Manifest build/packages/kubernetes/1.18.13
bin/save-manifest-assets.sh: line 139: packages/kubernetes/1.18.13/Manifest: No such file or directory
Makefile:204: recipe for target 'build/packages/kubernetes/1.18.13/images' failed
make[1]: *** [build/packages/kubernetes/1.18.13/images] Error 1
make: *** [dist/kubernetes-1.18.13.tar.gz] Error 2
make[1]: Leaving directory '/home/runner/work/kURL/kURL'
Makefile:192: recipe for target 'dist/kubernetes-1.18.13.tar.gz' failed
Error: Process completed with exit code 2.
```