### PR TITLE
Fix containerd migrate from docker on airgapped server

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.3.7/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.3.7/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.3.9/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.3.9/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.10/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.10/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.11/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.11/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.12/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.12/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.13/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.13/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.3/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.3/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.4/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.4/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.6/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.6/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.8/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.8/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -1,5 +1,7 @@
 
 CONTAINERD_NEEDS_RESTART=0
+CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -43,6 +45,12 @@ function containerd_install() {
         systemctl daemon-reload
         restart_systemd_and_wait containerd
         CONTAINERD_NEEDS_RESTART=0
+    fi
+
+    if [ "$AIRGAP" = "1" ] && [ "$CONTAINERD_DID_MIGRATE_FROM_DOCKER" = "1" ]; then
+        logStep "Migrating images from Docker to Containerd..."
+        containerd_migrate_images_from_docker
+        logSuccess "Images migrated successfully"
     fi
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
@@ -178,4 +186,46 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
+
+    CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
+}
+
+function containerd_can_migrate_images_from_docker() {
+    local images_kb="$(du -d0 -c /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+    local available_kb="$(df --output=avail /var/lib/containerd/ | awk 'NR > 1')"
+
+    if [ -z "$images_kb" ]; then
+        logWarn "Unable to determine size of Docker images"
+        return 0
+    elif [ -z "$available_kb" ]; then
+        logWarn "Unable to determine available disk space"
+        return 0
+    else
+        local images_kb_x2="$(expr $images_kb + $images_kb)"
+        if [ "$available_kb" -lt "$images_kb_x2" ]; then
+            local images_human="$(du -d0 -ch /var/lib/docker/overlay2 | grep total | awk '{print $1}')"
+            local available_human="$(df --output=avail -h /var/lib/containerd/ | awk 'NR > 1' | xargs)"
+            logFail "There is not enough available disk space (${available_human}) to migrate images (${images_human}) from Docker to Containerd."
+            logFail "Please make sure there is at least 2 x size of Docker images available disk space."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+function containerd_migrate_images_from_docker() {
+    if ! containerd_can_migrate_images_from_docker ; then
+        exit 1
+    fi
+
+    local tmpdir="$(mktemp -d)"
+    local imagefile=
+    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>'); do
+        imagefile="${tmpdir}/$(echo $image | tr -cd '[:alnum:]').tar"
+        (set -x; docker save $image -o "$imagefile")
+    done
+    for image in $tmpdir/* ; do
+        (set -x; ctr -n=k8s.io images import $image)
+    done
+    rm -rf "$tmpdir"
 }

--- a/addons/containerd/1.4.9/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/1.4.9/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -2,6 +2,24 @@
 CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
+function containerd_pre_init() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
+        cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
+    fi
+}
+
+function containerd_join() {
+    local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
+
+    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
+    if [ -d "$DIR/kustomize/kubeadm/join-patches" ]; then
+        cp "$src/kubeadm-join-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/join-patches/containerd-kubeadm-join-config-v1beta2.yml"
+    fi
+}
+
 function containerd_install() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -51,11 +69,6 @@ function containerd_install() {
         logStep "Migrating images from Docker to Containerd..."
         containerd_migrate_images_from_docker
         logSuccess "Images migrated successfully"
-    fi
-
-    # Explicitly configure kubelet to use containerd instead of detecting dockershim socket
-    if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
-        cp "$DIR/addons/containerd/$CONTAINERD_VERSION/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then

--- a/addons/containerd/template/base/kubeadm-join-config-v1beta2.yaml
+++ b/addons/containerd/template/base/kubeadm-join-config-v1beta2.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    container-runtime: remote
+    container-runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -39,3 +39,72 @@
       version: "latest"
     rook:
       version: "latest"
+- name: "Migrate from Docker to Containerd"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "Migrate from Docker to Containerd airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -91,7 +91,7 @@
       s3Override: "__testdist__"
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
     velero:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -23,7 +23,7 @@
       version: "latest"
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
@@ -68,7 +68,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
     velero:

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -375,8 +375,7 @@ function report_install_docker() {
 }
 
 function report_install_containerd() {
-    containerd_get_host_packages_online "$CONTAINERD_VERSION"
-    addon_install containerd "$CONTAINERD_VERSION"
+    addon_install "containerd" "$CONTAINERD_VERSION"
 }
 
 function load_images() {

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -186,19 +186,6 @@ function docker_get_host_packages_online() {
     fi
 }
 
-function containerd_get_host_packages_online() {
-    local version="$1"
-
-    if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
-        rm -rf $DIR/packages/containerd/${version} # Cleanup broken/incompatible packages from failed runs
-
-        local package="containerd-${version}.tar.gz"
-        package_download "${package}" $CONTAINERD_S3_OVERRIDE
-        tar xf "$(package_filepath "${package}")"
-        # rm containerd-${version}.tar.gz
-    fi
-}
-
 function canonical_image_name() {
     local image="$1"
     if echo "$image" | grep -vq '/' ; then

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -83,7 +83,8 @@ function upgrade_kubernetes_local_master_patch() {
     kubernetes_drain "$node"
  
     spinner_kubernetes_api_stable
-    kubeadm upgrade apply "v$k8sVersion" --yes --force
+    # ignore-preflight-errors, do not fail on fail to pull images for airgap
+    kubeadm upgrade apply "v$k8sVersion" --yes --force --ignore-preflight-errors=all
 
     kubernetes_install_host_packages "$k8sVersion"
     systemctl daemon-reload
@@ -182,7 +183,8 @@ function upgrade_kubernetes_local_master_minor() {
     kubernetes_drain "$node"
 
     spinner_kubernetes_api_stable
-    kubeadm upgrade apply "v$k8sVersion" --yes --force
+    # ignore-preflight-errors, do not fail on fail to pull images for airgap
+    kubeadm upgrade apply "v$k8sVersion" --yes --force --ignore-preflight-errors=all
     upgrade_etcd_image_18 "$k8sVersion"
 
     kubernetes_install_host_packages "$k8sVersion"

--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -35,12 +35,8 @@ function kubeadm_get_server_ca_key() {
 function kubeadm_addon_for_each() {
     local cmd="$1"
 
-    if [ "$cmd" = "addon_pre_init" ] || [ "$cmd" = "addon_join" ]; then
-        if [ -n "$DOCKER_VERSION" ] ; then
-            $cmd docker "$DOCKER_VERSION"
-        elif [ -n "$CONTAINERD_VERSION" ]; then
-            $cmd containerd "$CONTAINERD_VERSION"
-        fi
+    if [ "$cmd" != "addon_install" ]; then # this is run in install_cri
+        $cmd containerd "$CONTAINERD_VERSION"
     fi
     $cmd aws "$AWS_VERSION"
     $cmd nodeless "$NODELESS_VERSION"

--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -35,6 +35,13 @@ function kubeadm_get_server_ca_key() {
 function kubeadm_addon_for_each() {
     local cmd="$1"
 
+    if [ "$cmd" = "addon_pre_init" ] || [ "$cmd" = "addon_join" ]; then
+        if [ -n "$DOCKER_VERSION" ] ; then
+            $cmd docker "$DOCKER_VERSION"
+        elif [ -n "$CONTAINERD_VERSION" ]; then
+            $cmd containerd "$CONTAINERD_VERSION"
+        fi
+    fi
     $cmd aws "$AWS_VERSION"
     $cmd nodeless "$NODELESS_VERSION"
     $cmd calico "$CALICO_VERSION" "$CALICO_S3_OVERRIDE"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -149,11 +149,11 @@ function main() {
     configure_no_proxy
     ${K8S_DISTRO}_addon_for_each addon_fetch
     host_preflights "${MASTER:-0}" "1" "0"
-    install_cri
-    get_common
-    get_shared
-    setup_kubeadm_kustomize
     install_host_dependencies
+    get_common
+    setup_kubeadm_kustomize
+    install_cri
+    get_shared
     ${K8S_DISTRO}_addon_for_each addon_join
     helm_load
     kubernetes_host

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -127,12 +127,13 @@ function main() {
     configure_no_proxy
     ${K8S_DISTRO}_addon_for_each addon_fetch
     host_preflights "${MASTER:-0}" "1" "1"
-    install_cri
-    get_common
-    get_shared
-    maybe_upgrade
     install_host_dependencies
+    get_common
+    setup_kubeadm_kustomize
+    install_cri
+    get_shared
     ${K8S_DISTRO}_addon_for_each addon_join
+    maybe_upgrade
     outro
     package_cleanup
 

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -893,6 +893,8 @@
       version: latest
     registry:
       version: latest
+    ekco:
+      version: latest
     kotsadm:
       version: latest
       disableS3: true
@@ -906,6 +908,8 @@
     longhorn:
       version: latest
     registry:
+      version: latest
+    ekco:
       version: latest
     kotsadm:
       version: latest
@@ -922,6 +926,8 @@
       version: latest
     registry:
       version: latest
+    ekco:
+      version: latest
     kotsadm:
       version: latest
       disableS3: true
@@ -935,6 +941,8 @@
     longhorn:
       version: latest
     registry:
+      version: latest
+    ekco:
       version: latest
     kotsadm:
       version: latest

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -802,7 +802,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
     velero:
@@ -970,7 +970,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: 1.4.x
     velero:
@@ -1003,7 +1003,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: 1.4.x
     velero:
@@ -1113,7 +1113,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: 1.4.x
     velero:
@@ -1146,7 +1146,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: 1.4.x
     velero:
@@ -1164,7 +1164,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
   upgradeSpec:
@@ -1178,7 +1178,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
 - name: "Upgrade to 1.23 minimal airgap"
@@ -1193,7 +1193,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
   upgradeSpec:
@@ -1207,7 +1207,7 @@
       version: latest
     kotsadm:
       version: latest
-      s3Disabled: true
+      disableS3: true
     containerd:
       version: latest
   airgap: true

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -883,6 +883,65 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-1604
+- name: "Migrate from Docker to Containerd"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest
+- name: "Migrate from Docker to Containerd airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest
+  airgap: true
 - name: "Upgrade to 1.22"
   installerSpec:
     kubernetes:
@@ -896,8 +955,8 @@
       version: latest
     kotsadm:
       version: latest
-    containerd:
-      version: 1.4.x
+    docker:
+      version: 19.03.x
     velero:
       version: 1.6.x
   upgradeSpec:
@@ -916,6 +975,40 @@
       version: 1.4.x
     velero:
       version: 1.7.x
+- name: "Upgrade to 1.22 airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.20.x
+    weave:
+      version: latest
+    rook:
+      isBlockStorageEnabled: true
+      version: 1.5.x
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: 19.03.x
+    velero:
+      version: 1.6.x
+  upgradeSpec:
+    kubernetes:
+      version: 1.22.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: 1.4.x
+    velero:
+      version: 1.7.x
+  airgap: true
 - name: "K8s 1.23x Rook"
   installerSpec:
     kubernetes:
@@ -1005,8 +1098,8 @@
       version: latest
     kotsadm:
       version: latest
-    containerd:
-      version: 1.4.x
+    docker:
+      version: 20.10.x
     velero:
       version: 1.6.x
   upgradeSpec:
@@ -1025,6 +1118,99 @@
       version: 1.4.x
     velero:
       version: 1.7.x
+- name: "Upgrade to 1.23 airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.21.x
+    weave:
+      version: latest
+    rook:
+      isBlockStorageEnabled: true
+      version: 1.5.x
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: 20.10.x
+    velero:
+      version: 1.6.x
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: 1.4.x
+    velero:
+      version: 1.7.x
+  airgap: true
+- name: "Upgrade to 1.23 minimal"
+  installerSpec:
+    kubernetes:
+      version: 1.22.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: latest
+- name: "Upgrade to 1.23 minimal airgap"
+  installerSpec:
+    kubernetes:
+      version: 1.22.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      s3Disabled: true
+    containerd:
+      version: latest
+  airgap: true
 - name: k8s121-with-flags
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Fixes 3 issues:

- Airgapped migration from docker to containerd fails because of missing images
- Docker to containerd migration fails and reverts back to docker if script fails after migration but before removal of docker
- Airgapped Kubernetes upgrade fails with image pull errors from kubeadm

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:

I backported the changes from the template to most older containerd addon versions. You can just review the template.

Tests are failing because there are some changes outside of the add-on that do not get run as part of the pr test.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue causing a migration from Containerd to Docker to fail on airgapped instances with image pull errors.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE