### PR TITLE
Revert "add migrate-pvcs command to tasks"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.29.0 // indirect
-	github.com/replicatedhq/pvmigrate v0.1.1 // indirect
+	github.com/replicatedhq/pvmigrate v0.1.0 // indirect
 	github.com/replicatedhq/troubleshoot v0.13.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
@@ -66,6 +66,7 @@ require (
 
 replace (
 	github.com/longhorn/longhorn-manager => github.com/replicatedhq/longhorn-manager v1.1.2-0.20210622201804-05b01947b99d
+	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.8.3
 	k8s.io/api => k8s.io/api v0.20.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.20.2
@@ -87,5 +88,4 @@ replace (
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.20.2
 	k8s.io/metrics => k8s.io/metrics v0.20.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.0
-	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.8.3
 )

--- a/go.sum
+++ b/go.sum
@@ -977,8 +977,6 @@ github.com/replicatedhq/longhorn-manager v1.1.2-0.20210622201804-05b01947b99d h1
 github.com/replicatedhq/longhorn-manager v1.1.2-0.20210622201804-05b01947b99d/go.mod h1:/5iB5+3q/p1HOj7GXF8PT/YrPersNLAH3VjFfmN90Y4=
 github.com/replicatedhq/pvmigrate v0.1.0 h1:eMLFsLJsZ3KBjo8fIfezSR+hIcntnawgXXHiigaypyw=
 github.com/replicatedhq/pvmigrate v0.1.0/go.mod h1:NIcC2CW1rvkxTNQG556VIudMXSQPVC5cgBsCbLWgYvs=
-github.com/replicatedhq/pvmigrate v0.1.1 h1:lYEqyl+G3lgI/X5T6A/Z+Mra4F79eA/6Q6YpRLjHFk0=
-github.com/replicatedhq/pvmigrate v0.1.1/go.mod h1:HXPV+iTqyR2YXPkSKkVtfkAhps9t55W0UqdOeaQvULk=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.10.24 h1:7+KltlENmuF368HsaFc3t0NczKDdxI+1ARI+0KCgtko=
 github.com/replicatedhq/troubleshoot v0.10.24/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -12,7 +12,6 @@ function download_util_binaries() {
     BIN_INSTALLERMERGE=./bin/installermerge
     BIN_YAMLTOBASH=./bin/yamltobash
     BIN_BASHTOYAML=./bin/bashmerge
-    BIN_PVMIGRATE=./bin/pvmigrate
 
     mkdir -p /tmp/kurl-bin-utils/scripts
     CONFIGURE_SELINUX_SCRIPT=/tmp/kurl-bin-utils/scripts/configure_selinux.sh

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -3,12 +3,10 @@
 set -e
 
 # Magic begin: scripts are inlined for distribution. See "make build/tasks.sh"
-. $DIR/scripts/Manifest
 . $DIR/scripts/common/common.sh
 . $DIR/scripts/common/discover.sh
 . $DIR/scripts/common/prompts.sh
 . $DIR/scripts/common/host-packages.sh
-. $DIR/scripts/common/utilbinaries.sh
 . $DIR/scripts/distro/interface.sh
 . $DIR/scripts/distro/kubeadm/distro.sh
 . $DIR/scripts/distro/rke2/distro.sh
@@ -49,9 +47,6 @@ function tasks() {
             ;;
         taint-primaries|taint_primaries)
             taint_primaries
-            ;;
-        migrate-pvcs|migrate_pvcs)
-            migrate_pvcs $@
             ;;
         *)
             bail "Unknown task: $1"
@@ -472,104 +467,6 @@ EOF
         pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
         kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
     done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
-}
-
-function migrate_pvcs() {
-    export KUBECONFIG=/etc/kubernetes/admin.conf
-
-    # get params - specifically need airgap as that impacts binary downloads and skip-rook-health-checks to skip rook health checks
-    shift # the first param is migrate_pvcs/migrate-pvcs
-    while [ "$1" != "" ]; do
-        _param="$(echo "$1" | cut -d= -f1)"
-        _value="$(echo "$1" | grep '=' | cut -d= -f2-)"
-        case $_param in
-            airgap)
-                AIRGAP="1"
-                ;;
-            skip-rook-health-checks)
-                SKIP_ROOK_HEALTH_CHECKS="1"
-                ;;
-            skip-longhorn-health-checks)
-                SKIP_LONGHORN_HEALTH_CHECKS="1"
-                ;;
-            *)
-                echo >&2 "Error: unknown parameter \"$_param\""
-                exit 1
-                ;;
-        esac
-        shift
-    done
-
-    download_util_binaries
-
-    # check that rook-ceph is healthy
-    ROOK_CEPH_EXEC_TARGET=rook-ceph-operator
-    if kubectl get deployment -n rook-ceph rook-ceph-tools &>/dev/null; then
-        ROOK_CEPH_EXEC_TARGET=rook-ceph-tools
-    fi
-    CEPH_HEALTH_DETAIL=$(kubectl exec -n rook-ceph deployment/$ROOK_CEPH_EXEC_TARGET -- ceph health detail)
-    if [ "$CEPH_HEALTH_DETAIL" != "HEALTH_OK" ]; then
-        if [ "$SKIP_ROOK_HEALTH_CHECKS" = "1" ]; then
-            echo "Continuing with unhealthy rook due to skip-rook-health-checks flag"
-        else
-            echo "Ceph is not healthy, please resolve this before rerunning the script or rerun with the skip-rook-health-checks flag:"
-            echo "$CEPH_HEALTH_DETAIL"
-            return 1
-        fi
-    else
-        echo "rook-ceph appears to be healthy"
-    fi
-    CEPH_DISK_USAGE_TOTAL=$(kubectl exec -n rook-ceph deployment/$ROOK_CEPH_EXEC_TARGET -- ceph df | grep TOTAL | awk '{{ print $8$9 }}')
-
-    # check that longhorn is healthy
-    LONGHORN_NODES_STATUS=$(kubectl get nodes.longhorn.io -n longhorn-system -o=jsonpath='{.items[*].status.conditions.Ready.status}')
-    LONGHORN_NODES_SCHEDULABLE=$(kubectl get nodes.longhorn.io -n longhorn-system -o=jsonpath='{.items[*].status.conditions.Schedulable.status}')
-    pat="^True( True)*$" # match "True", "True True" etc but not "False True" or ""
-    if [[ $LONGHORN_NODES_STATUS =~ $pat ]] && [[ $LONGHORN_NODES_SCHEDULABLE =~ $pat ]]; then
-        echo "All Longhorn nodes are ready and schedulable"
-    else
-        if [ "$SKIP_LONGHORN_HEALTH_CHECKS" = "1" ]; then
-            echo "Continuing with unhealthy Longhorn due to skip-longhorn-health-checks flag"
-        else
-            echo "Longhorn is not healthy, please resolve this before rerunning the script or rerun with the skip-longhorn-health-checks flag:"
-            kubectl get nodes.longhorn.io -n longhorn-system
-            return 1
-        fi
-    fi
-
-    # provide large warning that this will stop the app
-    printf "${YELLOW}"
-    printf "WARNING: \n"
-    printf "\n"
-    printf "    This command will attempt to move data from rook-ceph to longhorn.\n"
-    printf "\n"
-    printf "    As part of this, all pods mounting PVCs will be stopped, taking down the application.\n"
-    printf "\n"
-    printf "    Copying the data currently stored within rook-ceph will require at least %s of free space across the cluster.\n" "$CEPH_DISK_USAGE_TOTAL"
-    printf "    It is recommended to take a snapshot or otherwise back up your data before starting this process.\n${NC}"
-    printf "\n"
-    printf "Would you like to continue? "
-
-    if ! confirmN; then
-        printf "Not migrating\n"
-        exit 1
-    fi
-
-    # set prometheus scale if it exists
-    if kubectl get namespace monitoring &>/dev/null; then
-        kubectl patch prometheus -n monitoring  k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
-    fi
-
-    # run the migration
-    $BIN_PVMIGRATE --source-sc default --dest-sc longhorn --rsync-image "$KURL_UTIL_IMAGE"
-
-    # reset prometheus scale
-    if kubectl get namespace monitoring &>/dev/null; then
-        kubectl patch prometheus -n monitoring  k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]'
-    fi
-
-    # print success message
-    printf "${GREEN}Migration from rook-ceph to longhorn completed successfully!\n${NC}"
 }
 
 tasks "$@"

