### PR TITLE
Create new minio version with latest upstream image tag to resolve CVEs

### DIFF
--- a/addons/minio/2022-06-11T19-55-32Z/Manifest
+++ b/addons/minio/2022-06-11T19-55-32Z/Manifest
@@ -1,0 +1,1 @@
+image minio minio/minio:RELEASE.2022-06-11T19-55-32Z

--- a/addons/minio/2022-06-11T19-55-32Z/deployment.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  strategy:
+    # Specifies the strategy used to replace old Pods by new ones
+    # Refer: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # This label is used as a selector in Service definition
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        # Volume mounts for this container
+        volumeMounts:
+        # Volume 'data' is mounted to path '/data'
+        - name: data 
+          mountPath: "/data"
+        # Pulls the lastest Minio image from Docker Hub
+        image: minio/minio:RELEASE.2022-06-11T19-55-32Z
+        args:
+        - --quiet
+        - server
+        - /data
+        env:
+        - name: MINIO_UPDATE
+          value: "off"
+        # MinIO access key and secret key
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_SECRET_KEY
+        ports:
+        - containerPort: 9000
+        # Readiness probe detects situations when MinIO server instance
+        # is not ready to accept traffic. Kubernetes doesn't forward
+        # traffic to the pod while readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20

--- a/addons/minio/2022-06-11T19-55-32Z/install.sh
+++ b/addons/minio/2022-06-11T19-55-32Z/install.sh
@@ -1,0 +1,206 @@
+DID_MIGRATE_ROOK_OBJECT_STORE=
+
+function minio_pre_init() {
+    if [ -z "$MINIO_NAMESPACE" ]; then
+        MINIO_NAMESPACE=minio
+    fi
+
+    if [ -z "$MINIO_CLAIM_SIZE" ]; then
+        MINIO_CLAIM_SIZE="10Gi"
+    fi
+}
+
+function minio() {
+    local src="$DIR/addons/minio/2022-06-11T19-55-32Z"
+    local dst="$DIR/kustomize/minio"
+
+    render_yaml_file "$src/tmpl-kustomization.yaml" > "$dst/kustomization.yaml"
+    render_yaml_file "$src/tmpl-namespace.yaml" > "$dst/namespace.yaml"
+
+    cp "$src/deployment.yaml" "$dst/"
+    cp "$src/service.yaml" "$dst/"
+
+    if [ -n "$MINIO_HOSTPATH" ]; then
+        render_yaml_file "$src/tmpl-deployment-hostpath.yaml" > "$dst/deployment-hostpath.yaml"
+        insert_patches_strategic_merge "$dst/kustomization.yaml" deployment-hostpath.yaml
+    else
+        render_yaml_file "$src/tmpl-pvc.yaml" > "$dst/pvc.yaml"
+        insert_resources "$dst/kustomization.yaml" pvc.yaml
+        render_yaml_file "$src/tmpl-deployment-pvc.yaml" > "$dst/deployment-pvc.yaml"
+        insert_patches_strategic_merge "$dst/kustomization.yaml" deployment-pvc.yaml
+    fi
+
+    minio_creds "$src" "$dst"
+
+    kubectl apply -k "$dst/"
+
+    allow_pvc_resize
+
+    minio_object_store_output
+
+    minio_migrate_from_rgw
+}
+
+function minio_already_applied() {
+    minio_object_store_output
+
+    minio_migrate_from_rgw
+}
+
+function minio_creds() {
+    local src="$1"
+    local dst="$2"
+
+    local MINIO_ACCESS_KEY=kurl
+    local MINIO_SECRET_KEY=$(kubernetes_secret_value minio minio-credentials MINIO_SECRET_KEY)
+
+    if [ -z "$MINIO_SECRET_KEY" ]; then
+        MINIO_SECRET_KEY=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c9)
+    fi
+
+    render_yaml_file "$src/tmpl-creds-secret.yaml" > "$dst/creds-secret.yaml"
+    insert_resources "$dst/kustomization.yaml" creds-secret.yaml
+
+    if [ -n "$MINIO_HOSTPATH" ]; then
+        # in the case of using a "hostPath", minio will generate a config in a ".minio.sys" directory
+        # that is used to control access to that hostPath. this can be a problem when that hostpath
+        # is a directory in a shared file system (an NFS mount for example) and the installer is being
+        # run on a fresh instance, because new credentials will be generated and minio won't be able access the old data,
+        # so we make sure that the config is regenerated from the current minio credentials.
+
+        # initialize some common variables
+        local MINIO_CONFIG_PATH="$MINIO_HOSTPATH/.minio.sys/config"
+        local KURL_DIR="$MINIO_HOSTPATH/.kurl"
+        local MINIO_KEYS_SHA_FILE="$KURL_DIR/minio-keys-sha.txt"
+        local NEW_MINIO_KEYS_SHA=$(echo -n "$MINIO_ACCESS_KEY,$MINIO_SECRET_KEY" | sha256sum)
+
+        if should_reset_minio_config; then
+            reset_minio_config
+        fi
+        if [ ! -d "$MINIO_CONFIG_PATH" ]; then
+            kubernetes_scale_down ${MINIO_NAMESPACE} deployment minio
+        fi
+        write_minio_keys_sha_file
+    fi
+}
+
+function should_reset_minio_config() {
+    if [ -z "$MINIO_HOSTPATH" ]; then
+        return 1
+    fi
+
+    if [ ! -d "$MINIO_CONFIG_PATH" ]; then
+        return 1
+    fi
+
+    if ! kubernetes_resource_exists ${MINIO_NAMESPACE} secret minio-credentials; then
+        return 0
+    fi
+
+    if [ ! -f "$MINIO_KEYS_SHA_FILE" ]; then
+        return 0
+    fi
+
+    local EXISTING_MINIO_KEYS_SHA=$(cat $MINIO_KEYS_SHA_FILE)
+    if [ "$NEW_MINIO_KEYS_SHA" == "$EXISTING_MINIO_KEYS_SHA" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+function reset_minio_config() {
+    if [ ! -d "$MINIO_CONFIG_PATH" ]; then
+        return 0
+    fi
+
+    printf "\n"
+    printf "\n"
+    printf "${RED}The $MINIO_HOSTPATH directory was previously configured by a different minio instance.\n"
+    printf "Proceeding will re-configure it to be used only by this new minio instance, and any other minio instance using this location will no longer have access.\n"
+    printf "If you are attempting to fully restore a prior installation, such as a disaster recovery scenario, this action is expected. Would you like to continue?${NC} "
+
+    if ! confirmN ; then
+        bail "\n\nWill not re-configure $MINIO_HOSTPATH."
+    fi
+
+    rm -rf "$MINIO_CONFIG_PATH"
+}
+
+function write_minio_keys_sha_file() {
+    if [ ! -d "$KURL_DIR" ]; then
+        mkdir -p "$KURL_DIR"
+    fi
+
+    echo "$NEW_MINIO_KEYS_SHA" > "$MINIO_KEYS_SHA_FILE"
+}
+
+function minio_object_store_output() {
+    # don't overwrite rook if also running
+    if object_store_exists; then
+        return 0;
+    fi
+    # create the docker-registry bucket through the S3 API
+    OBJECT_STORE_ACCESS_KEY=$(kubectl -n ${MINIO_NAMESPACE} get secret minio-credentials -ojsonpath='{ .data.MINIO_ACCESS_KEY }' | base64 --decode)
+    OBJECT_STORE_SECRET_KEY=$(kubectl -n ${MINIO_NAMESPACE} get secret minio-credentials -ojsonpath='{ .data.MINIO_SECRET_KEY }' | base64 --decode)
+    OBJECT_STORE_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
+    OBJECT_STORE_CLUSTER_HOST="http://minio.${MINIO_NAMESPACE}"
+
+    printf "awaiting minio readiness\n"
+    if ! spinner_until 120 minio_ready; then
+        bail "Minio API failed to report healthy"
+    fi
+}
+
+function minio_ready() {
+    curl --noproxy "*" -s "http://$OBJECT_STORE_CLUSTER_IP/minio/health/ready"
+}
+
+function minio_migrate_from_rgw() {
+    if [ -n "$ROOK_VERSION" ]; then # if rook is still specified in the kURL spec, don't migrate
+        return
+    fi
+
+    if ! kubernetes_resource_exists rook-ceph deployment rook-ceph-rgw-rook-ceph-store-a; then # if rook is not installed, don't migrate
+        return
+    fi
+
+    migrate_rgw_to_minio
+    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+}
+
+function allow_pvc_resize() {
+    if kubernetes_resource_exists "$MINIO_NAMESPACE" pvc minio-pv-claim; then
+        # check if the minio PVC's current size is not the desired size
+        current_size=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-pv-claim -o jsonpath='{.status.capacity.storage}')
+        desired_size=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}')
+
+        if [ -z "$current_size" ]; then
+            # if the current size is not set, then the PVC does not yet have a PV
+            # this is something that will be the case on first install, and the PV will be created with the right size
+            return
+        fi
+
+        if [ "$current_size" != "$desired_size" ]; then
+            # if it is not at the desired size, scale down the minio deployment
+            kubectl scale deployment -n "$MINIO_NAMESPACE" minio --replicas=0
+
+            printf "Waiting up to one minute for Minio PVC size to change from %s to %s\n" "$current_size" "$desired_size"
+            n=0
+            while [ "$current_size" != "$desired_size" ] && [ $n -lt 30 ]; do
+                sleep 2
+                current_size=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-pv-claim -o jsonpath='{.status.capacity.storage}')
+                n="$((n+1))"
+            done
+
+            if [ "$current_size" == "$desired_size" ]; then
+                printf "Successfully updated Minio PVC size to %s\n" "$current_size"
+            else
+                printf "Failed to update Minio PVC size from %s to %s after 1m, continuing with installation process\n" "$current_size" "$desired_size"
+            fi
+
+            # restore the scale to 1 (whether the minute of waiting worked or not)
+            kubectl scale deployment -n "$MINIO_NAMESPACE" minio --replicas=1
+        fi
+    fi
+}

