### PR TITLE
More cpus for testgrid specs where needed

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -168,7 +168,10 @@ function containerd_migrate_from_docker() {
     elif [ -f /opt/ekco/shutdown.sh ]; then
         bash /opt/ekco/shutdown.sh
     else
-        printf "${RED}EKCO shutdown script not available. Migration to containerd may fail\n${NC}"
+        logFail "EKCO shutdown script not available. Migration to containerd may fail\n"
+        if ! confirmN ; then
+            bail "Migration to Containerd has been aborted."
+        fi
     fi
 
     local node=$(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -44,7 +44,7 @@
       s3Override: "__testdist__"
 
 - name: upgrade-from-latest-rook
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: "latest"
@@ -55,6 +55,8 @@
     kotsadm:
       version: "latest"
     rook:
+      version: "latest"
+    ekco:
       version: "latest"
   upgradeSpec:
     kubernetes:
@@ -70,9 +72,11 @@
     longhorn:
       version: "__testver__"
       s3Override: "__testdist__"
+    ekco:
+      version: "latest"
 
 - name: upgrade-from-rook-1.5
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: "latest"
@@ -85,6 +89,8 @@
     rook:
       version: "1.5.x"
       isBlockStorageEnabled: true
+    ekco:
+      version: "latest"
   upgradeSpec:
     kubernetes:
       version: "latest"
@@ -99,6 +105,8 @@
     longhorn:
       version: "__testver__"
       s3Override: "__testdist__"
+    ekco:
+      version: "latest"
 
 - name: upgrade-from-oldest-longhorn
   installerSpec:

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -44,6 +44,7 @@
       s3Override: "__testdist__"
 
 - name: upgrade-from-latest-rook
+  cpu: 5
   installerSpec:
     kubernetes:
       version: "latest"
@@ -71,6 +72,7 @@
       s3Override: "__testdist__"
 
 - name: upgrade-from-rook-1.5
+  cpu: 5
   installerSpec:
     kubernetes:
       version: "latest"

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -1,4 +1,5 @@
-- installerSpec:
+- name: Rook minimal
+  installerSpec:
     kubernetes:
       version: "latest"
     weave:
@@ -13,7 +14,8 @@
       version: "__testver__"
       s3Override: "__testdist__"
       isBlockStorageEnabled: true
-- installerSpec:
+- name: Upgrade from 1.4.3
+  installerSpec:
     kubernetes:
       version: "latest"
     weave:
@@ -43,7 +45,8 @@
       s3Override: "__testdist__"
       isBlockStorageEnabled: true
       bypassUpgradeWarning: true
-- installerSpec:
+- name: Disable shared filesystem
+  installerSpec:
     kubernetes:
       version: "latest"
     weave:
@@ -59,7 +62,8 @@
       s3Override: "__testdist__"
       isSharedFilesystemDisabled: true
       isBlockStorageEnabled: true
-- installerSpec:
+- name: Upgrade from 1.0.4
+  installerSpec:
     kubernetes:
       version: "latest"
     weave:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -41,7 +41,7 @@
       version: "__testver__"
       s3Override: "__testdist__"
 - name: "Velero Remove Object Storage"
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -58,6 +58,8 @@
       version: latest
     velero:
       version: 1.6.x
+    ekco:
+      version: "latest"
   upgradeSpec:
     kubernetes:
       version: 1.21.x
@@ -75,3 +77,5 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
+    ekco:
+      version: "latest"

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -41,6 +41,7 @@
       version: "__testver__"
       s3Override: "__testdist__"
 - name: "Velero Remove Object Storage"
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.20.x

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -94,12 +94,13 @@ function uninstall_docker() {
         return
     fi
 
+    logStep "Uninstalling Docker..."
+
     docker rm -f $(docker ps -a -q) || true
     # The rm -rf /var/lib/docker command below may fail with device busy error, so remove as much
     # data as possible now
     docker system prune --all --volumes --force
 
-    logStep "Uninstalling Docker..."
     case "$LSB_DIST" in
         ubuntu)
             export DEBIAN_FRONTEND=noninteractive

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -619,6 +619,7 @@
       version: 1.1.2
   airgap: true
 - name: k8s1205_rook_upgrade
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.18.4
@@ -737,6 +738,7 @@
       version: 0.10.1
   airgap: true
 - name: k8s1205_rook_to_longhorn
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -763,6 +765,7 @@
     containerd:
       version: 1.4.6
 - name: remove_all_object_storage
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -933,6 +936,7 @@
       version: latest
   airgap: true
 - name: "Upgrade to 1.22"
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -966,6 +970,7 @@
     velero:
       version: 1.7.x
 - name: "Upgrade to 1.22 airgap"
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -1070,6 +1075,7 @@
       version: latest
   airgap: true
 - name: "Upgrade to 1.23"
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -1103,6 +1109,7 @@
     velero:
       version: 1.7.x
 - name: "Upgrade to 1.23 airgap"
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.21.x

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -619,7 +619,7 @@
       version: 1.1.2
   airgap: true
 - name: k8s1205_rook_upgrade
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.18.4
@@ -632,6 +632,8 @@
       version: 1.38.0
     containerd:
       version: 1.4.6
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.20.2
@@ -645,6 +647,8 @@
       version: 1.38.0
     containerd:
       version: 1.4.12
+    ekco:
+      version: latest
 - name: k8s121
   installerSpec:
     kubernetes:
@@ -738,7 +742,7 @@
       version: 0.10.1
   airgap: true
 - name: k8s1205_rook_to_longhorn
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -751,6 +755,8 @@
       version: 1.38.0
     containerd:
       version: 1.4.6
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.20.x
@@ -764,8 +770,10 @@
       version: 1.38.0
     containerd:
       version: 1.4.6
+    ekco:
+      version: latest
 - name: remove_all_object_storage
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -782,6 +790,8 @@
       version: latest
     velero:
       version: 1.6.x
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.21.x
@@ -798,6 +808,8 @@
       version: latest
     velero:
       version: 1.7.x
+    ekco:
+      version: latest
 - name: "K8s 1.22x Rook"
   installerSpec:
     kubernetes:
@@ -936,7 +948,7 @@
       version: latest
   airgap: true
 - name: "Upgrade to 1.22"
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -953,6 +965,8 @@
       version: 19.03.x
     velero:
       version: 1.6.x
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.22.x
@@ -969,8 +983,10 @@
       version: 1.4.x
     velero:
       version: 1.7.x
+    ekco:
+      version: latest
 - name: "Upgrade to 1.22 airgap"
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -987,6 +1003,8 @@
       version: 19.03.x
     velero:
       version: 1.6.x
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.22.x
@@ -1003,6 +1021,8 @@
       version: 1.5.x
     velero:
       version: 1.7.x
+    ekco:
+      version: latest
   airgap: true
 - name: "K8s 1.23x Rook"
   installerSpec:
@@ -1075,7 +1095,7 @@
       version: latest
   airgap: true
 - name: "Upgrade to 1.23"
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -1092,6 +1112,8 @@
       version: 20.10.x
     velero:
       version: 1.6.x
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.23.x
@@ -1108,8 +1130,10 @@
       version: 1.4.x
     velero:
       version: 1.7.x
+    ekco:
+      version: latest
 - name: "Upgrade to 1.23 airgap"
-  cpu: 5
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -1126,6 +1150,8 @@
       version: 20.10.x
     velero:
       version: 1.6.x
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.23.x
@@ -1142,6 +1168,8 @@
       version: 1.5.x
     velero:
       version: 1.7.x
+    ekco:
+      version: latest
   airgap: true
 - name: "Upgrade to 1.23 minimal"
   installerSpec:
@@ -1158,6 +1186,8 @@
       disableS3: true
     containerd:
       version: latest
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.23.x
@@ -1171,6 +1201,8 @@
       version: latest
       disableS3: true
     containerd:
+      version: latest
+    ekco:
       version: latest
 - name: "Upgrade to 1.23 minimal airgap"
   installerSpec:
@@ -1187,6 +1219,8 @@
       disableS3: true
     containerd:
       version: latest
+    ekco:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.23.x
@@ -1200,6 +1234,8 @@
       version: latest
       disableS3: true
     containerd:
+      version: latest
+    ekco:
       version: latest
   airgap: true
 - name: k8s121-with-flags


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

Increase cpus to 6 for k8s upgrade specs and include ekco.
Bail on upgrading kubernetes when ekco is not installed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The end user will now be prompted with a warning when attempting to migrate from Docker to Containerd without the EKCO add-on installed. The prompt will fail by default in non-interactive terminal sessions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE