### PR TITLE
swap openssl libs package for compatible version on RHEL7

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -164,6 +164,14 @@ EOF
     yum makecache --disablerepo=* --enablerepo=kurl.local
 
     # shellcheck disable=SC2086
+    if [[ "${packages[*]}" == *"openssl"* && -n $(uname -r | grep "el7") ]]; then
+        installed_version=$(yum list available | grep "openssl-libs" | awk '{print $2}' | cut -c 3-)
+        # if there is already an openssl-libs package installed, swap with the package version needed for RHEL7
+        if [[ -n "${installed_version}" ]]; then
+            yum swap openssl-libs-$installed_version openssl-libs-1.0.2k-22.el7_9 -y
+        fi
+    fi
+    # shellcheck disable=SC2086
     if [[ "${packages[*]}" == *"containerd.io"* && -n $(uname -r | grep "el8") ]]; then
         yum --disablerepo=* --enablerepo=kurl.local install --allowerasing -y "${packages[@]}"
     else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
This PR does fixes an issue regarding conflicting openssl-lib packages when installing on RHEL7.  The implementation swaps out any installed openssl-lib package for the correct one required for RHEL7 installation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/replicated-collab/puppet-kots/issues/208

#### Special notes for your reviewer:
Tested by deploying to a RHEL7 VM in GCP with no issue, confirmed installation completed and all pods came up.  Running VM can be viewed [here](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/stefan-rhel7?authuser=0&project=replicated-qa).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Fixes a bug that caused RHEL7 installations to fail because of conflicting openssl-lib package versions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
