### PR TITLE
Only run test-addon-pr workflow on path 'addons/**'

### DIFF
--- a/.github/workflows/test-addon-pr.yaml
+++ b/.github/workflows/test-addon-pr.yaml
@@ -3,7 +3,10 @@ name: test-addon-pr.yaml
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
+    paths:
+    - 'addons/**'
 
   workflow_dispatch: {}
 


### PR DESCRIPTION
Dependabot prs are failing because they dont have access to secret AWS_ACCESS_KEY_ID. To work around this only run this workflow if addon directory is changing. This is acceptable because the test-addon-pr.sh script detects changes in the addons/** directories.

https://github.com/replicatedhq/kURL/blob/6e794a926fc93a6f5ba1d6ee65f6bc19970b82a3/bin/test-addon-pr.sh#L38