### PR TITLE
update pvmigrate from v0.3.2 to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
-	github.com/replicatedhq/pvmigrate v0.3.2
+	github.com/replicatedhq/pvmigrate v0.4.1
 	github.com/replicatedhq/troubleshoot v0.22.2-0.20211201002858-27c5e5192046
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
@@ -43,7 +43,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.22.4
 	kubevirt.io/client-go v0.47.1
-	sigs.k8s.io/controller-runtime v0.9.5
+	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/controller-tools v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/replicatedhq/pvmigrate v0.3.2 h1:YmRL/jJVrMpcp6T9JKtLS+CYkfWO+EstA1FxBCWZvbg=
-github.com/replicatedhq/pvmigrate v0.3.2/go.mod h1:HXPV+iTqyR2YXPkSKkVtfkAhps9t55W0UqdOeaQvULk=
+github.com/replicatedhq/pvmigrate v0.4.1 h1:Na4UAI+0ZDrRHS4fY2u381/JIQX3ZYSXk61JVBFvDWg=
+github.com/replicatedhq/pvmigrate v0.4.1/go.mod h1:AcXPALy9FEcneEdRWt/i4o9xDCyevC4wryIswJtdl/0=
 github.com/replicatedhq/troubleshoot v0.22.2-0.20211201002858-27c5e5192046 h1:cR14062Ryz9e9SkyUShlNtL+kn/G1AHTI29mTbHtp7c=
 github.com/replicatedhq/troubleshoot v0.22.2-0.20211201002858-27c5e5192046/go.mod h1:BYlv9yFIb/iU2bRLTL6SaqhAUSxaJNuQ+sFTgzZl2zU=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=


### PR DESCRIPTION
closes https://github.com/replicatedhq/kURL/pull/2418