### PR TITLE
Wait for Kubernetes API after starting kubelet

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -52,6 +52,10 @@ function containerd_install() {
 
     if systemctl list-unit-files | grep -q kubelet.service; then
         systemctl start kubelet
+        # If using the internal load balancer the Kubernetes API server will be unavailable until
+        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+        # is available before proceeeding.
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
 
     load_images $src/images


### PR DESCRIPTION
This fixes a race condition seen on CentOS 7 when upgrading Kubernetes version and migrating from docker to containerd at the same time. The Kubernetes API server was not always ready to handle the upgrade when using the internal load balancer.