### PR TITLE
Migrate from docker to containerd

### DIFF
--- a/addons/containerd/1.3.7/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/1.3.7/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.3.9/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/1.3.9/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.3/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/1.4.3/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.4/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/1.4.4/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.6/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/1.4.6/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/template/base/kubeadm-init-config-v1beta2.yaml
+++ b/addons/containerd/template/base/kubeadm-init-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -334,7 +334,7 @@ function kubernetes_resource_exists() {
 
 function install_cri() {
     # In the event someone changes the installer spec from docker to containerd, maintain backward capability with old installs
-    if [ -n "$DOCKER_VERSION" ] || [ "$SKIP_DOCKER_INSTALL" = "1" ] ; then
+    if [ -n "$DOCKER_VERSION" ] ; then
         export REPORTING_CONTEXT_INFO="docker $DOCKER_VERSION"
         report_install_docker
         export REPORTING_CONTEXT_INFO=""
@@ -380,6 +380,26 @@ function try_1m() {
             try_output="$($fn $args 2>&1)" || true
             echo "$try_output"
             bail "spent 1m attempting to run \"$fn $args\" without success"
+        fi
+        sleep 2
+    done
+}
+
+# try a command every 2 seconds until it succeeds, up to 150 tries max; useful for kubectl commands
+# where the Kubernetes API could be restarting
+function try_5m() {
+    local fn="$1"
+    local args=${@:2}
+
+    n=0
+    while ! $fn $args 2>/dev/null ; do
+        n="$(( $n + 1 ))"
+        if [ "$n" -ge "150" ]; then
+            # for the final try print the error and let it exit
+            echo ""
+            try_output="$($fn $args 2>&1)" || true
+            echo "$try_output"
+            bail "spent 5m attempting to run \"$fn $args\" without success"
         fi
         sleep 2
     done

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -8,7 +8,9 @@ function discover() {
     # never upgrade docker underneath kubernetes
     if docker version >/dev/null 2>&1 ; then
         SKIP_DOCKER_INSTALL=1
-        echo "Docker already exists on this machine so no docker install will be performed"
+        if [ -n "$DOCKER_VERSION" ]; then
+            echo "Docker already exists on this machine so no docker install will be performed"
+        fi
     fi
 
     discover_public_ip

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -130,12 +130,6 @@ function check_docker_k8s_version() {
         return
     fi
 
-    # NOTE (ethan): This is probably the wrong thing to go here but i'm leaving it in so as not to
-    # break existing functionality.
-    if [ -z "$DOCKER_VERSION" ]; then
-        DOCKER_VERSION="${version}"
-    fi
-
     case "$KUBERNETES_TARGET_VERSION_MINOR" in 
         14|15)
             compareDockerVersions "$version" 1.13.1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -130,6 +130,7 @@ function main() {
     ${K8S_DISTRO}_addon_for_each addon_join
     outro
     package_cleanup
+    uninstall_docker
 
     popd_install_directory
 }


### PR DESCRIPTION
When docker is detected and the kurl spec has containerd follow these steps to migrate prior to installing containerd:

1. Run the ekco shutdown script to delete pods that depend on other pods on the node being running, i.e. pods that mount PVCs.
1. Delete all remaining pods from the node. This has to use the kubelet's kubeconfig since that's the only kubeconfig available on both primaries and secondaries. It does not have permission to do a drain, so manually delete every pod by UID.
1. Stop kubelet.
1. Force delete all docker containers.
1. Reconfigure kubelet to use containerd instead of the dockershim. This is done by adding `--container-runtime` and `--container-runtime` endpoint flags to /var/lib/kubelet/kubeadm-flags.env. Also patch the kubeadm.conf file to make these changes persistent.

When the script is complete, perform these steps to finish the migration.
1. Remove docker and its data
1. Start kubelet (remotes only - if kubeadm init was run kubelet will already be started).
1. Uncordon the node (remotes only - if kubeadm init was run the node will already be uncordoned).