### PR TITLE
Download bundle image overrides concurrently

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -22,6 +22,9 @@ func TestAllowRegistry(t *testing.T) {
 		{"799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl:latest", true},
 		{"ghcr.io/redis:2.0", true},
 		{"azurecr.io/redis:2.0", true},
+		{"kotsadm/kotsadm:2.0", true},
+		{"library/redis:2.0", true},
+		{"redis:2.0", true},
 	}
 	for _, test := range tests {
 		t.Run(test.image, func(t *testing.T) {


### PR DESCRIPTION
Pull and write image overrides to disk while concurrently streaming the rest of the bundle to limit the idle time when downloading a bundle.