### PR TITLE
Various fixes to CI packaging

### DIFF
--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -20,13 +20,13 @@ function pkgs() {
         fi
         # HACK: allow for conformance packages to be built for rke2 and k3s for versions we do not support of kubeadm.
         if [ -f "$dir/Manifest" ]; then
-            echo "${name}-${version}.tar.gz ${name} ${version}"
+            echo "${name}-${version}.tar.gz ${dir}/${name}/${version}/"
         fi
         if [ "${name}" = "kubernetes" ] || [ "${name}" = "k-3-s" ] || [ "${name}" = "rke-2" ]; then
             local minor="$(echo "${version}" | sed -E 's/^v?[0-9]+\.([0-9]+).[0-9]+.*$/\1/')"
             if [ "${minor}" -ge 17 ]; then
                 local conformance_version="$(echo "${version}" | sed -E 's/^v?([0-9]+\.[0-9]+.[0-9]+).*$/\1/')"
-                echo "kubernetes-conformance-${conformance_version}.tar.gz kubernetes ${conformance_version}"
+                echo "kubernetes-conformance-${conformance_version}.tar.gz ${dir}/kubernetes/${conformance_version}/"
             fi
         fi
     done
@@ -41,10 +41,10 @@ function list_all_packages() {
 }
 
 function list_other() {
-    echo "docker-18.09.8.tar.gz docker 18.09.8"
-    echo "docker-19.03.4.tar.gz docker 19.03.4"
-    echo "docker-19.03.10.tar.gz docker 19.03.10"
-    echo "docker-20.10.5.tar.gz docker 20.10.5"
+    echo "docker-18.09.8.tar.gz bundles/"
+    echo "docker-19.03.4.tar.gz bundles/"
+    echo "docker-19.03.10.tar.gz bundles/"
+    echo "docker-20.10.5.tar.gz bundles/"
     echo "common.tar.gz"
     echo "$KURL_BIN_UTILS_FILE"
 }

--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -26,7 +26,7 @@ function pkgs() {
             local minor="$(echo "${version}" | sed -E 's/^v?[0-9]+\.([0-9]+).[0-9]+.*$/\1/')"
             if [ "${minor}" -ge 17 ]; then
                 local conformance_version="$(echo "${version}" | sed -E 's/^v?([0-9]+\.[0-9]+.[0-9]+).*$/\1/')"
-                echo "kubernetes-conformance-${conformance_version}.tar.gz kubernetes-conformance ${conformance_version}"
+                echo "kubernetes-conformance-${conformance_version}.tar.gz kubernetes ${conformance_version}"
             fi
         fi
     done

--- a/bin/upload-dist-prod.sh
+++ b/bin/upload-dist-prod.sh
@@ -23,7 +23,7 @@ function upload_staging() {
 
     make "dist/${package}"
     MD5="$(openssl md5 -binary "dist/${package}" | base64)"
-    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
+    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" \
         --metadata md5="${MD5}",gitsha="${GITSHA}"
     make clean
     if [ -n "$DOCKER_PRUNE" ]; then

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -44,9 +44,9 @@ function upload() {
 
     make "dist/${package}"
     MD5="$(openssl md5 -binary "dist/${package}" | base64)"
-    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
+    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" \
         --metadata md5="${MD5}",gitsha="${GITSHA}"
-    aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG" \
+    aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/${package}" \
         --metadata md5="${MD5}",gitsha="${GITSHA}"
     make clean
     if [ -n "$DOCKER_PRUNE" ]; then
@@ -68,14 +68,14 @@ function deploy_package() {
             echo "s3://${S3_BUCKET}/staging/${package} no changes in package"
             local md5=
             md5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
-            aws s3 cp "s3://${S3_BUCKET}/staging/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/$PKG" \
+            aws s3 cp "s3://${S3_BUCKET}/staging/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" \
                 --metadata md5="${md5}",gitsha="${GITSHA}"
         fi
     else
         echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
         local md5=
         md5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG" \
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/${package}" \
             --metadata md5="${md5}",gitsha="${GITSHA}"
     fi
 }
@@ -90,7 +90,7 @@ function deploy_other() {
         echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
         local md5=
         md5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/$PKG" \
+        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/${package}" \
             --metadata md5="${md5}",gitsha="${GITSHA}"
     fi
 }

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -19,10 +19,13 @@ require S3_BUCKET "${S3_BUCKET}"
 GITSHA="$(git rev-parse HEAD)"
 
 function package_has_changes() {
-    local type="$1"
-    local package="$2"
-    local name="$3"
-    local version="$4"
+    local package="$1"
+    local path="$2"
+
+    if [ -z "${path}" ]; then
+        # if no path then we can't calculate changes
+        return 0
+    fi
 
     local upstream_gitsha=
     upstream_gitsha="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${package}" | grep '"gitsha":' | sed 's/[",:]//g' | awk '{print $2}')"
@@ -32,7 +35,7 @@ function package_has_changes() {
         return 0
     fi
 
-    if git diff --quiet "${upstream_gitsha}" -- "${type}/${name}/${version}/" "${GITSHA}" -- "${type}/${name}/${version}/" ; then
+    if git diff --quiet "${upstream_gitsha}" -- "${path}" "${GITSHA}" -- "${path}" ; then
         return 1
     else
         return 0
@@ -54,14 +57,12 @@ function upload() {
     fi
 }
 
-function deploy_package() {
-    local type="$1"
-    local package="$2"
-    local name="$3"
-    local version="$4"
+function deploy() {
+    local package="$1"
+    local path="$2"
 
     if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
-        if package_has_changes "${type}" "${package}" "${name}" "${version}" ; then
+        if package_has_changes "${package}" "${path}" ; then
             echo "s3://${S3_BUCKET}/staging/${package} has changes"
             upload "${package}"
         else
@@ -71,21 +72,6 @@ function deploy_package() {
             aws s3 cp "s3://${S3_BUCKET}/staging/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" \
                 --metadata md5="${md5}",gitsha="${GITSHA}"
         fi
-    else
-        echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
-        local md5=
-        md5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/staging/${package}" \
-            --metadata md5="${md5}",gitsha="${GITSHA}"
-    fi
-}
-
-function deploy_other() {
-    local package="$2"
-
-    if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
-        echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} upload"
-        upload "${package}"
     else
         echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
         local md5=
@@ -105,19 +91,21 @@ function main() {
     while read -r line
     do
         # shellcheck disable=SC2086
-        deploy_package "addon" ${line}
+        deploy "addon" ${line}
     done < <(list_all_addons)
 
+    # TODO: kubernetes changes do not yet take into account changes in bundles/
+    # These need to manually be rebuilt when changing that path.
     while read -r line
     do
         # shellcheck disable=SC2086
-        deploy_package "package" ${line}
+        deploy "package" ${line}
     done < <(list_all_packages)
 
     while read -r line
     do
         # shellcheck disable=SC2086
-        deploy_other "other" ${line}
+        deploy "other" ${line}
     done < <(list_other)
 }
 


### PR DESCRIPTION
Updated use of wrong variable PKG and replace with package. This is really a no op change cause the package is being moved into a directory and the name is not being changed.

Changes to artificial name and version of k8s conformance packages to reflect the real path to properly calculate a git diff for package rebuilding.

Adds caching for docker bundles.