### PR TITLE
Fix testgrid red

### DIFF
--- a/testgrid/deploy/README.md
+++ b/testgrid/deploy/README.md
@@ -40,7 +40,7 @@ You can exec into a VM with `kubectl virt console <vmi name>`, and the password 
 1. Click on any server
 1. Click SSH access, copy the command, and SSH into the server
 1. Find the upload proxy IP: kubectl -n cdi get service cdi-uploadproxy --no-headers | awk '{ print $3 }'
-1. Download the VM image. Pick image from tgrun/pkg/scheduler/static.go. `curl -LO https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2`
+1. Download the VM image. Pick image from testgrid/specs/os.yaml. `curl -LO https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2`
 1. Create a PVC from the image: `kubectl virt image-upload --uploadproxy-url=https://<upload proxy IP> --insecure --pvc-name=areed-disk --pvc-size=100Gi --image-path=`pwd`/CentOS-8-GenericCloud-8.3.2011-20201204.2.x86_64.qcow2`
 1. Create virtualmachineinstance with config and `kubectl apply` it
 ```

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -53,27 +53,6 @@
       version: latest
     minio:
       version: latest
-- name: rke2
-  installerSpec:
-    rke2:
-      version: latest
-    rook:
-      isBlockStorageEnabled: true
-      storageClassName: default
-      hostpathRequiresPrivileged: true
-      version: 1.4.x
-    registry:
-      version: latest
-    kotsadm:
-      uiBindPort: 30880
-      version: latest
-    velero:
-      resticRequiresPrivileged: true
-      version: latest
-  unsupportedOSIDs:
-  - ubuntu-1604
-  - ubuntu-1804
-  - ubuntu-2004
 - name: k8s119
   installerSpec:
     kubernetes:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -124,6 +124,12 @@
       version: 1.12.0
     ekco:
       version: 0.6.0
+  unsupportedOSIDs:
+  - centos-81
+  - centos-82
+  - centos-83
+  - centos-84
+  - ol-84
 - name: k8s118
   installerSpec:
     kubernetes:
@@ -712,47 +718,3 @@
     ekco:
       version: 0.10.1
   airgap: true
-- name: rke2
-  installerSpec:
-    rke2:
-      version: latest
-    rook:
-      isBlockStorageEnabled: true
-      storageClassName: default
-      hostpathRequiresPrivileged: true
-      version: 1.4.3
-    registry:
-      version: latest
-    kotsadm:
-      uiBindPort: 30880
-      version: latest
-    velero:
-      resticRequiresPrivileged: true
-      version: latest
-  unsupportedOSIDs:
-  - ubuntu-1604
-  - ubuntu-1804
-  - ubuntu-2004
-- name: rke2-airgap
-  installerSpec:
-    rke2:
-      version: latest
-    rook:
-      isBlockStorageEnabled: true
-      storageClassName: default
-      hostpathRequiresPrivileged: true
-      version: 1.4.3
-    registry:
-      version: latest
-    kotsadm:
-      uiBindPort: 30880
-      version: latest
-    velero:
-      resticRequiresPrivileged: true
-      version: latest
-  airgap: true
-  unsupportedOSIDs:
-  - ubuntu-1604
-  - ubuntu-1804
-  - ubuntu-2004
-


### PR DESCRIPTION
Remove rke2 tests.
Airgap violations are not a failure.
Weave 2.5.2 is unsupported on EL 8.
Fix missing libip4tc.so.0 after installing iptables on CentOS 8.1.