### PR TITLE
ekco-enable-internal-load-balancer flag

### DIFF
--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -144,6 +144,10 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 				installer.Spec.Kubernetes = &kurlv1beta1.Kubernetes{}
 			}
 			installer.Spec.Kubernetes.LoadBalancerAddress = split[1]
+		case "ekco-enable-internal-load-balancer":
+			if installer.Spec.Ekco != nil {
+				installer.Spec.Ekco.EnableInternalLoadBalancer = true
+			}
 		case "kubernetes-master-address":
 			if installer.Spec.Kubernetes == nil {
 				installer.Spec.Kubernetes = &kurlv1beta1.Kubernetes{}

--- a/kurl_util/cmd/bashmerge/main_test.go
+++ b/kurl_util/cmd/bashmerge/main_test.go
@@ -233,6 +233,25 @@ func Test_parseBashFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ekco-enable-internal-load-balancer",
+			oldInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Ekco: &kurlv1beta1.Ekco{
+						Version: "0.19.0",
+					},
+				},
+			},
+			bashFlags: "ekco-enable-internal-load-balancer",
+			mergedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Ekco: &kurlv1beta1.Ekco{
+						Version:                    "0.19.0",
+						EnableInternalLoadBalancer: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::feature

#### What this PR does / why we need it:

Addition of the  flag `ekco-enable-internal-load-balancer` to enable the Ekco Internal Load Balancer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
In addition to the `ekco.enableInternalLoadBalancer` parameter, the `ekco-enable-internal-load-balancer` flag can now be specified at install time to enable the Ekco [Internal Load Balancer](https://kurl.sh/docs/add-ons/ekco#internal-load-balancer).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->

https://github.com/replicatedhq/kurl.sh/pull/790
