### PR TITLE
move block device checks to addon code

### DIFF
--- a/addons/openebs/1.12.0/host-preflight.yaml
+++ b/addons/openebs/1.12.0/host-preflight.yaml
@@ -1,0 +1,25 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+
+  analyzers:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+      outcomes:
+      - pass:
+          when: ".* == 1"
+          message: One available block device
+      - pass:
+          when: ".* > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/openebs/1.6.0/host-preflight.yaml
+++ b/addons/openebs/1.6.0/host-preflight.yaml
@@ -1,0 +1,25 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+
+  analyzers:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+      outcomes:
+      - pass:
+          when: ".* == 1"
+          message: One available block device
+      - pass:
+          when: ".* > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/openebs/2.6.0/host-preflight.yaml
+++ b/addons/openebs/2.6.0/host-preflight.yaml
@@ -1,0 +1,25 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+
+  analyzers:
+  - blockDevices:
+      # cstor is enabled and not upgrade
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl and (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled) (not .IsUpgrade) | not }}'
+      outcomes:
+      - pass:
+          when: ".* == 1"
+          message: One available block device
+      - pass:
+          when: ".* > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.0.4-14.2.21/host-preflight.yaml
+++ b/addons/rook/1.0.4-14.2.21/host-preflight.yaml
@@ -1,0 +1,45 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl and (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (not .IsUpgrade) | not }}'
+
+  - diskUsage:
+      exclude: '{{kurl or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (.IsUpgrade) }}'
+      collectorName: "Ephemeral Disk Usage /opt/replicated/rook"
+      path: /opt/replicated/rook
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl and (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (not .IsUpgrade) | not }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices
+
+  - diskUsage:
+      checkName: "Ephemeral Disk Usage /opt/replicated/rook"
+      collectorName: "Ephemeral Disk Usage /opt/replicated/rook"
+      exclude: '{{kurl or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (.IsUpgrade) }}'
+      outcomes:
+      - fail:
+          when: "available < 10Gi"
+          message: The disk containing directory /opt/replicated/rook has less than 10Gi of available space
+      - fail:
+          when: "used/total > 80%"
+          message: The disk containing directory /opt/replicated/rook is more than 80% full
+      - warn:
+          when: "available < 25Gi"
+          message: The disk containing directory /opt/replicated/rook has less than 25Gi of available space
+      - pass:
+          message: The disk containing directory /opt/replicated/rook has at least 25Gi disk space available

--- a/addons/rook/1.0.4/host-preflight.yaml
+++ b/addons/rook/1.0.4/host-preflight.yaml
@@ -1,0 +1,45 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl and (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (not .IsUpgrade) | not }}'
+
+  - diskUsage:
+      exclude: '{{kurl or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (.IsUpgrade) }}'
+      collectorName: "Ephemeral Disk Usage /opt/replicated/rook"
+      path: /opt/replicated/rook
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl and (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (not .IsUpgrade) | not }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices
+
+  - diskUsage:
+      checkName: "Ephemeral Disk Usage /opt/replicated/rook"
+      collectorName: "Ephemeral Disk Usage /opt/replicated/rook"
+      exclude: '{{kurl or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (.IsUpgrade) }}'
+      outcomes:
+      - fail:
+          when: "available < 10Gi"
+          message: The disk containing directory /opt/replicated/rook has less than 10Gi of available space
+      - fail:
+          when: "used/total > 80%"
+          message: The disk containing directory /opt/replicated/rook is more than 80% full
+      - warn:
+          when: "available < 25Gi"
+          message: The disk containing directory /opt/replicated/rook has less than 25Gi of available space
+      - pass:
+          message: The disk containing directory /opt/replicated/rook has at least 25Gi disk space available