--- a/addons/minio/2022-06-11T19-55-32Z/service.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This name uniquely identifies the service
+  name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    # Looks for labels `app:minio` in the namespace and applies the spec
+    app: minio

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-creds-secret.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-creds-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+type: Opaque
+stringData:
+  MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+  MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-deployment-hostpath.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-deployment-hostpath.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      volumes:
+        - name: data
+          hostPath:
+            path: ${MINIO_HOSTPATH}

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-deployment-pvc.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-deployment-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-pv-claim

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-kustomization.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-kustomization.yaml
@@ -1,0 +1,6 @@
+namespace: ${MINIO_NAMESPACE}
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-namespace.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${MINIO_NAMESPACE}

--- a/addons/minio/2022-06-11T19-55-32Z/tmpl-pvc.yaml
+++ b/addons/minio/2022-06-11T19-55-32Z/tmpl-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. This is used in deployment.
+  name: minio-pv-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    # The volume is mounted as read-write by a single node
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: ${MINIO_CLAIM_SIZE}

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -318,6 +318,7 @@ module.exports.InstallerVersions = {
     "2.6.0",
   ],
   minio: [
+    "2022-06-11T19-55-32Z",
     "2020-01-25T02-50-51Z",
   ],
   collectd: [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::security

#### What this PR does / why we need it:

Creates a new minio version with latest upstream image tag to resolve CVEs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

`trivy image minio/minio:RELEASE.2022-06-11T19-55-32Z`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds MinIO version `2022-06-11T19-55-32Z` to address the following critical and high severity CVEs: CVE-2020-14040, CVE-2021-42836, CVE-2020-36067, CVE-2020-36066, CVE-2020-35380, CVE-2020-26521, CVE-2020-26892, CVE-2021-3121, CVE-2020-26160, CVE-2021-28831, CVE-2020-11080, CVE-2021-3450, CVE-2021-23840, CVE-2020-1967, CVE-2020-8286, CVE-2020-8285, CVE-2020-8231, CVE-2020-8177, CVE-2020-8169, CVE-2021-30139, CVE-2021-36159
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
