### PR TITLE
Dedicated primary

### DIFF
--- a/addons/ekco/0.1.0/deployment.yaml
+++ b/addons/ekco/0.1.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.1.0

--- a/addons/ekco/0.10.0/deployment.yaml
+++ b/addons/ekco/0.10.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.10.0

--- a/addons/ekco/0.10.1/deployment.yaml
+++ b/addons/ekco/0.10.1/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.10.1

--- a/addons/ekco/0.2.0/deployment.yaml
+++ b/addons/ekco/0.2.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.2.0

--- a/addons/ekco/0.2.1/deployment.yaml
+++ b/addons/ekco/0.2.1/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.2.1

--- a/addons/ekco/0.2.3/deployment.yaml
+++ b/addons/ekco/0.2.3/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.2.3

--- a/addons/ekco/0.2.4/deployment.yaml
+++ b/addons/ekco/0.2.4/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.2.4

--- a/addons/ekco/0.3.0/deployment.yaml
+++ b/addons/ekco/0.3.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.3.0

--- a/addons/ekco/0.4.0/deployment.yaml
+++ b/addons/ekco/0.4.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.4.0

--- a/addons/ekco/0.4.1/deployment.yaml
+++ b/addons/ekco/0.4.1/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.4.1

--- a/addons/ekco/0.4.2/deployment.yaml
+++ b/addons/ekco/0.4.2/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.4.2

--- a/addons/ekco/0.5.0/deployment.yaml
+++ b/addons/ekco/0.5.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.5.0

--- a/addons/ekco/0.6.0/deployment.yaml
+++ b/addons/ekco/0.6.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.6.0

--- a/addons/ekco/0.7.0/deployment.yaml
+++ b/addons/ekco/0.7.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.7.0

--- a/addons/ekco/0.8.0/deployment.yaml
+++ b/addons/ekco/0.8.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.8.0

--- a/addons/ekco/0.9.0/deployment.yaml
+++ b/addons/ekco/0.9.0/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       restartPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco:v0.9.0

--- a/addons/rook/1.4.3/cluster/kustomization.yaml
+++ b/addons/rook/1.4.3/cluster/kustomization.yaml
@@ -10,3 +10,4 @@ patchesStrategicMerge:
 - ceph-cluster-storage.yaml
 - ceph-block-pool-replicas.yaml
 - ceph-object-store-replicas.yaml
+- ceph-cluster-tolerate.yaml

--- a/addons/rook/1.4.3/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/1.4.3/cluster/patches/ceph-cluster-tolerate.yaml
@@ -1,0 +1,10 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  placement:
+    all:
+      tolerations:
+        - node-role.kubernetes.io/master

--- a/addons/rook/1.4.3/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/1.4.3/cluster/patches/ceph-cluster-tolerate.yaml
@@ -7,4 +7,5 @@ spec:
   placement:
     all:
       tolerations:
