### PR TITLE
Add missing NoExecute toleration to weave

### DIFF
--- a/addons/weave/2.5.2/daemonset.yaml
+++ b/addons/weave/2.5.2/daemonset.yaml
@@ -88,6 +88,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
         - name: weavedb
           hostPath:

--- a/addons/weave/2.6.4/daemonset.yaml
+++ b/addons/weave/2.6.4/daemonset.yaml
@@ -90,6 +90,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
         - name: weavedb
           hostPath:

--- a/addons/weave/2.6.5/daemonset.yaml
+++ b/addons/weave/2.6.5/daemonset.yaml
@@ -90,6 +90,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
         - name: weavedb
           hostPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Weave add-on versions are failing certified conformance testing.

```
[sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]
```

Weave is getting evicted which is causing error:

```
$ kubectl -n taint-multiple-pods-4684  describe pod taint-eviction-b1

  Warning  FailedKillPod  1s (x8 over 68s)  kubelet            error killing pod: failed to "KillPodSandbox" for "ea07d094-fdad-499d-84e7-82ad6d5e31bc" with KillPodSandboxError: "rpc error: code = Unknown desc = failed to destroy network for sandbox \"7c3b3b93172878ca18c4025d13b2ef831c82871dcb846cca47c9ed49a44e9b92\": Delete http://127.0.0.1:6784/ip/7c3b3b93172878ca18c4025d13b2ef831c82871dcb846cca47c9ed49a44e9b92: dial tcp 127.0.0.1:6784: connect: connection refused"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
curl -sSL https://k8s.kurl.sh/cncf-conformance | sudo bash
```

```
./sonobuoy run  --e2e-focus="NoExecuteTaintManager Multiple Pods \[Serial\] evicts pods with minTolerationSeconds \[Disruptive\] \[Conformance\]" --e2e-skip=''
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Added NoExecute toleration to Weave-Net DaemonSet for versions 2.6.5, 2.6.4 and 2.5.2.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
