### PR TITLE
allow restoring older snapshots of the registry addon onto newly created instances

### DIFF
--- a/addons/registry/2.7.1/tmpl-configmap-velero.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-velero.yaml
@@ -21,6 +21,11 @@ data:
   restore.sh: |-
     #!/bin/sh
     set -euo pipefail
+
+    if [ -z "\$OBJECT_STORE_HOSTNAME" ]; then
+      export OBJECT_STORE_HOSTNAME=\$OBJECT_STORE_CLUSTER_IP # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores
+    fi
+
     export S3_DIR=/backup/s3/
     export S3_BUCKET_NAME=docker-registry
     export S3_HOST=\$OBJECT_STORE_HOSTNAME

--- a/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
+++ b/addons/registry/2.7.1/tmpl-deployment-objectstore.yaml
@@ -56,6 +56,7 @@ stringData:
   access-key-id: ${OBJECT_STORE_ACCESS_KEY}
   secret-access-key: ${OBJECT_STORE_SECRET_KEY}
   object-store-hostname: ${objectStoreHostname}
+  object-store-cluster-ip: ${objectStoreHostname} # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
With the addition of ipv6 support, we changed from "object store cluster-ip" to "object store hostname" - and changed this name in secrets/configmaps. This made restoring a snapshot of the registry addon that expects "object-store-cluster-ip" impossible, because the deployment manifests expected a secret field to exist that no longer did.

To fix that, this PR reincludes the object-store-cluster-ip field, but with the same data as object-store-hostname. It also includes logic within the velero restore script to accept using either the OBJECT_STORE_HOSTNAME environment variable OR the previous OBJECT_STORE_CLUSTER_IP env var, as the script will be run with the environment variables present at time of snapshot creation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix restoring registry on a new cluster when [migrating](https://kurl.sh/docs/install-with-kurl/migrating).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE