### PR TITLE
fix: snapshot migration when velero already applied

### DIFF
--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -43,6 +43,8 @@ function minio() {
 
 function minio_already_applied() {
     minio_object_store_output
+
+    minio_migrate_from_rgw
 }
 
 function minio_creds() {


### PR DESCRIPTION
Is you already have the same version of velero (or minio) installed when you try to migrate from Rook to Longhorn, the migration code will not be picked up because the `_already_applied` lifecycle hook is run in the addon instead of `install`.