--- a/addons/rook/1.4.3/host-preflight.yaml
+++ b/addons/rook/1.4.3/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.4.9/host-preflight.yaml
+++ b/addons/rook/1.4.9/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.5.10/host-preflight.yaml
+++ b/addons/rook/1.5.10/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.5.11/host-preflight.yaml
+++ b/addons/rook/1.5.11/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.5.12/host-preflight.yaml
+++ b/addons/rook/1.5.12/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/1.5.9/host-preflight.yaml
+++ b/addons/rook/1.5.9/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/addons/rook/template/base/host-preflight.yaml
+++ b/addons/rook/template/base/host-preflight.yaml
@@ -1,0 +1,23 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  collectors:
+  - blockDevices:
+      exclude: '{{kurl .IsUpgrade }}'
+
+  analyzers:
+  - blockDevices:
+      includeUnmountedPartitions: true
+      minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
+          message: One available block device
+      - pass:
+          when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
+          message: Multiple available block devices
+      - fail:
+          message: No available block devices

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -16,9 +16,6 @@ spec:
         collectorName: "Ephemeral Disk Usage /var/lib/docker"
         path: /var/lib/docker
         exclude: '{{kurl not .Installer.Spec.Docker.Version}}'
-    - blockDevices:
-        # rook block storage or cstor is enabled and not upgrade
-        exclude: '{{kurl and (or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled)) (not .IsUpgrade) | not }}'
     - tcpLoadBalancer:
         collectorName: "Kubernetes API Server Load Balancer"
         port: 6443
@@ -117,8 +114,11 @@ spec:
           - warn:
               when: "used/total > 60%"
               message: The disk containing directory /var/lib/kubelet is more than 60% full
+          - warn:
+              when: "available < 10Gi"
+              message: The disk containing directory /var/lib/kubelet has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/kubelet has at least 30Gi disk space available
+              message: The disk containing directory /var/lib/kubelet has at least 10Gi of disk space available and is not nearly full
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/lib/docker"
         collectorName: "Ephemeral Disk Usage /var/lib/docker"
@@ -133,8 +133,11 @@ spec:
           - warn:
               when: "used/total > 60%"
               message: The disk containing directory /var/lib/docker is more than 60% full
+          - warn:
+              when: "available < 10Gi"
+              message: The disk containing directory /var/lib/docker has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/docker has at least 30Gi disk space available
+              message: The disk containing directory /var/lib/docker has at least 10Gi of disk space available and is not nearly full
     - tcpLoadBalancer:
         checkName: "Kubernetes API Server Load Balancer"
         collectorName: "Kubernetes API Server Load Balancer"
@@ -161,21 +164,6 @@ spec:
               message: Successfully connected to {{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }} via load balancer
           - warn:
               message: Unexpected port status
-    - blockDevices:
-        # rook block storage or cstor is enabled and not upgrade
-        includeUnmountedPartitions: true
-#        minimumAcceptableSize: 26843545600 # 1024 ^ 3 * 25, 25GiB
-        minimumAcceptableSize: 10737418240 # 1024 ^ 3 * 10, 10GiB
-        exclude: '{{kurl and (or (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.IsBlockStorageEnabled) (and .Installer.Spec.OpenEBS.Version .Installer.Spec.OpenEBS.IsCstorEnabled)) (not .IsUpgrade) | not }}'
-        outcomes:
-          - pass:
-              when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} == 1"
-              message: One available block device
-          - pass:
-              when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
-              message: Multiple available block devices
-          - fail:
-              message: No available block devices
     - tcpPortStatus:
         checkName: "Kubernetes API TCP Port Status"
         collectorName: "Kubernetes API TCP Port Status"

--- a/pkg/preflight/builtin_test.go
+++ b/pkg/preflight/builtin_test.go
@@ -39,15 +39,15 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 					value: `"true"`,
 				},
 				{
+					query: ".spec.collectors[] | select(.diskUsage != null) | select(.diskUsage.path == \"/var/lib/docker\") | .diskUsage.exclude",
+					value: `"true"`,
+				},
+				{
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
 					value: `"true"`,
 				},
 				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"true"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
+					query: ".spec.analyzers[] | select(.diskUsage != null) | select(.diskUsage.checkName == \"Ephemeral Disk Usage /var/lib/docker\")| .diskUsage.exclude",
 					value: `"true"`,
 				},
 			},
