### PR TITLE
IPv6 expanded support

### DIFF
--- a/addons/antrea/1.4.0/ipsec.yaml
+++ b/addons/antrea/1.4.0/ipsec.yaml
@@ -4017,7 +4017,7 @@ data:
     # - vxlan
     # - gre
     # - stt
-    tunnelType: gre
+    tunnelType: geneve
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
@@ -4027,7 +4027,7 @@ data:
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
-    trafficEncryptionMode: ipsec
+    trafficEncryptionMode: wireguard
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and

--- a/addons/antrea/template/base/install.sh
+++ b/addons/antrea/template/base/install.sh
@@ -23,9 +23,11 @@ function antrea() {
 
     if ! lsmod | grep ip_tables; then
         modprobe ip_tables
+        echo 'ip_tables' > /etc/modules-load.d/kurl-antrea.conf
     fi
     if [ "$IPV6_ONLY" = "1" ]; then
         modprobe ip6_tables
+        echo 'ip6_tables' > /etc/modules-load.d/kurl-antrea.conf
     fi
 
 
@@ -35,13 +37,13 @@ function antrea() {
         cp "$src/plaintext.yaml" "$dst/"
         insert_resources "$dst/kustomization.yaml" plaintext.yaml
         if [ "$IPV6_ONLY" = "1" ]; then
-            sed -i "/serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/plaintext.yaml"
+            sed -i "/#serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/plaintext.yaml"
         fi
     else
         cp "$src/ipsec.yaml" "$dst/"
         insert_resources "$dst/kustomization.yaml" ipsec.yaml
         if [ "$IPV6_ONLY" = "1" ]; then
-            sed -i "/serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/ipsec.yaml"
+            sed -i "/#serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/ipsec.yaml"
         fi
 
         ANTREA_IPSEC_PSK=$(kubernetes_secret_value kube-system antrea-ipsec psk)
@@ -62,6 +64,11 @@ function antrea() {
 function antrea_join() {
     if ! lsmod | grep ip_tables; then
         modprobe ip_tables
+        echo 'ip_tables' > /etc/modules-load.d/kurl-antrea.conf
+    fi
+    if [ "$IPV6_ONLY" = "1" ]; then
+        modprobe ip6_tables
+        echo 'ip6_tables' > /etc/modules-load.d/kurl-antrea.conf
     fi
 
     if kubernetes_is_master; then

--- a/addons/registry/2.7.1/install.sh
+++ b/addons/registry/2.7.1/install.sh
@@ -30,6 +30,7 @@ function registry_install() {
     if ! registry_pvc_exists && object_store_exists && [ "$REGISTRY_USE_PVC_STORAGE" != "1" ]; then
         registry_object_store_bucket
         objectStoreIP=$($DIR/bin/kurl format-address $OBJECT_STORE_CLUSTER_IP)
+        objectStoreHostname=$(echo $OBJECT_STORE_CLUSTER_HOST | sed 's/http:\/\///')
         render_yaml_file "$DIR/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml" > "$DIR/kustomize/registry/deployment-objectstore.yaml"
         insert_resources "$DIR/kustomize/registry/kustomization.yaml" deployment-objectstore.yaml
 

--- a/addons/registry/2.7.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.7.1/patch-deployment-velero.yaml
@@ -41,10 +41,10 @@ spec:
             secretKeyRef:
               key: secret-access-key
               name: registry-s3-secret
-        - name: OBJECT_STORE_CLUSTER_IP
+        - name: OBJECT_STORE_HOSTNAME
           valueFrom:
             secretKeyRef:
-              key: object-store-cluster-ip
+              key: object-store-hostname
               name: registry-s3-secret
       containers:
       - name: registry-backup
@@ -65,10 +65,10 @@ spec:
             secretKeyRef:
               key: secret-access-key
               name: registry-s3-secret
-        - name: OBJECT_STORE_CLUSTER_IP
+        - name: OBJECT_STORE_HOSTNAME
           valueFrom:
             secretKeyRef:
-              key: object-store-cluster-ip
+              key: object-store-hostname
               name: registry-s3-secret
         volumeMounts:
         - name: registry-velero-config

--- a/addons/registry/2.7.1/tmpl-configmap-velero.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-velero.yaml
@@ -11,7 +11,7 @@ data:
     set -euo pipefail
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
-    export S3_HOST=\$OBJECT_STORE_CLUSTER_IP
+    export S3_HOST=\$OBJECT_STORE_HOSTNAME
     rm -rf \$S3_DIR
     mkdir -p \$S3_DIR
     s3cmd --access_key=\$AWS_ACCESS_KEY_ID --secret_key=\$AWS_SECRET_ACCESS_KEY --host=\$S3_HOST --no-ssl --host-bucket=\$S3_BUCKET_NAME.\$S3_HOST sync s3://\$S3_BUCKET_NAME \$S3_DIR
@@ -21,7 +21,7 @@ data:
     set -euo pipefail
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
-    export S3_HOST=\$OBJECT_STORE_CLUSTER_IP
+    export S3_HOST=\$OBJECT_STORE_HOSTNAME
 
     if [ ! -d \$S3_DIR ]; then
         exit 0

--- a/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
+++ b/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
@@ -55,7 +55,7 @@ type: Opaque
 stringData:
   access-key-id: ${OBJECT_STORE_ACCESS_KEY}
   secret-access-key: ${OBJECT_STORE_SECRET_KEY}
-  object-store-cluster-ip: ${OBJECT_STORE_CLUSTER_IP}
+  object-store-hostname: ${objectStoreHostname}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -134,6 +134,7 @@ function rook_operator_deploy() {
 
     if [ "$IPV6_ONLY" = "1" ]; then
         sed -i "/\[global\].*/a\    ms bind ipv6 = true" "$dst/configmap-rook-config-override.yaml"
+        sed -i "/\[global\].*/a\    ms bind ipv4 = false" "$dst/configmap-rook-config-override.yaml"
     fi
 
     kubectl -n rook-ceph apply -k "$dst"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -134,6 +134,7 @@ function rook_operator_deploy() {
 
     if [ "$IPV6_ONLY" = "1" ]; then
         sed -i "/\[global\].*/a\    ms bind ipv6 = true" "$dst/configmap-rook-config-override.yaml"
+        sed -i "/\[global\].*/a\    ms bind ipv4 = false" "$dst/configmap-rook-config-override.yaml"
     fi
 
     kubectl -n rook-ceph apply -k "$dst"

--- a/addons/velero/1.7.1/install.sh
+++ b/addons/velero/1.7.1/install.sh
@@ -92,7 +92,8 @@ function velero_install() {
         if [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ] ; then
             bslArgs="--provider replicated.com/pvc --bucket velero-internal-snapshots --backup-location-config storageSize=${VELERO_PVC_SIZE},resticRepoPrefix=/var/velero-local-volume-provider/velero-internal-snapshots/restic"
         elif object_store_bucket_exists; then
-            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"  
+            local ip=$($DIR/bin/kurl format-address $OBJECT_STORE_CLUSTER_IP)
+            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${ip},s3ForcePathStyle=true"
         fi
     fi
 

--- a/addons/velero/template/base/install.sh.tmpl
+++ b/addons/velero/template/base/install.sh.tmpl
@@ -92,7 +92,8 @@ function velero_install() {
         if [ -n "$BETA_VELERO_USE_INTERNAL_PVC" ] && [ "$KOTSADM_DISABLE_S3" == 1 ] ; then
             bslArgs="--provider replicated.com/pvc --bucket velero-internal-snapshots --backup-location-config storageSize=${VELERO_PVC_SIZE},resticRepoPrefix=/var/velero-local-volume-provider/velero-internal-snapshots/restic"
         elif object_store_bucket_exists; then
-            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${OBJECT_STORE_CLUSTER_IP},s3ForcePathStyle=true"  
+	    local ip=$($DIR/bin/kurl format-address $OBJECT_STORE_CLUSTER_IP)
+            bslArgs="--provider aws --bucket $VELERO_LOCAL_BUCKET --backup-location-config region=us-east-1,s3Url=${OBJECT_STORE_CLUSTER_HOST},publicUrl=http://${ip},s3ForcePathStyle=true"
         fi
     fi
 

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -223,7 +223,10 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 		case "force-reapply-addons":
 			continue
 		case "ipv6":
-			continue
+			if installer.Spec.Kurl == nil {
+				installer.Spec.Kurl = &kurlv1beta1.Kurl{}
+			}
+			installer.Spec.Kurl.IPv6 = true
 		default:
 			return errors.New(fmt.Sprintf("string %s is not a bash flag", split[0]))
 		}

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -725,6 +725,12 @@ function get_remotes_flags() {
     done < <(kubectl get node --no-headers --selector='!node-role.kubernetes.io/master' -owide | awk '{ print $6 }')
 }
 
+function get_ipv6_flag() {
+    if [ "$IPV6_ONLY" = "1" ]; then
+        echo " ipv6"
+    fi
+}
+
 function systemd_restart_succeeded() {
     local oldPid=$1
     local serviceName=$2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -318,6 +318,7 @@ function outro() {
     common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
     common_flags="${common_flags}$(get_remotes_flags)"
+    common_flags="${common_flags}$(get_ipv6_flag)"
 
     KUBEADM_TOKEN_CA_HASH=$(cat /tmp/kubeadm-init | grep 'discovery-token-ca-cert-hash' | awk '{ print $2 }' | head -1)
 

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -270,6 +270,9 @@ function join_token() {
             ha)
                 HA_CLUSTER="1"
                 ;;
+            ipv6)
+                IPV6_ONLY="1"
+                ;;
             *)
                 echo >&2 "Error: unknown parameter \"$_param\""
                 exit 1
@@ -315,6 +318,7 @@ function join_token() {
     fi
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${kurl_install_directory}")"
     common_flags="${common_flags}$(get_remotes_flags)"
+    common_flags="${common_flags}$(get_ipv6_flag)"
 
     local prefix=
     prefix="$(build_installer_prefix "${installer_id}" "${KURL_VERSION}" "${kurl_url}" "")"


### PR DESCRIPTION
* Fix IPv6 on CentOS 8, RHEL 8, and Ubuntu 20.04
* Fix antrea serviceCIDRv6 for new 1.4.0 configmap
* Load ip6_tables modules on all nodes with antrea and persist after reboot (also fixed for IPv4)
* Antrea encryption ipv6 with wireguard. Antrea encryption with IPv4 uses IPSec, but [that's not known to work with antrea with IPv6](https://kubernetes.slack.com/archives/CR2J23M0X/p1639614609127500). The installer will bail if wireguard is not found.
* Fix snapshots/restores with IPv6 by using object store cluster hostname from scripts since the s3cmd fails when using an IPv6 IP as the host.