### PR TITLE
automated velero PRs should update plugin versions for the latest velero version

### DIFF
--- a/addons/velero/template/generate.sh
+++ b/addons/velero/template/generate.sh
@@ -11,7 +11,7 @@ function get_latest_release_version() {
         grep -i "^location" | \
         grep -Eo "1\.[0-9]+\.[0-9]+")
 
-    declare -g "$VAR_NAME=$version"
+    export "$VAR_NAME=$version"
 }
 
 function generate() {
@@ -45,13 +45,20 @@ function main() {
     get_latest_release_version AZURE_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/latest 
     get_latest_release_version GCP_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/latest 
 
+    echo "Found velero version ${VELERO_VERSION}"
+    echo "Found plugins AWS ${AWS_PLUGIN_VERSION} AZURE ${AZURE_PLUGIN_VERSION} GCP ${GCP_PLUGIN_VERSION}"
+
+    local IS_NEW_VERSION=1
     if [ -d "../${VELERO_VERSION}" ]; then
-        exit 0
+        rm -rf "../${VELERO_VERSION}"
+        IS_NEW_VERSION=0
     fi
 
     generate
 
-    add_as_latest
+    if [ "$IS_NEW_VERSION" == "1" ] ; then
+        add_as_latest
+    fi
 
     echo "::set-output name=velero_version::$VELERO_VERSION"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

This PR makes the automated velero PR action also update plugin versions if plugin versions are released independently of the main velero version.

If velero 1.9.0 has already been released by kURL, and a new plugin version 1.6.0 is released, the automated PR will update the velero 1.9.0 addon if there is not a newer version of velero available.

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
