### PR TITLE
allow dependency resolution when using rhel8 and containerd addon

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -164,7 +164,11 @@ EOF
     yum makecache --disablerepo=* --enablerepo=kurl.local
 
     # shellcheck disable=SC2086
-    yum --disablerepo=* --enablerepo=kurl.local install -y "${packages[@]}"
+    if [[ "${packages[*]}" == *"containerd.io"* && -n $(uname -r | grep "el8") ]]; then
+        yum --disablerepo=* --enablerepo=kurl.local install --allowerasing -y "${packages[@]}"
+    else
+        yum --disablerepo=* --enablerepo=kurl.local install -y "${packages[@]}"
+    fi
     yum clean metadata --disablerepo=* --enablerepo=kurl.local
     rm /etc/yum.repos.d/kurl.local.repo
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
kURL needs to allow users to create clusters on RHEL8 with containerd.  This PR fixes dependency resolution error that was failing when a user tried to deploy cluster on RHEL8 w/ containerd.  The fix utilizes the `--allowerasing` yum flag that allows yum to replace and resolve conflicting dependencies.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/replicated-collab/puppet-kots/issues/198

#### Special notes for your reviewer:
Tested by deploying a multinode cluster using RHEL 8 in GCP using containerd addon.  Also tested with single node on RHEL7 for posterity.

Master RHEL8 node: https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/stefan-rhel8?authuser=0&project=replicated-qa
Master RHEL7 node: https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/stefan-rhel7?authuser=0&project=replicated-qa

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Fixes dependency resolution bug when deploying a cluster on RHEL8 with containerd
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE