### PR TITLE
keep kotsadm-s3 secret for internal snapshots

### DIFF
--- a/addons/kotsadm/alpha/install.sh
+++ b/addons/kotsadm/alpha/install.sh
@@ -15,13 +15,15 @@ function kotsadm() {
     kotsadm_secret_password
     kotsadm_secret_postgres
     kotsadm_secret_dex_postgres
+    kotsadm_secret_s3 # this secret is currently only used for (re)configuring internal snapshots
     kotsadm_secret_session
     kotsadm_api_encryption_key
 
-    if kubernetes_resource_exists default secret kotsadm-s3; then
-        # kotsadm v1.46+ does not use an object store, patch the migrate-s3 init container to migrate the data
-        kotsadm_api_patch_s3_migration
-    fi
+    # kotsadm v1.46+ does not use an object store for the archives, patch the migrate-s3 init container to migrate the data.
+    # ideally, this should only be patched if an object store is detected, but we can't rely on that fact since kotsadm still requires
+    # an object store for internal snapshots, once that's resolved, we can start patching this only if an object store already exists in the cluster.
+    # the migration process is intelligent enough to detect whether an object store and a bucket exists or not.
+    kotsadm_api_patch_s3_migration
 
     if [ -n "$PROMETHEUS_VERSION" ]; then
         kotsadm_api_patch_prometheus
@@ -182,6 +184,14 @@ function kotsadm_secret_dex_postgres() {
     insert_resources "$DIR/kustomize/kotsadm/kustomization.yaml" secret-dex-postgres.yaml
 
     kubernetes_scale_down default statefulset kotsadm
+}
+
+function kotsadm_secret_s3() {
+    if [ -z "$VELERO_LOCAL_BUCKET" ]; then
+        VELERO_LOCAL_BUCKET=velero
+    fi
+    render_yaml_file "$DIR/addons/kotsadm/alpha/tmpl-secret-s3.yaml" > "$DIR/kustomize/kotsadm/secret-s3.yaml"
+    insert_resources "$DIR/kustomize/kotsadm/kustomization.yaml" secret-s3.yaml
 }
 
 function kotsadm_secret_session() {

--- a/addons/kotsadm/alpha/tmpl-secret-s3.yaml
+++ b/addons/kotsadm/alpha/tmpl-secret-s3.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kotsadm-s3
+stringData:
+  endpoint: ${OBJECT_STORE_CLUSTER_HOST}
+  access-key-id: ${OBJECT_STORE_ACCESS_KEY}
+  secret-access-key: ${OBJECT_STORE_SECRET_KEY}
+  velero-local-bucket: ${VELERO_LOCAL_BUCKET}
+  object-store-cluster-ip: ${OBJECT_STORE_CLUSTER_IP}


### PR DESCRIPTION
we need the kotsadm-s3 secret for internal snapshots. we don't create/initialize a 'kotsadm' bucket anymore, the s3 migration script will automatically detect if the bucket exists or not and skip the migration accordingly.