### PR TITLE
aws s3 cp command does not copy metadata

### DIFF
--- a/.github/workflows/build-package-prod.yaml
+++ b/.github/workflows/build-package-prod.yaml
@@ -30,4 +30,5 @@ jobs:
           GITSHA="$(git rev-parse HEAD)"
           aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG
+          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/build-package-staging.yaml
+++ b/.github/workflows/build-package-staging.yaml
@@ -23,4 +23,5 @@ jobs:
         GITSHA="$(git rev-parse HEAD)"
         aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
           --metadata md5="${MD5}",gitsha="${GITSHA}"
-        aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG
+        aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG \
+          --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -50,4 +50,5 @@ jobs:
           GITSHA="$(git rev-parse HEAD)"
           aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG
+          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -46,4 +46,5 @@ jobs:
           GITSHA="$(git rev-parse HEAD)"
           aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG
+          aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/bin/upload-dist-prod.sh
+++ b/bin/upload-dist-prod.sh
@@ -52,10 +52,14 @@ do
         MD5="$(openssl md5 -binary "dist/${package}" | base64)"
         aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-        aws s3 cp "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
+        aws s3 cp "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}" \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
     else
         # copy staging package to prod
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}"
+        MD5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}" \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
     fi
 done

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -22,7 +22,8 @@ function upload() {
     MD5="$(openssl md5 -binary "dist/${package}" | base64)"
     aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
         --metadata md5="${MD5}",gitsha="${GITSHA}"
-    aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG"
+    aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG" \
+        --metadata md5="${MD5}",gitsha="${GITSHA}"
     make clean
     if [ -n "$DOCKER_PRUNE" ]; then
         docker system prune --all --force
@@ -39,6 +40,8 @@ do
         upload "${package}"
     else
         echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG"
+        MD5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG" \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
     fi
 done


### PR DESCRIPTION
Explicitly include metadata when copying from one s3 key to another.

https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html

```
Note that if the object is copied over in parts, the source object's metadata will not be copied over, no matter the value for --metadata-directive, and instead the desired metadata values must be specified as parameters on the command line.
```