### PR TITLE
fix(antrea): warn missing wireguard on red hat OSes

### DIFF
--- a/addons/antrea/template/base/install.sh
+++ b/addons/antrea/template/base/install.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 
 function antrea_pre_init() {
     local src="$DIR/addons/antrea/$ANTREA_VERSION"
@@ -9,6 +10,12 @@ function antrea_pre_init() {
 
     if commandExists kubectl; then
         EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+    fi
+
+    # Encryption uses wireGuard, which does not require the 3rd
+    # ipsec container in the antrea-agent daemonset.
+    if [ ! "$ANTREA_DISABLE_ENCRYPTION" = "1" ] && ! modprobe wireguard; then
+        bail "Antrea with inter-node encryption enabled requires the wireguard kernel module be available. https://www.wireguard.com/install/"
     fi
 }
 
@@ -40,18 +47,23 @@ function antrea() {
             sed -i "/#serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/plaintext.yaml"
         fi
     else
-        cp "$src/ipsec.yaml" "$dst/"
-        insert_resources "$dst/kustomization.yaml" ipsec.yaml
-        if [ "$IPV6_ONLY" = "1" ]; then
-            sed -i "/#serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/ipsec.yaml"
-        fi
 
-        ANTREA_IPSEC_PSK=$(kubernetes_secret_value kube-system antrea-ipsec psk)
-        if [ -z "$ANTREA_IPSEC_PSK" ]; then
-            ANTREA_IPSEC_PSK=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c9)
+        if [ "$IPV6_ONLY" = "1" ]; then
+            cp "$src/plaintext.yaml" "$dst/"
+            insert_resources "$dst/kustomization.yaml" plaintext.yaml
+            sed -i "/#serviceCIDRv6:.*/a\    serviceCIDRv6: $SERVICE_CIDR" "$dst/plaintext.yaml"
+            sed -i "/#trafficEncryptionMode:.*/a\    trafficEncryptionMode: wireGuard" "$dst/plaintext.yaml"
+        else
+            cp "$src/ipsec.yaml" "$dst/"
+            insert_resources "$dst/kustomization.yaml" ipsec.yaml
+
+            ANTREA_IPSEC_PSK=$(kubernetes_secret_value kube-system antrea-ipsec psk)
+            if [ -z "$ANTREA_IPSEC_PSK" ]; then
+                ANTREA_IPSEC_PSK=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c9)
+            fi
+            render_yaml_file "$src/ipsec-psk.yaml" > "$dst/ipsec-psk.yaml"
+            insert_patches_strategic_merge "$dst/kustomization.yaml" ipsec-psk.yaml
         fi
-        render_yaml_file "$src/ipsec-psk.yaml" > "$dst/ipsec-psk.yaml"
-        insert_patches_strategic_merge "$dst/kustomization.yaml" ipsec-psk.yaml
     fi
 
     kubectl apply -k $dst

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -801,6 +801,7 @@
       version: 1.4.x
     antrea:
       version: 1.4.x
+      isEncryptionDisabled: true
     contour:
       version: 1.19.1
     rook:
@@ -850,6 +851,7 @@
       version: 1.4.x
     antrea:
       version: 1.4.x
+      isEncryptionDisabled: true
     contour:
       version: 1.19.1
     rook:


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Warns users that wireguard kernel module is missing when encryption is enabled.

#### Which issue(s) this PR fixes:
Fixes [SC-42009](https://app.shortcut.com/replicated/story/42009/antrea-1-4-w-encryption-broken)

#### Does this PR introduce a user-facing change?
```release-note
Trying to install Antrea 1.4.0+ with encryption and without the requisite wireguard kernel module will cause the installer to exit.
```

#### Does this PR require documentation?
TBD.
