### PR TITLE
check mount propagation is bidirectional in Longhorn

### DIFF
--- a/addons/longhorn/1.1.1/install.sh
+++ b/addons/longhorn/1.1.1/install.sh
@@ -126,9 +126,11 @@ function longhorn_preflight() {
 function check_mount_propagation() {
     local src=$1
 
+    kubectl get ns longhorn-system 2>/dev/null 1>/dev/null || kubectl create ns longhorn-system 1>/dev/null
+
     render_yaml_file "$src/tmpl-mount-propagation.yaml" > "$src/mount-propagation.yaml"
     kubectl create -f "$src/mount-propagation.yaml"
-    echo "Waiting for Longhorn Mount Propagation Check Daemonset to be ready"
+    echo "Waiting for the Longhorn Mount Propagation Check Daemonset to be ready"
     spinner_until 120 longhorn_daemonset_is_ready longhorn-manager
 
     validate_longhorn_ds

--- a/addons/longhorn/1.1.1/install.sh
+++ b/addons/longhorn/1.1.1/install.sh
@@ -153,7 +153,7 @@ function validate_longhorn_ds() {
         fi
 
         if [ "$bidirectional" -eq "0" ]; then
-            logWarn "No Longhorn mount propagation pods detected"
+            bail "No nodes with mount propagation enabled detected - Longhorn will not work. See https://longhorn.io/docs/1.1.1/deploy/install/#installation-requirements for details"
         fi
     fi
 }

--- a/addons/longhorn/1.1.1/install.sh
+++ b/addons/longhorn/1.1.1/install.sh
@@ -139,6 +139,8 @@ function check_mount_propagation() {
     kubectl delete -f "$src/mount-propagation.yaml"
 }
 
+# pass if at least one node will support longhorn, but with a warning if there are nodes that won't
+# only fail if there is no chance that longhorn will work on any nodes, as installations may have dedicated 'storage' vs 'not-storage' nodes
 function validate_longhorn_ds() {
     local allSupported=true
 

--- a/addons/longhorn/1.1.1/tmpl-mount-propagation.yaml
+++ b/addons/longhorn/1.1.1/tmpl-mount-propagation.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: longhorn-environment-check
+  name: longhorn-environment-check
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-environment-check
+  template:
+    metadata:
+      labels:
+        app: longhorn-environment-check
+    spec:
+      containers:
+      - name: longhorn-environment-check
+        image: $KURL_UTIL_IMAGE
+        args: ["/bin/sh", "-c", "sleep 1000000000"]
+        volumeMounts:
+        - name: mountpoint
+          mountPath: /tmp/longhorn-environment-check
+          mountPropagation: Bidirectional
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mountpoint
+        hostPath:
+          path: /tmp/longhorn-environment-check

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -126,9 +126,11 @@ function longhorn_preflight() {
 function check_mount_propagation() {
     local src=$1
 
+    kubectl get ns longhorn-system 2>/dev/null 1>/dev/null || kubectl create ns longhorn-system 1>/dev/null
+
     render_yaml_file "$src/tmpl-mount-propagation.yaml" > "$src/mount-propagation.yaml"
     kubectl create -f "$src/mount-propagation.yaml"
-    echo "Waiting for Longhorn Mount Propagation Check Daemonset to be ready"
+    echo "Waiting for the Longhorn Mount Propagation Check Daemonset to be ready"
     spinner_until 120 longhorn_daemonset_is_ready longhorn-manager
 
     validate_longhorn_ds

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -26,6 +26,8 @@ function longhorn() {
         insert_patches_strategic_merge "$dst/kustomization.yaml" "storageclass-configmap.yaml"
     fi
 
+    check_mount_propagation $src
+
     longhorn_host_init
     
 
@@ -51,7 +53,7 @@ function longhorn() {
     spinner_until 120 kubernetes_resource_exists longhorn-system sc longhorn
 
     echo "Waiting for Longhorn Manager Daemonset to be ready"
-    spinner_until 180 longhorn_manager_daemonset_is_ready
+    spinner_until 180 longhorn_daemonset_is_ready longhorn-manager
 }
 
 function longhorn_is_default_storageclass() {
@@ -72,9 +74,10 @@ function longhorn_has_default_storageclass() {
     return 1
 }
 
-function longhorn_manager_daemonset_is_ready() {
-    local desired=$(kubectl get daemonsets -n longhorn-system longhorn-manager --no-headers | tr -s ' ' | cut -d ' ' -f2)
-    local ready=$(kubectl get daemonsets -n longhorn-system longhorn-manager --no-headers | tr -s ' ' | cut -d ' ' -f4)
+function longhorn_daemonset_is_ready() {
+    local dsname=$1
+    local desired=$(kubectl get daemonsets -n longhorn-system $dsname --no-headers | tr -s ' ' | cut -d ' ' -f2)
+    local ready=$(kubectl get daemonsets -n longhorn-system $dsname --no-headers | tr -s ' ' | cut -d ' ' -f4)
         
     if [ "$desired" = "$ready" ] ; then
         return 0
@@ -118,4 +121,29 @@ function longhorn_install_service_if_missing() {
 function longhorn_preflight() {
     local src="${DIR}/addons/longhorn/${LONGHORN_VERSION}"
     echo "${src}/host-preflight.yaml"
+}
+
+function check_mount_propagation() {
+    local src=$1
+
+    render_yaml_file "$src/tmpl-mount-propagation.yaml" > "$src/mount-propagation.yaml"
+    kubectl create -f "$src/mount-propagation.yaml"
+    echo "Waiting for Longhorn Mount Propagation Check Daemonset to be ready"
+    spinner_until 120 longhorn_daemonset_is_ready longhorn-manager
+
+    validate_longhorn_ds
+
+    kubectl delete -f "$src/mount-propagation.yaml"
+}
+
+
+validate_longhorn_ds() {
+    local allSupported=true
+
+    local allpods=$(kubectl get daemonsets -n longhorn-system longhorn-environment-check --no-headers | tr -s ' ' | cut -d ' ' -f4)
+    local bidirectional=$(kubectl get pods -l app=longhorn-environment-check -o=jsonpath='{.items[*].spec.containers[0].volumeMounts[*]}' | grep -o 'Bidirectional' | wc -l)
+
+    if [ "$bidirectional" -lt "$allpods" ]; then
+        logWarn "Only $bidirectional of $allpods nodes support Longhorn storage"
+    fi
 }

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -29,7 +29,7 @@ function longhorn() {
     check_mount_propagation $src
 
     longhorn_host_init
-    
+
 
     render_yaml_file "$src/tmpl-ui-service.yaml" > "$dst/ui-service.yaml"
     render_yaml_file "$src/tmpl-ui-deployment.yaml" > "$dst/ui-deployment.yaml"
@@ -126,10 +126,10 @@ function longhorn_preflight() {
 function check_mount_propagation() {
     local src=$1
 
-    kubectl get ns longhorn-system 2>/dev/null 1>/dev/null || kubectl create ns longhorn-system 1>/dev/null
+    kubectl get ns longhorn-system >/dev/null 2>&1 || kubectl create ns longhorn-system >/dev/null 2>&1
 
     render_yaml_file "$src/tmpl-mount-propagation.yaml" > "$src/mount-propagation.yaml"
-    kubectl create -f "$src/mount-propagation.yaml"
+    kubectl apply -f "$src/mount-propagation.yaml"
     echo "Waiting for the Longhorn Mount Propagation Check Daemonset to be ready"
     spinner_until 120 longhorn_daemonset_is_ready longhorn-manager
 
@@ -138,8 +138,7 @@ function check_mount_propagation() {
     kubectl delete -f "$src/mount-propagation.yaml"
 }
 
-
-validate_longhorn_ds() {
+function validate_longhorn_ds() {
     local allSupported=true
 
     local allpods=$(kubectl get daemonsets -n longhorn-system longhorn-environment-check --no-headers | tr -s ' ' | cut -d ' ' -f4)
@@ -147,5 +146,9 @@ validate_longhorn_ds() {
 
     if [ "$bidirectional" -lt "$allpods" ]; then
         logWarn "Only $bidirectional of $allpods nodes support Longhorn storage"
+    fi
+
+    if [ "$bidirectional" -eq "0" ]; then
+        logWarn "no Longhorn mount propagation pods detected"
     fi
 }

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -61,13 +61,13 @@ function longhorn_is_default_storageclass() {
     [ "$(kubectl get sc longhorn -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')" = "true" ]; then
         return 0
     fi
-    return 1    
+    return 1
 }
 
 function longhorn_has_default_storageclass() {
     local hasDefaultStorageClass
     hasDefaultStorageClass=$(kubectl get sc -o jsonpath='{.items[*].metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')
-        
+
     if [ "$hasDefaultStorageClass" = "true" ] ; then
         return 0
     fi
@@ -78,7 +78,7 @@ function longhorn_daemonset_is_ready() {
     local dsname=$1
     local desired=$(kubectl get daemonsets -n longhorn-system $dsname --no-headers | tr -s ' ' | cut -d ' ' -f2)
     local ready=$(kubectl get daemonsets -n longhorn-system $dsname --no-headers | tr -s ' ' | cut -d ' ' -f4)
-        
+
     if [ "$desired" = "$ready" ] ; then
         return 0
     fi
@@ -153,7 +153,7 @@ function validate_longhorn_ds() {
         fi
 
         if [ "$bidirectional" -eq "0" ]; then
-            logWarn "No Longhorn mount propagation pods detected"
+            bail "No nodes with mount propagation enabled detected - Longhorn will not work. See https://longhorn.io/docs/1.1.1/deploy/install/#installation-requirements for details"
         fi
     fi
 }

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -139,6 +139,8 @@ function check_mount_propagation() {
     kubectl delete -f "$src/mount-propagation.yaml"
 }
 
+# pass if at least one node will support longhorn, but with a warning if there are nodes that won't
+# only fail if there is no chance that longhorn will work on any nodes, as installations may have dedicated 'storage' vs 'not-storage' nodes
 function validate_longhorn_ds() {
     local allSupported=true
 

--- a/addons/longhorn/template/base/tmpl-mount-propagation.yaml
+++ b/addons/longhorn/template/base/tmpl-mount-propagation.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: longhorn-environment-check
+  name: longhorn-environment-check
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-environment-check
+  template:
+    metadata:
+      labels:
+        app: longhorn-environment-check
+    spec:
+      containers:
+      - name: longhorn-environment-check
+        image: $KURL_UTIL_IMAGE
+        args: ["/bin/sh", "-c", "sleep 1000000000"]
+        volumeMounts:
+        - name: mountpoint
+          mountPath: /tmp/longhorn-environment-check
+          mountPropagation: Bidirectional
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mountpoint
+        hostPath:
+          path: /tmp/longhorn-environment-check


### PR DESCRIPTION
this duplicates the check within https://raw.githubusercontent.com/longhorn/longhorn/v1.1.1/scripts/environment_check.sh (but without the dependency on jq, and using the kurl util image instead of busybox)