### PR TITLE
Pin weaveexec container image to alpine 3.16

### DIFF
--- a/addons/weave/2.6.5/build-images/weaveexec/Dockerfile
+++ b/addons/weave/2.6.5/build-images/weaveexec/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM weaveworks/weaveexec:2.6.5 AS base
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 RUN apk add --update \
     curl \

--- a/addons/weave/2.8.1/build-images/weaveexec/Dockerfile
+++ b/addons/weave/2.8.1/build-images/weaveexec/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM weaveworks/weaveexec:2.8.1 AS base
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 RUN apk add --update --upgrade \
     curl \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::security

#### What this PR does / why we need it:

Weaveexec container image got pinned to the wrong alpine version
