### PR TITLE
Fix versioned kurl-util image and kurl-bin-utils file

### DIFF
--- a/web/src/controllers/Bundles.ts
+++ b/web/src/controllers/Bundles.ts
@@ -87,7 +87,7 @@ export class Bundle {
     response.type("application/json");
 
     const ret: BundleManifest = {layers: [], files: {}};
-    ret.layers = installer.packages().map((pkg) => getPackageUrl(this.distURL, kurlVersion, `${pkg}.tar.gz`));
+    ret.layers = installer.packages(kurlVersion).map((pkg) => getPackageUrl(this.distURL, kurlVersion, `${pkg}.tar.gz`));
 
     const kotsadmApplicationSlug = _.get(installer.spec, "kotsadm.applicationSlug");
     if (kotsadmApplicationSlug) {

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1160,11 +1160,13 @@ export class Installer {
     }
   }
 
-  public packages(): string[] {
-    const i = this.resolve();
+  public packages(kurlVersion: string|undefined): string[] {
     const special = /[+]/g;
 
-    const binUtils = String(process.env["KURL_BIN_UTILS_FILE"]).slice(0, -7); // remove .tar.gz
+    let binUtils = String(process.env["KURL_BIN_UTILS_FILE"] || "kurl-bin-utils-latest.tar.gz").slice(0, -7); // remove .tar.gz
+    if (kurlVersion) {
+      binUtils = `kurl-bin-utils-${kurlVersion}`
+    }
     const pkgs = [ "common", binUtils, "host-openssl" ];
 
     let kubernetesVersion = "";

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -996,7 +996,7 @@ spec:
   describe("packages", () => {
     it("should convert camel case to kebab case", () => {
       const i = Installer.parse(everyOption).resolve();
-      const pkgs = i.packages();
+      const pkgs = i.packages(undefined);
 
       const hasCertManager = _.some(pkgs, (pkg) => {
         return _.startsWith(pkg, "cert-manager");
@@ -1011,7 +1011,7 @@ spec:
 
     it("should include defaults", () => {
       const i = Installer.parse(min);
-      const pkgs = i.packages();
+      const pkgs = i.packages(undefined);
 
       const hasCommon = _.some(pkgs, (pkg) => {
         return pkg === "common";
@@ -1021,11 +1021,27 @@ spec:
       const hasOpenssl = _.some(pkgs, (pkg) => {
         return pkg === "host-openssl";
       });
+      expect(hasOpenssl).to.equal(true);
+
+      const hasKurlBinUtils = _.some(pkgs, (pkg) => {
+        return pkg === "kurl-bin-utils-latest";
+      });
+      expect(hasKurlBinUtils).to.equal(true);
+    });
+
+    it("should include a versioned kurl-bin-utils", () => {
+      const i = Installer.parse(min);
+      const pkgs = i.packages("v2021.05.27-0");
+
+      const hasKurlBinUtils = _.some(pkgs, (pkg) => {
+        return pkg === "kurl-bin-utils-v2021.05.27-0";
+      });
+      expect(hasKurlBinUtils).to.equal(true);
     });
 
     it("should include kubernetes conformance images", () => {
       const i = Installer.parse(conformance);
-      const pkgs = i.packages();
+      const pkgs = i.packages(undefined);
 
       const hasSonobuoy = _.some(pkgs, (pkg) => {
         return pkg === "sonobuoy-0.50.0";
@@ -1045,7 +1061,7 @@ spec:
 
     it("should not include kubernetes conformance images for versions < 1.17", () => {
       const i = Installer.parse(noConformance);
-      const pkgs = i.packages();
+      const pkgs = i.packages(undefined);
 
       const hasSonobuoy = _.some(pkgs, (pkg) => {
         return pkg === "sonobuoy-0.50.0";
@@ -1065,7 +1081,7 @@ spec:
 
     it("should not include removed Kubernetes versions", () => {
       const i = Installer.parse(noConformance);
-      const pkgs = i.packages();
+      const pkgs = i.packages(undefined);
 
       const hasKubernetes16 = _.some(pkgs, (pkg) => {
         return pkg === "kubernetes-1.16.4";

--- a/web/src/util/services/templates.ts
+++ b/web/src/util/services/templates.ts
@@ -130,6 +130,11 @@ export function bashStringEscape( unescaped : string): string {
 }
 
 export function manifestFromInstaller(i: Installer, kurlURL: string, replicatedAppURL: string, distURL: string, kurlUtilImage: string, kurlBinUtils: string, kurlVersion: string): Manifest {
+  kurlVersion = kurlVersionOrDefault(kurlVersion);
+  if (kurlVersion) {
+    kurlUtilImage = `replicated/kurl-util:${kurlVersion}`;
+    kurlBinUtils = `kurl-bin-utils-${kurlVersion}.tar.gz`;
+  }
   return {
     KURL_URL: kurlURL,
     DIST_URL: distURL,


### PR DESCRIPTION
running the following you get a partial bundle because it tries to include the latest kurl-bin-utils package which is not part of the older versioned bundle.

```
curl -LO https://kurl.sh/bundle/version/v2021.05.21-1/latest.tar.gz
```