### PR TITLE
fix(prom): fix nodeports for alertmanager and grafana

### DIFF
--- a/addons/prometheus/0.53.1-30.1.0/nodeport-services.yaml
+++ b/addons/prometheus/0.53.1-30.1.0/nodeport-services.yaml
@@ -7,6 +7,7 @@ spec:
   ports:
   - name: web
     port: 9093
+    protocol: TCP
     nodePort: 30903
   type: "NodePort"
 ---
@@ -32,4 +33,5 @@ spec:
   ports:
   - name: service
     port: 80
+    protocol: TCP
     nodePort: 30902

--- a/addons/prometheus/template/base/nodeport-services.yaml
+++ b/addons/prometheus/template/base/nodeport-services.yaml
@@ -7,6 +7,7 @@ spec:
   ports:
   - name: web
     port: 9093
+    protocol: TCP
     nodePort: 30903
   type: "NodePort"
 ---
@@ -32,4 +33,5 @@ spec:
   ports:
   - name: service
     port: 80
+    protocol: TCP
     nodePort: 30902


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Grafana and Alertmanager are not showing up on the documented fixed ports.

#### Which issue(s) this PR fixes:
Fixes [SC-41456](https://app.shortcut.com/replicated/story/41456/prometheus-addon-nodeports-are-not-set-correctly)

#### Does this PR introduce a user-facing change?
```release-note
Fix random Alert Manager and Grafana Nodeports for Prometheus addon 0.53.1-30.1.0+.
```

#### Does this PR require documentation?
NONE
