### PR TITLE
CIS audit logging

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -184,7 +184,7 @@ function init() {
 
     # ensure that /etc/kubernetes/audit.yaml exists
     cp $kustomize_kubeadm_init/audit.yaml /etc/kubernetes/audit.yaml
-    mkdir -p /etc/kubernetes/auditlog
+    mkdir -p /var/log/apiserver
 
     set -o pipefail
     kubeadm init \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -184,6 +184,7 @@ function init() {
 
     # ensure that /etc/kubernetes/audit.yaml exists
     cp $kustomize_kubeadm_init/audit.yaml /etc/kubernetes/audit.yaml
+    mkdir -p /etc/kubernetes/auditlog
 
     set -o pipefail
     kubeadm init \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -182,6 +182,9 @@ function init() {
         mv -f /etc/kubernetes/pki/apiserver.key /tmp/
     fi
 
+    # ensure that /etc/kubernetes/audit.yaml exists
+    cp $kustomize_kubeadm_init/audit.yaml /etc/kubernetes/audit.yaml
+
     set -o pipefail
     kubeadm init \
         --ignore-preflight-errors=all \

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -75,6 +75,7 @@ function join() {
 
     # ensure that /etc/kubernetes/audit.yaml exists
     cp $kustomize_kubeadm_join/audit.yaml /etc/kubernetes/audit.yaml
+    mkdir -p /etc/kubernetes/auditlog
 
     set +e
     (set -x; kubeadm join --config /opt/replicated/kubeadm.conf --ignore-preflight-errors=all)

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -73,6 +73,9 @@ function join() {
     $DIR/bin/yamlutil -r -fp $KUBEADM_CONF_DIR/kubeadm_conf_copy_in -yp metadata
     mv $KUBEADM_CONF_DIR/kubeadm_conf_copy_in $KUBEADM_CONF_FILE
 
+    # ensure that /etc/kubernetes/audit.yaml exists
+    cp $kustomize_kubeadm_join/audit.yaml /etc/kubernetes/audit.yaml
+
     set +e
     (set -x; kubeadm join --config /opt/replicated/kubeadm.conf --ignore-preflight-errors=all)
     _status=$?

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -75,7 +75,7 @@ function join() {
 
     # ensure that /etc/kubernetes/audit.yaml exists
     cp $kustomize_kubeadm_join/audit.yaml /etc/kubernetes/audit.yaml
-    mkdir -p /etc/kubernetes/auditlog
+    mkdir -p /var/log/apiserver
 
     set +e
     (set -x; kubeadm join --config /opt/replicated/kubeadm.conf --ignore-preflight-errors=all)

--- a/scripts/kustomize/kubeadm/init-orig/audit.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata

--- a/scripts/kustomize/kubeadm/init-orig/audit.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/audit.yaml
@@ -1,4 +1,158 @@
-apiVersion: audit.k8s.io/v1beta1
+# derived from https://github.com/kubernetes/kubernetes/blob/7b5c718/cluster/gce/gci/configure-helper.sh#L1176
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
-- level: Metadata
+  # The following requests were manually identified as high-volume and low-risk,
+  # so drop them.
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints", "services", "services/status"]
+  - level: None
+    # Ingress controller reads 'configmaps/ingress-uid' through the unsecured port.
+    # TODO(#46983): Change this to the ingress controller service account.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics.k8s.io"
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+      - /swagger*
+  # Don't log events requests because of performance impact.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+  - level: Request
+    users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  - level: Request
+    userGroups: ["system:nodes"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  # deletecollection calls can be large, don't log responses for expected namespace deletions
+  - level: Request
+    users: ["system:serviceaccount:kube-system:namespace-controller"]
+    verbs: ["deletecollection"]
+    omitStages:
+      - "RequestReceived"
+  # Secrets, ConfigMaps, TokenRequest and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps", "serviceaccounts/token"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
+    omitStages:
+      - "RequestReceived"
+  # Get responses can be large; skip them.
+  - level: Request
+    verbs: ["get", "list", "watch"]
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for known APIs
+  - level: RequestResponse
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for all other requests.
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -24,21 +24,20 @@ apiServer:
     service-node-port-range: "80-60000"
     tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     profiling: '"false"'
-# TODO improve this
-    audit-log-path: /tmp/k8s-audit.log
+    audit-log-path: /auditlog/k8s-audit.log
     audit-policy-file: /etc/kubernetes/audit.yaml
-    audit-log-maxage: '"1"'
+    audit-log-maxage: '"3"'
     audit-log-maxsize: '"100"'
-    audit-log-maxbackup: '"1"'
+    audit-log-maxbackup: '"3"'
   extraVolumes:
     - name: audit
       hostPath: /etc/kubernetes/audit.yaml
       mountPath: /etc/kubernetes/audit.yaml
       readOnly: true
       pathType: File
-    - name: tmp
-      hostPath: /tmp
-      mountPath: /tmp
+    - name: auditlog
+      hostPath: /etc/kubernetes/auditlog
+      mountPath: /auditlog
       pathType: Directory
   certSANs:
   - "$PRIVATE_ADDRESS"

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -27,15 +27,19 @@ apiServer:
 # TODO improve this
     audit-log-path: /tmp/k8s-audit.log
     audit-policy-file: /etc/kubernetes/audit.yaml
-    audit-log-maxage: "1"
-    audit-log-maxsize: "100"
-    audit-log-maxbackup: "1"
+    audit-log-maxage: '"1"'
+    audit-log-maxsize: '"100"'
+    audit-log-maxbackup: '"1"'
   extraVolumes:
     - name: audit
       hostPath: /etc/kubernetes/audit.yaml
       mountPath: /etc/kubernetes/audit.yaml
       readOnly: true
       pathType: File
+    - name: tmp
+      hostPath: /tmp
+      mountPath: /tmp
+      pathType: Directory
   certSANs:
   - "$PRIVATE_ADDRESS"
 scheduler:

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -24,6 +24,18 @@ apiServer:
     service-node-port-range: "80-60000"
     tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     profiling: '"false"'
+# TODO improve this
+    audit-log-path: /tmp/k8s-audit.log
+    audit-policy-file: /etc/kubernetes/audit.yaml
+    audit-log-maxage: "1"
+    audit-log-maxsize: "100"
+    audit-log-maxbackup: "1"
+  extraVolumes:
+    - name: audit
+      hostPath: /etc/kubernetes/audit.yaml
+      mountPath: /etc/kubernetes/audit.yaml
+      readOnly: true
+      pathType: File
   certSANs:
   - "$PRIVATE_ADDRESS"
 scheduler:

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-cluster-config-v1beta2.yml
@@ -36,7 +36,7 @@ apiServer:
       readOnly: true
       pathType: File
     - name: auditlog
-      hostPath: /etc/kubernetes/auditlog
+      hostPath: /var/log/apiserver
       mountPath: /auditlog
       pathType: Directory
   certSANs:

--- a/scripts/kustomize/kubeadm/join-orig/audit.yaml
+++ b/scripts/kustomize/kubeadm/join-orig/audit.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata

--- a/scripts/kustomize/kubeadm/join-orig/audit.yaml
+++ b/scripts/kustomize/kubeadm/join-orig/audit.yaml
@@ -1,4 +1,158 @@
-apiVersion: audit.k8s.io/v1beta1
+# derived from https://github.com/kubernetes/kubernetes/blob/7b5c718/cluster/gce/gci/configure-helper.sh#L1176
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
-- level: Metadata
+  # The following requests were manually identified as high-volume and low-risk,
+  # so drop them.
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints", "services", "services/status"]
+  - level: None
+    # Ingress controller reads 'configmaps/ingress-uid' through the unsecured port.
+    # TODO(#46983): Change this to the ingress controller service account.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes", "nodes/status"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  - level: None
+    users: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps", "endpoints"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics.k8s.io"
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+      - /swagger*
+  # Don't log events requests because of performance impact.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+  # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
+  - level: Request
+    users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  - level: Request
+    userGroups: ["system:nodes"]
+    verbs: ["update","patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes/status", "pods/status"]
+    omitStages:
+      - "RequestReceived"
+  # deletecollection calls can be large, don't log responses for expected namespace deletions
+  - level: Request
+    users: ["system:serviceaccount:kube-system:namespace-controller"]
+    verbs: ["deletecollection"]
+    omitStages:
+      - "RequestReceived"
+  # Secrets, ConfigMaps, TokenRequest and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps", "serviceaccounts/token"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
+    omitStages:
+      - "RequestReceived"
+  # Get responses can be large; skip them.
+  - level: Request
+    verbs: ["get", "list", "watch"]
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for known APIs
+  - level: RequestResponse
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "metrics.k8s.io"
+      - group: "networking.k8s.io"
+      - group: "node.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
+      - group: "storage.k8s.io"
+    omitStages:
+      - "RequestReceived"
+  # Default level for all other requests.
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This will enable audit logging for k8s, using a policy derived from https://github.com/kubernetes/kubernetes/blob/7b5c718/cluster/gce/gci/configure-helper.sh#L1176. 

Log files will be stored for at most three days, and may be 100MB in size (x3 for three files).

This PR stores logs in `/var/log/apiserver`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
kURL will now enable k8s audit logging, storing logs within `/var/log/apiserver`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
