### PR TITLE
fix(prom): prometheus for 1.22

### DIFF
--- a/addons/prometheus/0.53.1-30.1.0/operator/adapter.yaml
+++ b/addons/prometheus/0.53.1-30.1.0/operator/adapter.yaml
@@ -356,7 +356,7 @@ spec:
         emptyDir: {}
 ---
 # Source: prometheus-adapter/templates/custom-metrics-apiservice.yaml
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:    


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Prometheus breaks on k8s 1.22 with the following error:
```
error: unable to recognize "./kustomize/prometheus/operator/": no matches for kind "APIService" in version "apiregistration.k8s.io/v1beta1"
```

#### Does this PR introduce a user-facing change?
```release-note
Fix legacy `apiregistration.k8s.io/v1beta1` resource for Prometheus 0.53.1-30.1.0.
```

#### Does this PR require documentation?
NONE
