### PR TITLE
fix less command on amazon linux 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-18.04
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
 	${MAKE} build/packages/docker/$*/rhel-7
-	${MAKE} build/packages/docker/$*/rhel-7-force
+	${MAKE} build/packages/docker/$*/amzn-force
 	${MAKE} build/packages/docker/$*/rhel-8
 	mkdir -p dist
 	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64 > build/packages/docker/$*/runc
@@ -477,15 +477,15 @@ build/packages/docker/%/rhel-7:
 	docker rm docker-rhel7-$*
 
 build/packages/docker/18.09.8/rhel-8:
-	${MAKE} build/packages/docker/18.09.8/rhel-7-force
+	${MAKE} build/packages/docker/18.09.8/amzn-force
 
 build/packages/docker/19.03.4/rhel-8:
-	${MAKE} build/packages/docker/19.03.4/rhel-7-force
+	${MAKE} build/packages/docker/19.03.4/amzn-force
 
 build/packages/docker/19.03.10/rhel-8:
-	${MAKE} build/packages/docker/19.03.10/rhel-7-force
+	${MAKE} build/packages/docker/19.03.10/amzn-force
 
-build/packages/docker/%/rhel-7-force:
+build/packages/docker/%/amzn-force:
 	docker build \
 		--build-arg DOCKER_VERSION=$* \
 		-t kurl/rhel-7-force-docker:$* \

--- a/bundles/k8s-rhel7-force/Dockerfile
+++ b/bundles/k8s-rhel7-force/Dockerfile
@@ -1,8 +1,9 @@
-FROM centos:7
+FROM amazonlinux
 ARG KUBERNETES_VERSION
 COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN mkdir -p /packages/archives
 
+RUN yum install yum-utils -y
 RUN yumdownloader --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \

--- a/go.sum
+++ b/go.sum
@@ -1225,8 +1225,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/replicatedhq/pvmigrate v0.4.4 h1:1xIi1Nadv4huJjuclMnGAtDs5yxnX8hT7SUKJcFOo3E=
 github.com/replicatedhq/pvmigrate v0.4.4/go.mod h1:tcOluIOzScw8OIiCxKTwfIOZjFeoBDQ+gRBAuV77lQE=
-github.com/replicatedhq/troubleshoot v0.28.0 h1:0B7ibyxur/ao1+PSQPLh2GnjonIfUxUXoiwaoGSXMag=
-github.com/replicatedhq/troubleshoot v0.28.0/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
 github.com/replicatedhq/troubleshoot v0.32.0 h1:f2isUH0BM5aJmOGlcjJ4Ngbnb8HKb2EhqrHGNKx0wUE=
 github.com/replicatedhq/troubleshoot v0.32.0/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -92,6 +92,11 @@ function kubernetes_install_host_packages() {
 
     if kubernetes_host_commands_ok "$k8sVersion"; then
         logSuccess "Kubernetes host packages already installed"
+        # less command is broken if libtinfo.so.5 is missing in amazon linux 2
+        if [ "$LSB_DIST" == "amzn" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
+            install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" ncurses-compat-libs
+        fi
+
         return
     fi
 
@@ -923,4 +928,12 @@ function get_cpu_millicores_to_reserve() {
             $(get_resource_to_reserve_in_range $total_cpu_on_instance $start_range $end_range $percentage_to_reserve_for_range)))
     done
     echo $cpu_to_reserve
+}
+
+function file_exists() {
+   local filename=$1
+
+   if ! test -f "$filename"; then
+      return 1
+   fi
 }

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1450,3 +1450,12 @@
       shouldDisableRebootServices: false
       shouldDisableClearNodes: false
       shouldEnablePurgeNodes: false
+- name: less_command
+  installerSpec:
+    kubernetes:
+      version: "1.23.5"
+    docker:
+      version: "20.10.5"
+  postInstallScript: |
+    echo "this is text to test less command after installation" > test-less.txt
+    less test-less.txt > /dev/null


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug

#### What this PR does / why we need it:
This PR is to fix the less command on amazon linux 2 after installing kURL. This will also fix existing installations with the bug once the installer is rerun.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-43509](https://app.shortcut.com/replicated/story/43509/kurl-installation-in-amazon-linux-2-breaks-less-command)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Details to reproduce the issue are listed on the SC ticket linked above. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
#### Release note:
```release-note
- Fixes a bug where the less command breaks after installing kURL on amazon linux 2.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
