### PR TITLE
"version" is reserved, so use "InstallerVersion"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,7 +571,7 @@ build/bin/kurl:
 .PHONY: code
 code: build/kustomize build/addons
 
-build/bin/server:
+build/bin/server: cmd/server/main.go
 	go build -o build/bin/server cmd/server/main.go
 
 .PHONY: web

--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -117,7 +117,7 @@ func checkIfSkippedVariable(yamlString string) bool {
 		"FirewalldConfig.Firewalld",
 		"FirewalldConfig.FirewalldCmds",
 		"IptablesConfig.IptablesCmds",
-		"Kurl.Version",
+		"Kurl.InstallerVersion",
 		"SelinuxConfig.ChconCmds",
 		"SelinuxConfig.Selinux",
 		"SelinuxConfig.SemanageCmds",

--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -276,6 +276,8 @@ spec:
                     type: boolean
                   ignoreRemoteUpgradePrompt:
                     type: boolean
+                  installerVersion:
+                    type: string
                   nameserver:
                     type: string
                   noProxy:
@@ -289,8 +291,6 @@ spec:
                   proxyAddress:
                     type: string
                   publicAddress:
-                    type: string
-                  version:
                     type: string
                 type: object
               longhorn:

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -110,6 +110,7 @@ type Kurl struct {
 	HostnameCheck                string   `json:"hostnameCheck,omitempty" yaml:"hostnameCheck,omitempty"`
 	IgnoreRemoteLoadImagesPrompt bool     `json:"ignoreRemoteLoadImagesPrompt,omitempty" yaml:"ignoreRemoteLoadImagesPrompt,omitempty"`
 	IgnoreRemoteUpgradePrompt    bool     `json:"ignoreRemoteUpgradePrompt,omitempty" yaml:"ignoreRemoteUpgradePrompt,omitempty"`
+	InstallerVersion             string   `json:"installerVersion,omitempty" yaml:"installerVersion,omitempty"`
 	Nameserver                   string   `json:"nameserver,omitempty" yaml:"nameserver,omitempty"`
 	NoProxy                      bool     `json:"noProxy,omitempty" yaml:"noProxy,omitempty"`
 	PreflightIgnore              bool     `json:"preflightIgnore,omitempty" yaml:"preflightIgnore,omitempty"`
@@ -117,7 +118,6 @@ type Kurl struct {
 	PrivateAddress               string   `json:"privateAddress,omitempty" yaml:"privateAddress,omitempty"`
 	ProxyAddress                 string   `json:"proxyAddress,omitempty" yaml:"proxyAddress,omitempty"`
 	PublicAddress                string   `json:"publicAddress,omitempty" yaml:"publicAddress,omitempty"`
-	Version                      string   `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 type Minio struct {

--- a/web/src/controllers/Bundles.ts
+++ b/web/src/controllers/Bundles.ts
@@ -72,8 +72,8 @@ export class Bundle {
     }
     installer = installer.resolve();
 
-    // if installer.spec.kurl is set, fallback to installer.spec.kurl.version if kurlVersion was not set in the URL
-    kurlVersion = installer.spec.kurl ? (kurlVersion || installer.spec.kurl.version) : kurlVersion;
+    // if installer.spec.kurl is set, fallback to installer.spec.kurl.installerVersion if kurlVersion was not set in the URL
+    kurlVersion = installer.spec.kurl ? (kurlVersion || installer.spec.kurl.installerVersion) : kurlVersion;
 
     try {
       await this.metricsStore.saveSaasScriptEvent({

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -398,7 +398,7 @@ export interface KurlConfig {
   bypassFirewalldWarning?: boolean; // this is not in the installer crd
   hardFailOnFirewalld?: boolean; // this is not in the installer crd
   task?: string; // this is not in the installer crd
-  version?: string;
+  installerVersion?: string;
 }
 
 export const kurlConfigSchema = {
@@ -418,7 +418,7 @@ export const kurlConfigSchema = {
     publicAddress: { type: "string", flag: "public-address" , description: "The public address of the host (different for each host in the cluster), will be added as a CNAME to the k8s API server cert so you can use kubectl with this address" },
     bypassFirewalldWarning: { type: "boolean", flag: "bypass-firewalld-warning" , description: "Continue installing even if the firewalld service is active" },
     hardFailOnFirewalld: { type: "boolean", flag: "hard-fail-on-firewalld" , description: "Exit the install script if the firewalld service is active" },
-    version: { type: "string", description: "The upstream version of kURL to use as part of the installation - see https://kurl.sh/docs/install-with-kurl/#versioned-releases" },
+    installerVersion: { type: "string", description: "The upstream version of kURL to use as part of the installation - see https://kurl.sh/docs/install-with-kurl/#versioned-releases" },
   },
   additionalProperties: false,
 };

--- a/web/src/util/package/index.ts
+++ b/web/src/util/package/index.ts
@@ -21,7 +21,7 @@ export function getDistUrl(): string {
 export function kurlVersionOrDefault(kurlVersion?: string, i?: Installer): string {
   let iVersion: string | undefined
   if (i && i.spec.kurl) {
-    iVersion = i.spec.kurl.version
+    iVersion = i.spec.kurl.installerVersion
   }
 
   return kurlVersion || iVersion || process.env["KURL_VERSION"] || ""


### PR DESCRIPTION
see https://github.com/replicatedhq/kURL/pull/1695 and https://github.com/replicatedhq/kURL/pull/1697

`version` is used to determine if something is an actual package to be included: https://github.com/replicatedhq/kURL/blob/8563f20a6d189fbefdaca9a5fc038c7322b7d3a2/web/src/installers/index.ts#L1179-L1180