### PR TITLE
YAML Linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ supported-versions-gen.json
 addons-gen.json
 .envrc
 .github/workflows/payloads
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -709,3 +709,7 @@ shunit2: common-test #TODO include other tests
 .PHONY: common-test
 common-test:
 	./scripts/common/test/common-test.sh
+
+.PHONY: yaml-lint
+yaml-lint:
+	bin/yaml-lint.sh

--- a/bin/yaml-lint.sh
+++ b/bin/yaml-lint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if ! command -v yamllint &> /dev/null
+then
+  pip install --user yamllint
+fi
+
+
+find ./addons -mtime -1 -name '*.yaml' -print0 | 
+	while IFS= read -r -d '' line; do
+		echo "$line"
+		# strip all the {{kurl }} directives out of the yaml before we lint it
+		sed -r 's/^\s*\{\{kurl[^\}]*\}\}\s*$//' < "$line" | yamllint - 
+	done
+


### PR DESCRIPTION
I added yaml linter task.  It finds all yaml files in the add ins directory that have been modified in the last day.  If a yaml file has been modified it will have all the non yaml directives stripped from it and then be linted.  The reason that the script only looks for yaml that has been modified in the last day is because if you lint all the yaml in addons, you get so many failures that it would be onerous to change them all.  Eventually I'd like to create a Github action that requires a successful yaml lint step in order of the build to succeed.  It's not feasible to fix all the yaml problems in the addons directory so I was thinking that we would just require linting to pass on existing stuff we touch, or new stuff. 