### PR TITLE
Copy versioned staging packages to prod

### DIFF
--- a/.github/workflows/build-package-prod.yaml
+++ b/.github/workflows/build-package-prod.yaml
@@ -9,20 +9,25 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/setup-go@v2.1.3
-      with:
-        go-version: 1.16.0
+      - uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.16.0
 
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
-        PKG: ${{ github.event.client_payload.package }}
-      run: |
-        git fetch --tags
-        tag=$(git tag | grep '^v20' | sort | tail -1)
-        git checkout $tag
-        export KURL_UTIL_IMAGE=replicated/kurl-util:$tag # required if this is the common package
-        make dist/$PKG
-        aws s3 cp dist/$PKG s3://kurl-sh/dist/
+      - env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          PKG: ${{ github.event.client_payload.package }}
+        run: |
+          git fetch --tags
+          tag=$(git tag | grep '^v20' | sort | tail -1)
+          git checkout $tag
+          export KURL_UTIL_IMAGE=replicated/kurl-util:$tag # required if this is the common package
+          make dist/$PKG
+
+          MD5="$(openssl md5 -binary dist/$PKG | base64)"
+          GITSHA="$(git rev-parse HEAD)"
+          aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG

--- a/.github/workflows/build-package-staging.yaml
+++ b/.github/workflows/build-package-staging.yaml
@@ -18,4 +18,9 @@ jobs:
         KURL_UTIL_IMAGE: replicated/kurl-util:alpha # required if this is the common package
       run: |
         make dist/$PKG
-        aws s3 cp dist/$PKG s3://kurl-sh/staging/
+
+        MD5="$(openssl md5 -binary dist/$PKG | base64)"
+        GITSHA="$(git rev-parse HEAD)"
+        aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
+          --metadata md5="${MD5}",gitsha="${GITSHA}"
+        aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG

--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -45,4 +45,9 @@ jobs:
           git checkout $tag
           export KURL_UTIL_IMAGE=replicated/kurl-util:$tag # required if this is the common package
           make dist/$PKG
-          aws s3 cp dist/$PKG s3://kurl-sh/dist/
+
+          MD5="$(openssl md5 -binary dist/$PKG | base64)"
+          GITSHA="$(git rev-parse HEAD)"
+          aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -41,4 +41,9 @@ jobs:
           KURL_UTIL_IMAGE: replicated/kurl-util:alpha # required if this is the common package
         run: |
           make dist/$PKG
-          aws s3 cp dist/$PKG s3://kurl-sh/staging/
+
+          MD5="$(openssl md5 -binary dist/$PKG | base64)"
+          GITSHA="$(git rev-parse HEAD)"
+          aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+          aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG

--- a/bin/upload-dist-prod.sh
+++ b/bin/upload-dist-prod.sh
@@ -28,7 +28,7 @@ function upload_staging() {
     fi
 }
 
-# upload missing staging packages
+# build and upload missing staging packages
 for package in $(bin/list-all-packages.sh)
 do
     if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
@@ -54,6 +54,7 @@ do
             --metadata md5="${MD5}",gitsha="${GITSHA}"
         aws s3 cp "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
     else
+        # copy staging package to prod
         aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}"
         aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
     fi

--- a/bin/upload-dist-prod.sh
+++ b/bin/upload-dist-prod.sh
@@ -13,21 +13,48 @@ require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
 require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
 require S3_BUCKET "${S3_BUCKET}"
 
+GITSHA="$(git rev-parse HEAD)"
+
+function upload_staging() {
+    local package="$1"
+
+    make "dist/${package}"
+    MD5="$(openssl md5 -binary "dist/${package}" | base64)"
+    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
+        --metadata md5="${MD5}",gitsha="${GITSHA}"
+    make clean
+    if [ -n "$DOCKER_PRUNE" ]; then
+        docker system prune --all --force
+    fi
+}
+
+# upload missing staging packages
 for package in $(bin/list-all-packages.sh)
 do
-    if [ "$package" = "common.tar.gz" ]; then
+    if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
+        upload_staging "${package}"
+    else
+        echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
+    fi
+done
+
+for package in $(bin/list-all-packages.sh)
+do
+    if [ "$package" = "common.tar.gz" ] || echo "${package}" | grep -q "kurl-bin-utils" ; then
         # Common must be built rather than copied from staging because the staging common.tar.gz
         # package includes the alpha kurl-util image but the prod common.tar.gz needs a tagged version
         # of the kurl-util image
-        make dist/common.tar.gz
-        aws s3 cp dist/common.tar.gz s3://$S3_BUCKET/dist/
-    elif echo "$package" | grep -q "kurl-bin-utils"; then
+
         # The kurl-utils-bin package must be built rather than copied from staging because the staging
         # version is latest and the prod version is tagged.
-        make dist/$package
-        aws s3 cp dist/$package s3://$S3_BUCKET/dist/
+
+        make "dist/${package}"
+        MD5="$(openssl md5 -binary "dist/${package}" | base64)"
+        aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+        aws s3 cp "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
     else
-        # All other packages are copied directly from staging/ to dist/
-        aws s3 cp s3://$S3_BUCKET/staging/$package s3://$S3_BUCKET/dist/$package
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}"
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
     fi
 done

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -13,11 +13,16 @@ require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
 require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
 require S3_BUCKET "${S3_BUCKET}"
 
+GITSHA="$(git rev-parse HEAD)"
+
 function upload() {
     local package="$1"
 
-    make dist/$package
-    aws s3 cp dist/$package s3://$S3_BUCKET/staging/
+    make "dist/${package}"
+    MD5="$(openssl md5 -binary "dist/${package}" | base64)"
+    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
+        --metadata md5="${MD5}",gitsha="${GITSHA}"
+    aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG"
     make clean
     if [ -n "$DOCKER_PRUNE" ]; then
         docker system prune --all --force
@@ -30,9 +35,10 @@ upload kurl-bin-utils-latest.tar.gz
 
 for package in $(bin/list-all-packages.sh)
 do
-    if ! aws s3api head-object --bucket=$S3_BUCKET --key=staging/$package &>/dev/null; then
-        upload $package
+    if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
+        upload "${package}"
     else
-        echo "s3://$S3_BUCKET/staging/$package already exists"
+        echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG"
     fi
 done


### PR DESCRIPTION
In addition to uploading packages to the kurl-sh bucket at staging and dist, this pr will upload packages prefixed with the git ref. When deploying to prod, the workflow will now copy from the directory of the git ref of the tag being deployed from staging to prod. This will ensure that packages deployed to production are built from the same git ref as that which is being deployed.