### PR TITLE
feat(k8s): 1.22 support

### DIFF
--- a/packages/kubernetes/1.22.5/Manifest
+++ b/packages/kubernetes/1.22.5/Manifest
@@ -1,0 +1,13 @@
+image kube-apiserver k8s.gcr.io/kube-apiserver:v1.22.5
+image kube-controller-manager k8s.gcr.io/kube-controller-manager:v1.22.5
+image kube-scheduler k8s.gcr.io/kube-scheduler:v1.22.5
+image kube-proxy k8s.gcr.io/kube-proxy:v1.22.5
+image pause k8s.gcr.io/pause:3.5
+image etcd k8s.gcr.io/etcd:3.5.0-0
+image coredns k8s.gcr.io/coredns/coredns:v1.8.4
+
+asset kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.22.5/bin/linux/amd64/kubeadm
+asset crictl-linux-amd64.tar.gz https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz
+
+asset kustomize-v2.0.3 https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64
+asset kustomize-v3.5.4.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz

--- a/packages/kubernetes/1.22.5/conformance/Manifest
+++ b/packages/kubernetes/1.22.5/conformance/Manifest
@@ -1,0 +1,2 @@
+image conformance k8s.gcr.io/conformance:v1.22.5
+image nginx k8s.gcr.io/e2e-test-images/nginx:1.14-1

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -9,6 +9,12 @@ function find_available_versions() {
     # VERSIONS=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.[2][0-9]\.[0-9]+' | sort -rV | uniq))
     # echo "Found ${#VERSIONS[*]} versions for Kubernetes 1.20+: ${VERSIONS[*]}"
 
+    local versions122=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.22\.[0-9]+' | sort -rV | uniq))
+    if [ ${#versions122[@]} -gt 0 ]; then
+        echo "Found latest version for Kubernetes 1.22: ${versions122[0]}"
+        VERSIONS+=("${versions122[0]}")
+    fi
+
     local versions121=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.21\.[0-9]+' | sort -rV | uniq))
     if [ ${#versions121[@]} -gt 0 ]; then
         echo "Found latest version for Kubernetes 1.21: ${versions121[0]}"
@@ -19,12 +25,6 @@ function find_available_versions() {
     if [ ${#versions120[@]} -gt 0 ]; then
         echo "Found latest version for Kubernetes 1.20: ${versions120[0]}"
         VERSIONS+=("${versions120[0]}")
-    fi
-
-    local versions119=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.19\.[0-9]+' | sort -rV | uniq))
-    if [ ${#versions119[@]} -gt 0 ]; then
-        echo "Found latest version for Kubernetes 1.19: ${versions119[0]}"
-        VERSIONS+=("${versions119[0]}")
     fi
 
     echo "Found ${#VERSIONS[*]} versions for Kubernetes: ${VERSIONS[*]}"
@@ -111,6 +111,13 @@ function generate_conformance_package() {
 
 function update_available_versions() {
 
+    local version122=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.22' ) )
+    if [ ${#version122[@]} -gt 0 ]; then
+        if ! sed '0,/cron-kubernetes-update-122/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version122[0]}" ; then
+            sed -i "/cron-kubernetes-update-122/a\    \"${version122[0]}\"\," ../../../web/src/installers/versions.js
+        fi
+    fi
+
     local version121=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.21' ) )
     if [ ${#version121[@]} -gt 0 ]; then
         if ! sed '0,/cron-kubernetes-update-121/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version121[0]}" ; then
@@ -125,12 +132,6 @@ function update_available_versions() {
         fi
     fi
 
-    local version119=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.19' ) )
-    if [ ${#version119[@]} -gt 0 ]; then
-        if ! sed '0,/cron-kubernetes-update-119/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version119[0]}" ; then
-            sed -i "/cron-kubernetes-update-119/a\    \"${version119[0]}\"\," ../../../web/src/installers/versions.js
-        fi
-    fi
 }
 
 function main() {

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -789,3 +789,77 @@
       version: latest
     velero:
       version: 1.7.x
+- name: "K8s 1.22x Rook"
+  installerSpec:
+    kubernetes:
+      version: 1.22.x
+    containerd:
+      version: 1.4.x
+    antrea:
+      version: 1.4.x
+    contour:
+      version: 1.19.1
+    rook:
+      version: 1.5.12
+    registry:
+      version: 2.7.1
+    prometheus:
+      version: 0.49.0-17.1.3
+    kotsadm:
+      version: latest
+    velero:
+      version: 1.7.x
+    ekco:
+      version: latest
+  unsupportedOSIDs:
+  - ubuntu-1604
+- name: "K8s 1.22x Longhorn, disableS3"
+  installerSpec:
+    kubernetes:
+      version: 1.22.x
+    containerd:
+      version: 1.4.x
+    weave:
+      version: latest
+    contour:
+      version: 1.19.1
+    longhorn:
+      version: 1.2.2
+    registry:
+      version: 2.7.1
+    prometheus:
+      version: 0.49.0-17.1.3
+    kotsadm:
+      version: latest
+      disableS3: true
+    velero:
+      version: 1.7.x
+    ekco:
+      version: latest
+  unsupportedOSIDs:
+  - ubuntu-1604
+- name: "K8s 1.22x Airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.22.x
+    containerd:
+      version: 1.4.x
+    antrea:
+      version: 1.4.x
+    contour:
+      version: 1.19.1
+    rook:
+      version: 1.5.12
+    registry:
+      version: 2.7.1
+    prometheus:
+      version: 0.49.0-17.1.3
+    kotsadm:
+      version: latest
+    velero:
+      version: 1.7.x
+    ekco:
+      version: latest
+  airgap: true
+  unsupportedOSIDs:
+  - ubuntu-1604

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -24,6 +24,8 @@ module.exports.InstallerVersions = {
     "1.17.7",
     "1.17.3",
     "1.16.4",
+    // cron-kubernetes-update-122
+    "1.22.5",
     // cron-kubernetes-update-121
     "1.21.8",
     "1.21.5", 


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
Adds support for 1.22. There may be some addons like Ekco w/ known issues but these will be identified on staging.

#### Which issue(s) this PR fixes:
[SC-36576](https://app.shortcut.com/replicated/story/36576/kubernetes-1-22)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
```release-note
Add support for Kubernetes v1.22.5.
```

#### Does this PR require documentation?
None
