### PR TITLE
Fix rhel/centos 8 k8s install

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -109,7 +109,7 @@ EOF
         ;;
     esac
 
-    install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" kubelet kubectl kubernetes-cni git
+    install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}" kubernetes-cni git
 
     # Update crictl: https://listman.redhat.com/archives/rhsa-announce/2019-October/msg00038.html 
     tar -C /usr/bin -xzf "$DIR/packages/kubernetes/${k8sVersion}/assets/crictl-linux-amd64.tar.gz"


### PR DESCRIPTION
Fixing this error

```
Downloading Packages:
Error opening file for checksum: /var/lib/kurl/packages/kubernetes/1.17.13/rhel-8/c47efa28c5935ed2ffad234e2b402d937dde16ab072f2f6013c71d39ab526f40-kubelet-1.21.1-0.x86_64.rpm
Package "kubelet-1.21.1-0.x86_64" from local repository "kurl.local" has incorrect checksum
```