### PR TITLE
Create story on auto-merge failure

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -60,6 +60,44 @@ jobs:
           )
         run: echo "::notice ::auto-approve conditions satisfied"
 
+      - name: Create shortcut story if auto-merge conditions are not satisfied
+        if: ${{ steps.auto-approve-conditions.conclusion != 'success' }}
+        run: |
+          EXISTING_STORY="$(curl -X GET \
+            -H "Content-Type: application/json" \
+            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+            -d "{ \"page_size\": 1, \"query\": \"title:\\\"Automerge Failed for #${PR_NUMBER}\\\"\" }" \
+            -L "https://api.app.shortcut.com/api/v3/search/stories")"
+          if echo "${EXISTING_STORY}" | grep -q "Automerge Failed for #${PR_NUMBER} " ; then
+            echo "::notice ::shortcut story already exists"
+            exit 0
+          fi
+
+          PR_BODY="$(echo "${PR_BODY}" | sed -n '/--/q;p')"
+
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+            -d "{ \
+              \"group_id\": \"6125060f-c490-4005-8dd7-165aa0b9cc18\", \
+              \"owner_ids\": [\"61118e83-225b-4bff-9ae1-e5342ae0868f\"], \
+              \"name\": \"Automerge Failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'\", \
+              \"story_type\": \"chore\", \
+              \"description\": \"Dependabot was unable to automatically merge package update.\\n\\n${PR_BODY//\"/\\\"}\", \
+              \"workflow_state_id\": 500122316, \
+              \"estimate\": 1 }" \
+            -L "https://api.app.shortcut.com/api/v3/stories"
+
+          echo "::notice ::shortcut story created"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHORTCUT_API_TOKEN: ${{ secrets.SHORTCUT_API_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+
       - name: Approve Dependabot PR
         if: ${{ steps.auto-approve-conditions.conclusion == 'success' }}
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -63,30 +63,36 @@ jobs:
       - name: Create shortcut story if auto-merge conditions are not satisfied
         if: ${{ steps.auto-approve-conditions.conclusion != 'success' }}
         run: |
-          EXISTING_STORY="$(curl -X GET \
-            -H "Content-Type: application/json" \
-            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
-            -d "{ \"page_size\": 1, \"query\": \"title:\\\"Automerge Failed for #${PR_NUMBER}\\\"\" }" \
-            -L "https://api.app.shortcut.com/api/v3/search/stories")"
-          if echo "${EXISTING_STORY}" | grep -q "Automerge Failed for #${PR_NUMBER} " ; then
+          STORY_NAME="Dependabot auto-merge failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'"
+          STORY_DESCRIPTION="Dependabot auto-merge failed - auto-approve conditions not satisfied : update-type = ${{ steps.dependabot-metadata.outputs.update-type }}\\n\\n${PR_URL}"
+
+          EXISTING_STORY_ID="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json comments | grep -o '\[sc-[^]]*' | grep -o '[0-9]*' || true)"
+          if [ -n "${EXISTING_STORY_ID}" ] ; then
+            curl -X POST \
+              -H "Content-Type: application/json" \
+              -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+              -d "{ \"text\": \"${STORY_DESCRIPTION}\" }" \
+              -L "https://api.app.shortcut.com/api/v3/stories/${EXISTING_STORY_ID}/comments"
+
             echo "::notice ::shortcut story already exists"
             exit 0
           fi
 
-          PR_BODY="$(echo "${PR_BODY}" | sed -n '/--/q;p')"
-
-          curl -X POST \
+          NEW_STORY="$(curl -X POST \
             -H "Content-Type: application/json" \
             -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
             -d "{ \
               \"group_id\": \"6125060f-c490-4005-8dd7-165aa0b9cc18\", \
-              \"owner_ids\": [\"61118e83-225b-4bff-9ae1-e5342ae0868f\"], \
-              \"name\": \"Automerge Failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'\", \
+              \"project_id\": 28614, \
               \"story_type\": \"chore\", \
-              \"description\": \"Dependabot was unable to automatically merge package update.\\n\\n${PR_BODY//\"/\\\"}\", \
               \"workflow_state_id\": 500122316, \
-              \"estimate\": 1 }" \
-            -L "https://api.app.shortcut.com/api/v3/stories"
+              \"labels\": [{ \"name\": \"requester/dependabot\" }], \
+              \"name\": \"${STORY_NAME}\", \
+              \"description\": \"${STORY_DESCRIPTION}\" }" \
+            -L "https://api.app.shortcut.com/api/v3/stories")"
+          NEW_STORY_ID="$(echo "${NEW_STORY}" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')"
+
+          gh pr comment --repo "${GITHUB_REPO}" "${PR_NUMBER}" --body "[sc-${NEW_STORY_ID}]"
 
           echo "::notice ::shortcut story created"
         env:
@@ -96,11 +102,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
 
       - name: Approve Dependabot PR
         if: ${{ steps.auto-approve-conditions.conclusion == 'success' }}
