### PR TITLE
fix(api): add missing host preflight and longhorn fields for validation

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -405,11 +405,15 @@ export const ekcoConfigSchema = {
 export interface KurlConfig {
   additionalNoProxyAddresses: string[];
   airgap?: boolean;
+  excludeBuiltinHostPreflights?: boolean;
+  excludeBuiltinPreflights?: boolean;
   hostnameCheck?: string;
   ignoreRemoteLoadImagesPrompt?: boolean;
   ignoreRemoteUpgradePrompt?: boolean;
   ipv6?: boolean;
   hostPreflights?: object;
+  hostPreflightIgnore?: boolean;
+  hostPreflightEnforceWarnings?: boolean;
   licenseURL?: string;
   nameserver?: string;
   noProxy?: string;
@@ -419,7 +423,6 @@ export interface KurlConfig {
   proxyAddress?: string;
   publicAddress?: string;
   skipSystemPackageInstall?: boolean;
-  excludeBuiltinPreflights?: boolean;
   bypassFirewalldWarning?: boolean; // this is not in the installer crd
   hardFailOnFirewalld?: boolean; // this is not in the installer crd
   task?: string; // this is not in the installer crd
@@ -431,21 +434,24 @@ export const kurlConfigSchema = {
   properties: {
     additionalNoProxyAddresses: { type: "array", items: { type: "string" }, description: "Addresses that can be reached without a proxy" },
     airgap: { type: "boolean", flag: "airgap", description: "Indicates if this install is an airgap install" },
+    excludeBuiltinHostPreflights: { type: "boolean", flag: "exclude-builtin-host-preflights" , description: "Excludes the default built-in host preflights for kURL." },
     hostnameCheck: { type: "string", flag: "hostname-check" , description: "Used as a check during an upgrade to ensure the script will run only on the given hostname" },
     hostPreflights: { type: "object", description: "Used to add additional host preflight checks."},
+    hostPreflightIgnore: { type: "boolean", flag: "host-preflight-ignore" , description: "Ignore host preflight failures and warnings" },
+    hostPreflightEnforceWarnings: { type: "boolean", flag: "host-preflight-enforce-warnings" , description: "Fail on host preflight warnings as well as failures" },
     ignoreRemoteLoadImagesPrompt: { type: "boolean", flag: "ignore-remote-load-images-prompt" , description: "Bypass prompt to load images on remotes. This is useful for automating upgrades." },
     ignoreRemoteUpgradePrompt: { type: "boolean", flag: "ignore-remote-upgrade-prompt" , description: "Bypass prompt to upgrade remotes. This is useful for automating upgrades." },
     ipv6: { type: "boolean", description: "Install on IPv6 enabled hosts - see https://kurl.sh/docs/install-with-kurl/ipv6" },
     licenseURL: { type: "string", description: "A URL to a licensing agreement that will presented during installation and needs to be accepted or the install will exit." },
     nameserver: { type: "string" },
     noProxy: { type: "boolean", flag: "no-proxy" , description: "Don’t detect or configure a proxy" },
-    preflightIgnore: { type: "boolean", flag: "preflight-ignore" , description: "Ignore preflight failures and warnings" },
-    preflightIgnoreWarnings: { type: "boolean", flag: "preflight-ignore-warnings" , description: "Ignore preflight warnings" },
+    preflightIgnore: { type: "boolean", flag: "preflight-ignore" , description: "DEPRECATED: Ignore preflight failures and warnings. See `host-preflight-ignore` for replacement." },
+    preflightIgnoreWarnings: { type: "boolean", flag: "preflight-ignore-warnings" , description: "DEPRECATED: Ignore preflight warnings.  See `host-preflight-enforce-warnings` for replacement." },
     privateAddress: { type: "string", flag: "private-address" , description: "The local address of the host (different for each host in the cluster)" },
     proxyAddress: { type: "string", flag: "http-proxy" , description: "The address of the proxy to use for outbound connections" },
     publicAddress: { type: "string", flag: "public-address" , description: "The public address of the host (different for each host in the cluster), will be added as a CNAME to the k8s API server cert so you can use kubectl with this address" },
     skipSystemPackageInstall: { type: "boolean", flag: "skip-system-package-install" , description: "Skip the installation of system packages." },
-    excludeBuiltinPreflights: { type: "boolean", flag: "exclude-builtin-preflights" , description: "Excludes the default built-in host preflights for kURL." },
+    excludeBuiltinPreflights: { type: "boolean", flag: "exclude-builtin-preflights" , description: "DEPRECATED: Excludes the default built-in host preflights for kURL. See `exclude-builtin-host-preflights` for replacement." },
     bypassFirewalldWarning: { type: "boolean", flag: "bypass-firewalld-warning" , description: "Continue installing even if the firewalld service is active" },
     hardFailOnFirewalld: { type: "boolean", flag: "hard-fail-on-firewalld" , description: "Exit the install script if the firewalld service is active" },
     installerVersion: { type: "string", description: "The upstream version of kURL to use as part of the installation - see https://kurl.sh/docs/install-with-kurl/#versioned-releases" },
@@ -619,6 +625,7 @@ export const helmConfigSchema = {
 
 export interface LonghornConfig {
   s3Override?: string;
+  storageOverProvisioningPercentage?: number;
   uiBindPort?: number;
   uiReplicaCount?: number;
   version: string;
@@ -628,6 +635,7 @@ export const LonghornSchema = {
   type: "object",
   properties: {
     s3Override: { type: "string", flag: "s3-override", description: "Override the download location for addon package distribution (used for CI/CD testing alpha addons)" },
+    storageOverProvisioningPercentage: { type: "number", flag: "longhorn-storage-over-provisioning-percentage", description: "Determines the amount of PVC capacity that Longhorn will allow to be provisioned based on the real, available disk space. Default is 200 See Longhorn Documentation for a thorough explanation." },
     uiBindPort: { type: "number", flag: "longhorn-ui-bind-port", description: "This is the port where the Longhorn UI can be reached via the browser" },
     uiReplicaCount: { type: "number", flag: "longhorn-ui-replica-count", description: "The number of pods to deploy for the Longhorn UI (default is 0)" },
     version: { type: "string" },

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -98,20 +98,20 @@ spec:
     additionalNoProxyAddresses:
     - 10.128.0.3
     airgap: false
+    excludeBuiltinHostPreflights: false
     hostnameCheck: 2.2.2.2
+    hostPreflightIgnore: true
+    hostPreflightEnforceWarnings: true
     ignoreRemoteLoadImagesPrompt: false
     ignoreRemoteUpgradePrompt: false
     ipv6: false
     licenseURL: https://www.sec.gov/Archives/edgar/data/1029786/00011931250557724/dex104.htm
     nameserver: 8.8.8.8
     noProxy: false
-    preflightIgnore: true
-    preflightIgnoreWarnings: true
     privateAddress: 10.38.1.1
     proxyAddress: 1.1.1.1
     publicAddress: 101.38.1.1
     skipSystemPackageInstall: false
-    excludeBuiltinPreflights: false
     bypassFirewalldWarning: false
     hardFailOnFirewalld: false
   collectd:
@@ -139,6 +139,7 @@ spec:
     additionalImages:
     - postgres
   longhorn:
+    storageOverProvisioningPercentage: 200
     uiBindPort: 30880
     uiReplicaCount: 0
     version: 1.1.0
@@ -1032,7 +1033,7 @@ spec:
     describe("every option", () => {
       it(`=> service-cidr-range=/12 ...`, () => {
         const i = Installer.parse(everyOption);
-        expect(i.flags()).to.equal(`service-cidr-range=/12 service-cidr=100.1.1.1/12 ha=0 kuberenetes-master-address=192.168.1.1 load-balancer-address=10.128.10.1 container-log-max-size=256Ki container-log-max-files=4 bootstrap-token=token bootstrap-token-ttl=10min kubeadm-token-ca-hash=hash control-plane=0 cert-key=key bypass-storagedriver-warnings=0 hard-fail-on-loopback=0 no-ce-on-ee=0 docker-registry-ip=192.168.0.1 additional-no-proxy=129.168.0.2 no-docker=0 pod-cidr=39.1.2.3 pod-cidr-range=/12 disable-weave-encryption=0 storage-class-name=default ceph-replica-count=1 rook-block-storage-enabled=1 rook-block-device-filter=sd[a-z] rook-bypass-upgrade-warning=1 rook-hostpath-requires-privileged=1 openebs-namespace=openebs openebs-localpv-enabled=1 openebs-localpv-storage-class-name=default openebs-cstor-enabled=1 openebs-cstor-storage-class-name=cstor minio-namespace=minio minio-hostpath=/sentry contour-tls-minimum-protocol-version=1.3 contour-http-port=3080 contour-https-port=3443 registry-publish-port=20 fluentd-full-efk-stack=0 kotsadm-application-slug=sentry kotsadm-ui-bind-port=8800 kotsadm-hostname=1.1.1.1 kotsadm-application-namespaces=kots velero-namespace=velero velero-disable-cli=0 velero-disable-restic=0 velero-local-bucket=local velero-restic-requires-privileged=0 ekco-node-unreachable-toleration-duration=10m ekco-min-ready-master-node-count=3 ekco-min-ready-worker-node-count=1 ekco-should-disable-reboot-service=0 ekco-rook-should-use-all-nodes=0 airgap=0 hostname-check=2.2.2.2 ignore-remote-load-images-prompt=0 ignore-remote-upgrade-prompt=0 no-proxy=0 preflight-ignore=1 preflight-ignore-warnings=1 private-address=10.38.1.1 http-proxy=1.1.1.1 public-address=101.38.1.1 skip-system-package-install=0 exclude-builtin-preflights=0 bypass-firewalld-warning=0 hard-fail-on-firewalld=0 helmfile-spec=${helmfileSpec} longhorn-ui-bind-port=30880 longhorn-ui-replica-count=0`);
+        expect(i.flags()).to.equal(`service-cidr-range=/12 service-cidr=100.1.1.1/12 ha=0 kuberenetes-master-address=192.168.1.1 load-balancer-address=10.128.10.1 container-log-max-size=256Ki container-log-max-files=4 bootstrap-token=token bootstrap-token-ttl=10min kubeadm-token-ca-hash=hash control-plane=0 cert-key=key bypass-storagedriver-warnings=0 hard-fail-on-loopback=0 no-ce-on-ee=0 docker-registry-ip=192.168.0.1 additional-no-proxy=129.168.0.2 no-docker=0 pod-cidr=39.1.2.3 pod-cidr-range=/12 disable-weave-encryption=0 storage-class-name=default ceph-replica-count=1 rook-block-storage-enabled=1 rook-block-device-filter=sd[a-z] rook-bypass-upgrade-warning=1 rook-hostpath-requires-privileged=1 openebs-namespace=openebs openebs-localpv-enabled=1 openebs-localpv-storage-class-name=default openebs-cstor-enabled=1 openebs-cstor-storage-class-name=cstor minio-namespace=minio minio-hostpath=/sentry contour-tls-minimum-protocol-version=1.3 contour-http-port=3080 contour-https-port=3443 registry-publish-port=20 fluentd-full-efk-stack=0 kotsadm-application-slug=sentry kotsadm-ui-bind-port=8800 kotsadm-hostname=1.1.1.1 kotsadm-application-namespaces=kots velero-namespace=velero velero-disable-cli=0 velero-disable-restic=0 velero-local-bucket=local velero-restic-requires-privileged=0 ekco-node-unreachable-toleration-duration=10m ekco-min-ready-master-node-count=3 ekco-min-ready-worker-node-count=1 ekco-should-disable-reboot-service=0 ekco-rook-should-use-all-nodes=0 airgap=0 exclude-builtin-host-preflights=0 hostname-check=2.2.2.2 host-preflight-ignore=1 host-preflight-enforce-warnings=1 ignore-remote-load-images-prompt=0 ignore-remote-upgrade-prompt=0 no-proxy=0 private-address=10.38.1.1 http-proxy=1.1.1.1 public-address=101.38.1.1 skip-system-package-install=0 bypass-firewalld-warning=0 hard-fail-on-firewalld=0 helmfile-spec=repositories:\n- name: nginx-stable\n  url: https://helm.nginx.com/stable\nreleases:\n- name: test-nginx-ingress\n  chart: nginx-stable/nginx-ingress\n  values:\n  - controller:\n      service:\n        type: NodePort\n        httpPort:\n          nodePort: 30080\n        httpsPort:\n          nodePort: 30443\n longhorn-storage-over-provisioning-percentage=200 longhorn-ui-bind-port=30880 longhorn-ui-replica-count=0`);
       });
     });
   });


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes [SC-44630](https://app.shortcut.com/replicated/story/44630/can-t-add-host-preflights-through-the-api)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- Fixes false validation errors when creating a new installer with the fields `excludeBuiltinHostPreflights`,`hostPreflightIgnore`,`hostPreflightEnforceWarnings`, and/or `storageOverProvisioningPercentage`.
```

#### Does this PR require documentation?
NONE