### PR TITLE
feat(velero): backport pvc migration

### DIFF
--- a/addons/velero/1.5.3/install.sh
+++ b/addons/velero/1.5.3/install.sh
@@ -1,4 +1,4 @@
-
+# shellcheck disable=SC2148
 function velero_pre_init() {
     if [ -z "$VELERO_NAMESPACE" ]; then
         VELERO_NAMESPACE=velero
@@ -48,7 +48,7 @@ function velero_install() {
     fi
 
     local bslArgs="--no-default-backup-location"
-    if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
+    if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default && object_store_exists; then
         bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
     fi
 

--- a/addons/velero/1.5.4/install.sh
+++ b/addons/velero/1.5.4/install.sh
@@ -1,4 +1,4 @@
-
+# shellcheck disable=SC2148
 function velero_pre_init() {
     if [ -z "$VELERO_NAMESPACE" ]; then
         VELERO_NAMESPACE=velero
@@ -48,7 +48,7 @@ function velero_install() {
     fi
 
     local bslArgs="--no-default-backup-location"
-    if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
+    if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default && object_store_exists; then
         bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
     fi
 

--- a/addons/velero/1.6.0/Manifest
+++ b/addons/velero/1.6.0/Manifest
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v1.6.0
 image velero-aws velero/velero-plugin-for-aws:v1.2.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
-image local-volume-provider replicated/local-volume-provider:v0.1.0
-image local-volume-fileserver replicated/local-volume-fileserver:v0.1.0
+image local-volume-provider replicated/local-volume-provider:v0.3.0
+image s3cmd kurlsh/s3cmd:7f7dc75-20210331
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.0/velero-v1.6.0-linux-amd64.tar.gz

--- a/addons/velero/1.6.0/install.sh
+++ b/addons/velero/1.6.0/install.sh
@@ -1,4 +1,4 @@
-
+# shellcheck disable=SC2148
 function velero_pre_init() {
     if [ -z "$VELERO_NAMESPACE" ]; then
         VELERO_NAMESPACE=velero
@@ -6,15 +6,22 @@ function velero_pre_init() {
     if [ -z "$VELERO_LOCAL_BUCKET" ]; then
         VELERO_LOCAL_BUCKET=velero
     fi
+    # TODO (dans): make this configurable from the installer spec
+    # if [ -z "$VELERO_REQUESTED_CLAIM_SIZE" ]; then
+    #     VELERO_REQUESTED_CLAIM_SIZE="50Gi"
+    # fi
 }
 
+# runs on first install, and on version upgrades only
 function velero() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    cp "$src/kustomization.yaml" "$dst/"
+    render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
 
     velero_binary
+
+    determine_velero_pvc_size
 
     velero_install "$src" "$dst"
 
@@ -26,9 +33,37 @@ function velero() {
 
     velero_change_storageclass "$src" "$dst"
 
+    # If we already migrated, or we on a new install that has the disableS3 flag set, we need a PVC attached
+    # TODO (dans): remove beta fla
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots || { [ "$KOTSADM_DISABLE_S3" == "1" ] && [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ]; }; then
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+    fi
+
+    # Check if we need a migration
+    if velero_should_migrate_from_object_store; then
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
     kubectl apply -k "$dst"
 
     kubectl label -n default --overwrite service/kubernetes velero.io/exclude-from-backup=true
+
+    # Bail if the migrationn fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots; then
+
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+    fi
 }
 
 function velero_join() {
@@ -39,52 +74,103 @@ function velero_install() {
     local src="$1"
     local dst="$2"
 
+    # TODO: remove this from the migration
     # Pre-apply CRDs since kustomize reorders resources. Grep to strip out sailboat emoji.
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
 
     local resticArg="--use-restic"
     if [ "$VELERO_DISABLE_RESTIC" = "1" ]; then
         resticArg=""
     fi
 
+    # detect if we need to use object store or pvc
     local bslArgs="--no-default-backup-location"
     if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
-        bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
+
+        # TODO (dans): remove the BETA flag when this is GA
+        # Only use the PVC backup location for new installs where disableS3 is set to TRUE
+        if [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ] ; then
+            bslArgs="--provider replicated.com/pvc --bucket velero-internal-snapshots --backup-location-config storageSize=${VELERO_PVC_SIZE},resticRepoPrefix=/var/velero-local-volume-provider/velero-internal-snapshots/restic"
+        elif object_store_bucket_exists; then
+            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"  
+        fi
     fi
 
-    velero_credentials
+    # we need a secret file if it's already set for some other provider, OR
+    # If we have object storage AND are NOT actively opting out of the existing functionality
+    local secretArgs="--no-secret"
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials || { object_store_bucket_exists && ! { [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ]; }; }; then
+        velero_credentials
+        secretArgs="--secret-file velero-credentials"
+    fi
 
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install \
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install \
         $resticArg \
         $bslArgs \
-        --plugins velero/velero-plugin-for-aws:v1.2.0,velero/velero-plugin-for-gcp:v1.2.0,velero/velero-plugin-for-microsoft-azure:v1.2.0,replicated/local-volume-provider:v0.1.0,$KURL_UTIL_IMAGE \
-        --secret-file velero-credentials \
-        --use-volume-snapshots=false \
+        $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --dry-run -o yaml > "$dst/velero.yaml"
+        --plugins velero/velero-plugin-for-aws:v1.2.0,velero/velero-plugin-for-gcp:v1.2.0,velero/velero-plugin-for-microsoft-azure:v1.2.0,replicated/local-volume-provider:v0.3.0,"$KURL_UTIL_IMAGE" \
+        --use-volume-snapshots=false \
+        --dry-run -o yaml > "$dst/velero.yaml" 
 
-    rm velero-credentials
+    rm -f velero-credentials
 }
 
+# This runs when re-applying the same version to a cluster
 function velero_already_applied() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    velero_change_storageclass "$src" "$dst" true
+    # If we need to migrate, we're going to need to basically reconstruct the original install 
+    # underneath the migration
+    if velero_should_migrate_from_object_store; then
 
-    # This should only be applying the configmap if required
-    if compgen -G "$dst/*.yaml" > /dev/null; then
-        kubectl apply -f "$dst"
+        render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
+
+        determine_velero_pvc_size
+
+        velero_binary 
+        velero_install "$src" "$dst"
+        velero_patch_restic_privilege "$src" "$dst"
+        velero_kotsadm_restore_config "$src" "$dst"
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+        velero_patch_http_proxy "$src" "$dst"
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
+    # If we didn't need to migrate, reset the kustomization file and only apply the configmap
+    # This function will create a new, blank kustomization file.
+    velero_change_storageclass "$src" "$dst"
+
+    # In the case this is a rook re-apply, no changes might be required
+    if [ -f "$dst/kustomization.yaml" ]; then
+        kubectl apply -k "$dst"
+    fi
+
+    # Bail if the migration fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots && velero_should_migrate_from_object_store; then
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
     fi
 }
 
-# The --secret-file flag must always be used so that the generated velero deployment uses the
+# The --secret-file flag should be used so that the generated velero deployment uses the
 # cloud-credentials secret. Use the contents of that secret if it exists to avoid overwriting
-# any changes. Else if a local object store (Ceph/Minio) is configured, use its credentials.
+# any changes. 
 function velero_credentials() {
-   if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
-       kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
-       return 0
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
+        kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
+        return 0
     fi
 
     if [ -n "$OBJECT_STORE_CLUSTER_IP" ]; then
@@ -124,12 +210,12 @@ function velero_binary() {
         curl -L "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" > "$src/assets/velero.tar.gz"
     fi
 
-    pushd "$src/assets"
+    pushd "$src/assets" || exit 1
     tar xf "velero.tar.gz"
     if [ "$VELERO_DISABLE_CLI" != "1" ]; then
         cp velero-v${VELERO_VERSION}-linux-amd64/velero /usr/local/bin/velero
     fi
-    popd
+    popd || exit 1
 }
 
 function velero_kotsadm_restore_config() {
@@ -162,13 +248,128 @@ function velero_patch_http_proxy() {
 function velero_change_storageclass() {
     local src="$1"
     local dst="$2"
-    local disable_kustomization="$3"
 
     if kubectl get sc longhorn &> /dev/null && \
     [ "$(kubectl get sc longhorn -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')" = "true" ]; then
-        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
-        if [ -z "$disable_kustomization" ]; then
-            insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
+        # when re-applying the same velero version, this might not exist.
+        if [ ! -f "$dst/kustomization.yaml" ]; then
+            cat > "$dst/kustomization.yaml" <<EOF
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+EOF
         fi
+
+        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
+        insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
     fi
+}
+
+function velero_should_migrate_from_object_store() {
+    # TODO (dans): remove this feature flag when/if we decide to ship migration
+    if [ -z "$BETA_VELERO_USE_INTERNAL_PVC" ]; then 
+        return 1
+    fi
+
+    # If KOTSADM_DISABLE_S3 is set, force the migration
+    if [ "$KOTSADM_DISABLE_S3" != 1 ]; then 
+        return 1
+    fi
+    # if an object store isn't installed don't migrate
+    # TODO (dans): this doeesn't support minio in a non-standard namespace
+    if (! kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a) && (! kubernetes_resource_exists minio deployment minio); then 
+        return 1
+    fi
+    return 0
+}
+
+function velero_migrate_from_object_store() {
+    local src="$1"
+    local dst="$2"
+
+    export VELERO_S3_HOST=
+    export VELERO_S3_ACCESS_KEY_ID=
+    export VELERO_S3_ACCESS_KEY_SECRET=
+    if kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a; then 
+        echo "Previous installation of Rook Ceph detected."
+        VELERO_S3_HOST="rook-ceph-rgw-rook-ceph-store.rook-ceph"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep AccessKey | head -1 | awk '{print $2}' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep SecretKey | head -1 | awk '{print $2}' | base64 --decode)
+    else 
+        echo "Previous installation of Minio detected."
+        VELERO_S3_HOST="minio.minio"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_ACCESS_KEY }' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_SECRET_KEY }' | base64 --decode)
+    fi
+
+    # TODO (dans): figure out if there is enough space create a new volume with all the snapshot data
+
+    # create secret for migration init container to pull from object store
+    render_yaml_file "$src/tmpl-s3-migration-secret.yaml" > "$dst/s3-migration-secret.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-secret.yaml
+
+    # create configmap that holds the migration script
+    cp "$src/s3-migration-configmap.yaml" "$dst/s3-migration-configmap.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-configmap.yaml
+
+    # add patch to add init container for migration
+    render_yaml_file "$src/tmpl-s3-migration-deployment-patch.yaml" > "$dst/s3-migration-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" s3-migration-deployment-patch.yaml
+
+    # update the BackupstorageLocation
+    render_yaml_file "$src/tmpl-s3-migration-bsl.yaml" > "$dst/s3-migration-bsl.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-bsl.yaml
+}
+
+# add patches for the velero and restic to the current kustomization file that setup the PVC setup like the 
+# velero LVP plugin requires 
+function velero_patch_internal_pvc_snapshots() {
+    local src="$1"
+    local dst="$2"
+
+    # If we are migrating from Rook to Longhorn, longhorn is not yes the default storage class.
+    export VELERO_PVC_STORAGE_CLASS="default" # this is the rook-ceph default storage class
+    if [ -n "$LONGHORN_VERSION" ]; then
+        export VELERO_PVC_STORAGE_CLASS="longhorn"
+    fi
+
+    # create the PVC
+    render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
+    insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+
+    # add patch to add the pvc in the correct location for the velero deployment
+    cp "$src/internal-snaps-deployment-patch.yaml" "$dst/internal-snaps-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-deployment-patch.yaml
+
+    # add patch to add the pvc in the correct location for the restic daemonset
+    cp "$src/internal-snaps-ds-patch.yaml" "$dst/internal-snaps-ds-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-ds-patch.yaml
+
+}
+
+function velero_pvc_bound() {
+    kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.status.phase}' | grep -q "Bound"
+}
+
+# if the PVC size has already been set we should not reduce it
+function determine_velero_pvc_size() {
+    local velero_pvc_size="50Gi"
+    if kubernetes_resource_exists "${VELERO_NAMESPACE}" pvc velero-internal-snapshots; then
+        velero_pvc_size=$( kubectl get pvc -n "${VELERO_NAMESPACE}" velero-internal-snapshots -o jsonpath='{.spec.resources.requests.storage}')
+    fi
+
+    export VELERO_PVC_SIZE=$velero_pvc_size
+}
+
+function velero_pvc_migrated() {
+    velero_pod=$( kubectl get pods -n velero -l component=velero -o jsonpath='{.items[?(@.spec.containers[0].name=="velero")].metadata.name}')
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration ran successfully" &>/dev/null; then
+        return 0
+    fi
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration has already run" &>/dev/null; then
+        return 0
+    fi
+    return 1
 }

--- a/addons/velero/1.6.0/internal-snaps-deployment-patch.yaml
+++ b/addons/velero/1.6.0/internal-snaps-deployment-patch.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+      - name: velero
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: "status.podIP"
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/1.6.0/internal-snaps-ds-patch.yaml
+++ b/addons/velero/1.6.0/internal-snaps-ds-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+spec:
+  template:
+    spec:
+      containers:
+      - name: restic
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/1.6.0/s3-migration-configmap.yaml
+++ b/addons/velero/1.6.0/s3-migration-configmap.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: velero-migrate-s3-config
+  labels:
+    app: velero
+data:
+  migrate-s3.sh: |-
+    #!/bin/sh
+    set -euo pipefail
+    export S3_HOST=$OBJECT_STORE_CLUSTER_IP
+
+    export ARCHIVES_DIR=/var/lib/velero
+    export MIGRATION_FILE=$ARCHIVES_DIR/s3-migration.txt
+    if [ -f $MIGRATION_FILE ]; then
+        echo 'migration has already run. no-op.'
+        exit 0
+    fi
+
+    export S3CMD_FLAGS="--access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --host=$S3_HOST --no-ssl --host-bucket=$S3_BUCKET_NAME.$S3_HOST"
+
+    if s3cmd $S3CMD_FLAGS ls s3://$S3_BUCKET_NAME 2>&1 | grep -q 'NoSuchBucket'
+    then
+        echo "bucket $S3_BUCKET_NAME bucket not found, skipping migration ..."
+        exit 0
+    fi
+
+    echo 'object store detected, running migration ...'
+    s3cmd $S3CMD_FLAGS sync s3://$S3_BUCKET_NAME $ARCHIVES_DIR
+    echo 'migration ran successfully ...'
+    echo 'recording that the migration ran ...'
+    echo 'migration completed successfully $(date)'  > $MIGRATION_FILE

--- a/addons/velero/1.6.0/tmpl-internal-snaps-pvc.yaml
+++ b/addons/velero/1.6.0/tmpl-internal-snaps-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: velero-internal-snapshots
+  labels:
+    velero.io/exclude-from-backup: \"true\"
+spec:
+  storageClassName: ${VELERO_PVC_STORAGE_CLASS}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: ${VELERO_PVC_SIZE}

--- a/addons/velero/1.6.0/tmpl-kustomization.yaml
+++ b/addons/velero/1.6.0/tmpl-kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+- velero.yaml

--- a/addons/velero/1.6.0/tmpl-s3-migration-bsl.yaml
+++ b/addons/velero/1.6.0/tmpl-s3-migration-bsl.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+spec:
+  provider: replicated.com/pvc
+  objectStorage:
+    bucket: velero-internal-snapshots
+  config:
+    storageClassName: longhorn
+    storageSize: ${VELERO_PVC_SIZE}
+    resticRepoPrefix: /var/velero-local-volume-provider/velero-internal-snapshots/restic

--- a/addons/velero/1.6.0/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.6.0/tmpl-s3-migration-deployment-patch.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+  labels:
+    app: velero
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: migrate-s3
+        image: kurlsh/s3cmd:7f7dc75-20210331
+        imagePullPolicy: IfNotPresent
+        command:
+        - /migrate-s3.sh
+        volumeMounts:
+        - mountPath: /var/lib/velero
+          name: velero-internal-snapshots
+        - name: velero-migrate-s3-config
+          mountPath: /migrate-s3.sh
+          subPath: migrate-s3.sh
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: access-key-id
+              name: velero-s3-migration
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret-access-key
+              name: velero-s3-migration
+        - name: OBJECT_STORE_CLUSTER_IP
+          valueFrom:
+            secretKeyRef:
+              key: object-store-cluster-ip
+              name: velero-s3-migration
+        - name: S3_BUCKET_NAME  
+          value: ${VELERO_LOCAL_BUCKET}
+      volumes:
+      - name: velero-migrate-s3-config
+        configMap:
+          name: velero-migrate-s3-config
+          defaultMode: 0777

--- a/addons/velero/1.6.0/tmpl-s3-migration-secret.yaml
+++ b/addons/velero/1.6.0/tmpl-s3-migration-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-s3-migration 
+  labels:
+    app: velero
+type: Opaque
+stringData:
+  access-key-id: ${VELERO_S3_ACCESS_KEY_ID}
+  secret-access-key: ${VELERO_S3_ACCESS_KEY_SECRET}
+  object-store-cluster-ip: ${VELERO_S3_HOST}

--- a/addons/velero/1.6.1/Manifest
+++ b/addons/velero/1.6.1/Manifest
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v1.6.1
 image velero-aws velero/velero-plugin-for-aws:v1.2.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
-image local-volume-provider replicated/local-volume-provider:v0.1.0
-image local-volume-fileserver replicated/local-volume-fileserver:v0.1.0
+image local-volume-provider replicated/local-volume-provider:v0.3.0
+image s3cmd kurlsh/s3cmd:7f7dc75-20210331
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.1/velero-v1.6.1-linux-amd64.tar.gz

--- a/addons/velero/1.6.1/install.sh
+++ b/addons/velero/1.6.1/install.sh
@@ -1,4 +1,4 @@
-
+# shellcheck disable=SC2148
 function velero_pre_init() {
     if [ -z "$VELERO_NAMESPACE" ]; then
         VELERO_NAMESPACE=velero
@@ -6,15 +6,22 @@ function velero_pre_init() {
     if [ -z "$VELERO_LOCAL_BUCKET" ]; then
         VELERO_LOCAL_BUCKET=velero
     fi
+    # TODO (dans): make this configurable from the installer spec
+    # if [ -z "$VELERO_REQUESTED_CLAIM_SIZE" ]; then
+    #     VELERO_REQUESTED_CLAIM_SIZE="50Gi"
+    # fi
 }
 
+# runs on first install, and on version upgrades only
 function velero() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    cp "$src/kustomization.yaml" "$dst/"
+    render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
 
     velero_binary
+
+    determine_velero_pvc_size
 
     velero_install "$src" "$dst"
 
@@ -26,9 +33,37 @@ function velero() {
 
     velero_change_storageclass "$src" "$dst"
 
+    # If we already migrated, or we on a new install that has the disableS3 flag set, we need a PVC attached
+    # TODO (dans): remove beta fla
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots || { [ "$KOTSADM_DISABLE_S3" == "1" ] && [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ]; }; then
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+    fi
+
+    # Check if we need a migration
+    if velero_should_migrate_from_object_store; then
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
     kubectl apply -k "$dst"
 
     kubectl label -n default --overwrite service/kubernetes velero.io/exclude-from-backup=true
+
+    # Bail if the migrationn fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots; then
+
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+    fi
 }
 
 function velero_join() {
@@ -39,52 +74,103 @@ function velero_install() {
     local src="$1"
     local dst="$2"
 
+    # TODO: remove this from the migration
     # Pre-apply CRDs since kustomize reorders resources. Grep to strip out sailboat emoji.
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
 
     local resticArg="--use-restic"
     if [ "$VELERO_DISABLE_RESTIC" = "1" ]; then
         resticArg=""
     fi
 
+    # detect if we need to use object store or pvc
     local bslArgs="--no-default-backup-location"
     if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
-        bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
+
+        # TODO (dans): remove the BETA flag when this is GA
+        # Only use the PVC backup location for new installs where disableS3 is set to TRUE
+        if [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ] ; then
+            bslArgs="--provider replicated.com/pvc --bucket velero-internal-snapshots --backup-location-config storageSize=${VELERO_PVC_SIZE},resticRepoPrefix=/var/velero-local-volume-provider/velero-internal-snapshots/restic"
+        elif object_store_bucket_exists; then
+            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"  
+        fi
     fi
 
-    velero_credentials
+    # we need a secret file if it's already set for some other provider, OR
+    # If we have object storage AND are NOT actively opting out of the existing functionality
+    local secretArgs="--no-secret"
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials || { object_store_bucket_exists && ! { [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ]; }; }; then
+        velero_credentials
+        secretArgs="--secret-file velero-credentials"
+    fi
 
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install \
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install \
         $resticArg \
         $bslArgs \
-        --plugins velero/velero-plugin-for-aws:v1.2.0,velero/velero-plugin-for-gcp:v1.2.0,velero/velero-plugin-for-microsoft-azure:v1.2.0,replicated/local-volume-provider:v0.1.0,$KURL_UTIL_IMAGE \
-        --secret-file velero-credentials \
-        --use-volume-snapshots=false \
+        $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --dry-run -o yaml > "$dst/velero.yaml"
+        --plugins velero/velero-plugin-for-aws:v1.2.0,velero/velero-plugin-for-gcp:v1.2.0,velero/velero-plugin-for-microsoft-azure:v1.2.0,replicated/local-volume-provider:v0.3.0,"$KURL_UTIL_IMAGE" \
+        --use-volume-snapshots=false \
+        --dry-run -o yaml > "$dst/velero.yaml" 
 
-    rm velero-credentials
+    rm -f velero-credentials
 }
 
+# This runs when re-applying the same version to a cluster
 function velero_already_applied() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    velero_change_storageclass "$src" "$dst" true
+    # If we need to migrate, we're going to need to basically reconstruct the original install 
+    # underneath the migration
+    if velero_should_migrate_from_object_store; then
 
-    # This should only be applying the configmap if required
-    if compgen -G "$dst/*.yaml" > /dev/null; then
-        kubectl apply -f "$dst"
+        render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
+
+        determine_velero_pvc_size
+
+        velero_binary 
+        velero_install "$src" "$dst"
+        velero_patch_restic_privilege "$src" "$dst"
+        velero_kotsadm_restore_config "$src" "$dst"
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+        velero_patch_http_proxy "$src" "$dst"
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
+    # If we didn't need to migrate, reset the kustomization file and only apply the configmap
+    # This function will create a new, blank kustomization file.
+    velero_change_storageclass "$src" "$dst"
+
+    # In the case this is a rook re-apply, no changes might be required
+    if [ -f "$dst/kustomization.yaml" ]; then
+        kubectl apply -k "$dst"
+    fi
+
+    # Bail if the migration fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots && velero_should_migrate_from_object_store; then
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
     fi
 }
 
-# The --secret-file flag must always be used so that the generated velero deployment uses the
+# The --secret-file flag should be used so that the generated velero deployment uses the
 # cloud-credentials secret. Use the contents of that secret if it exists to avoid overwriting
-# any changes. Else if a local object store (Ceph/Minio) is configured, use its credentials.
+# any changes. 
 function velero_credentials() {
-   if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
-       kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
-       return 0
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
+        kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
+        return 0
     fi
 
     if [ -n "$OBJECT_STORE_CLUSTER_IP" ]; then
@@ -124,12 +210,12 @@ function velero_binary() {
         curl -L "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" > "$src/assets/velero.tar.gz"
     fi
 
-    pushd "$src/assets"
+    pushd "$src/assets" || exit 1
     tar xf "velero.tar.gz"
     if [ "$VELERO_DISABLE_CLI" != "1" ]; then
         cp velero-v${VELERO_VERSION}-linux-amd64/velero /usr/local/bin/velero
     fi
-    popd
+    popd || exit 1
 }
 
 function velero_kotsadm_restore_config() {
@@ -162,13 +248,128 @@ function velero_patch_http_proxy() {
 function velero_change_storageclass() {
     local src="$1"
     local dst="$2"
-    local disable_kustomization="$3"
 
     if kubectl get sc longhorn &> /dev/null && \
     [ "$(kubectl get sc longhorn -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')" = "true" ]; then
-        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
-        if [ -z "$disable_kustomization" ]; then
-            insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
+        # when re-applying the same velero version, this might not exist.
+        if [ ! -f "$dst/kustomization.yaml" ]; then
+            cat > "$dst/kustomization.yaml" <<EOF
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+EOF
         fi
+
+        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
+        insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
     fi
+}
+
+function velero_should_migrate_from_object_store() {
+    # TODO (dans): remove this feature flag when/if we decide to ship migration
+    if [ -z "$BETA_VELERO_USE_INTERNAL_PVC" ]; then 
+        return 1
+    fi
+
+    # If KOTSADM_DISABLE_S3 is set, force the migration
+    if [ "$KOTSADM_DISABLE_S3" != 1 ]; then 
+        return 1
+    fi
+    # if an object store isn't installed don't migrate
+    # TODO (dans): this doeesn't support minio in a non-standard namespace
+    if (! kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a) && (! kubernetes_resource_exists minio deployment minio); then 
+        return 1
+    fi
+    return 0
+}
+
+function velero_migrate_from_object_store() {
+    local src="$1"
+    local dst="$2"
+
+    export VELERO_S3_HOST=
+    export VELERO_S3_ACCESS_KEY_ID=
+    export VELERO_S3_ACCESS_KEY_SECRET=
+    if kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a; then 
+        echo "Previous installation of Rook Ceph detected."
+        VELERO_S3_HOST="rook-ceph-rgw-rook-ceph-store.rook-ceph"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep AccessKey | head -1 | awk '{print $2}' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep SecretKey | head -1 | awk '{print $2}' | base64 --decode)
+    else 
+        echo "Previous installation of Minio detected."
+        VELERO_S3_HOST="minio.minio"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_ACCESS_KEY }' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_SECRET_KEY }' | base64 --decode)
+    fi
+
+    # TODO (dans): figure out if there is enough space create a new volume with all the snapshot data
+
+    # create secret for migration init container to pull from object store
+    render_yaml_file "$src/tmpl-s3-migration-secret.yaml" > "$dst/s3-migration-secret.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-secret.yaml
+
+    # create configmap that holds the migration script
+    cp "$src/s3-migration-configmap.yaml" "$dst/s3-migration-configmap.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-configmap.yaml
+
+    # add patch to add init container for migration
+    render_yaml_file "$src/tmpl-s3-migration-deployment-patch.yaml" > "$dst/s3-migration-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" s3-migration-deployment-patch.yaml
+
+    # update the BackupstorageLocation
+    render_yaml_file "$src/tmpl-s3-migration-bsl.yaml" > "$dst/s3-migration-bsl.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-bsl.yaml
+}
+
+# add patches for the velero and restic to the current kustomization file that setup the PVC setup like the 
+# velero LVP plugin requires 
+function velero_patch_internal_pvc_snapshots() {
+    local src="$1"
+    local dst="$2"
+
+    # If we are migrating from Rook to Longhorn, longhorn is not yes the default storage class.
+    export VELERO_PVC_STORAGE_CLASS="default" # this is the rook-ceph default storage class
+    if [ -n "$LONGHORN_VERSION" ]; then
+        export VELERO_PVC_STORAGE_CLASS="longhorn"
+    fi
+
+    # create the PVC
+    render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
+    insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+
+    # add patch to add the pvc in the correct location for the velero deployment
+    cp "$src/internal-snaps-deployment-patch.yaml" "$dst/internal-snaps-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-deployment-patch.yaml
+
+    # add patch to add the pvc in the correct location for the restic daemonset
+    cp "$src/internal-snaps-ds-patch.yaml" "$dst/internal-snaps-ds-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-ds-patch.yaml
+
+}
+
+function velero_pvc_bound() {
+    kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.status.phase}' | grep -q "Bound"
+}
+
+# if the PVC size has already been set we should not reduce it
+function determine_velero_pvc_size() {
+    local velero_pvc_size="50Gi"
+    if kubernetes_resource_exists "${VELERO_NAMESPACE}" pvc velero-internal-snapshots; then
+        velero_pvc_size=$( kubectl get pvc -n "${VELERO_NAMESPACE}" velero-internal-snapshots -o jsonpath='{.spec.resources.requests.storage}')
+    fi
+
+    export VELERO_PVC_SIZE=$velero_pvc_size
+}
+
+function velero_pvc_migrated() {
+    velero_pod=$( kubectl get pods -n velero -l component=velero -o jsonpath='{.items[?(@.spec.containers[0].name=="velero")].metadata.name}')
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration ran successfully" &>/dev/null; then
+        return 0
+    fi
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration has already run" &>/dev/null; then
+        return 0
+    fi
+    return 1
 }

--- a/addons/velero/1.6.1/internal-snaps-deployment-patch.yaml
+++ b/addons/velero/1.6.1/internal-snaps-deployment-patch.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+      - name: velero
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: "status.podIP"
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/1.6.1/internal-snaps-ds-patch.yaml
+++ b/addons/velero/1.6.1/internal-snaps-ds-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+spec:
+  template:
+    spec:
+      containers:
+      - name: restic
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/1.6.1/s3-migration-configmap.yaml
+++ b/addons/velero/1.6.1/s3-migration-configmap.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: velero-migrate-s3-config
+  labels:
+    app: velero
+data:
+  migrate-s3.sh: |-
+    #!/bin/sh
+    set -euo pipefail
+    export S3_HOST=$OBJECT_STORE_CLUSTER_IP
+
+    export ARCHIVES_DIR=/var/lib/velero
+    export MIGRATION_FILE=$ARCHIVES_DIR/s3-migration.txt
+    if [ -f $MIGRATION_FILE ]; then
+        echo 'migration has already run. no-op.'
+        exit 0
+    fi
+
+    export S3CMD_FLAGS="--access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --host=$S3_HOST --no-ssl --host-bucket=$S3_BUCKET_NAME.$S3_HOST"
+
+    if s3cmd $S3CMD_FLAGS ls s3://$S3_BUCKET_NAME 2>&1 | grep -q 'NoSuchBucket'
+    then
+        echo "bucket $S3_BUCKET_NAME bucket not found, skipping migration ..."
+        exit 0
+    fi
+
+    echo 'object store detected, running migration ...'
+    s3cmd $S3CMD_FLAGS sync s3://$S3_BUCKET_NAME $ARCHIVES_DIR
+    echo 'migration ran successfully ...'
+    echo 'recording that the migration ran ...'
+    echo 'migration completed successfully $(date)'  > $MIGRATION_FILE

--- a/addons/velero/1.6.1/tmpl-internal-snaps-pvc.yaml
+++ b/addons/velero/1.6.1/tmpl-internal-snaps-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: velero-internal-snapshots
+  labels:
+    velero.io/exclude-from-backup: \"true\"
+spec:
+  storageClassName: ${VELERO_PVC_STORAGE_CLASS}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: ${VELERO_PVC_SIZE}

--- a/addons/velero/1.6.1/tmpl-kustomization.yaml
+++ b/addons/velero/1.6.1/tmpl-kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+- velero.yaml

--- a/addons/velero/1.6.1/tmpl-s3-migration-bsl.yaml
+++ b/addons/velero/1.6.1/tmpl-s3-migration-bsl.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+spec:
+  provider: replicated.com/pvc
+  objectStorage:
+    bucket: velero-internal-snapshots
+  config:
+    storageClassName: longhorn
+    storageSize: ${VELERO_PVC_SIZE}
+    resticRepoPrefix: /var/velero-local-volume-provider/velero-internal-snapshots/restic

--- a/addons/velero/1.6.1/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.6.1/tmpl-s3-migration-deployment-patch.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+  labels:
+    app: velero
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: migrate-s3
+        image: kurlsh/s3cmd:7f7dc75-20210331
+        imagePullPolicy: IfNotPresent
+        command:
+        - /migrate-s3.sh
+        volumeMounts:
+        - mountPath: /var/lib/velero
+          name: velero-internal-snapshots
+        - name: velero-migrate-s3-config
+          mountPath: /migrate-s3.sh
+          subPath: migrate-s3.sh
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: access-key-id
+              name: velero-s3-migration
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret-access-key
+              name: velero-s3-migration
+        - name: OBJECT_STORE_CLUSTER_IP
+          valueFrom:
+            secretKeyRef:
+              key: object-store-cluster-ip
+              name: velero-s3-migration
+        - name: S3_BUCKET_NAME  
+          value: ${VELERO_LOCAL_BUCKET}
+      volumes:
+      - name: velero-migrate-s3-config
+        configMap:
+          name: velero-migrate-s3-config
+          defaultMode: 0777

--- a/addons/velero/1.6.1/tmpl-s3-migration-secret.yaml
+++ b/addons/velero/1.6.1/tmpl-s3-migration-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-s3-migration 
+  labels:
+    app: velero
+type: Opaque
+stringData:
+  access-key-id: ${VELERO_S3_ACCESS_KEY_ID}
+  secret-access-key: ${VELERO_S3_ACCESS_KEY_SECRET}
+  object-store-cluster-ip: ${VELERO_S3_HOST}

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v__VELERO_VERSION__
 image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
 image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
 image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__
-image local-volume-provider replicated/local-volume-provider:v0.1.0
-image local-volume-fileserver replicated/local-volume-fileserver:v0.1.0
+image local-volume-provider replicated/local-volume-provider:v0.3.0
+image s3cmd kurlsh/s3cmd:7f7dc75-20210331
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v__VELERO_VERSION__/velero-v__VELERO_VERSION__-linux-amd64.tar.gz

--- a/addons/velero/template/base/install.sh.tmpl
+++ b/addons/velero/template/base/install.sh.tmpl
@@ -1,4 +1,4 @@
-
+# shellcheck disable=SC2148
 function velero_pre_init() {
     if [ -z "$VELERO_NAMESPACE" ]; then
         VELERO_NAMESPACE=velero
@@ -6,15 +6,22 @@ function velero_pre_init() {
     if [ -z "$VELERO_LOCAL_BUCKET" ]; then
         VELERO_LOCAL_BUCKET=velero
     fi
+    # TODO (dans): make this configurable from the installer spec
+    # if [ -z "$VELERO_REQUESTED_CLAIM_SIZE" ]; then
+    #     VELERO_REQUESTED_CLAIM_SIZE="50Gi"
+    # fi
 }
 
+# runs on first install, and on version upgrades only
 function velero() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    cp "$src/kustomization.yaml" "$dst/"
+    render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
 
     velero_binary
+
+    determine_velero_pvc_size
 
     velero_install "$src" "$dst"
 
@@ -26,9 +33,37 @@ function velero() {
 
     velero_change_storageclass "$src" "$dst"
 
+    # If we already migrated, or we on a new install that has the disableS3 flag set, we need a PVC attached
+    # TODO (dans): remove beta fla
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots || { [ "$KOTSADM_DISABLE_S3" == "1" ] && [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ]; }; then
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+    fi
+
+    # Check if we need a migration
+    if velero_should_migrate_from_object_store; then
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
     kubectl apply -k "$dst"
 
     kubectl label -n default --overwrite service/kubernetes velero.io/exclude-from-backup=true
+
+    # Bail if the migrationn fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots; then
+
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+    fi
 }
 
 function velero_join() {
@@ -39,52 +74,103 @@ function velero_install() {
     local src="$1"
     local dst="$2"
 
+    # TODO: remove this from the migration
     # Pre-apply CRDs since kustomize reorders resources. Grep to strip out sailboat emoji.
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install --crds-only | grep -v 'Velero is installed'
 
     local resticArg="--use-restic"
     if [ "$VELERO_DISABLE_RESTIC" = "1" ]; then
         resticArg=""
     fi
 
+    # detect if we need to use object store or pvc
     local bslArgs="--no-default-backup-location"
     if ! kubernetes_resource_exists "$VELERO_NAMESPACE" backupstoragelocation default; then
-        bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"
+
+        # TODO (dans): remove the BETA flag when this is GA
+        # Only use the PVC backup location for new installs where disableS3 is set to TRUE
+        if [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ] ; then
+            bslArgs="--provider replicated.com/pvc --bucket velero-internal-snapshots --backup-location-config storageSize=${VELERO_PVC_SIZE},resticRepoPrefix=/var/velero-local-volume-provider/velero-internal-snapshots/restic"
+        elif object_store_bucket_exists; then
+            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"  
+        fi
     fi
 
-    velero_credentials
+    # we need a secret file if it's already set for some other provider, OR
+    # If we have object storage AND are NOT actively opting out of the existing functionality
+    local secretArgs="--no-secret"
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials || { object_store_bucket_exists && ! { [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ]; }; }; then
+        velero_credentials
+        secretArgs="--secret-file velero-credentials"
+    fi
 
-    $src/assets/velero-v${VELERO_VERSION}-linux-amd64/velero install \
+    "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install \
         $resticArg \
         $bslArgs \
-        --plugins velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__,velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__,velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__,replicated/local-volume-provider:v0.1.0,$KURL_UTIL_IMAGE \
-        --secret-file velero-credentials \
-        --use-volume-snapshots=false \
+        $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --dry-run -o yaml > "$dst/velero.yaml"
+        --plugins velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__,velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__,velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__,replicated/local-volume-provider:v0.3.0,"$KURL_UTIL_IMAGE" \
+        --use-volume-snapshots=false \
+        --dry-run -o yaml > "$dst/velero.yaml" 
 
-    rm velero-credentials
+    rm -f velero-credentials
 }
 
+# This runs when re-applying the same version to a cluster
 function velero_already_applied() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    velero_change_storageclass "$src" "$dst" true
+    # If we need to migrate, we're going to need to basically reconstruct the original install 
+    # underneath the migration
+    if velero_should_migrate_from_object_store; then
 
-    # This should only be applying the configmap if required
-    if compgen -G "$dst/*.yaml" > /dev/null; then
-        kubectl apply -f "$dst"
+        render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
+
+        determine_velero_pvc_size
+
+        velero_binary 
+        velero_install "$src" "$dst"
+        velero_patch_restic_privilege "$src" "$dst"
+        velero_kotsadm_restore_config "$src" "$dst"
+        velero_patch_internal_pvc_snapshots "$src" "$dst"
+        velero_patch_http_proxy "$src" "$dst"
+        velero_migrate_from_object_store "$src" "$dst"
+    fi
+
+    # If we didn't need to migrate, reset the kustomization file and only apply the configmap
+    # This function will create a new, blank kustomization file.
+    velero_change_storageclass "$src" "$dst"
+
+    # In the case this is a rook re-apply, no changes might be required
+    if [ -f "$dst/kustomization.yaml" ]; then
+        kubectl apply -k "$dst"
+    fi
+
+    # Bail if the migration fails, preventing the original object store from being deleted
+    if velero_should_migrate_from_object_store; then
+        logWarn "Velero will migrate from object store to pvc"
+        try_5m velero_pvc_migrated
+        logSuccess "Velero migration complete"
+    fi
+
+    # Patch snapshots volumes to "Retain" in case of deletion
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots && velero_should_migrate_from_object_store; then
+        local velero_pv_name
+        echo "Patching internal snapshot volume Reclaim Policy to RECLAIM"
+        try_1m velero_pvc_bound
+        velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
+        kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
     fi
 }
 
-# The --secret-file flag must always be used so that the generated velero deployment uses the
+# The --secret-file flag should be used so that the generated velero deployment uses the
 # cloud-credentials secret. Use the contents of that secret if it exists to avoid overwriting
-# any changes. Else if a local object store (Ceph/Minio) is configured, use its credentials.
+# any changes. 
 function velero_credentials() {
-   if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
-       kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
-       return 0
+    if kubernetes_resource_exists "$VELERO_NAMESPACE" secret cloud-credentials; then
+        kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > velero-credentials
+        return 0
     fi
 
     if [ -n "$OBJECT_STORE_CLUSTER_IP" ]; then
@@ -124,12 +210,12 @@ function velero_binary() {
         curl -L "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" > "$src/assets/velero.tar.gz"
     fi
 
-    pushd "$src/assets"
+    pushd "$src/assets" || exit 1
     tar xf "velero.tar.gz"
     if [ "$VELERO_DISABLE_CLI" != "1" ]; then
         cp velero-v${VELERO_VERSION}-linux-amd64/velero /usr/local/bin/velero
     fi
-    popd
+    popd || exit 1
 }
 
 function velero_kotsadm_restore_config() {
@@ -162,13 +248,128 @@ function velero_patch_http_proxy() {
 function velero_change_storageclass() {
     local src="$1"
     local dst="$2"
-    local disable_kustomization="$3"
 
     if kubectl get sc longhorn &> /dev/null && \
     [ "$(kubectl get sc longhorn -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')" = "true" ]; then
-        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
-        if [ -z "$disable_kustomization" ]; then
-            insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
+        # when re-applying the same velero version, this might not exist.
+        if [ ! -f "$dst/kustomization.yaml" ]; then
+            cat > "$dst/kustomization.yaml" <<EOF
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+EOF
         fi
+
+        render_yaml_file "$src/tmpl-change-storageclass.yaml" > "$dst/change-storageclass.yaml"
+        insert_resources "$dst/kustomization.yaml" change-storageclass.yaml
+
     fi
+}
+
+function velero_should_migrate_from_object_store() {
+    # TODO (dans): remove this feature flag when/if we decide to ship migration
+    if [ -z "$BETA_VELERO_USE_INTERNAL_PVC" ]; then 
+        return 1
+    fi
+
+    # If KOTSADM_DISABLE_S3 is set, force the migration
+    if [ "$KOTSADM_DISABLE_S3" != 1 ]; then 
+        return 1
+    fi
+    # if an object store isn't installed don't migrate
+    # TODO (dans): this doeesn't support minio in a non-standard namespace
+    if (! kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a) && (! kubernetes_resource_exists minio deployment minio); then 
+        return 1
+    fi
+    return 0
+}
+
+function velero_migrate_from_object_store() {
+    local src="$1"
+    local dst="$2"
+
+    export VELERO_S3_HOST=
+    export VELERO_S3_ACCESS_KEY_ID=
+    export VELERO_S3_ACCESS_KEY_SECRET=
+    if kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a; then 
+        echo "Previous installation of Rook Ceph detected."
+        VELERO_S3_HOST="rook-ceph-rgw-rook-ceph-store.rook-ceph"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep AccessKey | head -1 | awk '{print $2}' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n rook-ceph get secret rook-ceph-object-user-rook-ceph-store-kurl -o yaml | grep SecretKey | head -1 | awk '{print $2}' | base64 --decode)
+    else 
+        echo "Previous installation of Minio detected."
+        VELERO_S3_HOST="minio.minio"
+        VELERO_S3_ACCESS_KEY_ID=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_ACCESS_KEY }' | base64 --decode)
+        VELERO_S3_ACCESS_KEY_SECRET=$(kubectl -n minio get secret minio-credentials -ojsonpath='{ .data.MINIO_SECRET_KEY }' | base64 --decode)
+    fi
+
+    # TODO (dans): figure out if there is enough space create a new volume with all the snapshot data
+
+    # create secret for migration init container to pull from object store
+    render_yaml_file "$src/tmpl-s3-migration-secret.yaml" > "$dst/s3-migration-secret.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-secret.yaml
+
+    # create configmap that holds the migration script
+    cp "$src/s3-migration-configmap.yaml" "$dst/s3-migration-configmap.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-configmap.yaml
+
+    # add patch to add init container for migration
+    render_yaml_file "$src/tmpl-s3-migration-deployment-patch.yaml" > "$dst/s3-migration-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" s3-migration-deployment-patch.yaml
+
+    # update the BackupstorageLocation
+    render_yaml_file "$src/tmpl-s3-migration-bsl.yaml" > "$dst/s3-migration-bsl.yaml"
+    insert_resources "$dst/kustomization.yaml" s3-migration-bsl.yaml
+}
+
+# add patches for the velero and restic to the current kustomization file that setup the PVC setup like the 
+# velero LVP plugin requires 
+function velero_patch_internal_pvc_snapshots() {
+    local src="$1"
+    local dst="$2"
+
+    # If we are migrating from Rook to Longhorn, longhorn is not yes the default storage class.
+    export VELERO_PVC_STORAGE_CLASS="default" # this is the rook-ceph default storage class
+    if [ -n "$LONGHORN_VERSION" ]; then
+        export VELERO_PVC_STORAGE_CLASS="longhorn"
+    fi
+
+    # create the PVC
+    render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
+    insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+
+    # add patch to add the pvc in the correct location for the velero deployment
+    cp "$src/internal-snaps-deployment-patch.yaml" "$dst/internal-snaps-deployment-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-deployment-patch.yaml
+
+    # add patch to add the pvc in the correct location for the restic daemonset
+    cp "$src/internal-snaps-ds-patch.yaml" "$dst/internal-snaps-ds-patch.yaml"
+    insert_patches_strategic_merge "$dst/kustomization.yaml" internal-snaps-ds-patch.yaml
+
+}
+
+function velero_pvc_bound() {
+    kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.status.phase}' | grep -q "Bound"
+}
+
+# if the PVC size has already been set we should not reduce it
+function determine_velero_pvc_size() {
+    local velero_pvc_size="50Gi"
+    if kubernetes_resource_exists "${VELERO_NAMESPACE}" pvc velero-internal-snapshots; then
+        velero_pvc_size=$( kubectl get pvc -n "${VELERO_NAMESPACE}" velero-internal-snapshots -o jsonpath='{.spec.resources.requests.storage}')
+    fi
+
+    export VELERO_PVC_SIZE=$velero_pvc_size
+}
+
+function velero_pvc_migrated() {
+    velero_pod=$( kubectl get pods -n velero -l component=velero -o jsonpath='{.items[?(@.spec.containers[0].name=="velero")].metadata.name}')
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration ran successfully" &>/dev/null; then
+        return 0
+    fi
+    if kubectl -n velero logs "$velero_pod" -c migrate-s3  | grep -q "migration has already run" &>/dev/null; then
+        return 0
+    fi
+    return 1
 }

--- a/addons/velero/template/base/internal-snaps-deployment-patch.yaml
+++ b/addons/velero/template/base/internal-snaps-deployment-patch.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+      - name: velero
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: "status.podIP"
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/template/base/internal-snaps-ds-patch.yaml
+++ b/addons/velero/template/base/internal-snaps-ds-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: restic
+spec:
+  template:
+    spec:
+      containers:
+      - name: restic
+        volumeMounts:
+        - mountPath: /var/velero-local-volume-provider/velero-internal-snapshots
+          name: velero-internal-snapshots
+      volumes:
+      - name: velero-internal-snapshots
+        persistentVolumeClaim:
+          claimName: velero-internal-snapshots

--- a/addons/velero/template/base/kustomization.yaml
+++ b/addons/velero/template/base/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-- velero.yaml

--- a/addons/velero/template/base/s3-migration-configmap.yaml
+++ b/addons/velero/template/base/s3-migration-configmap.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: velero-migrate-s3-config
+  labels:
+    app: velero
+data:
+  migrate-s3.sh: |-
+    #!/bin/sh
+    set -euo pipefail
+    export S3_HOST=$OBJECT_STORE_CLUSTER_IP
+
+    export ARCHIVES_DIR=/var/lib/velero
+    export MIGRATION_FILE=$ARCHIVES_DIR/s3-migration.txt
+    if [ -f $MIGRATION_FILE ]; then
+        echo 'migration has already run. no-op.'
+        exit 0
+    fi
+
+    export S3CMD_FLAGS="--access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY --host=$S3_HOST --no-ssl --host-bucket=$S3_BUCKET_NAME.$S3_HOST"
+
+    if s3cmd $S3CMD_FLAGS ls s3://$S3_BUCKET_NAME 2>&1 | grep -q 'NoSuchBucket'
+    then
+        echo "bucket $S3_BUCKET_NAME bucket not found, skipping migration ..."
+        exit 0
+    fi
+
+    echo 'object store detected, running migration ...'
+    s3cmd $S3CMD_FLAGS sync s3://$S3_BUCKET_NAME $ARCHIVES_DIR
+    echo 'migration ran successfully ...'
+    echo 'recording that the migration ran ...'
+    echo 'migration completed successfully $(date)'  > $MIGRATION_FILE

--- a/addons/velero/template/base/tmpl-internal-snaps-pvc.yaml
+++ b/addons/velero/template/base/tmpl-internal-snaps-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: velero-internal-snapshots
+  labels:
+    velero.io/exclude-from-backup: \"true\"
+spec:
+  storageClassName: ${VELERO_PVC_STORAGE_CLASS}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: ${VELERO_PVC_SIZE}

--- a/addons/velero/template/base/tmpl-kustomization.yaml
+++ b/addons/velero/template/base/tmpl-kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: ${VELERO_NAMESPACE}
+
+resources:
+- velero.yaml

--- a/addons/velero/template/base/tmpl-s3-migration-bsl.yaml
+++ b/addons/velero/template/base/tmpl-s3-migration-bsl.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+spec:
+  provider: replicated.com/pvc
+  objectStorage:
+    bucket: velero-internal-snapshots
+  config:
+    storageClassName: longhorn
+    storageSize: ${VELERO_PVC_SIZE}
+    resticRepoPrefix: /var/velero-local-volume-provider/velero-internal-snapshots/restic

--- a/addons/velero/template/base/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/template/base/tmpl-s3-migration-deployment-patch.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+  labels:
+    app: velero
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: migrate-s3
+        image: kurlsh/s3cmd:7f7dc75-20210331
+        imagePullPolicy: IfNotPresent
+        command:
+        - /migrate-s3.sh
+        volumeMounts:
+        - mountPath: /var/lib/velero
+          name: velero-internal-snapshots
+        - name: velero-migrate-s3-config
+          mountPath: /migrate-s3.sh
+          subPath: migrate-s3.sh
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: access-key-id
+              name: velero-s3-migration
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret-access-key
+              name: velero-s3-migration
+        - name: OBJECT_STORE_CLUSTER_IP
+          valueFrom:
+            secretKeyRef:
+              key: object-store-cluster-ip
+              name: velero-s3-migration
+        - name: S3_BUCKET_NAME  
+          value: ${VELERO_LOCAL_BUCKET}
+      volumes:
+      - name: velero-migrate-s3-config
+        configMap:
+          name: velero-migrate-s3-config
+          defaultMode: 0777

--- a/addons/velero/template/base/tmpl-s3-migration-secret.yaml
+++ b/addons/velero/template/base/tmpl-s3-migration-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-s3-migration 
+  labels:
+    app: velero
+type: Opaque
+stringData:
+  access-key-id: ${VELERO_S3_ACCESS_KEY_ID}
+  secret-access-key: ${VELERO_S3_ACCESS_KEY_SECRET}
+  object-store-cluster-ip: ${VELERO_S3_HOST}


### PR DESCRIPTION
Template and 1.6.1, 1.6.0 were updated with the changes from 1.6.2 in #2366. You can test by running the `generate.sh` script with hard-coded values. 

For 1.5.4 and 1.5.3, made it so that if you deploy without an object store, no default storage location will be picked. Further changes in KOTS would be needed to check for this condition.

Left 1.5.1 alone since there is already a check in there.