### PR TITLE
chore(testgrid): fix 1.22 daily tests

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -807,8 +807,8 @@
       version: 1.5.12
     registry:
       version: 2.7.1
-    prometheus:
-      version: 0.49.0-17.1.3
+    prometheus: 
+      version: "0.53.x"
     kotsadm:
       version: latest
     velero:
@@ -831,8 +831,8 @@
       version: 1.2.2
     registry:
       version: 2.7.1
-    prometheus:
-      version: 0.49.0-17.1.3
+    prometheus: 
+      version: "0.53.x"
     kotsadm:
       version: latest
       disableS3: true
@@ -856,8 +856,8 @@
       version: 1.5.12
     registry:
       version: 2.7.1
-    prometheus:
-      version: 0.49.0-17.1.3
+    prometheus: 
+      version: "0.53.x"
     kotsadm:
       version: latest
     velero:


### PR DESCRIPTION
#### What type of PR is this?
type::chore

#### Special Instructions for the Reviewer
I have a test run here: https://testgrid.kurl.sh/run/dans-k8s-122-prom-fix

#### What this PR does / why we need it:
Updates daily testgrid tests for k8s 1.22 to a compatible version of Prometheus.

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
