### PR TITLE
Github workflow max jobs is 256

### DIFF
--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -1,6 +1,11 @@
 name: cron-rebuild-packages-prod
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      index:
+        description: rebuild from index
+        required: true
+        default: 0
 
 jobs:
   build-matrix:
@@ -17,7 +22,7 @@ jobs:
           tag=$(git tag | grep '^v20' | sort | tail -1)
           export KURL_UTIL_IMAGE=replicated/kur-util:${tag}
           export KURL_BIN_UTILS_FILE=kurl-bin-utils-${tag}.tar.gz
-          OUTPUT=`bin/list-all-packages-actions-matrix.sh`
+          OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
           echo "::set-output name=matrix::$OUTPUT"
 
   build-upload-packages:

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -1,6 +1,11 @@
 name: cron-rebuild-packages-staging
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      index:
+        description: rebuild from index
+        required: true
+        default: 0
 
 jobs:
   build-matrix:
@@ -19,7 +24,7 @@ jobs:
           export KURL_BIN_UTILS_FILE=kurl-bin-utils-${VERSION_TAG}.tar.gz
           export KURL_BIN_UTILS_FILE_LATEST=kurl-bin-utils-latest.tar.gz
 
-          OUTPUT=`bin/list-all-packages-actions-matrix.sh`
+          OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
           echo "::set-output name=matrix::$OUTPUT"
 
   build-upload-packages:

--- a/bin/list-all-packages-actions-matrix.sh
+++ b/bin/list-all-packages-actions-matrix.sh
@@ -15,10 +15,22 @@ function require() {
 require KURL_UTIL_IMAGE "${KURL_UTIL_IMAGE}" # required for common package
 require KURL_BIN_UTILS_FILE "${KURL_BIN_UTILS_FILE}"
 
+index="${1:-0}"
+
+i=0
+
 comma=""
 printf '{"include": ['
 for package in $(list_all | awk '{print $1}')
 do
+    if [ "${i}" -lt "${index}" ]; then
+        i=$((i+1))
+        continue
+    fi
+    if [ "$(("${i}"-"${index}"))" = "255" ]; then
+        break
+    fi
+    i=$((i+1))
     printf '%s{"package": "%s"}' "${comma}" "${package}"
     comma=","
 done


### PR DESCRIPTION
Actions is getting error cron-rebuild-packages-staging : .github#L1 Strategy produced more than 256

This action no longer runs on a schedule. Its now on workflow dispatch.

This PR runs max matrix jobs 255 and additionally adds an input variable index to run the matrix starting at a given index.

This is quick and dirty to get it working again. In the future it may be best to batch these.