-        run: gh pr review --approve "$PR_URL"
+        run: gh pr review --approve "${PR_URL}"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +114,7 @@ jobs:
       # status checks.
       - name: Enable auto-merge for Dependabot PR
         if: ${{ steps.auto-approve-conditions.conclusion == 'success' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --merge "${PR_URL}"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-buildfailure.yaml
+++ b/.github/workflows/dependabot-buildfailure.yaml
@@ -11,7 +11,7 @@ on:
     types: [ completed ]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
 
@@ -28,32 +28,40 @@ jobs:
 
       - name: Create shortcut story if build-test fails
         run: |
-          EXISTING_STORY="$(curl -X GET \
-            -H "Content-Type: application/json" \
-            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
-            -d "{ \"page_size\": 1, \"query\": \"title:\\\"Automerge Failed for #${PR_NUMBER}\\\"\" }" \
-            -L "https://api.app.shortcut.com/api/v3/search/stories")"
-          if echo "${EXISTING_STORY}" | grep -q "Automerge Failed for #${PR_NUMBER} " ; then
+          PR_URL="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json url --jq '.url')"
+          PR_TITLE="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json title --jq '.title')"
+
+          STORY_NAME="Dependabot auto-merge failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'"
+          STORY_DESCRIPTION="Dependabot auto-merge failed - build-test workflow run failed ${{ github.event.workflow_run.html_url }}\\n\\n${PR_URL}"
+
+          EXISTING_STORY_ID="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json comments | grep -o '\[sc-[^]]*' | grep -o '[0-9]*' || true)"
+          if [ -n "${EXISTING_STORY_ID}" ] ; then
+            curl -X POST \
+              -H "Content-Type: application/json" \
+              -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+              -d "{ \"text\": \"${STORY_DESCRIPTION}\" }" \
+              -L "https://api.app.shortcut.com/api/v3/stories/${EXISTING_STORY_ID}/comments"
+
             echo "::notice ::shortcut story already exists"
             exit 0
           fi
 
-          PR_TITLE="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json title --jq '.title')"
-          PR_BODY="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" | sed -n '/--/q;p')"
-
-          curl -X POST \
+          NEW_STORY="$(curl -X POST \
             -H "Content-Type: application/json" \
             -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
             -d "{ \
               \"group_id\": \"6125060f-c490-4005-8dd7-165aa0b9cc18\", \
-              \"owner_ids\": [\"61118e83-225b-4bff-9ae1-e5342ae0868f\"], \
-              \"name\": \"Automerge Failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'\", \
+              \"project_id\": 28614, \
               \"story_type\": \"chore\", \
-              \"description\": \"Dependabot was unable to automatically merge package update.\\n\\n${PR_BODY//\"/\\\"}\", \
               \"workflow_state_id\": 500122316, \
-              \"estimate\": 1 }" \
-            -L "https://api.app.shortcut.com/api/v3/stories"
-          
+              \"labels\": [{ \"name\": \"requester/dependabot\" }], \
+              \"name\": \"${STORY_NAME}\", \
+              \"description\": \"${STORY_DESCRIPTION}\" }" \
+            -L "https://api.app.shortcut.com/api/v3/stories")"
+          NEW_STORY_ID="$(echo "${NEW_STORY}" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')"
+
+          gh pr comment --repo "${GITHUB_REPO}" "${PR_NUMBER}" --body "[sc-${NEW_STORY_ID}]"
+
           echo "::notice ::shortcut story created"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-buildfailure.yaml
+++ b/.github/workflows/dependabot-buildfailure.yaml
@@ -1,0 +1,62 @@
+###############################################################################
+# This action will create a shortcut story when build-test fails for dependabot
+# pull requests.
+###############################################################################
+
+name: dependabot-buildfailure
+
+on:
+  workflow_run:
+    workflows: [ "build-test" ]
+    types: [ completed ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+
+  on-failure:
+    runs-on: ubuntu-latest
+    # only run for dependabot pull requests
+    if: |
+      (
+        github.actor == 'dependabot[bot]'
+      ) && (
+        github.event.workflow_run.conclusion == 'failure'
+      )
+    steps:
+
+      - name: Create shortcut story if build-test fails
+        run: |
+          EXISTING_STORY="$(curl -X GET \
+            -H "Content-Type: application/json" \
+            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+            -d "{ \"page_size\": 1, \"query\": \"title:\\\"Automerge Failed for #${PR_NUMBER}\\\"\" }" \
+            -L "https://api.app.shortcut.com/api/v3/search/stories")"
+          if echo "${EXISTING_STORY}" | grep -q "Automerge Failed for #${PR_NUMBER} " ; then
+            echo "::notice ::shortcut story already exists"
+            exit 0
+          fi
+
+          PR_TITLE="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" --json title --jq '.title')"
+          PR_BODY="$(gh pr view --repo "${GITHUB_REPO}" "${PR_NUMBER}" | sed -n '/--/q;p')"
+
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "Shortcut-Token: ${SHORTCUT_API_TOKEN}" \
+            -d "{ \
+              \"group_id\": \"6125060f-c490-4005-8dd7-165aa0b9cc18\", \
+              \"owner_ids\": [\"61118e83-225b-4bff-9ae1-e5342ae0868f\"], \
+              \"name\": \"Automerge Failed for #${PR_NUMBER} - '${PR_TITLE//\"/\\\"}'\", \
+              \"story_type\": \"chore\", \
+              \"description\": \"Dependabot was unable to automatically merge package update.\\n\\n${PR_BODY//\"/\\\"}\", \
+              \"workflow_state_id\": 500122316, \
+              \"estimate\": 1 }" \
+            -L "https://api.app.shortcut.com/api/v3/stories"
+          
+          echo "::notice ::shortcut story created"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHORTCUT_API_TOKEN: ${{ secrets.SHORTCUT_API_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
This will create a story on Dependabot PR workflow failures for both build-test failures as well as when auto-merge conditions are not satisfied.