### PR TITLE
Debug output for testgrid airgap failures

### DIFF
--- a/testgrid/tgrun/pkg/runner/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/embed/runcmd.sh
@@ -32,16 +32,16 @@ function run_install() {
 
         echo "downloading install bundle"
 
-        curl -fsSL -o install.tar.gz "$KURL_URL"
+        curl -sSL -o install.tar.gz "$KURL_URL"
         if [ -n "$KURL_UPGRADE_URL" ]; then
             echo "downloading upgrade bundle"
 
-            curl -fsSL -o upgrade.tar.gz "$KURL_UPGRADE_URL"
+            curl -sSL -o upgrade.tar.gz "$KURL_UPGRADE_URL"
         fi
 
         disable_internet
 
-        tar -xzf install.tar.gz
+        tar -xzvf install.tar.gz
         local tar_exit_status="$?"
         if [ $tar_exit_status -ne 0 ]; then
             echo "failed to unpack airgap file with status $tar_exit_status"


### PR DESCRIPTION
There are a lot of testgrid airgap failures downloading the bundle. I'm trying to surface a little more info.

```
+ echo 'downloading install bundle'
downloading install bundle
+ curl -fsSL -o install.tar.gz https://staging.kurl.sh/bundle/867b283.tar.gz
+ '[' -n '' ']'
+ disable_internet
...
+ tar -xzf install.tar.gz

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
+ local tar_exit_status=2
+ '[' 2 -ne 0 ']'
+ echo 'failed to unpack airgap file with status 2'
failed to unpack airgap file with status 2
```