### PR TITLE
add resource limits for envoy

### DIFF
--- a/addons/contour/1.20.1/install.sh
+++ b/addons/contour/1.20.1/install.sh
@@ -23,6 +23,7 @@ function contour() {
 
     cp "$src/contour.yaml" "$dst/"
     cp "$src/patches/job-image.yaml" "$dst/"
+    cp "$src/patches/resource-limits.yaml" "$dst/"
 
     render_yaml_file "$src/tmpl-configmap.yaml" > "$dst/configmap.yaml"
     render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"

--- a/addons/contour/1.20.1/patches/resource-limits.yaml
+++ b/addons/contour/1.20.1/patches/resource-limits.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: envoy
+  namespace: projectcontour
+spec:
+  template:
+    spec:
+      containers:
+      - name: envoy
+        resources:
+          limits:
+            cpu: "1"
+          requests:
+            cpu: "0.5"

--- a/addons/contour/1.20.1/tmpl-kustomization.yaml
+++ b/addons/contour/1.20.1/tmpl-kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 patchesStrategicMerge:
 - service-patch.yaml
 - job-image.yaml
+- resource-limits.yaml

--- a/addons/contour/template/base/install.sh
+++ b/addons/contour/template/base/install.sh
@@ -23,6 +23,7 @@ function contour() {
 
     cp "$src/contour.yaml" "$dst/"
     cp "$src/patches/job-image.yaml" "$dst/"
+    cp "$src/patches/resource-limits.yaml" "$dst/"
 
     render_yaml_file "$src/tmpl-configmap.yaml" > "$dst/configmap.yaml"
     render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"

--- a/addons/contour/template/base/patches/resource-limits.yaml
+++ b/addons/contour/template/base/patches/resource-limits.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: envoy
+  namespace: projectcontour
+spec:
+  template:
+    spec:
+      containers:
+      - name: envoy
+        resources:
+          limits:
+            cpu: "1"
+          requests:
+            cpu: "0.5"

--- a/addons/contour/template/base/tmpl-kustomization.yaml
+++ b/addons/contour/template/base/tmpl-kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 patchesStrategicMerge:
 - service-patch.yaml
 - job-image.yaml
+- resource-limits.yaml


### PR DESCRIPTION
During high CPU operations, envoy pod may not get scheduled to run and hence does not get to run liveness probes and hangs for a long time. Specifying CPU limits may help.

https://github.com/replicated-collab/ferolabs-replicated/issues/1


type::bug

