### PR TITLE
Triggered Kotsadm version update 1.51.1-beta.0

### DIFF
--- a/addons/kotsadm/alpha/Manifest
+++ b/addons/kotsadm/alpha/Manifest
@@ -5,4 +5,4 @@ image kurl-proxy docker.io/kotsadm/kurl-proxy:alpha
 image postgres postgres:10.18-alpine
 image dex docker.io/kotsadm/dex:v2.28.1
 
-asset kots.tar.gz https://github.com/replicatedhq/kots/releases/download/v1.51.0/kots_linux_amd64.tar.gz
+asset kots.tar.gz https://github.com/replicatedhq/kots/releases/download/v1.51.1-beta.0/kots_linux_amd64.tar.gz

--- a/addons/kotsadm/alpha/install.sh
+++ b/addons/kotsadm/alpha/install.sh
@@ -377,7 +377,7 @@ function kotsadm_cli() {
     fi
     if [ ! -f "$src/assets/kots.tar.gz" ] && [ "$AIRGAP" != "1" ]; then
         mkdir -p "$src/assets"
-        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.51.0/kots_linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
+        curl -L "https://github.com/replicatedhq/kots/releases/download/v1.51.1-beta.0/kots_linux_amd64.tar.gz" > "$src/assets/kots.tar.gz"
     fi
 
     pushd "$src/assets"


### PR DESCRIPTION
Automated changes by the [auto-kotsadm-update](https://github.com/replicatedhq/kURL/blob/master/.github/workflows/update-kotsadm.yaml) GitHub action