### PR TITLE
Deploy prod versioned

### DIFF
--- a/.github/workflows/build-package-prod.yaml
+++ b/.github/workflows/build-package-prod.yaml
@@ -28,7 +28,7 @@ jobs:
 
           MD5="$(openssl md5 -binary dist/$PKG | base64)"
           GITSHA="$(git rev-parse HEAD)"
-          aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
+          aws s3 cp dist/$PKG s3://kurl-sh/dist/${tag}/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG \
+          aws s3 cp s3://kurl-sh/dist/${tag}/$PKG s3://kurl-sh/dist/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/build-package-staging.yaml
+++ b/.github/workflows/build-package-staging.yaml
@@ -21,7 +21,5 @@ jobs:
 
         MD5="$(openssl md5 -binary dist/$PKG | base64)"
         GITSHA="$(git rev-parse HEAD)"
-        aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
-          --metadata md5="${MD5}",gitsha="${GITSHA}"
-        aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG \
+        aws s3 cp dist/$PKG s3://kurl-sh/staging/$PKG \
           --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -48,7 +48,7 @@ jobs:
 
           MD5="$(openssl md5 -binary dist/$PKG | base64)"
           GITSHA="$(git rev-parse HEAD)"
-          aws s3 cp dist/$PKG s3://kurl-sh/dist/${GITSHA}/$PKG \
+          aws s3 cp dist/$PKG s3://kurl-sh/dist/${tag}/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/dist/${GITSHA}/$PKG s3://kurl-sh/dist/$PKG \
+          aws s3 cp s3://kurl-sh/dist/${tag}/$PKG s3://kurl-sh/dist/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -44,7 +44,5 @@ jobs:
 
           MD5="$(openssl md5 -binary dist/$PKG | base64)"
           GITSHA="$(git rev-parse HEAD)"
