### PR TITLE
Workflow build-test build testgrid web

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -90,6 +90,7 @@ jobs:
 
     - run: make -C testgrid/tgrun test build
     - run: make -C testgrid/tgapi test build
+    - run: make -C testgrid/web deps build-staging
 
   build-test-success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add testgrid/web build to build-test workflow to prevent breaking build.