### PR TITLE
Staging deployment fixes

### DIFF
--- a/.github/workflows/build-package-staging.yaml
+++ b/.github/workflows/build-package-staging.yaml
@@ -24,5 +24,7 @@ jobs:
 
           MD5="$(openssl md5 -binary dist/$PKG | base64)"
           GITSHA="$(git rev-parse HEAD)"
-          aws s3 cp dist/$PKG s3://kurl-sh/staging/$PKG \
+          aws s3 cp dist/$PKG s3://kurl-sh/staging/${VERSION_TAG}/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+          aws s3 cp s3://kurl-sh/staging/${VERSION_TAG}/$PKG s3://kurl-sh/staging/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -50,5 +50,7 @@ jobs:
 
           MD5="$(openssl md5 -binary dist/$PKG | base64)"
           GITSHA="$(git rev-parse HEAD)"
-          aws s3 cp dist/$PKG s3://kurl-sh/staging/$PKG \
+          aws s3 cp dist/$PKG s3://kurl-sh/staging/${VERSION_TAG}/$PKG \
+            --metadata md5="${MD5}",gitsha="${GITSHA}"
+          aws s3 cp s3://kurl-sh/staging/${VERSION_TAG}/$PKG s3://kurl-sh/staging/$PKG \
             --metadata md5="${MD5}",gitsha="${GITSHA}"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -125,7 +125,10 @@ jobs:
 
   deploy-staging-eks:
     runs-on: ubuntu-18.04
-    needs: staging-docker-image
+    needs:
+    - staging-docker-image
+    - kurl-util-image
+    - build-upload-packages
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
1. The deployment is getting deployed too early and caching the previous scripts
2. The rebuild jobs do not rebuild the versioned packages