### PR TITLE
sc-31335 disable profiling for scheduler, apiserver and controller-manager to …

### DIFF
--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -6,7 +6,9 @@ metadata:
 kubernetesVersion: v$KUBERNETES_VERSION
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
-controllerManager: {}
+controllerManager: 
+  extraArgs:
+    profiling: '"false"' 
 useHyperKubeImage: false
 dns:
   type: CoreDNS
@@ -21,5 +23,9 @@ apiServer:
   extraArgs:
     service-node-port-range: "80-60000"
     tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    profiling: '"false"'
   certSANs:
   - "$PRIVATE_ADDRESS"
+scheduler:
+  extraArgs:
+    profiling: '"false"'


### PR DESCRIPTION
#### What type of PR is this?
sc-31335

<!--
type::feature
-->

Tests
```
:~$ ps -ef | grep controller
root       14355   14236  1 22:09 ?        00:00:06 kube-controller-manager --authentication-kubeconfig=/etc/kubernetes/controller-manager.conf --authorization-kubeconfig=/etc/kubernetes/controller-manager.conf --bind-address=127.0.0.1 --client-ca-file=/etc/kubernetes/pki/ca.crt --cluster-name=kubernetes --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt --cluster-signing-key-file=/etc/kubernetes/pki/ca.key --controllers=*,bootstrapsigner,tokencleaner --kubeconfig=/etc/kubernetes/controller-manager.conf --leader-elect=true --port=0 --profiling=false --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --root-ca-file=/etc/kubernetes/pki/ca.crt --service-account-private-key-file=/etc/kubernetes/pki/sa.key --use-service-account-credentials=true

$ ps -ef | grep apiserver
root       14343   14220  7 22:09 ?        00:00:50 kube-apiserver --advertise-address=10.128.0.29 --allow-privileged=true --authorization-mode=Node,RBAC --client-ca-file=/etc/kubernetes/pki/ca.crt --enable-admission-plugins=NodeRestriction --enable-bootstrap-token-auth=true --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key --etcd-servers=https://127.0.0.1:2379 --insecure-port=0 --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --profiling=false --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --secure-port=6443 --service-account-key-file=/etc/kubernetes/pki/sa.pub --service-cluster-ip-range=10.96.0.0/22 --service-node-port-range=80-60000 --tls-cert-file=/etc/kubernetes/pki/apiserver.crt --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 --tls-private-key-file=/etc/kubernetes/pki/apiserver.key


$ ps -ef | grep scheduler
root       14395   14301  0 22:09 ?        00:00:03 kube-scheduler --authentication-kubeconfig=/etc/kubernetes/scheduler.conf --authorization-kubeconfig=/etc/kubernetes/scheduler.conf --bind-address=127.0.0.1 --kubeconfig=/etc/kubernetes/scheduler.conf --leader-elect=true --port=0 --profiling=false
jalaja     23958   18526  0 22:21 pts/0    00:00:00 grep --color=auto scheduler

```

-->
```release-note
Disable profiling for scheduler, apiserver and controller-manager in the specs to meet CIS compliance.
```

