### PR TITLE
Ensure that the --kubelet-certificate-authority argument is set as ap…

### DIFF
--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -24,7 +24,7 @@ apiServer:
     service-node-port-range: "80-60000"
     tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     profiling: '"false"'
-    kubelet-certificate-authority: '"/etc/kubernetes/pki/ca.crt"' 
+    kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
   certSANs:
   - "$PRIVATE_ADDRESS"
 scheduler:

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -24,6 +24,7 @@ apiServer:
     service-node-port-range: "80-60000"
     tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     profiling: '"false"'
+    kubelet-certificate-authority: '"/etc/kubernetes/pki/ca.crt"' 
   certSANs:
   - "$PRIVATE_ADDRESS"
 scheduler:


### PR DESCRIPTION
…propriate to meet CIS compliance

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
type::feature
SC-31335
-->

For reviewer
Refer:  https://docs.datadoghq.com/security_platform/default_rules/cis-kubernetes-1.5.1-1.2.6/

Tested output

```
Checked to make sure if the client cert is signed by the correct CA.crt 

# openssl verify -verbose -CAfile /etc/kubernetes/pki/ca.crt /etc/kubernetes/pki/apiserver-kubelet-client.crt
/etc/kubernetes/pki/apiserver-kubelet-client.crt: OK
```

```
$ ps -ef | grep apiserver
root      206120  206099 12 04:28 ?        00:00:23 kube-apiserver --advertise-address=10.128.0.29 --allow-privileged=true --authorization-mode=Node,RBAC --client-ca-file=/etc/kubernetes/pki/ca.crt --enable-admission-plugins=NodeRestriction --enable-bootstrap-token-auth=true --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key --etcd-servers=https://127.0.0.1:2379 --insecure-port=0 --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --profiling=false --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --secure-port=6443 --service-account-key-file=/etc/kubernetes/pki/sa.pub --service-cluster-ip-range=10.96.0.0/22 --service-node-port-range=80-60000 --tls-cert-file=/etc/kubernetes/pki/apiserver.crt --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 --tls-private-key-file=/etc/kubernetes/pki/apiserver.key

```

#### What this PR does / why we need it:



#### Special notes for your reviewer:

```release-note
Ensure that the --kubelet-certificate-authority argument is set for kube apiserver to meet CIS compliance

```

#### Does this PR require documentation?
<!--
NONE
-->
