### PR TITLE
Fix testgrid build, webpack ignore plugin options

### DIFF
--- a/testgrid/web/webpack.config.js
+++ b/testgrid/web/webpack.config.js
@@ -96,7 +96,10 @@ module.exports = (env) => {
     },
 
     plugins: [
-      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^\.\/locale$/,
+        contextRegExp: /moment$/,
+      }),
       new ESLintPlugin(),
       new HtmlWebpackPlugin({
         template: HtmlWebpackTemplate,


### PR DESCRIPTION
Fixes error

```
3:42:35 PM:    'Invalid options object. Ignore Plugin has been initialized using an options object that does not match the API schema.\n - options should be one of these:\n   object { resourceRegExp, contextRegExp? } | object { checkResource }\n   Details:\n    * options misses the property \'resourceRegExp\'. Should be:\n      RegExp\n      -> A RegExp to test the request against.\n    * options misses the property \'checkResource\'. Should be:\n      function\n      -> A filter function for resource and context.' }
```