### PR TITLE
Added support for Kubernetes 1.24.0

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,14 +260,8 @@ function init() {
 
     wait_for_nodes
 
-    # once the node is up, apply the master label only on primaries
-    # get the kubernetes version
-    local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
-    semverParse $kubernetes_version
-    if [ $major -ge 1 ] && [ $minor -ge 24 ]; then
-        local node=$(hostname | tr '[:upper:]' '[:lower:]')
-        kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
-    fi
+    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
 
     enable_rook_ceph_operator
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,12 +264,9 @@ function init() {
     # get the kubernetes version
     local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
     semverParse $kubernetes_version
-    KUBERNETES_CURRENT_VERSION_MAJOR="$major"
-    KUBERNETES_CURRENT_VERSION_MINOR="$minor"
-
-    if [ $KUBERNETES_CURRENT_VERSION_MAJOR -ge 1 ] && [ $KUBERNETES_CURRENT_VERSION_MINOR -ge 24 ]; then
+    if [ $major -ge 1 ] && [ $minor -ge 24 ]; then
         local node=$(hostname | tr '[:upper:]' '[:lower:]')
-        kubectl label --overwrite node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
+        kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
     fi
 
     enable_rook_ceph_operator

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -259,6 +259,19 @@ function init() {
     fi
 
     wait_for_nodes
+
+    # once the node is up, apply the master label only on primaries
+    # get the kubernetes version
+    local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+    semverParse $kubernetes_version
+    KUBERNETES_CURRENT_VERSION_MAJOR="$major"
+    KUBERNETES_CURRENT_VERSION_MINOR="$minor"
+
+    if [ $KUBERNETES_CURRENT_VERSION_MAJOR -ge 1 ] && [ $KUBERNETES_CURRENT_VERSION_MINOR -ge 24 ]; then
+        local node=$(hostname | tr '[:upper:]' '[:lower:]')
+        kubectl label node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
+    fi
+
     enable_rook_ceph_operator
 
     DID_INIT_KUBERNETES=1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,7 +269,7 @@ function init() {
 
     if [ $KUBERNETES_CURRENT_VERSION_MAJOR -ge 1 ] && [ $KUBERNETES_CURRENT_VERSION_MINOR -ge 24 ]; then
         local node=$(hostname | tr '[:upper:]' '[:lower:]')
-        kubectl label node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
+        kubectl label --overwrite node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
     fi
 
     enable_rook_ceph_operator

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -90,15 +90,8 @@ function join() {
     if [ "$MASTER" = "1" ]; then
         exportKubeconfig
 
-        # once the node is up, apply the master label only on primaries
-        # get the kubernetes version
-        local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
-        semverParse $kubernetes_version
-
-        if [ $major -ge 1 ] && [ $minor -ge 24 ]; then
-          local node=$(hostname | tr '[:upper:]' '[:lower:]')
-          kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
-        fi
+        local node=$(hostname | tr '[:upper:]' '[:lower:]')
+        kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
 
         if [ "$KUBERNETES_CIS_COMPLIANCE" == "1" ]; then
             # create an 'etcd' user and group and ensure that it owns the etcd data directory (we don't care what userid these have, as etcd will still run as root)

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -94,12 +94,10 @@ function join() {
         # get the kubernetes version
         local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
         semverParse $kubernetes_version
-        KUBERNETES_CURRENT_VERSION_MAJOR="$major"
-        KUBERNETES_CURRENT_VERSION_MINOR="$minor"
 
-        if [ $KUBERNETES_CURRENT_VERSION_MAJOR -ge 1 ] && [ $KUBERNETES_CURRENT_VERSION_MINOR -ge 24 ]; then
+        if [ $major -ge 1 ] && [ $minor -ge 24 ]; then
           local node=$(hostname | tr '[:upper:]' '[:lower:]')
-          kubectl label --overwrite node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
+          kubectl label --overwrite node "$node" node-role.kubernetes.io/master=
         fi
 
         if [ "$KUBERNETES_CIS_COMPLIANCE" == "1" ]; then

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -99,7 +99,7 @@ function join() {
 
         if [ $KUBERNETES_CURRENT_VERSION_MAJOR -ge 1 ] && [ $KUBERNETES_CURRENT_VERSION_MINOR -ge 24 ]; then
           local node=$(hostname | tr '[:upper:]' '[:lower:]')
-          kubectl label node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
+          kubectl label --overwrite node "$node" node-role.kubernetes.io/master= 2>/dev/null || true
         fi
 
         if [ "$KUBERNETES_CIS_COMPLIANCE" == "1" ]; then

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1352,6 +1352,9 @@ export class Installer {
     if (this.spec.containerd && this.spec.docker) {
       return {error: {message: `This spec contains both docker and containerd, please specifiy only one CRI`}};
     }
+    if (this.spec.docker && this.spec.kubernetes && semver.gte(this.spec.kubernetes.version, "1.24.0")) {
+      return {error: {message: "Docker is not supported with Kubernetes versions 1.24+, please choose Containerd"}};
+    }
     if (this.spec.collectd && !(await Installer.hasVersion("collectd", this.spec.collectd.version, installerVersion)) && !this.hasS3Override("collectd")) {
       return {error: {message: `Collectd version "${_.escape(this.spec.collectd.version)}" is not supported${installerVersion ? " for installer version " + _.escape(installerVersion) : ""}`}};
     }

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -1058,6 +1058,21 @@ spec:
         expect(out).to.deep.equal({ error: { message: "Openebs add-on is not compatible with Kubernetes versions 1.22+" } });
       });
     });
+
+  describe("docker is not supported with k8s version 1.24.0", () => {
+      it("=> ErrorResponse", async () => {
+        const yaml = `
+spec:
+  kubernetes:
+    version: 1.24.0
+  docker:
+    version: 20.10.5`;
+        const i = Installer.parse(yaml);
+        const out = await i.validate();
+
+        expect(out).to.deep.equal({ error: { message: "Docker is not supported with Kubernetes versions 1.24+, please choose Containerd" } });
+      });
+    });
   });
 
   describe("hasS3Override", () => {


### PR DESCRIPTION

The code requires `kubernetes.io/master` label on two places 
1. nodeSelectors
2. Tolerations

Add the `master` label right after kubeadm is inited and `before` installing the kurl addons. And this logic is added only if the current kubernetes version is >= 1.24.0

Tested for ekc-operator

```
$ kubectl get nodes --show-labels=true
NAME                                           STATUS   ROLES                  AGE   VERSION   LABELS
jalaja-k8s-v1-24-with-control-plane-labels-1   Ready    control-plane,master   26h   v1.24.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=jalaja-k8s-v1-24-with-control-plane-labels-1,kubernetes.io/os=linux,kurl.sh/cluster=true,node-role.kubernetes.io/control-plane=,node-role.kubernetes.io/master=,node.kubernetes.io/exclude-from-external-load-balancers=

```



#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

SC-48706


#### Does this PR introduce a user-facing change?
No

```release-note

Added support for Kubernetes 1.24.0
```

#### Does this PR require documentation?

Yes
TODO
