### PR TITLE
remove sbom as part of build-test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,29 +3,6 @@ name: build-test
 on: [ pull_request ]
 
 jobs:
-  generate-sbom:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.2.1'
-
-      - name: Get Cosign Key
-        run: |
-          echo $COSIGN_KEY | base64 -d > ./cosign.key
-        env:
-          COSIGN_KEY: ${{secrets.COSIGN_KEY}}
-
-      - name: Generate SBOM
-        run: |
-          make sbom
-        env: 
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
-          COSIGN_KEY: ${{secrets.COSIGN_KEY}}
-
   build-kurl-utils:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
build-test workflow is failing. make sbom is run on tag which should be good enough.