### PR TITLE
Kube-apiserver fails to start after docker to containerd migration, overridden pause image missing

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -71,6 +71,8 @@ function containerd_install() {
         logSuccess "Images migrated successfully"
     fi
 
+    load_images $src/images
+
     if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
         systemctl start kubelet
         # If using the internal load balancer the Kubernetes API server will be unavailable until
@@ -78,8 +80,6 @@ function containerd_install() {
         # is available before proceeeding.
         try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes
     fi
-
-    load_images $src/images
 }
 
 function containerd_configure() {

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -199,7 +199,6 @@ function containerd_migrate_from_docker() {
     containerdFlags="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
     sed -i "s@\(KUBELET_KUBEADM_ARGS=\".*\)\"@\1 $containerdFlags\" @" /var/lib/kubelet/kubeadm-flags.env
     systemctl daemon-reload
-}
 
     CONTAINERD_DID_MIGRATE_FROM_DOCKER=1
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug

#### What this PR does / why we need it:

Containerd overrides k8s pause image with 3.2. In scenario where containerd is migrated to docker must load the pause image or control plane cannot start.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
I think this is covered by release note here https://github.com/replicatedhq/kURL/pull/2855

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE