### PR TITLE
Suppress rpm signature verification errors. Log host package installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,6 +584,7 @@ watchrsync:
 
 .PHONY: deps
 deps:
+	go get golang.org/x/lint/golint
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,6 @@ watchrsync:
 
 .PHONY: deps
 deps:
-	go get -u golang.org/x/lint/golint
 
 .PHONY: lint
 lint:

--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -4,12 +4,14 @@ function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if [ "$SKIP_CONTAINERD_INSTALL" != "1" ]; then
+        logStep "Installing Containerd host packages"
         install_host_archives "$src"
         install_host_packages "$src"
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
         containerd_configure
         systemctl daemon-reload
+        logSuccess "Containerd host packages installed"
     fi
 
     systemctl enable containerd

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -4,12 +4,14 @@ function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if [ "$SKIP_CONTAINERD_INSTALL" != "1" ]; then
+        logStep "Installing Containerd host packages"
         install_host_archives "$src"
         install_host_packages "$src"
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
         containerd_configure
         systemctl daemon-reload
+        logSuccess "Containerd host packages installed"
     fi
 
     systemctl enable containerd

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -4,12 +4,14 @@ function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if [ "$SKIP_CONTAINERD_INSTALL" != "1" ]; then
+        logStep "Installing Containerd host packages"
         install_host_archives "$src"
         install_host_packages "$src"
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
         containerd_configure
         systemctl daemon-reload
+        logSuccess "Containerd host packages installed"
     fi
 
     systemctl enable containerd

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -4,12 +4,14 @@ function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if [ "$SKIP_CONTAINERD_INSTALL" != "1" ]; then
+        logStep "Installing Containerd host packages"
         install_host_archives "$src"
         install_host_packages "$src"
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
         containerd_configure
         systemctl daemon-reload
+        logSuccess "Containerd host packages installed"
     fi
 
     systemctl enable containerd

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -4,12 +4,14 @@ function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if [ "$SKIP_CONTAINERD_INSTALL" != "1" ]; then
+        logStep "Installing Containerd host packages"
         install_host_archives "$src"
         install_host_packages "$src"
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
         containerd_configure
         systemctl daemon-reload
+        logSuccess "Containerd host packages installed"
     fi
 
     systemctl enable containerd

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/itchyny/gojq v0.12.2
 	github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -317,7 +317,6 @@ github.com/googleapis/gnostic v0.5.1 h1:A8Yhf6EtqTv9RMsU6MQTyrtV1TjWlR6xU9BsZIwu
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -38,6 +38,7 @@ clean:
 
 .PHONY: deps
 deps:
+	go get golang.org/x/lint/golint
 
 .PHONY: lint
 lint:

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -38,7 +38,6 @@ clean:
 
 .PHONY: deps
 deps:
-	go get -u golang.org/x/lint/golint
 
 .PHONY: lint
 lint:

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -45,26 +45,29 @@ function restart_docker() {
 }
 
 docker_install() {
-   case "$LSB_DIST" in
+    logStep "Installing Docker host packages"
+
+    case "$LSB_DIST" in
         ubuntu)
-            export DEBIAN_FRONTEND=noninteractive
-            dpkg --install --force-depends-version $DIR/packages/docker/${DOCKER_VERSION}/ubuntu-${DIST_VERSION}/*.deb
+            DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version $DIR/packages/docker/${DOCKER_VERSION}/ubuntu-${DIST_VERSION}/*.deb
             cp $DIR/packages/docker/${DOCKER_VERSION}/runc $(which runc)
             DID_INSTALL_DOCKER=1
             return 0
             ;;
 
         centos|rhel|amzn|ol)
-            rpm --upgrade --force --nodeps $DIR/packages/docker/${DOCKER_VERSION}/rhel-7/*.rpm
+            rpm --upgrade --force --nodeps --nosignature $DIR/packages/docker/${DOCKER_VERSION}/rhel-7/*.rpm
             cp $DIR/packages/docker/${DOCKER_VERSION}/runc $(which runc)
             DID_INSTALL_DOCKER=1
             return 0
             ;;
+
+        *)
+            bail "Offline Docker install is not supported on ${LSB_DIST} ${DIST_MAJOR}"
+            ;;
     esac
 
-
-    printf "Offline Docker install is not supported on ${LSB_DIST} ${DIST_MAJOR}"
-    exit 1
+    logSuccess "Docker host packages installed"
 }
 
 check_docker_storage_driver() {

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -98,20 +98,19 @@ EOF
     case "$LSB_DIST" in
         ubuntu)
             sed "s:__ENV_LOCATION__:default:g" -i "$DIR/tmp-kubeadm.conf"
-            export DEBIAN_FRONTEND=noninteractive
-            dpkg --install --force-depends-version $DIR/packages/kubernetes/${k8sVersion}/ubuntu-${DIST_VERSION}/*.deb
+            DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version $DIR/packages/kubernetes/${k8sVersion}/ubuntu-${DIST_VERSION}/*.deb
             ;;
 
         centos|rhel|amzn|ol)
             case "$LSB_DIST$DIST_VERSION_MAJOR" in
                 rhel8|centos8)
                     sed "s:__ENV_LOCATION__:sysconfig:g" -i "$DIR/tmp-kubeadm.conf"
-                    rpm --upgrade --force --nodeps $DIR/packages/kubernetes/${k8sVersion}/rhel-8/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature $DIR/packages/kubernetes/${k8sVersion}/rhel-8/*.rpm
                     ;;
 
                 *)
                     sed "s:__ENV_LOCATION__:sysconfig:g" -i "$DIR/tmp-kubeadm.conf"
-                    rpm --upgrade --force --nodeps $DIR/packages/kubernetes/${k8sVersion}/rhel-7/*.rpm
+                    rpm --upgrade --force --nodeps --nosignature $DIR/packages/kubernetes/${k8sVersion}/rhel-7/*.rpm
                     ;;
             esac
         ;;


### PR DESCRIPTION
1. Adds `--nosignature` flag to rpm install to suppress package signature verification error
2. Adds logging around host package installs to report progress