### PR TITLE
set embedded kubernetes team as codowners for the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+## RULES 
+
+* @replicatedhq/embedded-kubernetes


### PR DESCRIPTION
Embedded Kubernetes team now owns all aspects of the kURL project. This change allows us to require approval from a team member since the team owns the outcome.