### PR TITLE
kubernetes upgrade fails when enabling EKCO with internal load balancer.

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -63,6 +63,7 @@ function upgrade_kubernetes_patch() {
 function upgrade_kubernetes_local_master_patch() {
     local k8sVersion="$1"
     local node="$(get_local_node_name)"
+    local upgrading_kubernetes=true
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         kubernetes_get_host_packages_online "$k8sVersion"
@@ -162,6 +163,7 @@ function upgrade_kubernetes_remote_node_patch() {
 function upgrade_kubernetes_local_master_minor() {
     local k8sVersion="$1"
     local node="$(get_local_node_name)"
+    local upgrading_kubernetes=true
 
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         kubernetes_get_host_packages_online "$k8sVersion"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
When we try to upgrade both kubernetes and EKCO versions in the same spec along with enabling internal load balancer feature the upgrade fails as the install.sh script will try check the api server endpoint of the internal load balancer (localhost:6444) which has not been deployed yet. 


<!--
Please choose from one of the following:
type::bug
-->

#### What this PR does / why we need it:
With this change we fetch the api server endpoint from the cluster and performing status checks on it during the upgrade.  So the upgrade of kubernetes doesn't fail.

#### Which issue(s) this PR fixes:
Fixes # https://github.com/replicated-collab/forwardnetworks-kots/issues/57


#### Does this PR introduce a user-facing change?
```None```


#### Does this PR require documentation?
```NONE```
