### PR TITLE
Fix staging versioned package again

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -128,6 +128,8 @@ jobs:
 
     - name: kustomize
       run: |
+        git fetch --tags -f
+        export VERSION_TAG=$(git tag | grep '^v20' | sort | tail -1)-dirty
         curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/v2.0.0 | \
           grep browser_download | \
           grep linux | \
@@ -137,7 +139,7 @@ jobs:
           sudo chmod +x /usr/local/bin/kustomize
         pushd kustomize/overlays/staging
         kustomize edit set image 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7}
-        kustomize build . > kurl.yaml
+        kustomize build . | sed "s/__VERSION_TAG__/${VERSION_TAG}/g" > kurl.yaml
         popd
 
     - name: ssh-key

--- a/kustomize/overlays/staging/deployment.yaml
+++ b/kustomize/overlays/staging/deployment.yaml
@@ -33,3 +33,7 @@ spec:
           value: staging
         - name: REPLICATED_APP_URL
           value: https://staging.replicated.app
+        - name: KURL_UTIL_IMAGE
+          value: replicated/kurl-util:__VERSION_TAG__
+        - name: KURL_VERSION
+          value: __VERSION_TAG__


### PR DESCRIPTION
This should pin the versioned image and package in the web server similar to production.