### PR TITLE
IPv6 Preflights and Doc Updates

### DIFF
--- a/docs/ipv6.md
+++ b/docs/ipv6.md
@@ -46,9 +46,7 @@ There is no auto-detection of ipv6 or fall-back to ipv4 when ipv6 is not enabled
 * Antrea with encryption requires the kernel wireguard module to be available. The installer will bail if wireguard module cannot be loaded. Follow this guide for your OS, then reboot before running kurl: https://www.wireguard.com/install/.
 * Rook is the only supported CSI (1.5.12+).
 * Snapshots require velero 1.7.1+.
-* External load balancer hasn't been tested.
-* HTTP proxy hasn't been tested.
-* Host preflight checks fail even though install succeeds.
+* External load balancer requires a DNS name. You cannot enter an IPv6 IP at the load balancer prompt.
 
 
 ## Host Requirements
@@ -68,6 +66,7 @@ Solution: `sudo ip -6 route add default dev ens5`
 Problem: upload license fails with `failed to execute get request: Get "https://replicated.app/license/ipv6": dial tcp: lookup replicated.app on [fd00:c00b:2::a]:53: server misbehaving`
 Solution: deploy a NAT64 server
 Solution: use airgap or just set env var "DISABLE_OUTBOUND_CONNECTIONS=1" on the kotsadm deployment
+Solution: Use an http proxy with dualstack enabled.
 Solution: wait for AAAA records to be added to replicated.app
 
 Problem: networking check fails in curl installer

--- a/pkg/cli/format_address.go
+++ b/pkg/cli/format_address.go
@@ -13,11 +13,7 @@ func NewFormatAddressCmd(cli CLI) *cobra.Command {
 		Short: "Adds brackets around ipv6 addresses",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			address := args[0]
-
-			if strings.Contains(address, ":") {
-				address = fmt.Sprintf("[%s]", address)
-			}
+			address := formatAddress(args[0])
 
 			_, err := fmt.Fprintln(cmd.OutOrStdout(), address)
 
@@ -25,4 +21,12 @@ func NewFormatAddressCmd(cli CLI) *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+func formatAddress(addr string) string {
+	if strings.Contains(addr, ":") {
+		return fmt.Sprintf("[%s]", addr)
+	}
+
+	return addr
 }

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -91,6 +91,7 @@ func NewHostPreflightCmd(cli CLI) *cobra.Command {
 			if data.IsJoin && data.IsPrimary && !data.IsUpgrade {
 				// Check connection to kubelet on all remotes
 				for _, remote := range remotes {
+					remote = formatAddress(remote)
 					name := fmt.Sprintf("kubelet %s", remote)
 
 					preflightSpec.Spec.Collectors = append(preflightSpec.Spec.Collectors, &v1beta2.HostCollect{
@@ -134,17 +135,13 @@ func NewHostPreflightCmd(cli CLI) *cobra.Command {
 										Message: fmt.Sprintf("Successfully connected to kubelet %s:10250", remote),
 									},
 								},
-								{
-									Warn: &v1beta2.SingleOutcome{
-										Message: fmt.Sprintf("Unexpected TCP connection status for kubelet %s:10250", remote),
-									},
-								},
 							},
 						},
 					})
 				}
 				// Check connection to etcd on all primaries
 				for _, primary := range data.PrimaryHosts {
+					primary = formatAddress(primary)
 					name := fmt.Sprintf("etcd peer %s", primary)
 
 					preflightSpec.Spec.Collectors = append(preflightSpec.Spec.Collectors, &v1beta2.HostCollect{
@@ -186,11 +183,6 @@ func NewHostPreflightCmd(cli CLI) *cobra.Command {
 									Pass: &v1beta2.SingleOutcome{
 										When:    collect.NetworkStatusConnected,
 										Message: fmt.Sprintf("Successfully connected to etcd peer %s:2380", primary),
-									},
-								},
-								{
-									Warn: &v1beta2.SingleOutcome{
-										Message: fmt.Sprintf("Unexpected TCP connection status for etcd peer %s:2380", primary),
 									},
 								},
 							},

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -357,8 +357,6 @@ spec:
           - pass:
               when: "connected"
               message: Successfully connected to the Kubernetes API at address {{kurl .Installer.Spec.Kubernetes.MasterAddress }}
-          - warn:
-              message: Unexpected TCP connection status
     - filesystemPerformance:
         collectorName: Filesystem Latency Two Minute Benchmark
         exclude: '{{kurl and .IsPrimary (not .IsUpgrade) | not }}'


### PR DESCRIPTION
- Add brackets to ipv6 addresses for join preflights.
- Remove default fallthrough conditions that don't have `when` since these always evaluate to true and cause warning to show up after a pass. This fix also affects IPv4 installs.
- Document IPv6 works with http proxy.
- Document IPv6 works with external load balancer with DNS name, not IP address.