### PR TITLE
if known, ekco should use the local IP address as the LB

### DIFF
--- a/addons/ekco/0.11.0/install.sh
+++ b/addons/ekco/0.11.0/install.sh
@@ -33,8 +33,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/addons/ekco/0.12.0/install.sh
+++ b/addons/ekco/0.12.0/install.sh
@@ -33,8 +33,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/addons/ekco/0.13.0/install.sh
+++ b/addons/ekco/0.13.0/install.sh
@@ -33,8 +33,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/addons/ekco/0.14.0/install.sh
+++ b/addons/ekco/0.14.0/install.sh
@@ -34,8 +34,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/addons/ekco/0.15.0/install.sh
+++ b/addons/ekco/0.15.0/install.sh
@@ -34,8 +34,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/addons/ekco/0.16.0/install.sh
+++ b/addons/ekco/0.16.0/install.sh
@@ -34,8 +34,13 @@ function ekco_pre_init() {
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
         HA_CLUSTER=1
-        LOAD_BALANCER_ADDRESS=localhost
         LOAD_BALANCER_PORT="6444"
+
+        if [ -z "$PRIVATE_ADDRESS" ]; then
+          LOAD_BALANCER_ADDRESS=localhost
+        else
+          LOAD_BALANCER_ADDRESS="$PRIVATE_ADDRESS"
+        fi
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,6 @@ function init() {
 
     local addr="$PRIVATE_ADDRESS"
     local port="6443"
-    API_SERVICE_ADDRESS="$PRIVATE_ADDRESS:6443"
     if [ "$HA_CLUSTER" = "1" ]; then
         addr="$LOAD_BALANCER_ADDRESS"
         port="$LOAD_BALANCER_PORT"


### PR DESCRIPTION
instead of just using 'localhost'

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
This PR changes the behavior of EKCO to use the local IP of the node as the LB address when providing an internal load balancer, because the LB address is used as the api server address later in the codebase, and that should not be the literal string `localhost`. 

Specifically, it breaks join scripts:

```
To add worker nodes to this installation, copy and unpack this bundle on your other nodes, and run the following:

    cat ./join.sh | sudo bash -s airgap kubernetes-master-address=localhost:6444
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix an error where using EKCO with `EnableInternalLoadBalancer: true` would cause join scrips to be generated incorrectly.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
