### PR TITLE
add new kurl_util function to get an addon spec as json

### DIFF
--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -55,7 +55,7 @@ test: lint vet
 .PHONY: build
 build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network
 
-bin/yamlutil:
+bin/yamlutil: cmd/yamlutil/main.go
 	go build ${LDFLAGS} -o bin/yamlutil cmd/yamlutil/main.go
 
 bin/subnet:

--- a/kurl_util/cmd/yamlutil/main_test.go
+++ b/kurl_util/cmd/yamlutil/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testfiles/latest.yaml
+var latestYaml string
+
+//go:embed testfiles/complex.yaml
+var complexYaml string
+
+func Test_jsonField(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		jsonPath string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "specific addon from latest",
+			filePath: "latest",
+			jsonPath: "spec.weave",
+			want:     `{"version":"latest"}`,
+		},
+		{
+			name:     "addon that does not exist from latest",
+			filePath: "latest",
+			jsonPath: "spec.longhorn",
+			want:     ``,
+			wantErr:  true,
+		},
+		{
+			name:     "multiline strings and quotes",
+			filePath: "complex",
+			jsonPath: "spec.docker",
+			want:     `{"daemonConfig":"this is a test file with newlines\nand quotes\"\nwithin it\n","version":"20.10.5"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			testReader := func(path string) []byte {
+				if path == "latest" {
+					return []byte(latestYaml)
+				}
+				if path == "complex" {
+					return []byte(complexYaml)
+				}
+				return nil
+			}
+			got, err := jsonField(testReader, tt.filePath, tt.jsonPath)
+			req.Equal(tt.want, got)
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+		})
+	}
+}

--- a/kurl_util/cmd/yamlutil/testfiles/complex.yaml
+++ b/kurl_util/cmd/yamlutil/testfiles/complex.yaml
@@ -1,0 +1,27 @@
+apiVersion: "cluster.kurl.sh/v1beta1"
+kind: "Installer"
+metadata:
+  name: "complex"
+spec:
+  kubernetes:
+    version: "latest"
+  weave:
+    version: "2.8.1"
+  rook:
+    version: "1.5.9"
+    isBlockStorageEnabled: true
+    bypassUpgradeWarning: true
+  contour:
+    version: "latest"
+  docker:
+    version: "20.10.5"
+    daemonConfig: |
+      this is a test file with newlines
+      and quotes"
+      within it
+  prometheus:
+    version: "0.47.0-15.2.0"
+  registry:
+    version: "latest"
+  ekco:
+    version: "latest"

--- a/kurl_util/cmd/yamlutil/testfiles/latest.yaml
+++ b/kurl_util/cmd/yamlutil/testfiles/latest.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cluster.kurl.sh/v1beta1"
+kind: "Installer"
+metadata:
+  name: "latest"
+spec:
+  kubernetes:
+    version: "latest"
+  weave:
+    version: "latest"
+  rook:
+    version: "latest"
+  contour:
+    version: "latest"
+  docker:
+    version: "latest"
+  prometheus:
+    version: "latest"
+  registry:
+    version: "latest"
+  ekco:
+    version: "latest"


### PR DESCRIPTION
example output,  from the default 'latestl yaml spec:
```
./kurl_util/bin/yamlutil -j -fp build/default.yaml -jf "spec.contour"
{"version":"latest"}
./kurl_util/bin/yamlutil -j -fp build/default.yaml -jf "spec"
{"contour":{"version":"latest"},"docker":{"version":"latest"},"ekco":{"version":"latest"},"kubernetes":{"version":"latest"},"prometheus":{"version":"latest"},"registry":{"version":"latest"},"rook":{"version":"latest"},"weave":{"version":"latest"}}
```