### PR TITLE
deduplicate host preflights error messages

### DIFF
--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -29,6 +29,12 @@ const HostPreflightCmdExample = `
   # Installer spec from STDIN
   $ kubectl get installer 6abe39c -oyaml | kurl host preflight -`
 
+const (
+	PREFLIGHTS_WARNING_CODE        = 3
+	PREFLIGHTS_IGNORE_WARNING_CODE = 2
+	PREFLIGHTS_ERROR_CODE          = 1
+)
+
 func NewHostPreflightCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "preflight [installer spec file|-]",
@@ -213,12 +219,12 @@ func NewHostPreflightCmd(cli CLI) *cobra.Command {
 
 			switch {
 			case preflightIsFail(results):
-				return errors.New("preflights have failures")
+				os.Exit(PREFLIGHTS_ERROR_CODE)
 			case preflightIsWarn(results):
 				if v.GetBool("ignore-warnings") {
-					fmt.Fprintln(cmd.ErrOrStderr(), "Warnings ignored by CLI flag \"ignore-warnings\"")
+					os.Exit(PREFLIGHTS_IGNORE_WARNING_CODE)
 				} else {
-					return ErrWarn
+					os.Exit(PREFLIGHTS_WARNING_CODE)
 				}
 			}
 			return nil

--- a/pkg/cli/host_preflight_test.go
+++ b/pkg/cli/host_preflight_test.go
@@ -131,7 +131,7 @@ func TestNewHostPreflightCmd(t *testing.T) {
 			bOut, bErr := bytes.NewBufferString(""), bytes.NewBufferString("")
 			cmd.SetOut(bOut)
 			cmd.SetErr(bErr)
-			args := []string{installerFilename}
+			args := []string{installerFilename, "--use-exit-codes=false"}
 			if tt.ignoreWarnings {
 				args = append(args, "--ignore-warnings")
 			}

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -588,6 +588,10 @@ function host_preflights() {
                     # fi
                     return 0
                     ;;  
+                2)
+                    logWarn "Host preflights warnings ignored"
+                    return 0
+                    ;;
                 1)
                     logFail "Host preflights have failures"
 


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
deduplicates error/warning messages for host preflights

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
