### PR TITLE
Add task to migrate RGW to Minio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.12.0
 	github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c
+	github.com/go-ini/ini v1.62.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0
@@ -25,6 +26,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/itchyny/gojq v0.12.4
 	github.com/mattn/go-isatty v0.0.13
+	github.com/minio/minio-go v6.0.14+incompatible // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/onsi/gomega v1.13.0
 	github.com/pelletier/go-toml v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,8 @@ github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540/go.mod h1:+s
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-ini/ini v1.62.0 h1:7VJT/ZXjzqSrvtraFp4ONq80hTcRQth1c9ZnQ3uNQvU=
+github.com/go-ini/ini v1.62.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -779,6 +781,8 @@ github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nr
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
+github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJdNZo6oqSENd4eW8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -9,4 +9,6 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	hostCmd.AddCommand(NewHostProtectedidCmd(cli))
 	hostCmd.AddCommand(NewHostPreflightCmd(cli))
 	cmd.AddCommand(hostCmd)
+
+	cmd.AddCommand(NewSyncObjectStoreCmd(cli))
 }

--- a/pkg/cli/sync_object_store.go
+++ b/pkg/cli/sync_object_store.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/minio/minio-go"
+	"github.com/spf13/cobra"
+)
+
+func NewSyncObjectStoreCmd(cli CLI) *cobra.Command {
+	var srcHost string
+	var srcAccessKeyID string
+	var srcAccessKeySecret string
+
+	var dstHost string
+	var dstAccessKeyID string
+	var dstAccessKeySecret string
+
+	syncObjectStoreCmd := &cobra.Command{
+		Use:   "sync-object-store",
+		Short: "Copies buckets and objects from one object store to another",
+		Run: func(cmd *cobra.Command, args []string) {
+			src, err := minio.New(
+				srcHost,
+				srcAccessKeyID,
+				srcAccessKeySecret,
+				false,
+			)
+			if err != nil {
+				log.Panic(err)
+			}
+
+			dst, err := minio.New(
+				dstHost,
+				dstAccessKeyID,
+				dstAccessKeySecret,
+				false,
+			)
+			if err != nil {
+				log.Panic(err)
+			}
+
+			ctx := context.Background()
+
+			srcBuckets, err := src.ListBuckets()
+			if err != nil {
+				log.Fatalf("Failed to list buckets in %s: %v", srcHost, err)
+			}
+
+			for _, srcBucket := range srcBuckets {
+				fmt.Printf("Syncing %s from %s to %s\n", srcBucket.Name, srcHost, dstHost)
+
+				count, err := SyncBucket(ctx, src, dst, srcBucket.Name)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				fmt.Printf("Successfully synced %d objects in bucket %s from %s to %s\n", count, srcBucket.Name, srcHost, dstHost)
+			}
+
+			fmt.Printf("Successfully synced %d buckets from %s to %s\n", len(srcBuckets), srcHost, dstHost)
+		},
+	}
+
+	syncObjectStoreCmd.Flags().StringVar(&srcHost, "source_host", "", "Hostname of the source object store")
+	syncObjectStoreCmd.Flags().StringVar(&srcAccessKeyID, "source_access_key_id", "", "Access key ID for the source object store")
+	syncObjectStoreCmd.Flags().StringVar(&srcAccessKeySecret, "source_access_key_secret", "", "Access key secret for the source object store")
+
+	syncObjectStoreCmd.Flags().StringVar(&dstHost, "dest_host", "", "Hostname of the destination object store")
+	syncObjectStoreCmd.Flags().StringVar(&dstAccessKeyID, "dest_access_key_id", "", "Access key ID for the destination object store")
+	syncObjectStoreCmd.Flags().StringVar(&dstAccessKeySecret, "dest_access_key_secret", "", "Access key secret for the destination object store")
+
+	return syncObjectStoreCmd
+}
+
+func SyncBucket(ctx context.Context, src *minio.Client, dst *minio.Client, bucket string) (int, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	count := 0
+
+	exists, err := dst.BucketExists(bucket)
+	if err != nil {
+		return count, fmt.Errorf("Failed to check if bucket %q exists in destination: %v", bucket, err)
+	}
+	if !exists {
+		if err := dst.MakeBucket(bucket, ""); err != nil {
+			return count, fmt.Errorf("Failed to make bucket %q in destination: %v", bucket, err)
+		}
+	}
+
+	srcObjectInfoChan := src.ListObjects(bucket, "", true, ctx.Done())
+
+	for srcObjectInfo := range srcObjectInfoChan {
+		srcObject, err := src.GetObject(bucket, srcObjectInfo.Key, minio.GetObjectOptions{})
+		if err != nil {
+			return count, fmt.Errorf("Get %s from source: %v", srcObjectInfo.Key, err)
+		}
+
+		_, err = dst.PutObject(bucket, srcObjectInfo.Key, srcObject, srcObjectInfo.Size, minio.PutObjectOptions{
+			ContentType:     srcObjectInfo.ContentType,
+			ContentEncoding: srcObjectInfo.Metadata.Get("Content-Encoding"),
+		})
+		srcObject.Close()
+		if err != nil {
+			return count, fmt.Errorf("Failed to copy object %s to destination: %v", srcObjectInfo.Key, err)
+		}
+
+		count++
+	}
+
+	return count, nil
+}

--- a/testgrid/tgrun/go.sum
+++ b/testgrid/tgrun/go.sum
@@ -341,6 +341,7 @@ github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540/go.mod h1:+s
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-ini/ini v1.62.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.3.0 h1:QZEva+odUF/G+yz7yjQLwUQxnSAS4S45V9+4O02yJ1Q=
 github.com/go-kit/kit v0.3.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -791,6 +792,7 @@ github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nr
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=


### PR DESCRIPTION
Add a new sync-object-store subcommand to the kurl CLI and run it in a
Pod.
This does not update kotsadm, velero, or the registry to use Minio.