### PR TITLE
Add cni plugin to less_command test

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1456,6 +1456,8 @@
       version: "1.23.5"
     docker:
       version: "20.10.5"
+    weave:
+      version: "2.6.5"
   postInstallScript: |
     echo "this is text to test less command after installation" > test-less.txt
     less test-less.txt > /dev/null


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::tests
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
Adds weave as the cni plugin for the less_command test. 

Currently testgrid shows "Failed Cluster Not Ready"
This is the node condition:
```
Ready            False   Fri, 27 May 2022 09:20:04 +0000   Fri, 27 May 2022 09:19:47 +0000   KubeletNotReady              container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of [SC-43509](https://app.shortcut.com/replicated/story/43509/kurl-installation-in-amazon-linux-2-breaks-less-command)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE