### PR TITLE
Increase CPU Limit in Staging

### DIFF
--- a/kustomize/overlays/staging/deployment.yaml
+++ b/kustomize/overlays/staging/deployment.yaml
@@ -15,7 +15,7 @@ spec:
           requests:
             cpu: 100m
           limits:
-            cpu: 1
+            cpu: 2
         envFrom:
         - secretRef:
             name: kurl-secrets


### PR DESCRIPTION
In staging, kURL is currently running up against its limit and being throttled resulting in slow download speeds at times. 