### PR TITLE
include the longhorn servicemonitor by default with prometheus

### DIFF
--- a/addons/prometheus/0.47.1-16.0.1/install.sh
+++ b/addons/prometheus/0.47.1-16.0.1/install.sh
@@ -18,6 +18,7 @@ function prometheus() {
     spinner_until -1 prometheus_crd_ready
 
     prometheus_rook_ceph "$operatordst"
+    prometheus_longhorn "$operatordst"
 
     # remove deployments and daemonsets that had labelselectors change (as those are immutable)
     kubectl delete deployment -n monitoring kube-state-metrics || true
@@ -113,6 +114,14 @@ function prometheus_rook_ceph() {
 
     if kubectl get ns | grep -q rook-ceph; then
             insert_resources "$dst/kustomization.yaml" rook-ceph-rolebindings.yaml
+    fi
+}
+
+function prometheus_longhorn() {
+    local dst="$1"
+
+    if kubectl get ns | grep -q longhorn-system; then
+            insert_resources "$dst/kustomization.yaml" longhorn.yaml
     fi
 }
 

--- a/addons/prometheus/0.47.1-16.0.1/operator/default.yaml
+++ b/addons/prometheus/0.47.1-16.0.1/operator/default.yaml
@@ -37461,10 +37461,7 @@ spec:
   retention: "15d"
   routePrefix: "/"
   serviceAccountName: k8s
-  serviceMonitorSelector:
-    matchLabels:
-      release: "v0.47.1-16.0.1"
-
+  serviceMonitorSelector: {}
   serviceMonitorNamespaceSelector: {}
   podMonitorSelector:
     matchLabels:

--- a/addons/prometheus/0.47.1-16.0.1/operator/longhorn.yaml
+++ b/addons/prometheus/0.47.1-16.0.1/operator/longhorn.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn-prometheus-servicemonitor
+  namespace: monitoring
+  labels:
+    name: longhorn-prometheus-servicemonitor
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  namespaceSelector:
+    matchNames:
+    - longhorn-system
+  endpoints:
+  - port: manager

--- a/addons/prometheus/template/base/install.sh
+++ b/addons/prometheus/template/base/install.sh
@@ -18,6 +18,7 @@ function prometheus() {
     spinner_until -1 prometheus_crd_ready
 
     prometheus_rook_ceph "$operatordst"
+    prometheus_longhorn "$operatordst"
 
     # remove deployments and daemonsets that had labelselectors change (as those are immutable)
     kubectl delete deployment -n monitoring kube-state-metrics || true
@@ -113,6 +114,14 @@ function prometheus_rook_ceph() {
 
     if kubectl get ns | grep -q rook-ceph; then
             insert_resources "$dst/kustomization.yaml" rook-ceph-rolebindings.yaml
+    fi
+}
+
+function prometheus_longhorn() {
+    local dst="$1"
+
+    if kubectl get ns | grep -q longhorn-system; then
+            insert_resources "$dst/kustomization.yaml" longhorn.yaml
     fi
 }
 

--- a/addons/prometheus/template/base/operator/longhorn.yaml
+++ b/addons/prometheus/template/base/operator/longhorn.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn-prometheus-servicemonitor
+  namespace: monitoring
+  labels:
+    name: longhorn-prometheus-servicemonitor
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  namespaceSelector:
+    matchNames:
+    - longhorn-system
+  endpoints:
+  - port: manager

--- a/addons/prometheus/template/values.yaml
+++ b/addons/prometheus/template/values.yaml
@@ -1977,7 +1977,7 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the servicemonitors created
     ##
-    serviceMonitorSelectorNilUsesHelmValues: true
+    serviceMonitorSelectorNilUsesHelmValues: false # originally true (replicated)
 
     ## ServiceMonitors to be selected for target discovery.
     ## If {}, select all ServiceMonitors


### PR DESCRIPTION
Also, don't require a matching label on servicemonitors - we don't have multiple prometheus operators running, and that will presumably never be a thing in a kurl cluster anyways, so keeping them is just a footgun