### PR TITLE
Rebuild rook images from UI

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,8 +1,12 @@
 # This rebuilds a single image
 name: build-image
 on:
-  repository_dispatch:
-    types: [build-image]
+  workflow_dispatch:
+    inputs:
+      image:
+        description: path to a Makefile that builds the image
+        required: true
+        default: addons/rook/1.0.4/build-images/ceph
 
 jobs:
   build:
@@ -17,8 +21,8 @@ jobs:
       run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
     - name: Install jq
       run: sudo apt-get install -y jq
-    - name: Build image ${{ github.event.client_payload.image }}
+    - name: Build image ${{ github.event.inputs.image }}
       env:
-        IMAGE: ${{ github.event.client_payload.image }}
+        IMAGE: ${{ github.event.inputs.image }}
       run: |
         make -C $IMAGE

--- a/addons/rook/1.0.4/build-images/README.md
+++ b/addons/rook/1.0.4/build-images/README.md
@@ -1,20 +1,7 @@
 
-# ceph
-
-```bash
-image=addons/rook/1.0.4/build-images/ceph
-curl -H "Authorization: token $GH_PAT" \
-  -H 'Accept: application/json' \
-  -d "{\"event_type\": \"build-image\", \"client_payload\": {\"image\": \"${image}\"}}" \
-  "https://api.github.com/repos/replicatedhq/kurl/dispatches"
-```
-
-# rook-ceph
-
-```bash
-image=addons/rook/1.0.4/build-images/rook-ceph
-curl -H "Authorization: token $GH_PAT" \
-  -H 'Accept: application/json' \
-  -d "{\"event_type\": \"build-image\", \"client_payload\": {\"image\": \"${image}\"}}" \
-  "https://api.github.com/repos/replicatedhq/kurl/dispatches"
-```
+1. Test changes to Dockerfile locally with `make build scan`
+1. Commit and push changes
+1. Go to https://github.com/replicatedhq/kURL/actions/workflows/build-image.yaml
+1. Select your branch with updated Dockerfile
+1. Enter addons/rook/1.0.4/build-images/ceph and click Run Workflow
+1. Enter addons/rook/1.0.4/build-images/rook-ceph and click Run Workflow

--- a/addons/rook/1.0.4/build-images/ceph/Dockerfile
+++ b/addons/rook/1.0.4/build-images/ceph/Dockerfile
@@ -23,4 +23,6 @@ RUN yum install -y \
     python3-libs \
     samba-client-libs \
     sudo \
+    libldb \
+    nettle \
   && yum clean all

--- a/addons/rook/1.0.4/build-images/rook-ceph/Dockerfile
+++ b/addons/rook/1.0.4/build-images/rook-ceph/Dockerfile
@@ -25,6 +25,7 @@ RUN yum install -y \
     python3-libs \
     samba-client-libs \
     sudo \
+    libldb \
   && yum clean all
 
 COPY --from=base /tini /tini


### PR DESCRIPTION
The UI allows you to choose the branch to build from, so we can fix images and get their tag in a single PR.