### PR TITLE
Fix testgrid run after deploy

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -227,6 +227,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: setup-go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.16
+
     - name: Tgrun Build
       working-directory: ./testgrid/tgrun
       run: make build

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -207,6 +207,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: setup-go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.16
+
     - name: Tgrun Build
       working-directory: ./testgrid/tgrun
       run: make build


### PR DESCRIPTION
```
pkg/runner/embed.go:4:2: package embed is not in GOROOT (/opt/hostedtoolcache/go/1.15.13/x64/src/embed)
```