### PR TITLE
Suppress key verification warning on airgap RPMs

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -577,11 +577,11 @@ function install_host_packages() {
         centos|rhel|amzn|ol)
             if [[ "$DIST_VERSION" =~ ^8 ]]; then
                 if test -n "$(shopt -s nullglob; echo ${dir}/rhel-8/*.rpm )" ; then
-                    rpm --upgrade --force --nodeps ${dir}/rhel-8/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature ${dir}/rhel-8/*.rpm
                 fi
             else
                 if test -n "$(shopt -s nullglob; echo ${dir}/rhel-7/*.rpm )" ; then
-                    rpm --upgrade --force --nodeps ${dir}/rhel-7/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature ${dir}/rhel-7/*.rpm
                 fi
             fi
             ;;
@@ -613,11 +613,11 @@ function install_host_archives() {
         centos|rhel|amzn|ol)
             if [[ "$DIST_VERSION" =~ ^8 ]]; then
                 if test -n "$(shopt -s nullglob; echo ${dir}/rhel-8/archives/*.rpm )" ; then
-                    rpm --upgrade --force --nodeps ${dir}/rhel-8/archives/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature ${dir}/rhel-8/archives/*.rpm
                 fi
             else
                 if test -n "$(shopt -s nullglob; echo ${dir}/rhel-7/archives/*.rpm )" ; then
-                    rpm --upgrade --force --nodeps ${dir}/rhel-7/archives/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature ${dir}/rhel-7/archives/*.rpm
                 fi
             fi
             ;;


### PR DESCRIPTION
Prior to this commit, airgap installs would print a key verification
warning for each host RPM installed.  Although the ideal solution would
be to have these RPMs signed such that these warnings do not print, it
would be better to suppress them for now.

With this commit, the warnings are no longer printed as the signature
key is no longer checked.