### PR TITLE
Correctly detect latest antrea release

### DIFF
--- a/addons/antrea/template/generate.sh
+++ b/addons/antrea/template/generate.sh
@@ -42,7 +42,7 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=antrea::$VERSION"
+    echo "::set-output name=antrea_version::$VERSION"
 }
 
 main "$@"

--- a/addons/antrea/template/generate.sh
+++ b/addons/antrea/template/generate.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 
 VERSION=
 function get_latest_version() {
-    VERSION=$(curl -I https://github.com/vmware-tanzu/antrea/releases/latest | \
-        grep -i "^location" | \
-        grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+    # semver sort
+    VERSION=$(curl -s https://api.github.com/repos/antrea-io/antrea/releases | \
+        grep '"tag_name": ' | \
+        grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" | \
+        sed '/-/!{s/$/_/}' | sort -Vr | sed 's/_$//' | \
+        head -1)
 }
 
 function add_as_latest() {


### PR DESCRIPTION
This is currently detecting the latest release, not the greatest release. Also repo moved to the antrea-io github org.

https://github.com/replicatedhq/kURL/pull/1555