### PR TITLE
Allow preflight spec from stdin CLI examples

### DIFF
--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -27,8 +27,7 @@ const HostPreflightCmdExample = `
   $ kurl host preflight spec.yaml
 
   # Installer spec from STDIN
-  $ kubectl get installer 6abe39c -oyaml | kurl host preflight -
-`
+  $ kubectl get installer 6abe39c -oyaml | kurl host preflight -`
 
 func NewHostPreflightCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -22,10 +22,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const HostPreflightCmdExample = `
+# Installer spec from file
+$ kurl host preflight spec.yaml
+
+# Installer spec from STDIN
+$ kubectl get installer 6abe39c -oyaml | kurl host preflight -
+`
+
 func NewHostPreflightCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "preflight [installer spec file]",
+		Use:          "preflight [installer spec file|-]",
 		Short:        "Runs kURL host preflight checks",
+		Example:      HostPreflightCmdExample,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -23,11 +23,11 @@ import (
 )
 
 const HostPreflightCmdExample = `
-# Installer spec from file
-$ kurl host preflight spec.yaml
+  # Installer spec from file
+  $ kurl host preflight spec.yaml
 
-# Installer spec from STDIN
-$ kubectl get installer 6abe39c -oyaml | kurl host preflight -
+  # Installer spec from STDIN
+  $ kubectl get installer 6abe39c -oyaml | kurl host preflight -
 `
 
 func NewHostPreflightCmd(cli CLI) *cobra.Command {


### PR DESCRIPTION
```
Runs kURL host preflight checks

Usage:
  kurl host preflight [installer spec file|-] [flags]

Examples:

  # Installer spec from file
  $ kurl host preflight spec.yaml

  # Installer spec from STDIN
  $ kubectl get installer 6abe39c -oyaml | kurl host preflight -


Flags:
  -h, --help                     help for preflight
...
```