### PR TITLE
move deployment_fully_updated function to common

### DIFF
--- a/addons/registry/2.8.1/install.sh
+++ b/addons/registry/2.8.1/install.sh
@@ -291,35 +291,3 @@ function registry_healthy() {
     echo "waiting for the registry to start"
     spinner_until 120 deployment_fully_updated kurl registry
 }
-
-# TODO move this to common
-function deployment_fully_updated() {
-    local namespace=$1
-    local deployment=$2
-
-    local desiredReplicas
-    desiredReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.replicas}')
-
-    local availableReplicas
-    availableReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.availableReplicas}')
-
-    local readyReplicas
-    readyReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.readyReplicas}')
-
-    local updatedReplicas
-    updatedReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.updatedReplicas}')
-
-    if [ "$desiredReplicas" != "$availableReplicas" ] ; then
-        return 1
-    fi
-
-    if [ "$desiredReplicas" != "$readyReplicas" ] ; then
-        return 1
-    fi
-
-    if [ "$desiredReplicas" != "$updatedReplicas" ] ; then
-        return 1
-    fi
-
-    return 0
-}

--- a/addons/registry/template/base/install.sh
+++ b/addons/registry/template/base/install.sh
@@ -291,35 +291,3 @@ function registry_healthy() {
     echo "waiting for the registry to start"
     spinner_until 120 deployment_fully_updated kurl registry
 }
-
-# TODO move this to common
-function deployment_fully_updated() {
-    local namespace=$1
-    local deployment=$2
-
-    local desiredReplicas
-    desiredReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.replicas}')
-
-    local availableReplicas
-    availableReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.availableReplicas}')
-
-    local readyReplicas
-    readyReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.readyReplicas}')
-
-    local updatedReplicas
-    updatedReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.updatedReplicas}')
-
-    if [ "$desiredReplicas" != "$availableReplicas" ] ; then
-        return 1
-    fi
-
-    if [ "$desiredReplicas" != "$readyReplicas" ] ; then
-        return 1
-    fi
-
-    if [ "$desiredReplicas" != "$updatedReplicas" ] ; then
-        return 1
-    fi
-
-    return 0
-}

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -832,3 +832,35 @@ function build_installer_prefix() {
 function get_local_node_name() {
     hostname | tr '[:upper:]' '[:lower:]'
 }
+
+# this waits for a deployment to have all replicas up-to-date and available
+function deployment_fully_updated() {
+    local namespace=$1
+    local deployment=$2
+
+    local desiredReplicas
+    desiredReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.replicas}')
+
+    local availableReplicas
+    availableReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.availableReplicas}')
+
+    local readyReplicas
+    readyReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.readyReplicas}')
+
+    local updatedReplicas
+    updatedReplicas=$(kubectl get deployment -n "$namespace" "$deployment" -o jsonpath='{.status.updatedReplicas}')
+
+    if [ "$desiredReplicas" != "$availableReplicas" ] ; then
+        return 1
+    fi
+
+    if [ "$desiredReplicas" != "$readyReplicas" ] ; then
+        return 1
+    fi
+
+    if [ "$desiredReplicas" != "$updatedReplicas" ] ; then
+        return 1
+    fi
+
+    return 0
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This is a function that should be used a lot - it returns false if a deployment is not yet fully running. A lot of addons use `spinner pod_running` instead, which does not actually wait for the pod to be available and invites race conditions when rolling out an update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
