### PR TITLE
Yum module reset kurl.local to prevent yum update error

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -153,6 +153,8 @@ EOF
     yum clean metadata --disablerepo=* --enablerepo=kurl.local
     rm /etc/yum.repos.d/kurl.local.repo
 
+    reset_dnf_module_kurl_local
+
     logSuccess "Host packages ${packages[*]} installed"
 }
 
@@ -179,4 +181,17 @@ function _yum_get_host_packages_path() {
         echo "$(realpath "${dir}")/rhel-7${dir_prefix}"
     fi
     return 0
+}
+
+# we use a hack and install packages on the host as dnf modules. we need to
+# reset the modules after each install as running yum update throws an error
+# because it cannot resolve modular dependencies.
+function reset_dnf_module_kurl_local() {
+    if ! commandExists dnf; then
+        return
+    fi
+    if ! dnf module list | grep -q kurl.local ; then
+        return
+    fi
+    yum module reset -y kurl.local
 }


### PR DESCRIPTION
Running `yum update` throws dependency errors:

```
$ yum update
Last metadata expiration check: 0:01:44 ago on Tue 05 Oct 2021 05:55:26 PM UTC.
Error:
Problem 1: package grub2-tools-extra-1:2.02-99.el8_4.1.x86_64 requires grub2-tools-minimal = 1:2.02-99.el8_4.1, but none of the providers can be installed

- cannot install the best update candidate for package grub2-tools-extra-1:2.02-90.el8.x86_64
- package grub2-tools-minimal-1:2.02-99.el8_4.1.x86_64 is filtered out by modular filtering
Problem 2: package grub2-pc-1:2.02-99.el8_4.1.x86_64 requires grub2-tools-minimal = 1:2.02-99.el8_4.1, but none of the providers can be installed
...
```

We currently [install packages as modules](https://github.com/replicatedhq/kURL/blob/8bb1fb48f0fe008eecd956284f6b2475b2ea2023/bin/save-manifest-assets.sh#L108-L109). I spent a while trying to install without bundling as modules but was unsuccessful. I found that if we reset the module after install then the user can successfully update packages without dependency errors.