### PR TITLE
checking hashed tokens

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3205,6 +3205,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3210,11 +3210,6 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3205,6 +3205,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
     "crypto-js": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "ajv": "^8.6.2",
     "aws-sdk": "^2.964.0",
     "cors": "^2.8.5",
+    "crypto": "^1.0.1",
     "crypto-js": "^4.1.1",
     "express": "^4.17.1",
     "express-rate-limit": "^5.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "ajv": "^8.6.2",
     "aws-sdk": "^2.964.0",
     "cors": "^2.8.5",
+    "crypto-js": "^4.1.1",
     "express": "^4.17.1",
     "express-rate-limit": "^5.3.0",
     "js-yaml": "^4.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,6 @@
     "aws-sdk": "^2.964.0",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
-    "crypto-js": "^4.1.1",
     "express": "^4.17.1",
     "express-rate-limit": "^5.3.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
For web access (promoting installers, etc), tokens are required for authentication.  New User and Service Account tokens are sha256 hashed and base64 encoded.  kURL must check for an unhashed team token first, and if no results are found, must hash the token and check again for a user or service account token.