### PR TITLE
Upgrade pvmigrate to v0.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
-	github.com/replicatedhq/pvmigrate v0.4.2
+	github.com/replicatedhq/pvmigrate v0.4.3
 	github.com/replicatedhq/troubleshoot v0.28.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1274,6 +1274,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/replicatedhq/pvmigrate v0.4.2 h1:mR0ZXMpscfvHZaPhp3i5BC8co+zXhspMctRUO7E5SxM=
 github.com/replicatedhq/pvmigrate v0.4.2/go.mod h1:aZKHDuup3W29uYaLmu1LjYAIn6yORCGAuTCJV1zkr9U=
+github.com/replicatedhq/pvmigrate v0.4.3 h1:S+fQuw55n+VdwD/XjPuEYe98ryKMeIq0pD9QqsXPHvY=
+github.com/replicatedhq/pvmigrate v0.4.3/go.mod h1:aZKHDuup3W29uYaLmu1LjYAIn6yORCGAuTCJV1zkr9U=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.28.0 h1:0B7ibyxur/ao1+PSQPLh2GnjonIfUxUXoiwaoGSXMag=
 github.com/replicatedhq/troubleshoot v0.28.0/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Upgrades pvmigrate to v0.4.3 to fix a nil pointer dereference issue

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue where persistent volume migrations were sometimes failing due to a nil pointer dereference.
```

#### Does this PR require documentation?
NONE
