### PR TITLE
Enable kubelet to use pki based cacert instead of self-signed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -275,6 +275,11 @@ function init() {
     labelNodes
     kubectl cluster-info
 
+    #approve csrs on the masters if cis compliance is enabled
+    if [ "$CIS_COMPLIANCE" == "1" ]; then
+        kubectl get csr | grep 'Pending' | grep 'kubelet-serving' | awk '{ print $1 }' | xargs -I {} kubectl certificate approve {}
+    fi
+
     # create kurl namespace if it doesn't exist
     kubectl get ns kurl 2>/dev/null 1>/dev/null || kubectl create ns kurl 1>/dev/null
 

--- a/scripts/kustomize/kubeadm/init-orig/patch-cluster-config-cis-compliance.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/patch-cluster-config-cis-compliance.yaml
@@ -6,3 +6,4 @@ apiServer:
   extraArgs:
     enable-admission-plugins: NodeRestriction
     insecure-port: '"0"'
+    kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt

--- a/scripts/kustomize/kubeadm/init-orig/patch-kubelet-cis-compliance.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/patch-kubelet-cis-compliance.yaml
@@ -3,3 +3,4 @@ kind: KubeletConfiguration
 metadata:
   name: kubelet-configuration
 protectKernelDefaults: true
+serverTLSBootstrap: true


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #
SC-31335

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
-->
```release-note
Enable kubelet to use pki based cacert instead of self-signed
```

