### PR TITLE
update TestGrid test cases

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -142,6 +142,8 @@
       version: 2.6.5
     contour:
       version: 1.0.1
+    longhorn:
+      version: 1.2.2
     registry:
       version: 2.7.1
     prometheus:
@@ -150,8 +152,10 @@
       version: latest
     velero:
       version: 1.2.0
+    minio: 
+      version: latest
     ekco:
-      version: 0.6.0
+      version: latest
 - name: k8s121x_containerd
   installerSpec:
     kubernetes:
@@ -162,6 +166,8 @@
       version: 2.6.5
     contour:
       version: 1.0.1
+    longhorn:
+      version: 1.2.2
     registry:
       version: 2.7.1
     prometheus:
@@ -170,8 +176,10 @@
       version: latest
     velero:
       version: 1.2.0
+    minio: 
+      version: latest      
     ekco:
-      version: 0.6.0
+      version: latest
 - name: k8s119x-airgap
   installerSpec:
     kubernetes:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -132,10 +132,10 @@
   - centos-83
   - centos-84
   - ol-84
-- name: k8s118
+- name: k8s120x_docker
   installerSpec:
     kubernetes:
-      version: 1.18.x
+      version: 1.20.x
     docker:
       version: 19.03.10
     weave:
@@ -154,12 +154,12 @@
       version: 1.2.0
     ekco:
       version: 0.6.0
-- name: k8s1184
+- name: k8s121x_containerd
   installerSpec:
     kubernetes:
-      version: 1.18.4
-    docker:
-      version: 19.03.10
+      version: 1.21.x
+    containerd:
+      version: 1.4.6
     weave:
       version: 2.6.5
     contour:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -142,8 +142,6 @@
       version: 2.6.5
     contour:
       version: 1.0.1
-    rook:
-      version: 1.0.4
     registry:
       version: 2.7.1
     prometheus:
@@ -164,8 +162,6 @@
       version: 2.6.5
     contour:
       version: 1.0.1
-    rook:
-      version: 1.0.4
     registry:
       version: 2.7.1
     prometheus:


### PR DESCRIPTION
SC: 40502

- Update TestGrid test cases from k8s 1.18.x to 1.20.x and 1.21.x