### PR TITLE
Fix testgrid update grub failure

### DIFF
--- a/testgrid/deploy/tg-script.sh
+++ b/testgrid/deploy/tg-script.sh
@@ -2,8 +2,13 @@
 
 set -e
 
+export DEBIAN_FRONTEND=noninteractive
+
 apt update
-DEBIAN_FRONTEND=noninteractive apt upgrade -y
+
+touch /boot/grub/menu.lst
+update-grub2
+apt upgrade -y
 
 echo "Setting up RAID0 for openebs local storage."
 apt install -y btrbk


### PR DESCRIPTION
Fixes error:

```
Could not find /boot/grub/menu.lst file. Would you like /boot/grub/menu.lst generated for you? (y/N) /usr/sbin/update-grub-legacy-ec2: line 1101: read: read error: 0: Bad file descriptor
```