### PR TITLE
chore(ci): fix testgrid tests for kotsadm add-on

### DIFF
--- a/addons/kotsadm/template/testgrid/k8s-docker.yaml
+++ b/addons/kotsadm/template/testgrid/k8s-docker.yaml
@@ -1,12 +1,126 @@
-- installerSpec:
+- name: "minimal rook"
+  installerSpec:
     kubernetes:
       version: "latest"
     weave:
       version: "latest"
     rook:
-      version: "latest"
-    docker:
+      version: 1.5.x
+    containerd:
       version: "latest"
     kotsadm:
       version: "__testver__"
       s3Override: "__testdist__"
+- name: "minimal airgap"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: 1.5.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true
+- name: "minimal disableS3"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: 1.5.x
+    containerd:
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: "__testver__"
+      s3Override: "__testdist__"
+      disableS3: true
+  airgap: true
+- name: "all optional addons longhorn"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    longhorn:
+      version: "latest"
+    containerd:
+      version: "latest"
+    velero: 
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "upgrade from 1.49"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    longhorn:
+      version: "latest"
+    containerd:
+      version: "latest"
+    velero: 
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: 1.49.0
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    longhorn:
+      version: "latest"
+    containerd:
+      version: "latest"
+    velero: 
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "upgrade from 1.49 into disableS3"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    longhorn:
+      version: "latest"
+    containerd:
+      version: "latest"
+    velero: 
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: 1.49.0
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    longhorn:
+      version: "latest"
+    containerd:
+      version: "latest"
+    velero: 
+      version: "latest"
+    registry:
+      version: "latest"
+    kotsadm:
+      version: "__testver__"
+      s3Override: "__testdist__"
+      disableS3: true


### PR DESCRIPTION
This is currently breaking here because it's no longer a valid spec: https://github.com/replicatedhq/kURL/runs/4611529324?check_suite_focus=true#step:6:2362

Added some additional test cases as well.