### PR TITLE
Add priority class to metadata server

### DIFF
--- a/addons/rook/1.4.3/cluster/shared-fs.yaml
+++ b/addons/rook/1.4.3/cluster/shared-fs.yaml
@@ -16,6 +16,7 @@ spec:
   metadataServer:
     activeCount: 1
     activeStandby: true
+    priorityClassName: rook-critical
     resources:
       limits:
         cpu: "500m"


### PR DESCRIPTION
The metadata server is part of the shared filesystem for ReadWriteMany PVCs.