### PR TITLE
automatically uninstall rook after migrating PVCs and object store data

### DIFF
--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -1,3 +1,4 @@
+DID_MIGRATE_ROOK_OBJECT_STORE=
 
 function minio_pre_init() {
     if [ -z "$MINIO_NAMESPACE" ]; then
@@ -156,4 +157,5 @@ function minio_migrate_from_rgw() {
     fi
 
     migrate_rgw_to_minio
+    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
 }

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -10,3 +10,30 @@
     minio:
       version: "__testver__"
       s3Override: "__testdist__"
+
+- installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    rook:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    rook:
+      version: "latest"
+    minio:
+      version: "__testver__"
+      s3Override: "__testdist__"
+      migrateFromRGW: true

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -108,3 +108,14 @@ function rook_ceph_to_longhorn() {
     # print success message
     printf "${GREEN}Migration from rook-ceph to longhorn completed successfully!\n${NC}"
 }
+
+# if PVCs and object store data have both been migrated from rook-ceph and rook-ceph is no longer specified in the kURL spec, remove rook-ceph
+function maybe_cleanup_rook() {
+    if [ -z "$ROOK_VERSION" ]; then
+        if [ "$DID_MIGRATE_ROOK_PVCS" == "1" ] && [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+            report_addon_start "rook-ceph-removal" "v1"
+            remove_rook_ceph
+            report_addon_success "rook-ceph-removal" "v1"
+        fi
+    fi
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -453,6 +453,7 @@ function main() {
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed
     kurl_init_config
     ${K8S_DISTRO}_addon_for_each addon_install
+    maybe_cleanup_rook
     helmfile_sync
     post_init
     outro


### PR DESCRIPTION
(if rook is no longer specified in the installer spec, of course)