### PR TITLE
Testgrid cloud-init fails on errors

### DIFF
--- a/testgrid/deploy/tg-script.sh
+++ b/testgrid/deploy/tg-script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 apt update
 DEBIAN_FRONTEND=noninteractive apt upgrade -y
 


### PR DESCRIPTION
Add `set -e` to the testgrid cloud-init script. This is to avoid the scenario where a testgrid hypervisor has an unhealthy installation of kubevirt but still starts and runs the tgrun service.