### PR TITLE
Build test success job

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,6 +3,7 @@ name: build-test
 on: [ pull_request ]
 
 jobs:
+
   build-kurl-utils:
     runs-on: ubuntu-18.04
     steps:
@@ -19,7 +20,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - run: make -C kurl_util deps test build
-
 
   build-web:
     runs-on: ubuntu-18.04
@@ -57,7 +57,6 @@ jobs:
       - run: |
           make -C kurlkinds deps test manager
 
-
   build-bin-kurl:
     runs-on: ubuntu-18.04
     steps:
@@ -75,7 +74,6 @@ jobs:
 
       - run: make deps test build/bin/kurl
 
-
   build-testgrid:
     runs-on: ubuntu-18.04
     steps:
@@ -92,3 +90,15 @@ jobs:
 
     - run: make -C testgrid/tgrun test build
     - run: make -C testgrid/tgapi test build
+
+  build-test-success:
+    runs-on: ubuntu-latest
+    needs:
+    - build-kurl-utils
+    - build-web
+    - test-shell
+    - build-kurlkinds
+    - build-bin-kurl
+    - build-testgrid
+    steps:
+    - run: echo "::notice ::build test success"


### PR DESCRIPTION
This is needed to make build-test status check in its entirety protected by branch protection for automatic merging of dependabot prs.