### PR TITLE
fix(kotsadm): airgap images in 1.60.0

### DIFF
--- a/addons/kotsadm/1.60.0/postgres.yaml
+++ b/addons/kotsadm/1.60.0/postgres.yaml
@@ -57,7 +57,7 @@ spec:
             mode: 420
             path: passwd
       containers:
-      - image: postgres:10.18-alpine
+      - image: postgres:10.19-alpine
         name: kotsadm-postgres
         ports:
         - name: postgres

--- a/addons/kotsadm/alpha/postgres.yaml
+++ b/addons/kotsadm/alpha/postgres.yaml
@@ -57,7 +57,7 @@ spec:
             mode: 420
             path: passwd
       containers:
-      - image: postgres:10.18-alpine
+      - image: postgres:10.19-alpine
         name: kotsadm-postgres
         ports:
         - name: postgres

--- a/addons/kotsadm/nightly/postgres.yaml
+++ b/addons/kotsadm/nightly/postgres.yaml
@@ -57,7 +57,7 @@ spec:
             mode: 420
             path: passwd
       containers:
-      - image: postgres:10.18-alpine
+      - image: postgres:10.19-alpine
         name: kotsadm-postgres
         ports:
         - name: postgres

--- a/addons/kotsadm/template/base/postgres.yaml
+++ b/addons/kotsadm/template/base/postgres.yaml
@@ -57,7 +57,7 @@ spec:
             mode: 420
             path: passwd
       containers:
-      - image: postgres:10.18-alpine
+      - image: postgres:__POSTGRES_TAG__
         name: kotsadm-postgres
         ports:
         - name: postgres

--- a/addons/kotsadm/template/generate.sh
+++ b/addons/kotsadm/template/generate.sh
@@ -35,7 +35,7 @@ function generate() {
     # and update manifest with latest image tags
     export $(curl https://raw.githubusercontent.com/replicatedhq/kots/master/.image.env | sed 's/#.*//g' | xargs)
     sed -i -e "s/__MINIO_TAG__/$MINIO_TAG/g" "${dir}/Manifest"
-    sed -i -e "s/__POSTGRES_TAG__/$POSTGRES_ALPINE_TAG/g" "${dir}/Manifest"
+    find "$dir" -type f -exec sed -i -e "s/__POSTGRES_TAG__/$POSTGRES_ALPINE_TAG/g" {} \;
     sed -i -e "s/__DEX_TAG__/$DEX_TAG/g" "${dir}/Manifest"
 
 }


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
KOTSADM addon manifests reference an older postgres version that is not shipped in the bundle.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a problem with mismatched PostgreSQL versions causing KOTS deployment issues in airgap installs.
```

#### Does this PR require documentation?
NONE
