### PR TITLE
Update md5sum to sha256sum

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -70,7 +70,7 @@ function package_matches_checksum() {
         return 1
     elif [ ! -f "${filepath}" ] || [ ! -s "${filepath}" ]; then # if not exists or empty
         return 1
-    elif ! md5sum "${filepath}" | grep -Fq "${checksum}" ; then
+    elif ! sha256sum "${filepath}" | grep -Fq "${checksum}" ; then
         echo "Package ${package} checksum does not match"
         return 1
     fi


### PR DESCRIPTION
With the recent supply chain attacks associated with Codecov, it is imperative that checksum verification of downloadable files should be kept in place. `sha256sum` is more secure compared to `md5sum` in this regard, since `md5sum` is highly prone to a collision attack.