### PR TITLE
only load kubectl completion if `bash-completion` is installed

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -334,7 +334,7 @@ exportKubeconfig() {
     chmod 440 ${kubeconfig}
     if ! grep -q "kubectl completion bash" /etc/profile; then
         echo "export KUBECONFIG=${kubeconfig}" >> /etc/profile
-        echo "source <(kubectl completion bash)" >> /etc/profile
+        echo "if  type _init_completion >/dev/null 2>&1; then source <(kubectl completion bash); fi" >> /etc/profile
     fi
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

t
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::chore

#### What this PR does / why we need it:

only load kubectl completion if `bash-completion` is installed

prevents a situation where hitting `tab` causes a print of `bash: _get_comp_words_by_ref: command not found` to the CLI when `bash-completion` is not installed by default on fresh systems 


on a fresh kurl cluster installed on RHEL8
```
[ada@ada-temp-rke2 ~]$ kubectl roll-bash: _get_comp_words_by_ref: command not found
^C
```



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
prevents loading `kubectl` completion if `bash-completion` is not installed


```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE