### PR TITLE
Create contour namespace with --save-config

### DIFF
--- a/addons/contour/1.18.0/install.sh
+++ b/addons/contour/1.18.0/install.sh
@@ -34,7 +34,7 @@ function contour() {
         kubectl delete namespace heptio-contour
     fi
 
-    kubectl create namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
+    kubectl create --save-config namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
 
     kubectl apply -k "$dst/"
 }

--- a/addons/contour/1.19.1/install.sh
+++ b/addons/contour/1.19.1/install.sh
@@ -34,7 +34,7 @@ function contour() {
         kubectl delete namespace heptio-contour
     fi
 
-    kubectl create namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
+    kubectl create --save-config namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
 
     kubectl apply -k "$dst/"
 }

--- a/addons/contour/template/base/install.sh
+++ b/addons/contour/template/base/install.sh
@@ -34,7 +34,7 @@ function contour() {
         kubectl delete namespace heptio-contour
     fi
 
-    kubectl create namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
+    kubectl create --save-config namespace "$CONTOUR_NAMESPACE" 2>/dev/null || true
 
     kubectl apply -k "$dst/"
 }


### PR DESCRIPTION
Fix warning

> Warning: resource namespaces/projectcontour is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
