### PR TITLE
feat(kotsadm): allow kotsadm to deploy without object store

### DIFF
--- a/addons/kotsadm/alpha/install.sh
+++ b/addons/kotsadm/alpha/install.sh
@@ -32,7 +32,7 @@ function kotsadm() {
     kotsadm_secret_password
     kotsadm_secret_postgres
     kotsadm_secret_dex_postgres
-    kotsadm_secret_s3 # this secret is currently only used for (re)configuring internal snapshots
+    kotsadm_secret_s3           # this secret is only used for (re)configuring internal snapshots; will not be created if there is no object store 
     kotsadm_secret_session
     kotsadm_api_encryption_key
 
@@ -225,6 +225,11 @@ function kotsadm_secret_dex_postgres() {
 }
 
 function kotsadm_secret_s3() {
+    # When no object store is defined and S3 is disabled for KOTS, bail from adding the secret. 
+    if [ -z "$OBJECT_STORE_ACCESS_KEY" ] && [ "$KOTSADM_DISABLE_S3" == "1" ]; then
+        return
+    fi
+
     if [ -z "$VELERO_LOCAL_BUCKET" ]; then
         VELERO_LOCAL_BUCKET=velero
     fi

--- a/addons/kotsadm/template/base/install.sh
+++ b/addons/kotsadm/template/base/install.sh
@@ -32,7 +32,7 @@ function kotsadm() {
     kotsadm_secret_password
     kotsadm_secret_postgres
     kotsadm_secret_dex_postgres
-    kotsadm_secret_s3 # this secret is currently only used for (re)configuring internal snapshots
+    kotsadm_secret_s3           # this secret is only used for (re)configuring internal snapshots; will not be created if there is no object store 
     kotsadm_secret_session
     kotsadm_api_encryption_key
 
@@ -225,6 +225,11 @@ function kotsadm_secret_dex_postgres() {
 }
 
 function kotsadm_secret_s3() {
+    # When no object store is defined and S3 is disabled for KOTS, bail from adding the secret. 
+    if [ -z "$OBJECT_STORE_ACCESS_KEY" ] && [ "$KOTSADM_DISABLE_S3" == "1" ]; then
+        return
+    fi
+
     if [ -z "$VELERO_LOCAL_BUCKET" ]; then
         VELERO_LOCAL_BUCKET=velero
     fi


### PR DESCRIPTION
Test spec:
```yaml
INSTALLER_YAML=apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata: 
  name: test
spec: 
  kubernetes: 
    version: 1.19.15
  weave: 
    version: 2.6.5
  registry: 
    version: 2.7.1
  containerd: 
    version: 1.4.3
  velero: 
    version: 1.6.2
  kotsadm: 
    version: alpha
    disableS3: true
  longhorn: 
    version: 1.1.2
```

Snapshots will not default to internal, but to "S3-other":
![image](https://user-images.githubusercontent.com/12867130/139485172-92e01809-d381-486a-9c33-1f3399612b11.png)

If you click to take a snapshot, it will fail without having a default source:
![image](https://user-images.githubusercontent.com/12867130/139485220-4baa0c1a-0ace-4cb5-941d-efe914333998.png)
