### PR TITLE
do not attempt to restart a disabled kubelet when installing containerd

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/addons/containerd/template/Dockerfile.centos8
+++ b/addons/containerd/template/Dockerfile.centos8
@@ -1,4 +1,4 @@
-FROM centos:8.1.1911
+FROM rockylinux:8.5
 
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -50,7 +50,7 @@ function containerd_install() {
         cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if systemctl list-unit-files | grep -q kubelet.service; then
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -78,7 +78,7 @@ function build_rhel_8() {
     # packages are included.
     docker run \
         --name "rhel-8-${PACKAGE_NAME}" \
-        centos:8.1.1911 \
+        rockylinux:8.5 \
         /bin/bash -c "\
             set -x
             echo -e \"fastestmirror=1\nmax_parallel_downloads=8\" >> /etc/dnf/dnf.conf && \
@@ -97,7 +97,7 @@ function createrepo_rhel_8() {
     docker run \
         --name "rhel-8-createrepo-${PACKAGE_NAME}" \
         -v "${outdir}/archives":/packages/archives \
-        centos:8.1.1911 \
+        rockylinux:8.5 \
         /bin/bash -c "\
             set -x
             echo -e \"fastestmirror=1\nmax_parallel_downloads=8\" >> /etc/dnf/dnf.conf && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This PR changes the containerd addon to not attempt to restart kubelet if the service has not yet been enabled.

It also changes containerd to build with rocky linux 8.5 instead of centos 8.1, as the centos 8 repos [have been disabled](https://forums.centos.org/viewtopic.php?f=54&t=78708).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Containerd will not attempt to restart kubelet if the kubelet service is disabled.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
~NONE~
Possibly a warning for ubuntu 16.04 + containerd 1.4.9+