### PR TITLE
Updated bail message when private address can not be resolved

### DIFF
--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -311,7 +311,7 @@ function prompt_for_private_ip() {
     fi
 
     if ! prompts_can_prompt ; then
-        bail "kurl.privateAddress required"
+        bail "kurl.privateAddress required. Try passing the private address to this script e.g. 'sudo ./install.sh private-address=1.2.3.4' or supply the privateAddress field to the kurl add-on."
     fi
 
     printf "The installer was unable to automatically detect the private IP address of this machine.\n"

--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -311,7 +311,7 @@ function prompt_for_private_ip() {
     fi
 
     if ! prompts_can_prompt ; then
-        bail "kurl.privateAddress required. Try passing the private address to this script e.g. 'sudo ./install.sh private-address=1.2.3.4' or supply the privateAddress field to the kurl add-on."
+        bail "Multiple network interfaces present, please select an IP address. Try passing the selected address to this script e.g. 'sudo ./install.sh private-address=1.2.3.4' or assign an IP address to the privateAddress field in the kurl add-on."
     fi
 
     printf "The installer was unable to automatically detect the private IP address of this machine.\n"


### PR DESCRIPTION
See [Short Cut Issue](https://app.shortcut.com/replicated/story/38223/when-an-installation-fails-because-a-private-ip-address-is-required-include-remedies-in-error-message)