### PR TITLE
do not attempt to change existing velero-internal-snapshots PVCs

### DIFF
--- a/addons/velero/1.7.1/install.sh
+++ b/addons/velero/1.7.1/install.sh
@@ -359,9 +359,11 @@ function velero_patch_internal_pvc_snapshots() {
         export VELERO_PVC_STORAGE_CLASS="longhorn"
     fi
 
-    # create the PVC
-    render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
-    insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+    # create the PVC if it does not already exist
+    if (! kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots ) ; then
+          render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
+          insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+    fi
 
     # add patch to add the pvc in the correct location for the velero deployment
     render_yaml_file "$src/tmpl-internal-snaps-deployment-patch.yaml" > "$dst/internal-snaps-deployment-patch.yaml"

--- a/addons/velero/template/base/install.sh.tmpl
+++ b/addons/velero/template/base/install.sh.tmpl
@@ -359,9 +359,11 @@ function velero_patch_internal_pvc_snapshots() {
         export VELERO_PVC_STORAGE_CLASS="longhorn"
     fi
 
-    # create the PVC
-    render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
-    insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+    # create the PVC if it does not already exist
+    if (! kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots ) ; then
+          render_yaml_file "$src/tmpl-internal-snaps-pvc.yaml" > "$dst/internal-snaps-pvc.yaml"
+          insert_resources "$dst/kustomization.yaml" internal-snaps-pvc.yaml
+    fi
 
     # add patch to add the pvc in the correct location for the velero deployment
     render_yaml_file "$src/tmpl-internal-snaps-deployment-patch.yaml" > "$dst/internal-snaps-deployment-patch.yaml"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

This PR prevents the velero addon from attempting to reapply the velero-internal-snapshots if it already exists, because PVCs are immutable and so any real change will just result in an installer error.

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
