### PR TITLE
fix(preflights): failing tcp lb check for internal lb

### DIFF
--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 # Gather any additional information required from the user that could not be discovered and was not
 # passed with a flag
 
@@ -234,7 +235,9 @@ function prompt_for_load_balancer_address() {
         LOAD_BALANCER_PORT=6443
     fi
 
-    $BIN_BASHTOYAML -c $MERGED_YAML_SPEC -f "load-balancer-address=${LOAD_BALANCER_ADDRESS}:${LOAD_BALANCER_PORT}"
+    if [ -n "$LOAD_BALANCER_ADDRESS" ]; then
+        $BIN_BASHTOYAML -c "$MERGED_YAML_SPEC" -f "load-balancer-address=${LOAD_BALANCER_ADDRESS}:${LOAD_BALANCER_PORT}"
+    fi
 }
 
 # if remote nodes are in the cluster and this is an airgap install, prompt the user to run the


### PR DESCRIPTION
Signed-off-by: Dan Stough <dans@replicated.com>

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes a failing preflight check for the TCP Loadbalancer when using the internal lb and not entering any hostname/port at the prompt.

#### Which issue(s) this PR fixes:
Fixes [SC-37071](https://app.shortcut.com/replicated/story/37071/kurl-k8s-api-server-preflight-fails-when-load-balancer-address-is-left-empty)

#### Does this PR introduce a user-facing change?
```release-note
- Fixes a failing preflight for the TCP load balancer check when EKCO's internal load balancer is enabled.
```

#### Does this PR require documentation?
NONE