### PR TITLE
log at the beginning of the load-images task

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -82,6 +82,7 @@ function tasks() {
 }
 
 function load_all_images() {
+    printf "loading all infrastructure images\n"
     # get params - specifically need kurl-install-directory, as they impact load images scripts
     shift # the first param is load_images/load-images
     while [ "$1" != "" ]; do


### PR DESCRIPTION
there can be some time (30s) before the first line from the actual load commands shows up otherwise

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
