### PR TITLE
Fixes an issue where migrating from Docker to Containerd was failing when upgrading two minor kubernetes versions at the same time.

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -113,6 +113,10 @@ function main() {
     download_util_binaries
     get_machine_id
     merge_yaml_specs
+    # Parse yaml into bash variables so we can get final kubernetes version for cases where we are upgrading 2 minor versions
+    # Must run this prior to applying bash flag overrides since kubernetes-version gets overwritten on CLI to enforce single step minor upgrades
+    parse_yaml_into_bash_variables
+    local finalK8sVersion=${KUBERNETES_VERSION}
     apply_bash_flag_overrides "$@"
     parse_yaml_into_bash_variables
     parse_kubernetes_target_version
@@ -131,7 +135,26 @@ function main() {
     ${K8S_DISTRO}_addon_for_each addon_join
     outro
     package_cleanup
-    uninstall_docker
+
+    local kubeletVersion=
+    kubeletVersion="$(kubelet_version)"
+
+    semverParse "$kubeletVersion"
+    local kubeletMinor="$minor"
+    local kubeletPatch="$patch"
+
+    semverParse "$finalK8sVersion"
+    local finalMinor="$minor"
+    local finalPatch="$patch"
+
+    if [ "$kubeletMinor" -eq "$finalMinor" ] && [ "$kubeletPatch" -eq "$finalPatch" ] && [ "$HA_CLUSTER" = "1" ]; then 
+    # Docker was being uninstalled on the first upgrade attempt which caused kubeadm to fail in a HA scenario.
+    # This was because kubeadm on the nodes being upgraded would see the dockershim.sock file on the node set as
+    # the load balancer, and would attempt to use docker on machines where it had already been uninstalled.
+        uninstall_docker
+    elif [ "$HA_CLUSTER" != "1" ]; then
+        uninstall_docker
+    fi
 
     popd_install_directory
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
Delay uninstallation of docker in HA cluster until nodes are fully upgraded.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/replicated-collab/swimlane-replicated/issues/248
https://github.com/replicated-collab/swimlane-support/issues/19

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where migrating from Docker to Containerd was failing when upgrading two minor kubernetes versions at the same time.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