--- a/testgrid/tgrun/go.sum
+++ b/testgrid/tgrun/go.sum
@@ -139,6 +139,7 @@ github.com/aws/aws-sdk-go v1.15.77/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.16/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.67 h1:OCeXMKiiM8X7HAKPCE5yD+t+sEsRaj8EwDs2tlgvX2c=
@@ -972,8 +973,10 @@ github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYL
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c/go.mod h1:7oQvGNiJsGvrUgB+7AH8bmdzuR0uhULfwKb43Ht0hUk=
-github.com/replicatedhq/pvmigrate v0.1.1/go.mod h1:HXPV+iTqyR2YXPkSKkVtfkAhps9t55W0UqdOeaQvULk=
+github.com/replicatedhq/pvmigrate v0.1.0/go.mod h1:NIcC2CW1rvkxTNQG556VIudMXSQPVC5cgBsCbLWgYvs=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
+github.com/replicatedhq/troubleshoot v0.10.24/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
+github.com/replicatedhq/troubleshoot v0.13.1 h1:x75YrMdkwX3GRA6T2lOjL7sgLHCqDvO5NobFdFQ42Lg=
 github.com/replicatedhq/troubleshoot v0.13.1/go.mod h1:INf+DZhU9XXCHBeab5jLOhwsKzHcGCoEw4H6hGt9X5o=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
@@ -1032,6 +1035,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1074,6 +1078,8 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spf13/viper v1.8.0 h1:QRwDgoG8xX+kp69di68D+YYTCWfYEckbZRfUlEIAal0=
+github.com/spf13/viper v1.8.0/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
@@ -1819,6 +1825,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyz
 sigs.k8s.io/cluster-api v0.3.11-0.20210106212952-b6c1b5b3db3d/go.mod h1:HwDMTKYusSK0SnTAr/P3htrxdiykBADqffkamkiUXhk=
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
 sigs.k8s.io/controller-runtime v0.7.1-0.20201215171748-096b2e07c091/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
+sigs.k8s.io/controller-runtime v0.8.3 h1:GMHvzjTmaWHQB8HadW+dIvBoJuLvZObYJ5YoZruPRao=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
 sigs.k8s.io/controller-runtime v0.9.2 h1:MnCAsopQno6+hI9SgJHKddzXpmv2wtouZz6931Eax+Q=
 sigs.k8s.io/controller-runtime v0.9.2/go.mod h1:TxzMCHyEUpaeuOiZx/bIdc2T81vfs/aKdvJt9wuu0zk=


### PR DESCRIPTION
Reverts replicatedhq/kURL#1842

This change appears to have broken tasks.sh rendering, with `curl https://staging.kurl.sh/latest/tasks.sh` yielding `{"error":{"message":"A server error has occurred"}}`.