### PR TITLE
use try_1m to retry applying the updated installer spec

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -96,7 +96,7 @@ EOL
         kubectl apply -f "$ORIGINAL_INSTALLER_SPEC"
     fi
 
-    kubectl apply -f "$MERGED_YAML_SPEC"
+    try_1m kubectl apply -f "$MERGED_YAML_SPEC"
 
     installer_label_velero_exclude_from_backup
 }


### PR DESCRIPTION
this avoids issues where the updated CRD is not yet used by the k8s API