### PR TITLE
pvc backing store migration binary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.29.0 // indirect
+	github.com/replicatedhq/pvmigrate v0.1.0
 	github.com/replicatedhq/troubleshoot v0.10.24
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/afero v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/replicatedhq/pvmigrate v0.1.0 h1:eMLFsLJsZ3KBjo8fIfezSR+hIcntnawgXXHiigaypyw=
+github.com/replicatedhq/pvmigrate v0.1.0/go.mod h1:NIcC2CW1rvkxTNQG556VIudMXSQPVC5cgBsCbLWgYvs=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.10.24 h1:7+KltlENmuF368HsaFc3t0NczKDdxI+1ARI+0KCgtko=
 github.com/replicatedhq/troubleshoot v0.10.24/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -53,7 +53,7 @@ test: lint vet
 	go test ./cmd/...
 
 .PHONY: build
-build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network bin/toml bin/veleroplugin
+build: bin/yamlutil bin/subnet bin/docker-config bin/config bin/installermerge bin/yamltobash bin/bashmerge bin/bcrypt bin/htpasswd bin/network bin/toml bin/veleroplugin bin/pvmigrate
 
 bin/yamlutil: cmd/yamlutil/main.go
 	go build ${LDFLAGS} -o bin/yamlutil cmd/yamlutil/main.go
@@ -90,6 +90,9 @@ bin/toml:
 
 bin/veleroplugin: cmd/veleroplugin/main.go
 	go build ${LDFLAGS} -o bin/veleroplugin cmd/veleroplugin/main.go
+
+bin/pvmigrate: cmd/pvmigrate/main.go
+	go build ${LDFLAGS} -o bin/pvmigrate cmd/pvmigrate/main.go
 
 .PHONY: kurl-util-image
 kurl-util-image:

--- a/kurl_util/cmd/pvmigrate/main.go
+++ b/kurl_util/cmd/pvmigrate/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/kurl/pkg/version"
+	"github.com/replicatedhq/pvmigrate/pkg/migrate"
+)
+
+func main() {
+	fmt.Printf("Running pvmigrate build:\n")
+	version.Print()
+
+	migrate.Cli()
+}

--- a/kurl_util/deploy/Dockerfile
+++ b/kurl_util/deploy/Dockerfile
@@ -24,6 +24,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y --no
     sysstat \
     tcpdump \
     telnet \
+    rsync \
     \
   && rm -rf /var/lib/apt/lists/*
 

--- a/testgrid/tgrun/go.sum
+++ b/testgrid/tgrun/go.sum
@@ -794,6 +794,7 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
+github.com/replicatedhq/pvmigrate v0.1.0/go.mod h1:NIcC2CW1rvkxTNQG556VIudMXSQPVC5cgBsCbLWgYvs=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.10.24/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=


### PR DESCRIPTION
The code originally intended for this PR has been moved to https://github.com/replicatedhq/pvmigrate (and the code actually in this PR calls it)