### PR TITLE
Fix kurlsh/s3cmd build action

### DIFF
--- a/addons/registry/build-images/s3cmd/Makefile
+++ b/addons/registry/build-images/s3cmd/Makefile
@@ -38,7 +38,7 @@ scan:
 
 .PHONY: push
 push:
-	docker push $(IMAGE)-$(GIT_SHA)-$(DATE)
+	docker push $(IMAGE):$(GIT_SHA)-$(DATE)
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::chore

#### What this PR does / why we need it:

Fixes kurlsh/s3cmd image name in push not matching build

```
An image does not exist locally with the tag: kurlsh/s3cmd-98af828-20220705
```
