### PR TITLE
Fix weave reset script

### DIFF
--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -82,7 +82,7 @@ function kubeadm_weave_reset() {
 
     DOCKER_BRIDGE=docker0
 
-    # https://github.com/weaveworks/weave/blob/05ab1139db615c61b99074c63184076ba72e2416/weave#L460
+    # https://github.com/weaveworks/weave/blob/v2.8.1/weave#L461
     for NETDEV in $BRIDGE $DATAPATH ; do
         if [ -d /sys/class/net/$NETDEV ] ; then
             if [ -d /sys/class/net/$NETDEV/bridge ] ; then
@@ -109,6 +109,7 @@ function kubeadm_weave_reset() {
         kubeadm_run_iptables -t filter -D FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP 2>/dev/null || true
     fi
 
+    kubeadm_run_iptables -t filter -D INPUT -d 127.0.0.1/32 -p tcp --dport 6784 -m addrtype ! --src-type LOCAL -m conntrack ! --ctstate RELATED,ESTABLISHED -m comment --comment "Block non-local access to Weave Net control port" -j DROP >/dev/null 2>&1 || true
     kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
     kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p tcp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
 

--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -58,8 +58,9 @@ function kubeadm_addon_for_each() {
 }
 
 function kubeadm_reset() {
-    
-    WEAVE_TAG="$(get_weave_version)"
+    if [ -z "$WEAVE_TAG" ]; then
+        WEAVE_TAG="$(get_weave_version)"
+    fi
 
     if [ -n "$DOCKER_VERSION" ]; then
         kubeadm reset --force
@@ -69,9 +70,87 @@ function kubeadm_reset() {
     printf "kubeadm reset completed\n"
 
     if [ -f /etc/cni/net.d/10-weave.conflist ]; then
-        weave_reset
+        kubeadm_weave_reset
     fi
     printf "weave reset completed\n"
+}
+
+function kubeadm_weave_reset() {
+    BRIDGE=weave
+    DATAPATH=datapath
+    CONTAINER_IFNAME=ethwe
+
+    DOCKER_BRIDGE=docker0
+
+    # https://github.com/weaveworks/weave/blob/05ab1139db615c61b99074c63184076ba72e2416/weave#L460
+    for NETDEV in $BRIDGE $DATAPATH ; do
+        if [ -d /sys/class/net/$NETDEV ] ; then
+            if [ -d /sys/class/net/$NETDEV/bridge ] ; then
+                ip link del $NETDEV
+            else
+                if [ -n "$DOCKER_VERSION" ]; then
+                    docker run --rm --pid host --net host --privileged --entrypoint=/usr/bin/weaveutil weaveworks/weaveexec:$WEAVE_TAG delete-datapath $NETDEV
+                else
+                    # --pid host
+                    local guid=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c16)
+                    # TODO(ethan): rke2 containerd.sock path is incorrect
+                    ctr -n=k8s.io run --rm --net-host --privileged docker.io/weaveworks/weaveexec:$WEAVE_TAG $guid /usr/bin/weaveutil delete-datapath $NETDEV
+                fi
+            fi
+        fi
+    done
+
+    # Remove any lingering bridged fastdp, pcap and attach-bridge veths
+    for VETH in $(ip -o link show | grep -o v${CONTAINER_IFNAME}[^:@]*) ; do
+        ip link del $VETH >/dev/null 2>&1 || true
+    done
+
+    if [ "$DOCKER_BRIDGE" != "$BRIDGE" ] ; then
+        kubeadm_run_iptables -t filter -D FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP 2>/dev/null || true
+    fi
+
+    kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p tcp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
+
+    if [ -n "$DOCKER_VERSION" ]; then
+        DOCKER_BRIDGE_IP=$(docker run --rm --pid host --net host --privileged -v /var/run/docker.sock:/var/run/docker.sock --entrypoint=/usr/bin/weaveutil weaveworks/weaveexec:$WEAVE_TAG bridge-ip $DOCKER_BRIDGE)
+
+        kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p tcp --dst $DOCKER_BRIDGE_IP --dport $PORT          -j DROP >/dev/null 2>&1 || true
+        kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dst $DOCKER_BRIDGE_IP --dport $PORT          -j DROP >/dev/null 2>&1 || true
+        kubeadm_run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dst $DOCKER_BRIDGE_IP --dport $(($PORT + 1)) -j DROP >/dev/null 2>&1 || true
+    fi
+
+    kubeadm_run_iptables -t filter -D FORWARD -i $BRIDGE ! -o $BRIDGE -j ACCEPT 2>/dev/null || true
+    kubeadm_run_iptables -t filter -D FORWARD -o $BRIDGE -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+    kubeadm_run_iptables -t filter -D FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT 2>/dev/null || true
+    kubeadm_run_iptables -F WEAVE-NPC >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-NPC 2>/dev/null || true
+    kubeadm_run_iptables -t filter -D FORWARD -o $BRIDGE -m state --state NEW -j NFLOG --nflog-group 86 2>/dev/null || true
+    kubeadm_run_iptables -t filter -D FORWARD -o $BRIDGE -j DROP 2>/dev/null || true
+    kubeadm_run_iptables -X WEAVE-NPC >/dev/null 2>&1 || true
+
+    kubeadm_run_iptables -F WEAVE-EXPOSE >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-EXPOSE 2>/dev/null || true
+    kubeadm_run_iptables -X WEAVE-EXPOSE >/dev/null 2>&1 || true
+
+    kubeadm_run_iptables -t nat -F WEAVE >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t nat -D POSTROUTING -j WEAVE >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t nat -D POSTROUTING -o $BRIDGE -j ACCEPT >/dev/null 2>&1 || true
+    kubeadm_run_iptables -t nat -X WEAVE >/dev/null 2>&1 || true
+
+    for LOCAL_IFNAME in $(ip link show | grep v${CONTAINER_IFNAME}pl | cut -d ' ' -f 2 | tr -d ':') ; do
+        ip link del ${LOCAL_IFNAME%@*} >/dev/null 2>&1 || true
+    done
+}
+
+function kubeadm_run_iptables() {
+    # -w is recent addition to iptables
+    if [ -z "$CHECKED_IPTABLES_W" ] ; then
+        iptables -S -w >/dev/null 2>&1 && IPTABLES_W=-w
+        CHECKED_IPTABLES_W=1
+    fi
+
+    iptables $IPTABLES_W "$@"
 }
 
 function kubeadm_containerd_restart() {


### PR DESCRIPTION
1. Allow WEAVE_TAG to be specified in the environment in case weave version cannot be looked up
2. Add missing run_iptables command
3. Move weave reset to kubeadm/distro.sh script since that is where it is called from
4. Default weave tag 2.6.5 since that is the latest version
5. Pulled in latest changes from 2.8.1