### PR TITLE
Use docker rhel 8 packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-18.04
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
 	${MAKE} build/packages/docker/$*/rhel-7
+	${MAKE} build/packages/docker/$*/rhel-8
 	mkdir -p dist
 	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64 > build/packages/docker/$*/runc
 	chmod +x build/packages/docker/$*/runc
@@ -446,6 +447,27 @@ build/packages/docker/%/rhel-7:
 	mkdir -p build/packages/docker/$*/rhel-7
 	docker cp docker-rhel7-$*:/packages/archives/. build/packages/docker/$*/rhel-7
 	docker rm docker-rhel7-$*
+
+build/packages/docker/18.09.8/rhel-8:
+	# unsupported
+
+build/packages/docker/19.03.4/rhel-8:
+	# unsupported
+
+build/packages/docker/19.03.10/rhel-8:
+	# unsupported
+
+build/packages/docker/%/rhel-8:
+	docker build \
+		--build-arg DOCKER_VERSION=$* \
+		-t kurl/rhel-8-docker:$* \
+		-f bundles/docker-rhel8/Dockerfile \
+		bundles/docker-rhel8
+	-docker rm -f docker-rhel8 2>/dev/null
+	docker create --name docker-rhel8-$* kurl/rhel-8-docker:$*
+	mkdir -p build/packages/docker/$*/rhel-8
+	docker cp docker-rhel8-$*:/packages/archives/. build/packages/docker/$*/rhel-8
+	docker rm docker-rhel8-$*
 
 build/packages/kubernetes/%/ubuntu-16.04:
 	docker build \

--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -55,6 +55,7 @@ function list_other() {
     echo "docker-18.09.8.tar.gz bundles/"
     echo "docker-19.03.4.tar.gz bundles/"
     echo "docker-19.03.10.tar.gz bundles/"
+    echo "docker-19.03.15.tar.gz bundles/"
     echo "docker-20.10.5.tar.gz bundles/"
 }
 

--- a/bundles/docker-rhel8/Dockerfile
+++ b/bundles/docker-rhel8/Dockerfile
@@ -1,6 +1,8 @@
-FROM centos:7
+FROM centos:8
 
-RUN yum install -y createrepo
+RUN yum install -y yum-utils createrepo
+RUN yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+RUN yum install -y modulemd-tools
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 RUN mkdir -p /packages/archives
 
@@ -9,6 +11,8 @@ ARG DOCKER_VERSION
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
     docker-ce-$(yum list --showduplicates 'docker-ce' | grep ${DOCKER_VERSION} | tail -1 | awk '{ print $2 }' | sed 's/.\://') \
     docker-ce-cli-$(yum list --showduplicates 'docker-ce-cli' | grep ${DOCKER_VERSION} | tail -1 | awk '{ print $2 }' | sed 's/.\://')
-RUN createrepo /packages/archives
+RUN createrepo_c /packages/archives
+RUN repo2module --module-name=kurl.local --module-stream=stable /packages/archives /tmp/modules.yaml
+RUN modifyrepo_c --mdtype=modules /tmp/modules.yaml /packages/archives/repodata
 
 CMD cp -r /packages/archives/* /out/

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -44,17 +44,8 @@ function restart_docker() {
     systemctl restart docker
 }
 
-docker_install() {
-    # we do not build docker packages for 8.x versions
-    local o_distversionmajor="${DIST_VERSION_MAJOR}"
-    case "$LSB_DIST" in
-        centos|rhel|amzn|ol)
-            DIST_VERSION_MAJOR=7
-            ;;
-    esac
-
+function docker_install() {
     install_host_packages "${DIR}/packages/docker/${DOCKER_VERSION}" docker-ce docker-ce-cli
-    DIST_VERSION_MAJOR="${o_distversionmajor}"
 
     cp "${DIR}/packages/docker/${DOCKER_VERSION}/runc" "$(which runc)"
     export DID_INSTALL_DOCKER=1

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -3,7 +3,7 @@ function preflights() {
     require64Bit
     bailIfUnsupportedOS
     mustSwapoff
-    promptIfDockerUnsupportedOS
+    bail_if_docker_unsupported_os
     checkDockerK8sVersion
     checkFirewalld
     checkUFW
@@ -139,26 +139,30 @@ checkDockerK8sVersion()
     esac
 }
 
-promptIfDockerUnsupportedOS()
-{
-    if [ -z "$DOCKER_VERSION" ]; then
+function bail_if_docker_unsupported_os() {
+    if is_docker_version_supported ; then
         return
     fi
 
+    if commandExists "docker" ; then
+        return
+    fi
+
+    bail "Docker ${DOCKER_VERSION} is not supported on ${LSB_DIST} ${DIST_VERSION}"
+}
+
+function is_docker_version_supported() {
     case "$LSB_DIST" in
     centos|rhel)
-        if [[ "$DIST_VERSION" =~ ^8 ]]; then
-            logWarn "Docker is not supported on ${LSB_DIST} ${DIST_VERSION}."
-            logWarn "The containerd addon is recommended. https://kurl.sh/docs/add-ons/containerd"
-            if ! commandExists "docker" ; then
-                printf "${YELLOW}Continue? ${NC}" 1>&2
-                if ! confirmY ; then
-                    exit 1
-                fi
-            fi
-        fi
+        ;;
+    *)
+        return 0
         ;;
     esac
+    if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
+        return 1
+    fi
+    return 0
 }
 
 checkFirewalld() {

--- a/testgrid/tgrun/pkg/instances/k8s119.go
+++ b/testgrid/tgrun/pkg/instances/k8s119.go
@@ -25,7 +25,7 @@ func init() {
 					Version: "1.0.1",
 				},
 				Docker: &kurlv1beta1.Docker{
-					Version: "19.03.10",
+					Version: "19.03.15",
 				},
 				Prometheus: &kurlv1beta1.Prometheus{
 					Version: "0.33.0",

--- a/testgrid/tgrun/pkg/instances/k8s119_nameserver_collectd_rook_block.go
+++ b/testgrid/tgrun/pkg/instances/k8s119_nameserver_collectd_rook_block.go
@@ -16,7 +16,7 @@ func init() {
 					Version: "2.8.1",
 				},
 				Docker: &kurlv1beta1.Docker{
-					Version: "19.03.10",
+					Version: "19.03.15",
 				},
 				Kurl: &kurlv1beta1.Kurl{
 					Nameserver: "8.8.8.8",

--- a/testgrid/tgrun/pkg/instances/k8s119_selinux.go
+++ b/testgrid/tgrun/pkg/instances/k8s119_selinux.go
@@ -15,7 +15,7 @@ func init() {
 				Version: "2.8.1",
 			},
 			Docker: &kurlv1beta1.Docker{
-				Version: "19.03.10",
+				Version: "19.03.15",
 			},
 			SelinuxConfig: &kurlv1beta1.SelinuxConfig{
 				Selinux: "permissive",

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -31,6 +31,7 @@ module.exports.InstallerVersions = {
   ],
   docker: [
     "20.10.5",
+    "19.03.15",
     "19.03.10",
     "19.03.4",
     "18.09.8",


### PR DESCRIPTION
This will now use the official repos for docker on rhel 8 based distros.

Docker 18.09.8, 19.03.4 and 19.03.10 will no longer work on rhel 8 based distros.

I will include a follow up pr to add back the brute force method for installing old docker on rhel 8.