### PR TITLE
Shipping Kubernetes 1.21 as Latest

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -773,7 +773,7 @@ export class Installer {
     const installerVersions = await getInstallerVersions(distUrl, kurlVersion);
 
     i.id = "latest";
-    i.spec.kubernetes = { version: "1.22.x" };
+    i.spec.kubernetes = { version: "1.21.x" };
     i.spec.containerd = { version: this.toDotXVersion(installerVersions.containerd[0]) };
     i.spec.weave = { version: this.toDotXVersion(installerVersions.weave[0]) };
     i.spec.longhorn = { version: this.toDotXVersion(installerVersions.longhorn[0]) };


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

Latest Kubernetes should be version 1.21, due to an incompatibility with the latest Prometheus version available.
This is in response to an internal Sev1 where the default "latest" installer will fail.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Changing default Kubernetes version to 1.21 to avoid incompatibility with the default Prometheus version.
```

#### Does this PR require documentation?
NONE