@@ -98,73 +98,6 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 			},
 		},
 		{
-			name: "blockDevices rook.isBlockStorageEnabled==true",
-			spec: clusterv1beta1.Installer{
-				Spec: clusterv1beta1.InstallerSpec{
-					Rook: &clusterv1beta1.Rook{
-						Version:               "1.4.3",
-						IsBlockStorageEnabled: true,
-						BlockDeviceFilter:     "vd[b-z]",
-					},
-				},
-			},
-			isPrimary: true,
-			want: []jsonquery{
-				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.outcomes",
-					value: `- pass:
-    when: "vd[b-z] == 1"
-    message: One available block device
-- pass:
-    when: "vd[b-z] > 1"
-    message: Multiple available block devices
-- fail:
-    message: No available block devices`,
-				},
-			},
-		},
-		{
-			name: "blockDevices openebs.isCstorEnabled==true",
-			spec: clusterv1beta1.Installer{
-				Spec: clusterv1beta1.InstallerSpec{
-					OpenEBS: &clusterv1beta1.OpenEBS{
-						Version:        "1.12.0",
-						IsCstorEnabled: true,
-					},
-				},
-			},
-			isPrimary: true,
-			want: []jsonquery{
-				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.outcomes",
-					value: `- pass:
-    when: ".* == 1"
-    message: One available block device
-- pass:
-    when: ".* > 1"
-    message: Multiple available block devices
-- fail:
-    message: No available block devices`,
-				},
-			},
-		},
-		{
 			name: "join primary",
 			spec: clusterv1beta1.Installer{
 				Spec: clusterv1beta1.InstallerSpec{
@@ -189,25 +122,6 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 				{
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
 					value: `"true"`,
-				},
-				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.outcomes",
-					value: `- pass:
-    when: "vd[b-z] == 1"
-    message: One available block device
-- pass:
-    when: "vd[b-z] > 1"
-    message: Multiple available block devices
-- fail:
-    message: No available block devices`,
 				},
 			},
 		},
@@ -235,26 +149,6 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 				{
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
 					value: `"true"`,
-				},
-
-				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"false"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.outcomes",
-					value: `- pass:
-    when: "vd[b-z] == 1"
-    message: One available block device
-- pass:
-    when: "vd[b-z] > 1"
-    message: Multiple available block devices
-- fail:
-    message: No available block devices`,
 				},
 			},
 		},
@@ -284,14 +178,6 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
 					value: `"true"`,
 				},
-				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"true"`,
-				},
-				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"true"`,
-				},
 			},
 		},
 		{
@@ -319,13 +205,34 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
 					value: `"true"`,
 				},
+			},
+		},
+		{
+			name: "docker",
+			spec: clusterv1beta1.Installer{
+				Spec: clusterv1beta1.InstallerSpec{
+					Docker: &clusterv1beta1.Docker{
+						Version: "latest",
+					},
+				},
+			},
+			isPrimary: true,
+			want: []jsonquery{
 				{
-					query: ".spec.collectors[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"true"`,
+					query: ".spec.collectors[] | select(.diskUsage != null) | select(.diskUsage.path == \"/var/lib/docker\") | .diskUsage.exclude",
+					value: `"false"`,
 				},
 				{
-					query: ".spec.analyzers[] | select(.blockDevices != null) | .blockDevices.exclude",
-					value: `"true"`,
+					query: ".spec.collectors[] | select(.diskUsage != null) | select(.diskUsage.path == \"/var/lib/docker\") | .diskUsage.path",
+					value: `"/var/lib/docker"`,
+				},
+				{
+					query: ".spec.analyzers[] | select(.diskUsage != null) | select(.diskUsage.checkName == \"Ephemeral Disk Usage /var/lib/docker\")| .diskUsage.exclude",
+					value: `"false"`,
+				},
+				{
+					query: ".spec.analyzers[] | select(.diskUsage != null) | select(.diskUsage.checkName == \"Ephemeral Disk Usage /var/lib/docker\")| .diskUsage.collectorName",
+					value: `"Ephemeral Disk Usage /var/lib/docker"`,
 				},
 			},
 		},


### PR DESCRIPTION
this way it always runs for rook 1.4+

also add disk space check for /opt/replicated/rook when appropriate

finally check available, not just total and percentage, space in /var/lib/docker and /var/lib/kubelet