### PR TITLE
Default pod cidr range to 20

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -406,7 +406,7 @@ function discover_pod_subnet() {
     fi
     local size="$POD_CIDR_RANGE"
     if [ -z "$size" ]; then
-        size="22"
+        size="20"
     fi
     # find a network for the Pods, preferring start at 10.32.0.0 
     if podnet=$($DIR/bin/subnet --subnet-alloc-range "10.32.0.0/16" --cidr-range "$size" "$excluded"); then


### PR DESCRIPTION
/24 blocks are recommended for each node. The current default of /22 only scales to 4 nodes. /20 will allow the cluster to scale to 16 nodes with recommended size blocks for each node.