### PR TITLE
Update weaveexec image base container to alpine 3.16

### DIFF
--- a/addons/weave/2.6.5/Manifest
+++ b/addons/weave/2.6.5/Manifest
@@ -1,3 +1,3 @@
 image weave-kube kurlsh/weave-kube:2.6.5-45e04df-20220616
 image weave-npc kurlsh/weave-npc:2.6.5-45e04df-20220616
-image weaveexec kurlsh/weaveexec:2.6.5-45e04df-20220616
+image weaveexec kurlsh/weaveexec:2.6.5-5a904da-20220713

--- a/addons/weave/2.6.5/daemonset.yaml
+++ b/addons/weave/2.6.5/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
             - name: CHECKPOINT_DISABLE
               value: "1"
             - name: EXEC_IMAGE
-              value: "kurlsh/weaveexec:2.6.5-45e04df-20220616"
+              value: "kurlsh/weaveexec:2.6.5-5a904da-20220713"
           image: kurlsh/weave-kube:2.6.5-45e04df-20220616
           livenessProbe:
             httpGet:

--- a/addons/weave/2.8.1/Manifest
+++ b/addons/weave/2.8.1/Manifest
@@ -1,3 +1,3 @@
 image weave-kube kurlsh/weave-kube:2.8.1-45e04df-20220616
 image weave-npc kurlsh/weave-npc:2.8.1-45e04df-20220616
-image weaveexec kurlsh/weaveexec:2.8.1-45e04df-20220616
+image weaveexec kurlsh/weaveexec:2.8.1-5a904da-20220713

--- a/addons/weave/2.8.1/weave-daemonset-k8s-1.11.yaml
+++ b/addons/weave/2.8.1/weave-daemonset-k8s-1.11.yaml
@@ -151,7 +151,7 @@ items:
                       apiVersion: v1
                       fieldPath: spec.nodeName
                 - name: EXEC_IMAGE
-                  value: "kurlsh/weaveexec:2.8.1-45e04df-20220616"
+                  value: "kurlsh/weaveexec:2.8.1-5a904da-20220713"
               image: 'kurlsh/weave-kube:2.8.1-45e04df-20220616'
               readinessProbe:
                 httpGet:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::security

#### What this PR does / why we need it:

Weaveexec container image got pinned to the wrong alpine version


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The [Weave add-on](https://kurl.sh/docs/add-ons/weave) now uses alpine:3.16 as the base image for container image weaveexec for versions 2.8.1 and 2.6.5.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE