### PR TITLE
create an etcd user and group, and ensure it owns /var/lib/etcd for CIS compliance

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,7 +223,12 @@ function init() {
         new_admission_plugins='--enable-admission-plugins=NodeRestriction,PodSecurityPolicy'
         sed -i "s%$old_admission_plugins%$new_admission_plugins%g"  /etc/kubernetes/manifests/kube-apiserver.yaml
         spinner_kubernetes_api_stable
-    fi 
+
+        # create an 'etcd' user and group and ensure that it owns the etcd data directory (we don't care what userid these have, as etcd will still run as root)
+        useradd etcd || true
+        groupadd etcd || true
+        chown -R etcd:etcd /var/lib/etcd
+    fi
 
     wait_for_nodes
     enable_rook_ceph_operator

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -89,6 +89,14 @@ function join() {
 
     if [ "$MASTER" = "1" ]; then
         exportKubeconfig
+
+        if [ "$CIS_COMPLIANCE" == "1" ]; then
+            # create an 'etcd' user and group and ensure that it owns the etcd data directory (we don't care what userid these have, as etcd will still run as root)
+            useradd etcd || true
+            groupadd etcd || true
+            chown -R etcd:etcd /var/lib/etcd
+        fi
+
         logSuccess "Master node joined successfully"
     else
         logSuccess "Node joined successfully"


### PR DESCRIPTION
I'm leaving this in the 'CIS Compliance only' section for the moment until we're sure we want to just create users/groups for people.

...and until I'm sure that it actually was that simple, and I don't need to use a static userid for etcd somehow. Or change the etcd pod manifest. Or much of anything, really.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Ensure that /var/lib/etcd is owned by etcd:etcd for CIS compliance.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
