### PR TITLE
use amazonlinux and install ncurses-compat-libs to fix less command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-18.04
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
 	${MAKE} build/packages/docker/$*/rhel-7
-	${MAKE} build/packages/docker/$*/rhel-7-force
+	${MAKE} build/packages/docker/$*/amzn-force
 	${MAKE} build/packages/docker/$*/rhel-8
 	mkdir -p dist
 	curl -L https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64 > build/packages/docker/$*/runc
@@ -477,15 +477,15 @@ build/packages/docker/%/rhel-7:
 	docker rm docker-rhel7-$*
 
 build/packages/docker/18.09.8/rhel-8:
-	${MAKE} build/packages/docker/18.09.8/rhel-7-force
+	${MAKE} build/packages/docker/18.09.8/amzn-force
 
 build/packages/docker/19.03.4/rhel-8:
-	${MAKE} build/packages/docker/19.03.4/rhel-7-force
+	${MAKE} build/packages/docker/19.03.4/amzn-force
 
 build/packages/docker/19.03.10/rhel-8:
-	${MAKE} build/packages/docker/19.03.10/rhel-7-force
+	${MAKE} build/packages/docker/19.03.10/amzn-force
 
-build/packages/docker/%/rhel-7-force:
+build/packages/docker/%/amzn-force:
 	docker build \
 		--build-arg DOCKER_VERSION=$* \
 		-t kurl/rhel-7-force-docker:$* \

--- a/bundles/k8s-rhel7-force/Dockerfile
+++ b/bundles/k8s-rhel7-force/Dockerfile
@@ -1,12 +1,14 @@
-FROM centos:7
+FROM amazonlinux
 ARG KUBERNETES_VERSION
 COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN mkdir -p /packages/archives
 
+RUN yum install yum-utils -y
 RUN yumdownloader --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \
 	kubernetes-cni \
+	ncurses-compat-libs \
 	git
 
 CMD cp -r /packages/archives/* /out/

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1450,3 +1450,12 @@
       shouldDisableRebootServices: false
       shouldDisableClearNodes: false
       shouldEnablePurgeNodes: false
+- name: less_command
+  installerSpec:
+    kubernetes:
+      version: "1.23.5"
+    docker:
+      version: "20.10.5"
+  postInstallScript: |
+    echo "this is text to test less command after installation" > test-less.txt
+    less test-less.txt > /dev/null


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug

#### What this PR does / why we need it:
This PR is to fix the less command on amazon linux 2 after installing kURL. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-43509](https://app.shortcut.com/replicated/story/43509/kurl-installation-in-amazon-linux-2-breaks-less-command)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Most of these changes are being added back from the previous [revert](https://github.com/replicatedhq/kURL/pull/2915/files) that was done so it wouldn't block the release.
Only new changes are in [scripts/common/kubernetes.sh](https://github.com/replicatedhq/kURL/compare/luisgarcia3795/sc-43509/amazon-less-cmd?expand=1#diff-289c11f03a3d8d7b38bab6cc5e4c5c1e5590dc90fe7e25623acb9ad9efe26302):
- Now checking that it's not an airgap install.
- Checking that the kubernetes package directory exists.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Details to reproduce the issue are listed on the SC ticket linked above. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
#### Release note:
```release-note
- Fixes a bug where the less command breaks after installing kURL on amazon linux 2.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
