### PR TITLE
Pin read file action to working version

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -172,7 +172,7 @@ jobs:
 
     - name: Read Changelog
       id: read-changelog
-      uses: juliangruber/read-file-action@v1
+      uses: juliangruber/read-file-action@v1.0.0
       with:
         path: ./CHANGELOG.md
 


### PR DESCRIPTION
The latest v1 [release of the read-file-action](https://github.com/juliangruber/read-file-action/releases) expects a `trim` option to be defined as a boolean. Pin to 1.0.0 to avoid future incompatibility.