### PR TITLE
Use latest kurlsh/s3cmd tag in velero and registry add-ons

### DIFF
--- a/addons/registry/2.8.1/Manifest
+++ b/addons/registry/2.8.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.8.1
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20220711-9578884

--- a/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20220711-9578884
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.8.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.8.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20220711-9578884
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20220711-9578884
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/registry/template/base/Manifest
+++ b/addons/registry/template/base/Manifest
@@ -1,2 +1,2 @@
 image registry registry:__registry_version__
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:__S3CMD_TAG__

--- a/addons/registry/template/base/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/template/base/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:__S3CMD_TAG__
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/template/base/patch-deployment-velero.yaml
+++ b/addons/registry/template/base/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:__S3CMD_TAG__
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:__S3CMD_TAG__
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/registry/template/generate.sh
+++ b/addons/registry/template/generate.sh
@@ -10,6 +10,11 @@ function get_latest_version() {
         sed 's/v//')
 }
 
+S3CMD_TAG=
+function s3cmd_get_tag() {
+    S3CMD_TAG="$(. ../../../bin/s3cmd-get-latest-tag.sh)"
+}
+
 function generate() {
     # make the base set of files
     mkdir -p "../${VERSION}"
@@ -20,6 +25,9 @@ function generate() {
     sed -i "s/__registry_version__/$VERSION/g" "../$VERSION/install.sh"
     sed -i "s/__registry_version__/$VERSION/g" "../$VERSION/deployment-pvc.yaml"
     sed -i "s/__registry_version__/$VERSION/g" "../$VERSION/tmpl-deployment-objectstore.yaml"
+    sed -i "s/__S3CMD_TAG__/$S3CMD_TAG/g" "../$VERSION/Manifest"
+    sed -i "s/__S3CMD_TAG__/$S3CMD_TAG/g" "../$VERSION/patch-deployment-migrate-s3.yaml"
+    sed -i "s/__S3CMD_TAG__/$S3CMD_TAG/g" "../$VERSION/patch-deployment-velero.yaml"
 }
 
 function add_as_latest() {
@@ -40,6 +48,8 @@ function main() {
     else
         add_as_latest
     fi
+
+    s3cmd_get_tag
 
     generate
 

--- a/addons/velero/1.9.0/Manifest
+++ b/addons/velero/1.9.0/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.5.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.0
 image local-volume-provider replicated/local-volume-provider:v0.3.5
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20220711-9578884
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.0/velero-v1.9.0-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.0/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.0/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20220711-9578884
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
 image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
 image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__
 image local-volume-provider replicated/local-volume-provider:v0.3.5
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:__S3CMD_TAG__
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v__VELERO_VERSION__/velero-v__VELERO_VERSION__-linux-amd64.tar.gz
 

--- a/addons/velero/template/base/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/template/base/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:__S3CMD_TAG__
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/template/generate.sh
+++ b/addons/velero/template/generate.sh
@@ -14,6 +14,10 @@ function get_latest_release_version() {
     export "$VAR_NAME=$version"
 }
 
+function get_s3cmd_tag() {
+    S3CMD_TAG="$(. ../../../bin/s3cmd-get-latest-tag.sh)"
+}
+
 function generate() {
     mkdir -p "../${VELERO_VERSION}"
     cp -r ./base/* "../${VELERO_VERSION}"
@@ -22,12 +26,15 @@ function generate() {
     sed -i "s/__AWS_PLUGIN_VERSION__/$AWS_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
     sed -i "s/__AZURE_PLUGIN_VERSION__/$AZURE_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
     sed -i "s/__GCP_PLUGIN_VERSION__/$GCP_PLUGIN_VERSION/g" "../$VELERO_VERSION/Manifest.tmpl"
+    sed -i "s/__S3CMD_TAG__/$S3CMD_TAG/g" "../$VELERO_VERSION/Manifest.tmpl"
     mv "../$VELERO_VERSION/Manifest.tmpl" "../$VELERO_VERSION/Manifest"
 
     sed -i "s/__AWS_PLUGIN_VERSION__/$AWS_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
     sed -i "s/__AZURE_PLUGIN_VERSION__/$AZURE_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
     sed -i "s/__GCP_PLUGIN_VERSION__/$GCP_PLUGIN_VERSION/g" "../$VELERO_VERSION/install.sh.tmpl"
     mv "../$VELERO_VERSION/install.sh.tmpl" "../$VELERO_VERSION/install.sh"
+
+    sed -i "s/__S3CMD_TAG__/$S3CMD_TAG/g" "../$VELERO_VERSION/tmpl-s3-migration-deployment-patch.yaml"
 }
 
 function add_as_latest() {
@@ -38,6 +45,7 @@ VELERO_VERSION=""
 AWS_PLUGIN_VERSION=""
 AZURE_PLUGIN_VERSION=""
 GCP_PLUGIN_VERSION=""
+S3CMD_TAG=""
 function main() {
     get_latest_release_version VELERO_VERSION https://github.com/vmware-tanzu/velero/releases/latest 
 
@@ -45,8 +53,11 @@ function main() {
     get_latest_release_version AZURE_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/latest 
     get_latest_release_version GCP_PLUGIN_VERSION https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/latest 
 
+    get_s3cmd_tag
+
     echo "Found velero version ${VELERO_VERSION}"
     echo "Found plugins AWS ${AWS_PLUGIN_VERSION} AZURE ${AZURE_PLUGIN_VERSION} GCP ${GCP_PLUGIN_VERSION}"
+    echo "Found kurlsh/s3cmd tag ${S3CMD_TAG}"
 
     local IS_NEW_VERSION=1
     if [ -d "../${VELERO_VERSION}" ]; then

--- a/bin/s3cmd-get-latest-tag.sh
+++ b/bin/s3cmd-get-latest-tag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+function main() {
+    get_latest_tag
+}
+
+function get_latest_tag() {
+    docker run quay.io/skopeo/stable --override-os linux \
+        list-tags "docker://kurlsh/s3cmd" \
+        | jq -r '.Tags | .[]' \
+        | grep -E "^2[0-9]{7}-" \
+        | sort -r \
+        | head -n 1
+}
+
+main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Dynamically inject latest kurlsh/s3cmd image tag when generating new add-on versions.

Additionally update kurlsh/s3cmd image tag to 20220711-9578884 for registry and velero add-ons.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates kurlsh/s3cmd image 20220711-9578884 for registry and velero add-ons.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
