### PR TITLE
Upgrade containerd and runc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
 	${MAKE} build/packages/docker/$*/rhel-7
 	mkdir -p dist
-	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64 > build/packages/docker/$*/runc
+	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64 > build/packages/docker/$*/runc
 	chmod +x build/packages/docker/$*/runc
 	tar cf - -C build packages/docker/$* | gzip > dist/docker-$*.tar.gz
 

--- a/addons/containerd/1.3.7/Manifest
+++ b/addons/containerd/1.3.7/Manifest
@@ -4,5 +4,5 @@ dockerout ubuntu-16.04 addons/containerd/template/Dockerfile.ubuntu16 1.3.7
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.3.7
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.3.7
 yum libzstd
-asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64
 image pause k8s.gcr.io/pause:3.1

--- a/addons/containerd/1.3.9/Manifest
+++ b/addons/containerd/1.3.9/Manifest
@@ -4,5 +4,5 @@ dockerout ubuntu-16.04 addons/containerd/template/Dockerfile.ubuntu16 1.3.9
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.3.9
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.3.9
 yum libzstd
-asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64
 image pause k8s.gcr.io/pause:3.1

--- a/addons/containerd/1.4.3/Manifest
+++ b/addons/containerd/1.4.3/Manifest
@@ -4,5 +4,5 @@ dockerout ubuntu-16.04 addons/containerd/template/Dockerfile.ubuntu16 1.4.3
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.4.3
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.4.3
 yum libzstd
-asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64
 image pause k8s.gcr.io/pause:3.2

--- a/addons/containerd/1.4.4/Manifest
+++ b/addons/containerd/1.4.4/Manifest
@@ -4,5 +4,5 @@ dockerout ubuntu-16.04 addons/containerd/template/Dockerfile.ubuntu16 1.4.4
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.4.4
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.4.4
 yum libzstd
-asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64
 image pause k8s.gcr.io/pause:3.2

--- a/addons/containerd/template/base/Manifest
+++ b/addons/containerd/template/base/Manifest
@@ -4,4 +4,4 @@ dockerout ubuntu-16.04 addons/containerd/template/Dockerfile.ubuntu16 __version_
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 __version__
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 __version__
 yum libzstd
-asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc92/runc.amd64
+asset runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -137,6 +137,8 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 			continue
 		case "secondary-host":
 			continue
+		case "force-reapply-addons":
+			continue
 		default:
 			return errors.New(fmt.Sprintf("string %s is not a bash flag", split[0]))
 		}

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -353,13 +353,7 @@ function report_install_docker() {
 }
 
 function report_install_containerd() {
-    report_addon_start "containerd" "$CONTAINERD_VERSION"
-
-    containerd_get_host_packages_online "$CONTAINERD_VERSION"
-    . $DIR/addons/containerd/$CONTAINERD_VERSION/install.sh
-    containerd_install
-
-    report_addon_success "containerd" "$CONTAINERD_VERSION"
+    addon_install containerd "$CONTAINERD_VERSION"
 }
 
 function load_images() {
@@ -709,6 +703,13 @@ function get_docker_registry_ip_flag() {
         return
     fi
     echo " docker-registry-ip=${docker_registry_ip}"
+}
+
+function get_force_reapply_addons_flag() {
+    if [ "${FORCE_REAPPLY_ADDONS}" != "1" ]; then
+        return
+    fi
+    echo " force-reapply-addons"
 }
 
 function get_additional_no_proxy_addresses_flag() {

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -11,11 +11,6 @@ function discover() {
         echo "Docker already exists on this machine so no docker install will be performed"
     fi
 
-    if ctr --version >/dev/null 2>&1 ; then
-        SKIP_CONTAINERD_INSTALL=1
-        echo "Containerd already exists on this machine so no containerd install will be performed"
-    fi
-
     discover_public_ip
     discover_private_ip
 

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -296,7 +296,6 @@ function require_cri() {
     fi
 
     if commandExists ctr ; then
-        SKIP_CONTAINERD_INSTALL=1
         return 0
     fi
 


### PR DESCRIPTION
1. Upgrade or reinstall containerd to match the spec. Previously containerd was never upgraded or reinstalled.
2. Use the file `containerd-last-applied` to store the hash of the last applied config for that host. The `kurl-current-config` configmap does not work for containerd because Kubernetes cluster may not be up when containerd is installed and because containerd needs to be installed on every node in the cluster.
3. Use runc version 1.0.0-rc95 in containerd and docker. Docker is never upgraded or reinstalled so only new installs will have this version of runc. Containerd installs will get the new version of runc on upgrade or by passing the `force-reapply-addons` flag.
4. Fixed a bug where the install failed when the `force-reapply-addons` flag was passed.

There is no change to the behavior of changing from docker to containerd. Docker will remain installed and containerd install will be skipped.