### PR TITLE
Use unique version for bugsnag appVersion

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -24,7 +24,7 @@ jobs:
         npm i -g npm @bugsnag/source-maps
         bugsnag-source-maps upload-node \
           --api-key ${{ secrets.BUGSNAG_API_KEY }} \
-          --app-version ${VERSION_TAG} \
+          --app-version ${GITHUB_SHA:0:7} \
           --directory ./web/build
 
     - run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -150,7 +150,7 @@ jobs:
         npm i -g npm @bugsnag/source-maps
         bugsnag-source-maps upload-node \
           --api-key ${{ secrets.BUGSNAG_API_KEY }} \
-          --app-version ${VERSION_TAG} \
+          --app-version ${GITHUB_SHA:0:7} \
           --directory ./web/build
       env:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,7 +40,7 @@ func main() {
 		bugsnag.Configure(bugsnag.Configuration{
 			APIKey:       bugsnagKey,
 			ReleaseStage: os.Getenv("ENVIRONMENT"),
-			AppVersion:   os.Getenv("KURL_VERSION"),
+			AppVersion:   os.Getenv("VERSION"),
 		})
 	}
 

--- a/web/src/commands/serve.ts
+++ b/web/src/commands/serve.ts
@@ -36,7 +36,7 @@ export async function main(argv: any): Promise<void> {
       apiKey: process.env["BUGSNAG_KEY"] || "",
       releaseStage: process.env["NODE_ENV"],
       plugins: [BugsnagPluginExpress],
-      appVersion: process.env["KURL_VERSION"],
+      appVersion: process.env["VERSION"],
     });
   }
 


### PR DESCRIPTION
Staging build is broken. Bugsnag complains about duplicate version for source maps. Use git sha instead.