### PR TITLE
Always regenerate containerd config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/onsi/gomega v1.12.0
+	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.10.24
 	github.com/spf13/afero v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,8 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.9.1 h1:a6qW1EVNZWH9WGI6CsYdD8WAylkoXBS5yv0XHlh17Tc=
+github.com/pelletier/go-toml v1.9.1/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -53,7 +53,7 @@ test: lint vet
 	go test ./cmd/...
 
 .PHONY: build
-build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network
+build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network bin/toml
 
 bin/yamlutil: cmd/yamlutil/main.go
 	go build ${LDFLAGS} -o bin/yamlutil cmd/yamlutil/main.go
@@ -84,6 +84,9 @@ bin/htpasswd:
 
 bin/network:
 	go build ${LDFLAGS} -o bin/network cmd/network/main.go
+
+bin/toml:
+	go build ${LDFLAGS} -o bin/toml cmd/toml/main.go
 
 .PHONY: kurl-util-image
 kurl-util-image:

--- a/kurl_util/cmd/toml/main.go
+++ b/kurl_util/cmd/toml/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+
+	"github.com/pelletier/go-toml"
+)
+
+func main() {
+	var basefile string
+	var patchfile string
+
+	flag.StringVar(&basefile, "basefile", "/etc/containerd/config.toml", "filename the patch will be applied to")
+	flag.StringVar(&patchfile, "patchfile", "/tmp/containerd.toml", "filename of the patch")
+
+	flag.Parse()
+
+	base, err := toml.LoadFile(basefile)
+	if err != nil {
+		log.Fatalf("Failed to load %s: %v", basefile, err)
+	}
+	patch, err := toml.LoadFile(patchfile)
+	if err != nil {
+		log.Fatalf("Failed to load %s: %v", patchfile, err)
+	}
+
+	str := merge(base, patch)
+	if err := ioutil.WriteFile(basefile, []byte(str), 0644); err != nil {
+		log.Fatalf("Failed to write %s", basefile)
+	}
+}
+
+func merge(base, patch *toml.Tree) string {
+	patchKeys := listLeaves(patch)
+	for _, patchKey := range patchKeys {
+		patchVal := patch.GetPath(patchKey)
+		base.SetPath(patchKey, patchVal)
+	}
+
+	return base.String()
+}
+
+func listLeaves(tree *toml.Tree, path ...string) [][]string {
+	var leaves [][]string
+
+	keys := tree.Keys()
+	for _, key := range keys {
+		v := tree.GetPath([]string{key})
+
+		fullKeyPath := append([]string{}, path...)
+		fullKeyPath = append(fullKeyPath, key)
+
+		switch val := v.(type) {
+		case *toml.Tree:
+			subTreeLeaves := listLeaves(val, fullKeyPath...)
+			leaves = append(leaves, subTreeLeaves...)
+		default:
+			leaves = append(leaves, fullKeyPath)
+		}
+	}
+
+	return leaves
+}

--- a/kurl_util/cmd/toml/main_test.go
+++ b/kurl_util/cmd/toml/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListLeaves(t *testing.T) {
+	var treeString = `
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    systemd_cgroup = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"`
+	tree, err := toml.Load(treeString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := [][]string{
+		{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "runtime_type"},
+		{"plugins", "io.containerd.grpc.v1.cri", "systemd_cgroup"},
+	}
+	actual := listLeaves(tree)
+
+	for _, leaf := range expect {
+		assert.Contains(t, actual, leaf)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	base := `
+version = 2
+
+[debug]
+  level = ""
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    systemd_cgroup = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"`
+
+	patch := `
+[debug]
+  level = "warn"
+[plugins."io.containerd.grpc.v1.cri"]
+  systemd_cgroup = true
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"`
+
+	baseTree, err := toml.Load(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patchTree, err := toml.Load(patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merge(baseTree, patchTree)
+
+	assert.Equal(t, "warn", baseTree.GetPath([]string{"debug", "level"}))
+	assert.Equal(t, true, baseTree.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "systemd_cgroup"}))
+	assert.Equal(t, "io.containerd.runc.v2", baseTree.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "runtime_type"}))
+}

