### PR TITLE
fix(web): set kots uiBindPort for rke2 and k3s installers

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -798,6 +798,7 @@ export class Installer {
     i.spec.registry = { version: this.toDotXVersion(installerVersions.registry[0]) };
     i.spec.kotsadm = {
       version: this.toDotXVersion(installerVersions.kotsadm[0]),
+      uiBindPort: 30880,
       disableS3: true,
     };
 
@@ -816,6 +817,7 @@ export class Installer {
     i.spec.registry = { version: this.toDotXVersion(installerVersions.registry[0]) };
     i.spec.kotsadm = {
       version: this.toDotXVersion(installerVersions.kotsadm[0]),
+      uiBindPort: 30880,
       disableS3: true,
     };
     i.spec.openebs = {
@@ -1375,6 +1377,15 @@ export class Installer {
       if (incompatibleAddons.length > 0) {
         return {error: {message: `The following add-ons are not compatible with rke2: ${incompatibleAddons.join(", ")}`}};
       }
+    }
+
+    // K3S and RKE2 can only use Nodeports 30000-32767
+    if ((this.spec.k3s && this.spec.k3s.version ) || (this.spec.rke2 && this.spec.rke2.version) ) {
+        if (this.spec.kotsadm && this.spec.kotsadm.version) {
+            if ( !this.spec.kotsadm.uiBindPort || 30000 > this.spec.kotsadm.uiBindPort || this.spec.kotsadm.uiBindPort > 32767) {
+                return {error: {message: `Nodeports for this distro must use a NodePort between 30000-32767`}};
+            }
+        }
     }
   }
 

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -872,6 +872,7 @@ spec:
     version: v1.23.3+k3s1
   kotsadm:
     version: 1.63.0
+    uiBindPort: 30880
   containerd:
     version: 1.4.6
   contour: 
@@ -880,6 +881,40 @@ spec:
         const out = await i.validate();
 
         expect(out).to.deep.equal({ error: { message: "The following add-ons are not compatible with k3s: contour, containerd" } });
+      });
+    });
+
+    describe("k3s invalid bind port for KOTS", () => {
+        it("=> ErrorResponse", async () => {
+          const yaml = `
+  spec:
+    k3s:
+      version: v1.23.3+k3s1
+    kotsadm:
+      version: 1.63.0`;
+          const i = Installer.parse(yaml);
+          const out = await i.validate();
+  
+          expect(out).to.deep.equal({ error: { message: "Nodeports for this distro must use a NodePort between 30000-32767" } });
+        });
+      });
+
+    describe("valid k3s spec", () => {
+      it("=> ErrorResponse", async () => {
+        const yaml = `
+spec:
+  k3s:
+    version: v1.23.3+k3s1
+  registry: 
+    version: 2.7.1
+  kotsadm: 
+    version: 1.63.0
+    uiBindPort: 30880
+    disableS3: true`;
+        const i = Installer.parse(yaml);
+        const out = await i.validate();
+
+        expect(out).to.deep.equal(undefined);
       });
     });
 
@@ -893,6 +928,7 @@ spec:
     version: 2.7.1
   kotsadm: 
     version: 1.63.0
+    uiBindPort: 30880
     disableS3: true`;
         const i = Installer.parse(yaml);
         const out = await i.validate();
@@ -909,6 +945,7 @@ spec:
     version: v1.22.6+rke2r1
   kotsadm:
     version: 1.63.0
+    uiBindPort: 30880
   containerd:
     version: 1.4.6
   contour: 
@@ -920,6 +957,22 @@ spec:
       });
     });
 
+    describe("rke2 invalid bind port for KOTS", () => {
+        it("=> ErrorResponse", async () => {
+          const yaml = `
+  spec:
+    rke2:
+      version: v1.22.6+rke2r1
+    kotsadm:
+      version: 1.63.0
+      uiBindPort: 8800`;
+          const i = Installer.parse(yaml);
+          const out = await i.validate();
+  
+          expect(out).to.deep.equal({ error: { message: "Nodeports for this distro must use a NodePort between 30000-32767" } });
+        });
+      });
+
     describe("valid rke2 spec", () => {
       it("=> ErrorResponse", async () => {
         const yaml = `
@@ -930,6 +983,7 @@ spec:
     version: 2.7.1
   kotsadm: 
     version: 1.63.0
+    uiBindPort: 30880
     disableS3: true
   velero:
     version: 1.6.0


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
KOTS can't deploy 

#### Which issue(s) this PR fixes:
Fixes [SC-43770](https://app.shortcut.com/replicated/story/43770/kurl-sh-k3s-and-kurl-sh-rke2-should-include-uibindport-in-valid-range)

#### Does this PR introduce a user-facing change?
```release-note
- Fixed the KOTSADM uiBindPort for the Beta K3s and RKE2 installers so that it won't error on deploy. This port now defaults to 30880, and the allowable range is ports 30000-32767.
```

#### Does this PR require documentation?
NONE
