### PR TITLE
Preserve kurl addon installerVersion field when saving/promoting an installer

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1051,9 +1051,7 @@ export class Installer {
   constructor(
     public readonly teamID?: string,
   ) {
-    this.spec = {
-      kubernetes: { version: "" },
-    };
+    this.spec = {};
   }
 
   public clone(): Installer {

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1181,7 +1181,7 @@ export class Installer {
 
     // add spec properties in order they should be rendered in yaml
     _.each(specSchema.properties, (val, key) => {
-      if (this.spec[key] && this.spec[key].version) {
+      if (this.spec[key]) {
         obj.spec[key] = _.cloneDeep(this.spec[key]);
       }
     });

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -267,14 +267,6 @@ spec:
     applicationSlug: sentry-enterprise
 `;
 
-const kotsNoSlug = `
-spec:
-  kubernetes:
-    version: latest
-  kotsadm:
-    version: 0.9.9
-`;
-
 const kotsNoVersion = `
 spec:
   kubernetes:
@@ -407,6 +399,14 @@ spec:
     version: 1.16.4
   sonobuoy:
     version: 0.50.0
+`;
+
+const kurlInstallerVersion = `
+spec:
+  kubernetes:
+    version: 1.19.7
+  kurl:
+    installerVersion: v2022.03.04-1
 `;
 
 describe("Installer", () => {
@@ -598,6 +598,22 @@ kind: Installer
 metadata:
   name: ''
 spec: {}
+`);
+      });
+
+      it("preserves kurl addon installerVersion", () => {
+        const parsed = Installer.parse(kurlInstallerVersion);
+        const yaml = parsed.toYAML();
+
+        expect(yaml).to.equal(`apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: ''
+spec:
+  kubernetes:
+    version: 1.19.7
+  kurl:
+    installerVersion: v2022.03.04-1
 `);
       });
     });


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Preserves the kurl addon installerVersion field when saving/promoting an installer

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug where the `installerVersion` field for the [kURL add-on](/docs/add-ons/kurl) was being stripped when creating or promoting the installer.
```

#### Does this PR require documentation?
NONE
