### PR TITLE
Allow the user to specify system-reserved resources

### DIFF
--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -218,6 +218,7 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 		"Kubernetes.S3Override":                      "SERVICE_S3_OVERRIDE",
 		"Kubernetes.ServiceCIDR":                     "SERVICE_CIDR",
 		"Kubernetes.ServiceCidrRange":                "SERVICE_CIDR_RANGE",
+		"Kubernetes.SystemReservedResources":         "SYSTEM_RESERVED",
 		"Kubernetes.UseStandardNodePortRange":        "USE_STANDARD_PORT_RANGE",
 		"Kubernetes.Version":                         "KUBERNETES_VERSION",
 		"Kurl.AdditionalNoProxyAddresses":            "ADDITIONAL_NO_PROXY_ADDRESSES",

--- a/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/kurlkinds/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -284,6 +284,8 @@ spec:
                     type: string
                   serviceCidrRange:
                     type: string
+                  systemReservedResources:
+                    type: string
                   useStandardNodePortRange:
                     type: boolean
                   version:

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -110,6 +110,7 @@ type Kubernetes struct {
 	UseStandardNodePortRange bool   `json:"useStandardNodePortRange,omitempty" yaml:"useStandardNodePortRange,omitempty"`
 	KubernetesReserved       bool   `json:"kubernetesReserved,omitempty" yaml:"kubernetesReserved,omitempty"`
 	EvictionThreshold        string `json:"evictionThreshold,omitempty" yaml:"evictionThreshold,omitempty"`
+	SystemReservedResources  string `json:"systemReservedResources,omitempty" yaml:"systemReservedResources,omitempty"`
 	Version                  string `json:"version" yaml:"version"`
 	CisCompliance            bool   `json:"cisCompliance,omitempty" yaml:"cisCompliance,omitempty"`
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,6 +141,13 @@ function init() {
 
         render_yaml_file $kustomize_kubeadm_init/patch-kubelet-eviction-threshold.tpl > $kustomize_kubeadm_init/patch-kubelet-eviction-threshold.yaml
     fi
+    if [ -n "$SYSTEM_RESERVED" ]; then
+        insert_patches_strategic_merge \
+            $kustomize_kubeadm_init/kustomization.yaml \
+            patch-kubelet-system-reserved.yaml
+
+        render_yaml_file $kustomize_kubeadm_init/patch-kubelet-system-reserved.tpl > $kustomize_kubeadm_init/patch-kubelet-system-reserved.yaml
+    fi
 
     if [ -n "$CONTAINER_LOG_MAX_SIZE" ]; then
         insert_patches_strategic_merge \

--- a/scripts/kustomize/kubeadm/init-orig/patch-kubelet-system-reserved.tpl
+++ b/scripts/kustomize/kubeadm/init-orig/patch-kubelet-system-reserved.tpl
@@ -1,0 +1,5 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+metadata:
+  name: kubelet-configuration
+systemReserved: $SYSTEM_RESERVED

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -208,6 +208,7 @@
       version: "1.23.x"
       kubernetesReserved: true
       evictionThreshold: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
+      systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
     containerd:
       version: "latest"
     weave:
@@ -219,3 +220,7 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep -A 4 evictionHard
     sudo cat /var/lib/kubelet/config.yaml | grep "memory.available: 234Mi"
+    sudo cat /var/lib/kubelet/config.yaml | grep -A 4 systemReserved
+    sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
+    sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
+    sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1165,13 +1165,19 @@
       version: "1.23.x"
       kubernetesReserved: true
       evictionThreshold: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
+      systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
     containerd:
       version: "latest"
     weave:
       version: "latest"
   postInstallScript: |
+    set -eo pipefail
     echo "validating kubelet config contains reserved resources"
     sudo cat /var/lib/kubelet/config.yaml | grep -A 4 kubeReserved
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep -A 4 evictionHard
     sudo cat /var/lib/kubelet/config.yaml | grep "memory.available: 234Mi"
+    sudo cat /var/lib/kubelet/config.yaml | grep -A 4 systemReserved
+    sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
+    sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
+    sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -36,6 +36,7 @@ export interface KubernetesConfig {
   certKey?: string;
   kubernetesReserved?: boolean;
   evictionThreshold?: string;
+  systemReservedResources?: string;
 }
 
 export const kubernetesConfigSchema = {
@@ -59,6 +60,7 @@ export const kubernetesConfigSchema = {
     cisCompliance: { type: "boolean", flag: "kubernetes-cis-compliance", description: "Indicates if this install should meet all CIS compliance requirements" },
     kubernetesReserved: {type: "boolean", flag: "kubernetes-reserved", description: "Reserved CPU, memory and disk for kubernetes"},
     evictionThreshold: { type: "string", flag: "eviction-threshold", description: "Provided as eviction-threshold to kubelet configuration as described in https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration" },
+    systemReservedResources: { type: "string", flag: "system-reserved-resources", description: "Provided as system-reserved to kubelet configuration as described in https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration" },
   },
   required: [ "version" ],
   additionalProperties: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
This PR allows kURL specs to specify kubernetes system reserved resources, which are laid out [here](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved). The format is a map of strings to resource values, as described in the systemReserved section [here](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Allow specifying system-reserved resources
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
to-be-written
