### PR TITLE
Add namespace to contour 1.7.0 envoy service patch

### DIFF
--- a/addons/contour/1.7.0/tmpl-service-patch.yaml
+++ b/addons/contour/1.7.0/tmpl-service-patch.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: envoy
+  namespace: projectcontour
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
fixes

```
error: no matches for IdId ~G_v1_Service|~X|envoy; failed to find unique target for patch ~G_v1_Service|envoy
```