### PR TITLE
remove invalid utf8 chars from testgrid logs before persisting them

### DIFF
--- a/testgrid/tgapi/pkg/handlers/cluster_node.go
+++ b/testgrid/tgapi/pkg/handlers/cluster_node.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/replicatedhq/kurl/testgrid/tgapi/pkg/logger"
@@ -71,7 +72,9 @@ func NodeLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	nodeID := mux.Vars(r)["nodeId"]
-	if err := testinstance.NodeLogs(nodeID, logs); err != nil {
+
+	cleanLogs := strings.ToValidUTF8(string(logs), " ")
+	if err := testinstance.NodeLogs(nodeID, cleanLogs); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return

--- a/testgrid/tgapi/pkg/testinstance/testinstance.go
+++ b/testgrid/tgapi/pkg/testinstance/testinstance.go
@@ -507,7 +507,7 @@ func UpdateNodeStatus(id string, status string) error {
 	return nil
 }
 
-func NodeLogs(id string, logs []byte) error {
+func NodeLogs(id string, logs string) error {
 	db := persistence.MustGetPGSession()
 
 	query := `update clusternode set output = $2 where id = $1`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This removes invalid utf8 characters from testgrid logs before attempting to save them, which prevents the update from being rejected by postgres.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
