### PR TITLE
update weave add-on to use patched images

### DIFF
--- a/addons/weave/2.6.5/Manifest
+++ b/addons/weave/2.6.5/Manifest
@@ -1,3 +1,3 @@
-image weave-kube weaveworks/weave-kube:2.6.5
-image weave-npc weaveworks/weave-npc:2.6.5
-image weaveexec weaveworks/weaveexec:2.6.5
+image weave-kube kurlsh/weave-kube:2.6.5-45e04df-20220616
+image weave-npc kurlsh/weave-npc:2.6.5-45e04df-20220616
+image weaveexec kurlsh/weaveexec:2.6.5-45e04df-20220616

--- a/addons/weave/2.6.5/daemonset.yaml
+++ b/addons/weave/2.6.5/daemonset.yaml
@@ -34,7 +34,9 @@ spec:
               value: "--log-level=info" # default log level is debug
             - name: CHECKPOINT_DISABLE
               value: "1"
-          image: weaveworks/weave-kube:2.6.5
+            - name: EXEC_IMAGE
+              value: "kurlsh/weaveexec:2.6.5-45e04df-20220616"
+          image: kurlsh/weave-kube:2.6.5-45e04df-20220616
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -70,7 +72,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: weaveworks/weave-npc:2.6.5
+          image: kurlsh/weave-npc:2.6.5-45e04df-20220616
           resources:
             requests:
               cpu: 50m

--- a/addons/weave/2.8.1/Manifest
+++ b/addons/weave/2.8.1/Manifest
@@ -1,3 +1,3 @@
-image weave-kube weaveworks/weave-kube:2.8.1
-image weave-npc weaveworks/weave-npc:2.8.1
-image weaveexec weaveworks/weaveexec:2.8.1
+image weave-kube kurlsh/weave-kube:2.8.1-45e04df-20220616
+image weave-npc kurlsh/weave-npc:2.8.1-45e04df-20220616
+image weaveexec kurlsh/weaveexec:2.8.1-45e04df-20220616

--- a/addons/weave/2.8.1/weave-daemonset-k8s-1.11.yaml
+++ b/addons/weave/2.8.1/weave-daemonset-k8s-1.11.yaml
@@ -120,7 +120,7 @@ items:
         spec:
           initContainers:
             - name: weave-init
-              image: 'weaveworks/weave-kube:2.8.1'
+              image: 'kurlsh/weave-kube:2.8.1-45e04df-20220616'
               command:
                 - /home/weave/init.sh
               env:
@@ -150,7 +150,9 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'weaveworks/weave-kube:2.8.1'
+                - name: EXEC_IMAGE
+                  value: "kurlsh/weaveexec:2.8.1-45e04df-20220616"
+              image: 'kurlsh/weave-kube:2.8.1-45e04df-20220616'
               readinessProbe:
                 httpGet:
                   host: 127.0.0.1
@@ -180,7 +182,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'weaveworks/weave-npc:2.8.1'
+              image: 'kurlsh/weave-npc:2.8.1-45e04df-20220616'
 #npc-args
               resources:
                 requests:

--- a/addons/weave/template/testgrid/k8s-docker.yaml
+++ b/addons/weave/template/testgrid/k8s-docker.yaml
@@ -18,3 +18,15 @@
       s3Override: "__testdist__"
   numPrimaryNodes: 1
   numSecondaryNodes: 2
+- name: "weave airgap latest multi node"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    docker:
+      version: "latest"
+    weave:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+  airgap: true

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -395,9 +395,15 @@ function get_weave_version() {
     local weave_version=$(KUBECONFIG=/etc/kubernetes/admin.conf kubectl get daemonset -n kube-system weave-net -o jsonpath="{..spec.containers[0].image}" | sed 's/^.*://')
     if [ -z "$weave_version" ]; then
         if [ -n "$DOCKER_VERSION" ]; then
-            weave_version=$(docker image ls | grep weaveworks/weave-npc | awk '{ print $2 }' | head -1)
+            weave_version=$(docker image ls | grep kurlsh/weave-npc | awk '{ print $2 }' | head -1)
+            if [ -z "$weave_version" ]; then
+                weave_version=$(docker image ls | grep weaveworks/weave-npc | awk '{ print $2 }' | head -1)
+            fi
         else
-            weave_version=$(crictl images list | grep weaveworks/weave-npc | awk '{ print $2 }' | head -1)
+            weave_version=$(crictl images list | grep kurlsh/weave-npc | awk '{ print $2 }' | head -1)
+            if [ -z "$weave_version" ]; then
+                weave_version=$(crictl images list | grep weaveworks/weave-npc | awk '{ print $2 }' | head -1)
+            fi
         fi
         if [ -z "$weave_version" ]; then
             # if we don't know the exact weave tag, use a sane default


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::chore
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
Updates images for weave add-on versions 2.6.5 and 2.8.1. New images are patched for CVEs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[SC-49336](https://app.shortcut.com/replicated/story/49336/weave-2-8-1-cves)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes CVEs for weave 2.8.1 plugin
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
