### PR TITLE
Add registry certs to containerd

### DIFF
--- a/scripts/common/k3s.sh
+++ b/scripts/common/k3s.sh
@@ -395,6 +395,14 @@ function k3s_main() {
     apply_installer_crd
     kurl_init_config
     ${K8S_DISTRO}_addon_for_each addon_install
+
+    ${K8S_DISTRO}_registry_containerd_configure "${DOCKER_REGISTRY_IP}"
+    if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
+        ${K8S_DISTRO}_containerd_restart
+        spinner_kubernetes_api_healthy
+        CONTAINERD_NEEDS_RESTART=0
+    fi
+
     k3s_post_init
     k3s_outro                            
     package_cleanup

--- a/scripts/common/rke2.sh
+++ b/scripts/common/rke2.sh
@@ -408,6 +408,14 @@ function rke2_main() {
     apply_installer_crd
     kurl_init_config
     ${K8S_DISTRO}_addon_for_each addon_install
+
+    ${K8S_DISTRO}_registry_containerd_configure "${DOCKER_REGISTRY_IP}"
+    if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
+        ${K8S_DISTRO}_containerd_restart
+        spinner_kubernetes_api_healthy
+        CONTAINERD_NEEDS_RESTART=0
+    fi
+
     rke2_post_init
     rke2_outro                           
     package_cleanup


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

With k3s and rke2 distros, containerd is not installed as an add-on and so registry certificates are not configured.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that caused containerd to fail with x509 errors when pulling images from local kURL registry.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE