### PR TITLE
Force install old docker on rhel 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,13 +449,25 @@ build/packages/docker/%/rhel-7:
 	docker rm docker-rhel7-$*
 
 build/packages/docker/18.09.8/rhel-8:
-	# unsupported
+	${MAKE} build/packages/docker/18.09.8/rhel-7-force
 
 build/packages/docker/19.03.4/rhel-8:
-	# unsupported
+	${MAKE} build/packages/docker/19.03.4//rhel-7-force
 
 build/packages/docker/19.03.10/rhel-8:
-	# unsupported
+	${MAKE} build/packages/docker/19.03.10/rhel-7-force
+
+build/packages/docker/%/rhel-7-force:
+	docker build \
+		--build-arg DOCKER_VERSION=$* \
+		-t kurl/rhel-7-force-docker:$* \
+		-f bundles/docker-rhel7-force/Dockerfile \
+		bundles/docker-rhel7-force
+	-docker rm -f docker-rhel7-force 2>/dev/null
+	docker create --name docker-rhel7-force-$* kurl/rhel-7-force-docker:$*
+	mkdir -p build/packages/docker/$*/rhel-7-force
+	docker cp docker-rhel7-force-$*:/packages/archives/. build/packages/docker/$*/rhel-7-force
+	docker rm docker-rhel7-force-$*
 
 build/packages/docker/%/rhel-8:
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -448,14 +448,11 @@ build/packages/docker/%/rhel-7:
 	docker cp docker-rhel7-$*:/packages/archives/. build/packages/docker/$*/rhel-7
 	docker rm docker-rhel7-$*
 
-build/packages/docker/18.09.8/rhel-8:
-	${MAKE} build/packages/docker/18.09.8/rhel-7-force
+build/packages/docker/18.09.8/rhel-8: build/packages/docker/18.09.8/rhel-7-force
 
-build/packages/docker/19.03.4/rhel-8:
-	${MAKE} build/packages/docker/19.03.4//rhel-7-force
+build/packages/docker/19.03.4/rhel-8: build/packages/docker/19.03.4//rhel-7-force
 
-build/packages/docker/19.03.10/rhel-8:
-	${MAKE} build/packages/docker/19.03.10/rhel-7-force
+build/packages/docker/19.03.10/rhel-8: build/packages/docker/19.03.10/rhel-7-force
 
 build/packages/docker/%/rhel-7-force:
 	docker build \

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -73,17 +73,14 @@ function docker_install_rhel_7_force() {
 function is_docker_version_supported() {
     case "$LSB_DIST" in
     centos|rhel|ol)
-        if [ "${DIST_VERSION_MAJOR}" = "7" ]; then
-            return 0
+        if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
+            if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
+                return 1
+            fi
         fi
         ;;
-    *)
-        return 0
-        ;;
     esac
-    if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
-        return 1
-    fi
+
     return 0
 }
 

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -54,7 +54,7 @@ function docker_install() {
         ;;
     esac
 
-    if [ "${DID_INSTALL_DOCKER}"  != "1" ]; then
+    if [ "${DID_INSTALL_DOCKER}" != "1" ]; then
         install_host_packages "${DIR}/packages/docker/${DOCKER_VERSION}" docker-ce docker-ce-cli
         export DID_INSTALL_DOCKER=1
     fi

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -88,7 +88,7 @@ function _yum_install_host_packages() {
     logStep "Installing host packages ${packages[*]}"
 
     local fullpath=
-    fullpath="$(_yum_get_host_packages_path)"
+    fullpath="$(_yum_get_host_packages_path "${dir}" "${dir_prefix}")"
     if ! test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
         echo "Will not install host packages ${packages[*]}, no packages found."
         return 0
@@ -113,12 +113,15 @@ EOF
 }
 
 function _yum_get_host_packages_path() {
+    local dir="$1"
+    local dir_prefix="$2"
+
     local fullpath=
     if [ "${LSB_DIST}" = "ol" ]; then
         if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
-            fullpath="$(realpath "${dir}")/ol-8"
+            fullpath="$(realpath "${dir}")/ol-8${dir_prefix}"
         else
-            fullpath="$(realpath "${dir}")/ol-7"
+            fullpath="$(realpath "${dir}")/ol-7${dir_prefix}"
         fi
         if test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
             echo "${fullpath}"
@@ -127,9 +130,9 @@ function _yum_get_host_packages_path() {
     fi
 
     if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
-        echo "$(realpath "${dir}")/rhel-8"
+        echo "$(realpath "${dir}")/rhel-8${dir_prefix}"
     else
-        echo "$(realpath "${dir}")/rhel-7"
+        echo "$(realpath "${dir}")/rhel-7${dir_prefix}"
     fi
     return 0
 }

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -89,7 +89,7 @@ function _yum_install_host_packages() {
 
     local fullpath=
     fullpath="$(_yum_get_host_packages_path)"
-    if ! test -n "$(shopt -s nullglob; echo "${fullpath}/*.rpm")" ; then
+    if ! test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
         echo "Will not install host packages ${packages[*]}, no packages found."
         return 0
     fi
@@ -116,20 +116,20 @@ function _yum_get_host_packages_path() {
     local fullpath=
     if [ "${LSB_DIST}" = "ol" ]; then
         if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
-            fullpath="$(realpath "${dir}")/ol-8${dir_prefix}"
+            fullpath="$(realpath "${dir}")/ol-8"
         else
-            fullpath="$(realpath "${dir}")/ol-7${dir_prefix}"
+            fullpath="$(realpath "${dir}")/ol-7"
         fi
-        if test -n "$(shopt -s nullglob; echo "${fullpath}/*.rpm")" ; then
+        if test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
             echo "${fullpath}"
             return 0
         fi
     fi
 
     if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
-        echo "$(realpath "${dir}")/rhel-8${dir_prefix}"
+        echo "$(realpath "${dir}")/rhel-8"
     else
-        echo "$(realpath "${dir}")/rhel-7${dir_prefix}"
+        echo "$(realpath "${dir}")/rhel-7"
     fi
     return 0
 }

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -3,7 +3,7 @@ function preflights() {
     require64Bit
     bailIfUnsupportedOS
     mustSwapoff
-    bail_if_docker_unsupported_os
+    prompt_if_docker_unsupported_os
     checkDockerK8sVersion
     checkFirewalld
     checkUFW
@@ -139,7 +139,7 @@ checkDockerK8sVersion()
     esac
 }
 
-function bail_if_docker_unsupported_os() {
+function prompt_if_docker_unsupported_os() {
     if is_docker_version_supported ; then
         return
     fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -144,28 +144,17 @@ function bail_if_docker_unsupported_os() {
         return
     fi
 
+    logWarn "Docker ${DOCKER_VERSION} is not supported on ${LSB_DIST} ${DIST_VERSION}."
+    logWarn "The containerd addon is recommended. https://kurl.sh/docs/add-ons/containerd"
+
     if commandExists "docker" ; then
         return
     fi
 
-    bail "Docker ${DOCKER_VERSION} is not supported on ${LSB_DIST} ${DIST_VERSION}"
-}
-
-function is_docker_version_supported() {
-    case "$LSB_DIST" in
-    centos|rhel|ol)
-        if [ "${DIST_VERSION_MAJOR}" = "7" ]; then
-            return 0
-        fi
-        ;;
-    *)
-        return 0
-        ;;
-    esac
-    if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
-        return 1
+    printf "${YELLOW}Continue? ${NC}" 1>&2
+    if ! confirmY ; then
+        exit 1
     fi
-    return 0
 }
 
 checkFirewalld() {


### PR DESCRIPTION
This will force install docker rpms on rhel 8 based distros for docker versions 18.09.8, 19.03.4 and 19.03.10