### PR TITLE
cleanly shut down the kurl server during rollouts

### DIFF
--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -26,6 +26,11 @@ spec:
       volumes:
       - name: images
         emptyDir: {}
+      terminationGracePeriodSeconds: 900 # allow 15 minutes for shutdowns to allow airgap downloads to complete
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 3
       containers:
       - name: server
         image: replicated/kurl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This PR blocks exiting the airgap bundle download server for up to 15 minutes to wait for active connections to complete. (if there are no active connections, it exits immediately)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Increase the reliability of airgap bundle downloads
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
