### PR TITLE
feat: update latest installer to k8s 1.23

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -773,7 +773,7 @@ export class Installer {
     const installerVersions = await getInstallerVersions(distUrl, kurlVersion);
 
     i.id = "latest";
-    i.spec.kubernetes = { version: "1.21.x" };
+    i.spec.kubernetes = { version: "1.23.x" };
     i.spec.containerd = { version: this.toDotXVersion(installerVersions.containerd[0]) };
     i.spec.weave = { version: this.toDotXVersion(installerVersions.weave[0]) };
     i.spec.longhorn = { version: this.toDotXVersion(installerVersions.longhorn[0]) };


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
Updates the `latest` installer on the kurl.sh (the default) to Kubernetes 1.23

#### Does this PR introduce a user-facing change?
```release-note
- Updates the `latest` installer specification on the kurl.sh homepage to Kubernetes 1.23.x.
```

#### Does this PR require documentation?
NONE