--- a/kurl_util/cmd/toml/main_test.go
+++ b/kurl_util/cmd/toml/main_test.go
@@ -36,9 +36,6 @@ func TestMerge(t *testing.T) {
 	base := `
 version = 2
 
-[debug]
-  level = ""
-
 [timeouts]
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"
@@ -71,9 +68,31 @@ version = 2
 		t.Fatal(err)
 	}
 
-	merge(baseTree, patchTree)
+	expect := `version = 2
 
-	assert.Equal(t, "warn", baseTree.GetPath([]string{"debug", "level"}))
-	assert.Equal(t, true, baseTree.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "systemd_cgroup"}))
-	assert.Equal(t, "io.containerd.runc.v2", baseTree.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "runc", "runtime_type"}))
+[debug]
+  level = "warn"
+
+[plugins]
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    systemd_cgroup = true
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+`
+
+	out := merge(baseTree, patchTree)
+
+	assert.Equal(t, expect, out)
 }

--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -142,6 +142,8 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 		"Collectd.Version":                       "COLLECTD_VERSION",
 		"CertManager.S3Override":                 "CERT_MANAGER_S3_OVERRIDE",
 		"CertManager.Version":                    "CERT_MANAGER_VERSION",
+		"Containerd.PreserveConfig":              "CONTAINERD_PRESERVE_CONFIG",
+		"Containerd.TomlConfig":                  "CONTAINERD_TOML_CONFIG",
 		"Containerd.S3Override":                  "CONTAINERD_S3_OVERRIDE",
 		"Containerd.Version":                     "CONTAINERD_VERSION",
 		"Contour.HTTPPort":                       "CONTOUR_HTTP_PORT",
@@ -294,7 +296,9 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 			if t == "" {
 				bashVal = ""
 			} else {
-				bashVal = "\"" + t + "\""
+				// preserve inner double quotes
+				ts := strings.ReplaceAll(t, `"`, `\"`)
+				bashVal = "\"" + ts + "\""
 			}
 		case bool:
 			if t == true {

--- a/kurlkinds/README.md
+++ b/kurlkinds/README.md
@@ -2,8 +2,5 @@ To make a change to the Installer type.
 
 1. Edit ./pkg/apis/cluster/v1beta1/installer_types.go
 1. Run `make generate`
-1. Make a PR and merge.
-1. cd to ../kurl_util
-1. Run `go get github.com/replicatedhq/kurl/kurlkinds`
 1. Define a new bash variable in kurl_util/cmd/yamltobash/main.go to hold the value of the new field.
 1. Use the new bash variable in kurl install scripts.

--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -79,7 +79,11 @@ spec:
                 type: object
               containerd:
                 properties:
+                  preserveConfig:
+                    type: boolean
                   s3Override:
+                    type: string
+                  tomlConfig:
                     type: string
                   version:
                     type: string

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -235,8 +235,10 @@ type Calico struct {
 }
 
 type Containerd struct {
-	S3Override string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
-	Version    string `json:"version" yaml:"version" yaml:"version" yaml:"version"`
+	S3Override     string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	TomlConfig     string `json:"tomlConfig,omitempty" yaml:"tomlConfig,omitempty"`
+	PreserveConfig bool   `json:"preserveConfig,omitempty" yaml:"preserveConfig,omitempty"`
+	Version        string `json:"version" yaml:"version" yaml:"version" yaml:"version"`
 }
 
 type Collectd struct {

--- a/testgrid/tgrun/go.sum
+++ b/testgrid/tgrun/go.sum
@@ -628,8 +628,9 @@ github.com/ovirt/go-ovirt v4.3.4+incompatible/go.mod h1:r33ZGjVKCPMiI6hw791/Zx8t
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
-github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.9.1 h1:a6qW1EVNZWH9WGI6CsYdD8WAylkoXBS5yv0XHlh17Tc=
+github.com/pelletier/go-toml v1.9.1/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/web/src/client/containerd_test.ts
+++ b/web/src/client/containerd_test.ts
@@ -1,0 +1,37 @@
+import {describe, it} from "mocha";
+import {expect} from "chai";
+import { KurlClient } from "./";
+
+const kurlURL = process.env.KURL_URL || "http://localhost:30092";
+const client = new KurlClient(kurlURL);
+
+const containerd = `
+apiVersion: kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: containerd
+spec:
+  kubernetes:
+    version: 1.21.1
+  containerd:
+    version: 1.4.4
+    tomlConfig: |
+      [timeouts]
+        "io.containerd.shim-timeout": "15s"
+  antrea:
+    version: 0.13.1
+`;
+
+describe("script with containerd toml config", () => {
+  it("200", async () => {
+    const uri = await client.postInstaller(containerd);
+
+    expect(uri).to.match(/66f6a6e/);
+
+    const script = await client.getInstallScript("66f6a6e");
+
+    expect(script).to.match(new RegExp(`containerd:`));
+    expect(script).to.match(new RegExp(`version: 1.4.4`));
+    expect(script).to.include(`\\"io.containerd.shim-timeout\\": \\"15s\\"`);
+  });
+});

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -430,6 +430,8 @@ export const containerdConfigSchema = {
   type: "object",
   properties: {
     version: { type: "string" },
+    tomlConfig: { type: "string" },
+    preserveConfig: { type: "boolean" },
     s3Override: { type: "string", flag: "s3-override", description: "Override the download location for addon package distribution (used for CI/CD testing alpha addons)" },
   },
   required: ["version"],


### PR DESCRIPTION
Previously we did not regenerate containerd's config file so that users
could make modifications and not have them wiped out the next time kurl
runs. That leads to deprecated options being used with containerd 1.4+.
Examples include runtime_type = "io.containerd.runc.v1" and
sandbox_image = "k8s.gcr.io/pause:3.1".

Add a new field `containerd.preserveConfig` to always preserve the existing config file and a new field `containerd.tomlConfig` to specify config that will be merged into the containerd config.