-          aws s3 cp dist/$PKG s3://kurl-sh/staging/${GITSHA}/$PKG \
-            --metadata md5="${MD5}",gitsha="${GITSHA}"
-          aws s3 cp s3://kurl-sh/staging/${GITSHA}/$PKG s3://kurl-sh/staging/$PKG \
+          aws s3 cp dist/$PKG s3://kurl-sh/staging/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -33,7 +33,7 @@ function pkgs() {
 }
 
 function list_all_addons() {
-    pkgs addons
+    pkgs addons | sort
 }
 
 function list_all_packages() {

--- a/bin/upload-dist-prod.sh
+++ b/bin/upload-dist-prod.sh
@@ -15,15 +15,42 @@ function require() {
 require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
 require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
 require S3_BUCKET "${S3_BUCKET}"
+require VERSION_TAG "${VERSION_TAG}"
 
 GITSHA="$(git rev-parse HEAD)"
 
-function upload_staging() {
+function package_has_changes() {
+    local key="$1"
+    local path="$2"
+
+    if [ -z "${path}" ]; then
+        # if no path then we can't calculate changes
+        return 0
+    fi
+
+    local upstream_gitsha=
+    upstream_gitsha="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "${key}" | grep '"gitsha":' | sed 's/[",:]//g' | awk '{print $2}')"
+
+    if [ -z "${upstream_gitsha}" ]; then
+        # if package doesn't exist or have a gitsha it has changes
+        return 0
+    fi
+
+    if git diff --quiet "${upstream_gitsha}" -- "${path}" "${VERSION_TAG}" -- "${path}" ; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function build_and_upload() {
     local package="$1"
 
     make "dist/${package}"
     MD5="$(openssl md5 -binary "dist/${package}" | base64)"
-    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" \
+    aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/dist/${VERSION_TAG}/${package}" \
+        --metadata md5="${MD5}",gitsha="${VERSION_TAG}"
+    aws s3 cp "s3://${S3_BUCKET}/dist/${VERSION_TAG}/${package}" "s3://${S3_BUCKET}/dist/${package}" \
         --metadata md5="${MD5}",gitsha="${GITSHA}"
     make clean
     if [ -n "$DOCKER_PRUNE" ]; then
@@ -31,38 +58,62 @@ function upload_staging() {
     fi
 }
 
-# build and upload missing staging packages
-for package in $(list_all | awk '{print $1}')
-do
-    if ! aws s3api head-object --bucket="${S3_BUCKET}" --key="staging/${GITSHA}/${package}" &>/dev/null; then
-        upload_staging "${package}"
-    else
-        echo "s3://${S3_BUCKET}/staging/${GITSHA}/${package} already exists"
+function copy_package_staging() {
+    local package="$1"
+
+    local md5=
+    md5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
+    aws s3 cp "s3://${S3_BUCKET}/staging/${package}" "s3://${S3_BUCKET}/dist/${VERSION_TAG}/${package}" \
+        --metadata md5="${md5}",gitsha="${GITSHA}"
+    aws s3 cp "s3://${S3_BUCKET}/staging/${package}" "s3://${S3_BUCKET}/dist/${package}" \
+        --metadata md5="${md5}",gitsha="${GITSHA}"
+}
+
+function deploy() {
+    local package="$1"
+    local path="$2"
+
+    # Common must be built rather than copied from staging because the staging common.tar.gz
+    # package includes the alpha kurl-util image but the prod common.tar.gz needs a tagged version
+    # of the kurl-util image
+    if [ "$package" = "common.tar.gz" ] ; then
+        echo "s3://${S3_BUCKET}/${package} build and upload"
+        build_and_upload "${package}"
+        return
     fi
-done
 
-for package in $(list_all | awk '{print $1}')
-do
-    if [ "$package" = "common.tar.gz" ] || echo "${package}" | grep -q "kurl-bin-utils" ; then
-        # Common must be built rather than copied from staging because the staging common.tar.gz
-        # package includes the alpha kurl-util image but the prod common.tar.gz needs a tagged version
-        # of the kurl-util image
-
-        # The kurl-utils-bin package must be built rather than copied from staging because the staging
-        # version is latest and the prod version is tagged.
-
-        make "dist/${package}"
-        MD5="$(openssl md5 -binary "dist/${package}" | base64)"
-        aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" \
-            --metadata md5="${MD5}",gitsha="${GITSHA}"
-        aws s3 cp "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}" \
-            --metadata md5="${MD5}",gitsha="${GITSHA}"
-    else
-        # copy staging package to prod
-        MD5="$(aws s3api head-object --bucket "${S3_BUCKET}" --key "staging/${GITSHA}/${package}" | grep '"md5":' | sed 's/[",:]//g' | awk '{print $2}')"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${GITSHA}/${package}" \
-            --metadata md5="${MD5}",gitsha="${GITSHA}"
-        aws s3 cp "s3://${S3_BUCKET}/staging/${GITSHA}/${package}" "s3://${S3_BUCKET}/dist/${package}" \
-            --metadata md5="${MD5}",gitsha="${GITSHA}"
+    # The kurl-utils-bin package must be built rather than copied from staging because the staging
+    # version is latest and the prod version is tagged.
+    if echo "${package}" | grep -q "kurl-bin-utils" ; then
+        echo "s3://${S3_BUCKET}/${package} build and upload"
+        build_and_upload "${package}"
+        return
     fi
-done
+
+    if package_has_changes "dist/${package}" "${path}" ; then
+        if package_has_changes "staging/${package}" "${path}" ; then
+            echo "s3://${S3_BUCKET}/${package} has changes"
+            build_and_upload "${package}"
+        else
+            echo "s3://${S3_BUCKET}/${package} no changes in staging package"
+            copy_package_staging "${package}"
+        fi
+    else
+        echo "s3://${S3_BUCKET}/dist/${package} no changes in package"
+    fi
+}
+
+function main() {
+    git fetch
+
+    # TODO: kubernetes changes do not yet take into account changes in bundles/
+    # These need to manually be rebuilt when changing that path.
+
+    while read -r line
+    do
+        # shellcheck disable=SC2086
+        deploy ${line}
+    done < <(list_all)
+}
+
+main "$@"

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -61,11 +61,11 @@ function deploy() {
 
     # always upload small packages that change often
     if [ "$package" = "common.tar.gz" ] ; then
-        echo "s3://${S3_BUCKET}/${package} build and upload"
+        echo "s3://${S3_BUCKET}/staging/${package} build and upload"
         build_and_upload "${package}"
         return
     elif echo "${package}" | grep -q "kurl-bin-utils" ; then
-        echo "s3://${S3_BUCKET}/${package} build and upload"
+        echo "s3://${S3_BUCKET}/staging/${package} build and upload"
         build_and_upload "${package}"
         return
     fi


### PR DESCRIPTION
This will add versioned directories to the dist directory when deploying to prod.

This also fixes the cron and manual build workflows to mimic the merge and push tag workflows.