### PR TITLE
specify nodejs command in k8s deployment so that it receives sigterm

### DIFF
--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -60,6 +60,7 @@ spec:
       - name: kurl
         image: replicated/kurl
         imagePullPolicy: IfNotPresent
+        command: ["node", "--no-deprecation", "bin/kurl", "serve"]
         ports:
         - name: kurl
           containerPort: 3000


### PR DESCRIPTION
if we use the container entrypoint, it is called via 'sh' which does not pass through sigterm on alpine

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
