### PR TITLE
feat: latest installer moves to k8s 1.22

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -867,3 +867,36 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-1604
+- name: "Upgrade to 1.22"
+  installerSpec:
+    kubernetes:
+      version: 1.20.x
+    weave:
+      version: latest
+    rook:
+      isBlockStorageEnabled: true
+      version: 1.5.x
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: latest
+    velero:
+      version: 1.6.x
+  upgradeSpec:
+    kubernetes:
+      version: 1.22.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: latest
+    velero:
+      version: 1.7.x

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -773,7 +773,7 @@ export class Installer {
     const installerVersions = await getInstallerVersions(distUrl, kurlVersion);
 
     i.id = "latest";
-    i.spec.kubernetes = { version: "1.21.x" };
+    i.spec.kubernetes = { version: "1.22.x" };
     i.spec.containerd = { version: this.toDotXVersion(installerVersions.containerd[0]) };
     i.spec.weave = { version: this.toDotXVersion(installerVersions.weave[0]) };
     i.spec.longhorn = { version: this.toDotXVersion(installerVersions.longhorn[0]) };


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes [SC-36576](https://app.shortcut.com/replicated/story/36576/kubernetes-1-22)

#### Does this PR introduce a user-facing change?
```release-note
The `latest` installer on kurl.sh moves to Kubernetes 1.22.5.
```

#### Does this PR require documentation?
NONE
