### PR TITLE
Validate cluster network after CNI is installed

### DIFF
--- a/addons/antrea/0.13.1/install.sh
+++ b/addons/antrea/0.13.1/install.sh
@@ -45,6 +45,8 @@ function antrea() {
     kubectl apply -k $dst
 
     antrea_cli
+
+    check_network
 }
 
 function antrea_join() {

--- a/addons/antrea/1.0.0/install.sh
+++ b/addons/antrea/1.0.0/install.sh
@@ -45,6 +45,8 @@ function antrea() {
     kubectl apply -k $dst
 
     antrea_cli
+
+    check_network
 }
 
 function antrea_join() {

--- a/addons/antrea/template/base/install.sh
+++ b/addons/antrea/template/base/install.sh
@@ -45,6 +45,8 @@ function antrea() {
     kubectl apply -k $dst
 
     antrea_cli
+
+    check_network
 }
 
 function antrea_join() {

--- a/addons/weave/2.5.2/install.sh
+++ b/addons/weave/2.5.2/install.sh
@@ -23,6 +23,7 @@ function weave() {
 
     kubectl apply -k "$DIR/kustomize/weave/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/addons/weave/2.6.4/install.sh
+++ b/addons/weave/2.6.4/install.sh
@@ -23,6 +23,7 @@ function weave() {
 
     kubectl apply -k "$DIR/kustomize/weave/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/addons/weave/2.6.5/install.sh
+++ b/addons/weave/2.6.5/install.sh
@@ -23,6 +23,7 @@ function weave() {
 
     kubectl apply -k "$DIR/kustomize/weave/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/addons/weave/2.7.0/install.sh
+++ b/addons/weave/2.7.0/install.sh
@@ -26,6 +26,7 @@ function weave() {
 
     kubectl apply -k "${dst}/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/addons/weave/2.8.1/install.sh
+++ b/addons/weave/2.8.1/install.sh
@@ -26,6 +26,7 @@ function weave() {
 
     kubectl apply -k "${dst}/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/addons/weave/template/base/install.sh
+++ b/addons/weave/template/base/install.sh
@@ -26,6 +26,7 @@ function weave() {
 
     kubectl apply -k "${dst}/"
     weave_ready_spinner
+    check_network
 }
 
 function weave_resource_secret() {

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -3,6 +3,7 @@ KURL_UTIL_IMAGE ?= replicated/kurl-util:alpha
 VERSION_PACKAGE = github.com/replicatedhq/kurl/pkg/version
 VERSION ?= 0.0.1
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+CURRENT_USER := $(shell id -u -n)
 
 export GO111MODULE=on
 
@@ -52,7 +53,7 @@ test: lint vet
 	go test ./cmd/...
 
 .PHONY: build
-build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd
+build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network
 
 bin/yamlutil:
 	go build ${LDFLAGS} -o bin/yamlutil cmd/yamlutil/main.go
@@ -81,6 +82,9 @@ bin/bcrypt:
 bin/htpasswd:
 	go build ${LDFLAGS} -o bin/htpasswd cmd/htpasswd/main.go
 
+bin/network:
+	go build ${LDFLAGS} -o bin/network cmd/network/main.go
+
 .PHONY: kurl-util-image
 kurl-util-image:
 	docker build -t $(KURL_UTIL_IMAGE) -f deploy/Dockerfile --build-arg commit="${GIT_SHA}" ../
@@ -88,3 +92,8 @@ kurl-util-image:
 .PHONY: build-and-push-kurl-util-image
 build-and-push-kurl-util-image: kurl-util-image
 	docker push $(KURL_UTIL_IMAGE)
+
+.PHONY: build-ttl.sh
+build-ttl.sh:
+	docker build --pull -f deploy/Dockerfile -t ttl.sh/$(CURRENT_USER)/kurl_util:12h ../
+	docker push ttl.sh/${CURRENT_USER}/kurl_util:12h

--- a/kurl_util/cmd/network/main.go
+++ b/kurl_util/cmd/network/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	var isServer bool
+	var isClient bool
+	var address string
+	var request string
+	var response string
+
+	flag.BoolVar(&isServer, "server", false, "Run the server component")
+	flag.BoolVar(&isClient, "client", false, "Run the client component")
+	flag.StringVar(&address, "address", "", "IP to attempt to connect to the server")
+	flag.StringVar(&request, "request", "kurl-client", "Request body sent by client")
+	flag.StringVar(&response, "response", "kurl-server", "Response body sent by server")
+
+	flag.Parse()
+
+	exit := make(chan bool)
+
+	if isServer {
+		server := &http.Server{
+			Addr: ":8080",
+		}
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Println(err.Error())
+				return
+			}
+			if string(body) != request {
+				log.Printf("Got request %q, want %q", string(body), request)
+				http.Error(w, "Bad Request", http.StatusBadRequest)
+				return
+			}
+			_, err = w.Write([]byte(response))
+			if err != nil {
+				log.Println(err.Error())
+				return
+			}
+			go func() {
+				server.Shutdown(context.Background())
+				exit <- true
+			}()
+		})
+
+		log.Printf("Listening on %s", server.Addr)
+		err := server.ListenAndServe()
+		if err != http.ErrServerClosed {
+			log.Println(err.Error())
+			os.Exit(1)
+		}
+
+		<-exit
+		log.Println("Success")
+		return
+	}
+
+	if isClient {
+		for {
+			time.Sleep(time.Second)
+
+			resp, err := http.Post(address, "text/plain", strings.NewReader(request))
+			if err != nil {
+				log.Println(err.Error())
+				continue
+			}
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Println(err.Error())
+				continue
+			}
+			if string(body) != response {
+				log.Printf("Got response %q, want %q", string(body), response)
+				continue
+			}
+			log.Println("Success")
+			break
+		}
+		return
+	}
+
+	log.Println("Either --server or --client is required")
+	os.Exit(1)
+}


### PR DESCRIPTION
Run a client and server pod. The client continuously attempts to connect
to the server with the kurlnet service name. A successful connection
means cluster DNS, service networking and pod networking are not
fundamentally broken and it's safe to continue installing other add-ons.

To validate the feature, temporarily block service or pod cidr traffic:
```
sudo iptables -A INPUT -d 10.96.0.0/22 -j DROP
```

Wait for the check network spinner and the client connection error logs. Then unblock traffic and see the script proceed.

```
sudo iptables -L INPUT --line-numbers
sudo iptables -D INPUT 6 # line number will vary
```