### PR TITLE
log when a registry backup/restore/migration script starts/finishes

### DIFF
--- a/addons/registry/2.7.1/tmpl-configmap-migrate-s3.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-migrate-s3.yaml
@@ -11,6 +11,7 @@ data:
     set -euo pipefail
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=\$OBJECT_STORE_CLUSTER_IP
+    echo 'migration starting ...'
 
     export ARCHIVES_DIR=/var/lib/registry
     export MIGRATION_FILE=\$ARCHIVES_DIR/s3-migration.txt

--- a/addons/registry/2.7.1/tmpl-configmap-velero.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-velero.yaml
@@ -9,12 +9,14 @@ data:
   backup.sh: |-
     #!/bin/sh
     set -euo pipefail
+    echo 'backup starting ...'
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=\$OBJECT_STORE_HOSTNAME
     rm -rf \$S3_DIR
     mkdir -p \$S3_DIR
     s3cmd --access_key=\$AWS_ACCESS_KEY_ID --secret_key=\$AWS_SECRET_ACCESS_KEY --host=\$S3_HOST --no-ssl --host-bucket=\$S3_BUCKET_NAME.\$S3_HOST sync s3://\$S3_BUCKET_NAME \$S3_DIR
+    echo 'backup completed successfully'
 
   restore.sh: |-
     #!/bin/sh
@@ -22,6 +24,7 @@ data:
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=\$OBJECT_STORE_HOSTNAME
+    echo 'restore starting ...'
 
     if [ ! -d \$S3_DIR ]; then
         exit 0
@@ -37,3 +40,4 @@ data:
 
     s3cmd \$S3CMD_FLAGS sync \$S3_DIR s3://\$S3_BUCKET_NAME
     rm -rf \$S3_DIR
+    echo 'restore completed successfully'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::security
type::chore
type::tests
-->
type::feature


#### What this PR does / why we need it:
This PR makes it easier to tell that registry scripts have started the backup/restore/migration process, instead of having 30+s of no logs in the container.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Registry backup and restore scripts will include more user-friendly logging within the container.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE