### PR TITLE
Ensure openebs runs with critical priority

### DIFF
--- a/addons/openebs/1.12.0/cstor-provisioner.yaml
+++ b/addons/openebs/1.12.0/cstor-provisioner.yaml
@@ -26,6 +26,7 @@ spec:
         openebs.io/component-name: openebs-provisioner
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner

--- a/addons/openebs/1.12.0/localpv-provisioner.yaml
+++ b/addons/openebs/1.12.0/localpv-provisioner.yaml
@@ -21,6 +21,7 @@ spec:
         openebs.io/component-name: openebs-localpv-provisioner
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner-hostpath

--- a/addons/openebs/1.12.0/ndm.yaml
+++ b/addons/openebs/1.12.0/ndm.yaml
@@ -59,6 +59,7 @@ spec:
         openebs.io/component-name: ndm
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-node-critical
       serviceAccountName: openebs-maya-operator
       hostNetwork: true
       containers:

--- a/addons/openebs/1.12.0/operator.yaml
+++ b/addons/openebs/1.12.0/operator.yaml
@@ -97,6 +97,7 @@ spec:
         openebs.io/component-name: maya-apiserver
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
@@ -209,6 +210,7 @@ spec:
         openebs.io/component-name: admission-webhook
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
@@ -260,6 +262,7 @@ spec:
         openebs.io/component-name: ndm-operator
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator

--- a/addons/openebs/1.12.0/snapshot-operator.yaml
+++ b/addons/openebs/1.12.0/snapshot-operator.yaml
@@ -26,6 +26,7 @@ spec:
         openebs.io/component-name: openebs-snapshot-operator
         openebs.io/version: 1.12.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-snapshot-controller

--- a/addons/openebs/1.6.0/cstor-provisioner.yaml
+++ b/addons/openebs/1.6.0/cstor-provisioner.yaml
@@ -22,6 +22,7 @@ spec:
         openebs.io/component-name: openebs-provisioner
         openebs.io/version: 1.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner

--- a/addons/openebs/1.6.0/localpv-provisioner.yaml
+++ b/addons/openebs/1.6.0/localpv-provisioner.yaml
@@ -21,6 +21,7 @@ spec:
         openebs.io/component-name: openebs-localpv-provisioner
         openebs.io/version: 1.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner-hostpath

--- a/addons/openebs/1.6.0/ndm.yaml
+++ b/addons/openebs/1.6.0/ndm.yaml
@@ -68,6 +68,7 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       #nodeSelector:
       #  "openebs.io/nodegroup": "storage-node"
+      priorityClassName: system-node-critical
       serviceAccountName: openebs-maya-operator
       hostNetwork: true
       containers:

--- a/addons/openebs/1.6.0/operator.yaml
+++ b/addons/openebs/1.6.0/operator.yaml
@@ -109,6 +109,7 @@ spec:
         openebs.io/component-name: maya-apiserver
         openebs.io/version: 1.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
@@ -269,6 +270,7 @@ spec:
         openebs.io/component-name: admission-webhook
         openebs.io/version: 1.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
@@ -310,6 +312,7 @@ spec:
         openebs.io/component-name: ndm-operator
         openebs.io/version: 1.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator

--- a/addons/openebs/2.6.0/cstor-provisioner.yaml
+++ b/addons/openebs/2.6.0/cstor-provisioner.yaml
@@ -4639,6 +4639,7 @@ spec:
         openebs.io/component-name: cspc-operator
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: cspc-operator
@@ -4703,6 +4704,7 @@ spec:
         openebs.io/component-name: cvc-operator
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: cvc-operator
@@ -4775,6 +4777,7 @@ spec:
         openebs.io/component-name: cstor-admission-webhook
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: admission-webhook

--- a/addons/openebs/2.6.0/operator.yaml
+++ b/addons/openebs/2.6.0/operator.yaml
@@ -98,6 +98,7 @@ spec:
         openebs.io/component-name: maya-apiserver
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
@@ -267,6 +268,7 @@ spec:
         openebs.io/component-name: openebs-provisioner
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner
@@ -344,6 +346,7 @@ spec:
         openebs.io/component-name: openebs-snapshot-operator
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: snapshot-controller
@@ -477,6 +480,7 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       #nodeSelector:
       #  "openebs.io/nodegroup": "storage-node"
+      priorityClassName: system-node-critical
       serviceAccountName: openebs-maya-operator
       hostNetwork: true
       # host PID is used to check status of iSCSI Service when the NDM
@@ -591,6 +595,7 @@ spec:
         openebs.io/component-name: ndm-operator
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
@@ -664,6 +669,7 @@ spec:
         openebs.io/component-name: admission-webhook
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: admission-webhook
@@ -720,6 +726,7 @@ spec:
         openebs.io/component-name: openebs-localpv-provisioner
         openebs.io/version: 2.6.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner-hostpath


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
Ensures that openebs pods run with critical priority so that they are not evicted before the pods that use their storageclass.

#### Does this PR introduce a user-facing change?
```release-note
Ensures that openEBS pods run with critical priority so that they aren't evicted before other pods that depend on them.
```

#### Does this PR require documentation?
NONE
