### PR TITLE
when running with an ekco-provided internal LB, skip the LB connection preflight

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -62,7 +62,8 @@ spec:
     - tcpConnect:
         collectorName: "Kubernetes API TCP Connection Status"
         address: '{{kurl .Installer.Spec.Kubernetes.MasterAddress }}'
-        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.MasterAddress .IsJoin | not }}'
+        # run the collector if 1. there is a master address set AND this is a node joining the cluster AND this is not an EKCO internalLB install
+        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.MasterAddress .IsJoin (and .Installer.Spec.Ekco.Version .Installer.Spec.Ekco.EnableInternalLoadBalancer | not) | not }}'
     - filesystemPerformance:
         collectorName: Filesystem Latency Two Minute Benchmark
         exclude: '{{kurl and .IsPrimary (not .IsUpgrade) | not }}'
@@ -343,7 +344,8 @@ spec:
     - tcpConnect:
         checkName: "Kubernetes API TCP Connection Status"
         collectorName: "Kubernetes API TCP Connection Status"
-        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.MasterAddress .IsJoin | not }}'
+        # run the analyzer if 1. there is a master address set AND this is a node joining the cluster AND this is not an EKCO internalLB install
+        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.MasterAddress .IsJoin (and .Installer.Spec.Ekco.Version .Installer.Spec.Ekco.EnableInternalLoadBalancer | not) | not }}'
         outcomes:
           - fail:
               when: "connection-refused"


### PR DESCRIPTION
this preflight will fail as it attempts to connect to localhost:6444 on a new node which has no haproxy yet

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:


This PR disables the"Kubernetes API TCP Connection Status" host preflight for EKCO internal-LB based installations.

This is because the API to be checked is localhost:6444, which is provided by a yet-to-be-initialized HAProxy installation and will thus always fail.

Despite the preflight failing, installations would complete successfully.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix an erroneous host preflight failure when using EKCO's [internal load balancer](https://kurl.sh/docs/add-ons/ekco#internal-load-balancer).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
