### PR TITLE
fix testgrid ref kurl version

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -234,6 +234,11 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: Get the version
+      id: get_tag
+      shell: bash
+      run: echo ::set-output name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
+
     - name: Tgrun Build
       working-directory: ./testgrid/tgrun
       run: make build


### PR DESCRIPTION
Fixes the testgrid ref and adds the release tag. Ref currently looks something like this `PROD-release--20210720191039`