### PR TITLE
Ability to skip validation when creating installers

### DIFF
--- a/web/src/controllers/InstallerAPI.ts
+++ b/web/src/controllers/InstallerAPI.ts
@@ -14,7 +14,6 @@ import { Installer, InstallerObject, InstallerStore } from "../installers";
 import decode from "../util/jwt";
 import { getInstallerVersions } from "../installers/installer-versions";
 import { getDistUrl } from "../util/package";
-import { ServerError } from "../server/errors";
 
 interface ErrorResponse {
   error: any;
@@ -139,8 +138,9 @@ export class Installers {
     @Res() response: Express.Response,
     @Req() request: Express.Request,
     @PathParams("id") id: string,
+    @QueryParams("skipValidation") skipValidation: boolean,
   ): Promise<string | ErrorResponse> {
-    return await this.doMakeInstaller(response, request, id, "");
+    return await this.doMakeInstaller(response, request, id, "", skipValidation);
   }
 
   /**
@@ -158,8 +158,9 @@ export class Installers {
     @Req() request: Express.Request,
     @PathParams("id") id: string,
     @PathParams("slug") slug: string,
+    @QueryParams("skipValidation") skipValidation: boolean,
   ): Promise<string | ErrorResponse> {
-    return await this.doMakeInstaller(response, request, id, slug);
+    return await this.doMakeInstaller(response, request, id, slug, skipValidation);
   }
 
   /**
@@ -230,7 +231,7 @@ export class Installers {
     return "";
   }
 
-  async doMakeInstaller( response: Express.Response, request: Express.Request, id: string, slug: string): Promise<string | ErrorResponse> {
+  async doMakeInstaller( response: Express.Response, request: Express.Request, id: string, slug: string, skipValidation: boolean): Promise<string | ErrorResponse> {
     const auth = request.header("Authorization");
     if (!auth) {
       response.status(401);
@@ -274,10 +275,14 @@ export class Installers {
       }
     }
 
-    const err = await (await i.resolve()).validate();
-    if (err) {
-      response.status(400);
-      return err;
+    await i.resolve();
+
+    if (!skipValidation) {
+      const err = await i.validate();
+      if (err) {
+        response.status(400);
+        return err;
+      }
     }
 
     await this.installerStore.saveTeamInstaller(i);


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

Adds the ability to skip validation when creating installers. This won't be documented, it is only used by our hosted APIs.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

pass `skipValidation` as a url parameter

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
