### PR TITLE
Fixup registry velero config

### DIFF
--- a/addons/registry/2.7.1/tmpl-configmap-velero.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-velero.yaml
@@ -10,7 +10,7 @@ data:
     #!/bin/sh
     set -euo pipefail
     echo 'backup starting ...'
-    if [ -z "\$OBJECT_STORE_HOSTNAME" ]; then
+    if [ -z "\${OBJECT_STORE_HOSTNAME-}" ]; then
       export OBJECT_STORE_HOSTNAME=\$OBJECT_STORE_CLUSTER_IP # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores
     fi
     export S3_DIR=/backup/s3/
@@ -25,7 +25,7 @@ data:
     #!/bin/sh
     set -euo pipefail
 
-    if [ -z "\$OBJECT_STORE_HOSTNAME" ]; then
+    if [ -z "\${OBJECT_STORE_HOSTNAME-}" ]; then
       export OBJECT_STORE_HOSTNAME=\$OBJECT_STORE_CLUSTER_IP # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores
     fi
 

--- a/addons/registry/2.7.1/tmpl-configmap-velero.yaml
+++ b/addons/registry/2.7.1/tmpl-configmap-velero.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   backup.sh: |-
     #!/bin/sh
-    set -euo pipefail
+    set -eu
     echo 'backup starting ...'
     if [ -z "\${OBJECT_STORE_HOSTNAME-}" ]; then
       export OBJECT_STORE_HOSTNAME=\$OBJECT_STORE_CLUSTER_IP # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores
@@ -23,7 +23,7 @@ data:
 
   restore.sh: |-
     #!/bin/sh
-    set -euo pipefail
+    set -eu
 
     if [ -z "\${OBJECT_STORE_HOSTNAME-}" ]; then
       export OBJECT_STORE_HOSTNAME=\$OBJECT_STORE_CLUSTER_IP # included for backwards compatibility for snapshot restores with pre-ipv6 snapshot restores


### PR DESCRIPTION
#### What type of PR is this?

type::bug


#### What this PR does / why we need it:

This changeset fixes compatibility issues with backup/restore of the Registry addon when a new cluster is restored from a Velero backup generated by kURL versions older than v2021.12.17-0.

#### Which issue(s) this PR fixes:

 - Fixes an "OBJECT_STORE_HOSTNAME: unbound variable" error that occurs when restoring from a backup.
 - Fixes a "command terminated with exit code 2" error that occurs when attempting to generate new backups post-restore.
 - Removes `set -o pipefail` bashisms that are undefined when executing under `/bin/sh`

#### Special notes for your reviewer:

This changeset mitigates some of the issues observed in replicated-collab/puppet-kots#188. Manual testing has been done using backups generated by kURL version v2021.10.08-0 restored into kURL version v2022.02.04-0.

#### Does this PR introduce a user-facing change?

```release-note
Fixes compatibility issues with backup/restore of the Registry addon when a new cluster is restored from a Velero backup generated by kURL versions older than v2021.12.17-0.
```

#### Does this PR require documentation?

NONE
