### PR TITLE
Run ekco shutdown before reset

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -165,6 +165,10 @@ function reset() {
 
     discover
 
+    if [ -f /opt/ekco/shutdown.sh ]; then
+        bash /opt/ekco/shutdown.sh
+    fi
+
     if commandExists "kubeadm"; then
         printf "Resetting kubeadm\n"
         kubeadm_reset


### PR DESCRIPTION
This prevents pods with PVCs from hanging while unmounting.