-        - node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/master
+          operator: Exists

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -107,6 +107,7 @@ function rook_cluster_deploy() {
 
     # patches
     cp "$src/patches/ceph-cluster-mons.yaml" "$dst/"
+    cp "$src/patches/ceph-cluster-tolerate.yaml" "$dst/"
     render_yaml_file "$src/patches/tmpl-ceph-cluster-image.yaml" > "$dst/ceph-cluster-image.yaml"
     render_yaml_file "$src/patches/tmpl-ceph-block-pool-replicas.yaml" > "$dst/ceph-block-pool-replicas.yaml"
     render_yaml_file "$src/patches/tmpl-ceph-object-store.yaml" > "$dst/ceph-object-store-replicas.yaml"

--- a/addons/rook/1.4.3/operator/kustomization.yaml
+++ b/addons/rook/1.4.3/operator/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 - ceph-toolbox.yaml
 - config-override.yaml
 - priorityclass.yaml
+
+patchesStrategicMerge:
+- ceph-operator-tolerate.yaml

--- a/addons/rook/1.4.3/operator/kustomization.yaml
+++ b/addons/rook/1.4.3/operator/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 - priorityclass.yaml
 
 patchesStrategicMerge:
-- ceph-operator-tolerate.yaml
+- patches/ceph-operator-tolerate.yaml

--- a/addons/rook/1.4.3/operator/patches/ceph-operator-tolerate.yaml
+++ b/addons/rook/1.4.3/operator/patches/ceph-operator-tolerate.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: rook-ceph-operator
+          env:
+            - name: DISCOVER_TOLERATION_KEY
+              value: node-role.kubernetes.io/master
+            - name: CSI_PROVISIONER_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - name: CSI_PLUGIN_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists

--- a/addons/rook/1.4.9/cluster/kustomization.yaml
+++ b/addons/rook/1.4.9/cluster/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
+- ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.4.9/cluster/kustomization.yaml
+++ b/addons/rook/1.4.9/cluster/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
-- ceph-cluster-tolerate.yaml
+- patches/ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.4.9/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/1.4.9/cluster/patches/ceph-cluster-tolerate.yaml
@@ -1,0 +1,11 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  placement:
+    all:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists

--- a/addons/rook/1.4.9/operator/kustomization.yaml
+++ b/addons/rook/1.4.9/operator/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - psp.yaml
 - namespace.yaml
 - configmap-rook-config-override.yaml
+
+patchesStrategicMerge:
+- deployment-tolerations.yaml

--- a/addons/rook/1.4.9/operator/kustomization.yaml
+++ b/addons/rook/1.4.9/operator/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 - configmap-rook-config-override.yaml
 
 patchesStrategicMerge:
-- deployment-tolerations.yaml
+- patches/deployment-tolerations.yaml

--- a/addons/rook/1.4.9/operator/patches/deployment-tolerations.yaml
+++ b/addons/rook/1.4.9/operator/patches/deployment-tolerations.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: rook-ceph-operator
+          env:
+            - name: DISCOVER_TOLERATION_KEY
+              value: node-role.kubernetes.io/master
+            - name: CSI_PROVISIONER_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - name: CSI_PLUGIN_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists

--- a/addons/rook/1.5.10/cluster/kustomization.yaml
+++ b/addons/rook/1.5.10/cluster/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
+- ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.5.10/cluster/kustomization.yaml
+++ b/addons/rook/1.5.10/cluster/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
-- ceph-cluster-tolerate.yaml
+- patches/ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.5.10/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/1.5.10/cluster/patches/ceph-cluster-tolerate.yaml
@@ -1,0 +1,11 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  placement:
+    all:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists

--- a/addons/rook/1.5.10/operator/kustomization.yaml
+++ b/addons/rook/1.5.10/operator/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - psp.yaml
 - namespace.yaml
 - configmap-rook-config-override.yaml
+
+patchesStrategicMerge:
+- deployment-tolerations.yaml

--- a/addons/rook/1.5.10/operator/kustomization.yaml
+++ b/addons/rook/1.5.10/operator/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 - configmap-rook-config-override.yaml
 
 patchesStrategicMerge:
-- deployment-tolerations.yaml
+- patches/deployment-tolerations.yaml

--- a/addons/rook/1.5.10/operator/patches/deployment-tolerations.yaml
+++ b/addons/rook/1.5.10/operator/patches/deployment-tolerations.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: rook-ceph-operator
+          env:
+            - name: DISCOVER_TOLERATION_KEY
+              value: node-role.kubernetes.io/master
+            - name: CSI_PROVISIONER_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - name: CSI_PLUGIN_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists

--- a/addons/rook/1.5.9/cluster/kustomization.yaml
+++ b/addons/rook/1.5.9/cluster/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
+- ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.5.9/cluster/kustomization.yaml
+++ b/addons/rook/1.5.9/cluster/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - cluster.yaml
 
 patchesStrategicMerge:
-- ceph-cluster-tolerate.yaml
+- patches/ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/1.5.9/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/1.5.9/cluster/patches/ceph-cluster-tolerate.yaml
@@ -1,0 +1,11 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  placement:
+    all:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists

--- a/addons/rook/1.5.9/operator/kustomization.yaml
+++ b/addons/rook/1.5.9/operator/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - psp.yaml
 - namespace.yaml
 - configmap-rook-config-override.yaml
+
+patchesStrategicMerge:
+- deployment-tolerations.yaml

--- a/addons/rook/1.5.9/operator/kustomization.yaml
+++ b/addons/rook/1.5.9/operator/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 - configmap-rook-config-override.yaml
 
 patchesStrategicMerge:
-- deployment-tolerations.yaml
+- patches/deployment-tolerations.yaml

--- a/addons/rook/1.5.9/operator/patches/deployment-tolerations.yaml
+++ b/addons/rook/1.5.9/operator/patches/deployment-tolerations.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: rook-ceph-operator
+          env:
+            - name: DISCOVER_TOLERATION_KEY
+              value: node-role.kubernetes.io/master
+            - name: CSI_PROVISIONER_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - name: CSI_PLUGIN_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists

--- a/addons/rook/template/base/cluster/kustomization.yaml
+++ b/addons/rook/template/base/cluster/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 
 patchesStrategicMerge:
-- ceph-cluster-tolerate.yaml
+- patches/ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/template/base/cluster/kustomization.yaml
+++ b/addons/rook/template/base/cluster/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 
 patchesStrategicMerge:
+- ceph-cluster-tolerate.yaml
 
 patchesJson6902:
 - target:

--- a/addons/rook/template/base/cluster/patches/ceph-cluster-tolerate.yaml
+++ b/addons/rook/template/base/cluster/patches/ceph-cluster-tolerate.yaml
@@ -1,0 +1,11 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  placement:
+    all:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists

--- a/addons/rook/template/base/operator/kustomization.yaml
+++ b/addons/rook/template/base/operator/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 - configmap-rook-config-override.yaml
 
 patchesStrategicMerge:
-- deployment-tolerations.yaml
+- patches/deployment-tolerations.yaml

--- a/addons/rook/template/base/operator/kustomization.yaml
+++ b/addons/rook/template/base/operator/kustomization.yaml
@@ -1,3 +1,6 @@
 resources:
 - namespace.yaml
 - configmap-rook-config-override.yaml
+
+patchesStrategicMerge:
+- deployment-tolerations.yaml

--- a/addons/rook/template/base/operator/patches/deployment-tolerations.yaml
+++ b/addons/rook/template/base/operator/patches/deployment-tolerations.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+      containers:
+        - name: rook-ceph-operator
+          env:
+            - name: DISCOVER_TOLERATION_KEY
+              value: node-role.kubernetes.io/master
+            - name: CSI_PROVISIONER_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - name: CSI_PLUGIN_TOLERATIONS
+              value: |
+                - key: node-role.kubernetes.io/master
+                  operator: Exists

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -387,7 +387,7 @@ function taint_primaries() {
     # Rook tolerations
     if kubectl get namespace rook-ceph &>/dev/null; then
         kubectl -n rook-ceph patch cephclusters rook-ceph --type=merge -p '{"spec":{"placement":{"all":{"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Exists"}]}}}}'
-		cat <<EOF | kubectl -n rook-ceph patch deployment rook-ceph-operator -p "$(cat)"
+        cat <<EOF | kubectl -n rook-ceph patch deployment rook-ceph-operator -p "$(cat)"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -435,7 +435,7 @@ EOF
         kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
     done < <(lsblk | grep '^rbd[0-9]' | awk '{ print $7 }' | awk -F '/' '{ print $6 }')
 
-    # Delete local pods using the Ceph filesystem so they get rescheduled on worker
+    # Delete local pods using the Ceph filesystem so they get rescheduled to worker nodes immediately
     while read -r uid; do
         pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
         kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false


### PR DESCRIPTION
Add `taint_primaries` task that adds the default kubeadm taint back to primary nodes, which kurl leaves off because the first node installed must always be a primary that can run workloads.

Add tolerations to rook and ekco by default and in the task to support older installs. Weave and Antrea already have tolerations for the taint.