### PR TITLE
add kotsadm-minio image that is used by file system snapshots

### DIFF
--- a/addons/kotsadm/alpha/Manifest
+++ b/addons/kotsadm/alpha/Manifest
@@ -1,5 +1,6 @@
 image kotsadm-migrations docker.io/kotsadm/kotsadm-migrations:alpha
 image kotsadm-operator docker.io/kotsadm/kotsadm-operator:alpha
+image kotsadm-minio docker.io/kotsadm/minio:v1.33.1
 image kotsadm docker.io/kotsadm/kotsadm:alpha
 image kurl-proxy docker.io/kotsadm/kurl-proxy:alpha
 image postgres postgres:10.16-alpine

--- a/addons/kotsadm/alpha/Manifest
+++ b/addons/kotsadm/alpha/Manifest
@@ -1,6 +1,6 @@
 image kotsadm-migrations docker.io/kotsadm/kotsadm-migrations:alpha
 image kotsadm-operator docker.io/kotsadm/kotsadm-operator:alpha
-image kotsadm-minio docker.io/kotsadm/minio:v1.33.1
+image kotsadm-minio docker.io/kotsadm/minio:alpha
 image kotsadm docker.io/kotsadm/kotsadm:alpha
 image kurl-proxy docker.io/kotsadm/kurl-proxy:alpha
 image postgres postgres:10.16-alpine


### PR DESCRIPTION
File system snapshots in kotsadm uses the `kotsadm/minio` image (e.g. NFS and Hostpath). This is currently broken in airgap mode since we don't include and load the image in the kotsadm addon as part of the airgap bundle.