### PR TITLE
only use strong ciphers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -125,12 +125,14 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 shutdownGracePeriod: 30s
 shutdownGracePeriodCriticalPods: 10s
+cipherSuites: [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
 EOF
     else
         cat << EOF >> $KUBEADM_CONF_FILE
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: systemd
+cipherSuites: [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
 EOF
     fi
 

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -13,6 +13,8 @@ dns:
 etcd:
   local:
     dataDir: /var/lib/etcd
+    extraArgs:
+      cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 networking:
   serviceSubnet: $SERVICE_CIDR
 apiServer:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug


#### What this PR does / why we need it:
This PR make sure kubeadm and etcd use strong ciphers by setting cipherSuite to a specific set of strong ciphers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
Cluster stood up [in this VM](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/stefan-strongciphers2?authuser=0&project=replicated-qa) utilizing this selective cipherSuite.  Ran SSL tests via `sudo docker run --rm -ti drwetter/testssl.sh https://<private ip>:2379/`  referenced in [this SC story](https://app.shortcut.com/replicated/story/42595/limit-etcd-tls-cipher-suites-to-address-vulnerabilities)  and do not see the vulnerabilities anymore.  Attached screenshot shows output of this run.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->

NONE
![Screen Shot 2022-02-03 at 2 23 53 PM](https://user-images.githubusercontent.com/97482262/152431342-87dda944-c876-4cd2-9e46-b8def4ea9bf2.png)

