### PR TITLE
Add RKE2 and K3s to the generated supported versions json file

### DIFF
--- a/generate-addons.js
+++ b/generate-addons.js
@@ -100,6 +100,12 @@ fs.readdir(specDir, (err, files) => {
   supportedVersions.kubernetes = preferredVersions.kubernetes;
   supportedVersions.kubernetes.unshift("latest");
 
+  supportedVersions.rke2 = preferredVersions.rke2;
+  supportedVersions.rke2.unshift("latest");
+
+  supportedVersions.k3s = preferredVersions.k3s;
+  supportedVersions.k3s.unshift("latest");
+
   supportedVersions.docker = preferredVersions.docker;
   supportedVersions.docker.unshift("latest");
 


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Adds RKE2 and K3s to the generated supported versions json file

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
