### PR TITLE
Automatically update image tags to match whats in KOTS

### DIFF
--- a/addons/kotsadm/template/base/Manifest
+++ b/addons/kotsadm/template/base/Manifest
@@ -1,8 +1,8 @@
 image kotsadm-migrations docker.io/kotsadm/kotsadm-migrations:__KOTSADM_TAG__
-image kotsadm-minio minio/minio:RELEASE.2021-09-15T04-54-25Z
+image kotsadm-minio minio/minio:__MINIO_TAG__
 image kotsadm docker.io/kotsadm/kotsadm:__KOTSADM_TAG__
 image kurl-proxy docker.io/kotsadm/kurl-proxy:__KOTSADM_TAG__
-image postgres postgres:10.18-alpine
-image dex docker.io/kotsadm/dex:v2.28.1
+image postgres postgres:__POSTGRES_TAG__
+image dex docker.io/kotsadm/dex:__DEX_TAG__
 
 asset kots.tar.gz https://github.com/replicatedhq/kots/releases/download/__KOTSADM_BINARY_VERSION__/kots_linux_amd64.tar.gz

--- a/addons/kotsadm/template/generate.sh
+++ b/addons/kotsadm/template/generate.sh
@@ -31,6 +31,13 @@ function generate() {
     find "$dir" -type f -exec sed -i -e "s/__KOTSADM_DIR__/$kotsadm_dir/g" {} \;
     find "$dir" -type f -exec sed -i -e "s/__KOTSADM_BINARY_VERSION__/$kotsadm_binary_version/g" {} \;
 
+    # grab generated dot env file containing the latest version tags, export environment variables in dot env file
+    # and update manifest with latest image tags
+    export $(curl https://raw.githubusercontent.com/replicatedhq/kots/master/.image.env | sed 's/#.*//g' | xargs)
+    sed -i -e "s/__MINIO_TAG__/$MINIO_TAG/g" "${dir}/Manifest"
+    sed -i -e "s/__POSTGRES_TAG__/$POSTGRES_ALPINE_TAG/g" "${dir}/Manifest"
+    sed -i -e "s/__DEX_TAG__/$DEX_TAG/g" "${dir}/Manifest"
+
 }
 
 function add_as_latest() {


### PR DESCRIPTION
This change will pull the 'source of truth' for the latest image tags from KOTS, and use them to update kotsadm Manifest