### PR TITLE
Save private IP on initial run and don't prompt on future runs

### DIFF
--- a/scripts/common/k3s.sh
+++ b/scripts/common/k3s.sh
@@ -256,6 +256,7 @@ EOF
 }
 
 function k3s_post_init() {
+    k3s_save_known_vars
     kurl_config
 }
 
@@ -596,4 +597,15 @@ EOF
     fi
 
     source /etc/profile
+}
+
+KNOWN_VARS_FILE="$KURL_INSTALL_DIRECTORY/kurl.env"
+function k3s_load_known_vars() {
+    if [ -f "$KNOWN_VARS_FILE" ]; then
+        source $KNOWN_VARS_FILE
+    fi
+}
+
+function k3s_save_known_vars() {
+    echo "PRIVATE_ADDRESS=$PRIVATE_ADDRESS" > $KNOWN_VARS_FILE
 }

--- a/scripts/distro/k3s/distro.sh
+++ b/scripts/distro/k3s/distro.sh
@@ -1,6 +1,7 @@
 # TODO (dan): consolidate this with the rke2 distro
 function k3s_discover_private_ip() {
-    echo "$(cat /var/lib/rancher/k3s/agent/pod-manifests/etcd.yaml 2>/dev/null | grep initial-cluster | grep -o "${HOSTNAME}-[a-z0-9]*=https*://[^\",]*" | sed -n -e 's/.*https*:\/\/\(.*\):.*/\1/p')"
+    k3s_load_known_vars
+    echo $PRIVATE_ADDRESS
 }
 
 function k3s_get_kubeconfig() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

On initial install.sh run, we automatically detect host's private IP.  On subsequent runs, the IP address cannot be detected automatically, so we read it from distro's config files.   k3s does not have a file where this IP address is easily accessible.

This PR creates it's own file in kURL's install directory (`/var/lib/kurl/kurl.env` by default) and loads it on subsequent runs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that caused installer to prompt the user for host's private IP when it should be detected automatically.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE