### PR TITLE
Make sure kurl-config exists in k3s and rke2 installs

### DIFF
--- a/scripts/common/k3s.sh
+++ b/scripts/common/k3s.sh
@@ -255,6 +255,10 @@ EOF
     printf "${RED}\n\nCONTINUING AT YOUR OWN RISK....${NC}\n\n"
 }
 
+function k3s_post_init() {
+    kurl_config
+}
+
 function k3s_outro() {
     echo
     # if [ -z "$PUBLIC_ADDRESS" ]; then
@@ -391,7 +395,7 @@ function k3s_main() {
     apply_installer_crd
     kurl_init_config
     ${K8S_DISTRO}_addon_for_each addon_install
-    # post_init                          # TODO(dan): more kubeadm token setup
+    k3s_post_init
     k3s_outro                            
     package_cleanup
     # report_install_success # TODO(dan) remove reporting for now.
@@ -466,8 +470,6 @@ function k3s_host_packages_ok() {
         echo "k3s command missing - will install host components"
         return 1
     fi
-
-    kubelet --version | grep -q "$(echo $k3s_version | sed "s/-/+/")"
 }
 
 function k3s_get_host_packages_online() {

--- a/scripts/common/rke2.sh
+++ b/scripts/common/rke2.sh
@@ -268,6 +268,10 @@ EOF
     printf "${RED}\n\nCONTINUING AT YOUR OWN RISK....${NC}\n\n"
 }
 
+function rke2_post_init() {
+    kurl_config
+}
+
 function rke2_outro() {
     echo
     # if [ -z "$PUBLIC_ADDRESS" ]; then
@@ -404,7 +408,7 @@ function rke2_main() {
     apply_installer_crd
     kurl_init_config
     ${K8S_DISTRO}_addon_for_each addon_install
-    # post_init                          # TODO(dan): more kubeadm token setup
+    rke2_post_init
     rke2_outro                           
     package_cleanup
     # report_install_success # TODO(dan) remove reporting for now.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -268,7 +268,7 @@ EOF
     fi
 }
 
-function post_init() {
+function kubeadm_post_init() {
     BOOTSTRAP_TOKEN_EXPIRY=$(kubeadm token list | grep $BOOTSTRAP_TOKEN | awk '{print $3}')
     kurl_config
     uninstall_docker
@@ -492,7 +492,7 @@ function main() {
     ${K8S_DISTRO}_addon_for_each addon_install
     maybe_cleanup_rook
     helmfile_sync
-    post_init
+    kubeadm_post_init
     outro
     package_cleanup
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

kURL clusters have `kurl-config` ConfigMap in the `kube-system` namespace.  This config map is missing with k3s and rke2 distros.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that resulted in  `kurl-config` ConfigMap to be missing when using k3s and rke2 distros.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE