### PR TITLE
quote k8s version in version not supported message

### DIFF
--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -1294,7 +1294,7 @@ export class Installer {
 
     if (this.spec.kubernetes) {
       if (!(await Installer.hasVersion("kubernetes", this.spec.kubernetes.version, installerVersion)) && !this.hasS3Override("kubernetes")) {
-        return {error: {message: `Kubernetes version ${_.escape(this.spec.kubernetes.version)} is not supported${installerVersion ? " for installer version " + _.escape(installerVersion) : ""}`}};
+        return {error: {message: `Kubernetes version "${_.escape(this.spec.kubernetes.version)}" is not supported${installerVersion ? " for installer version " + _.escape(installerVersion) : ""}`}};
       }
       if (this.spec.kubernetes.serviceCidrRange && !Installer.isValidCidrRange(this.spec.kubernetes.serviceCidrRange)) {
         return {error: {message: `Kubernetes serviceCidrRange "${_.escape(this.spec.kubernetes.serviceCidrRange)}" is invalid`}};

--- a/web/src/test/controllers/installers.ts
+++ b/web/src/test/controllers/installers.ts
@@ -731,7 +731,7 @@ spec:
     version: "0.15.3"
 `;
         const badK8sOut = await Installer.parse(badK8s).validate();
-        expect(badK8sOut).to.deep.equal({ error: { message: "Kubernetes version 0.15.3 is not supported" } });
+        expect(badK8sOut).to.deep.equal({ error: { message: `Kubernetes version "0.15.3" is not supported` } });
       });
     });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

Show error messages like `Kubernetes version "1.19.3 " is not supported` instead of `Kubernetes version 1.19.3  is not supported`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
