### PR TITLE
Update local-volume-provider image to v0.3.6

### DIFF
--- a/addons/velero/1.8.1/Manifest
+++ b/addons/velero/1.8.1/Manifest
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v1.8.1
 image velero-aws velero/velero-plugin-for-aws:v1.4.1
 image velero-gcp velero/velero-plugin-for-gcp:v1.4.1
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.4.1
-image local-volume-provider replicated/local-volume-provider:v0.3.5
+image local-volume-provider replicated/local-volume-provider:v0.3.6
 image s3cmd kurlsh/s3cmd:7f7dc75-20210331
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.8.1/velero-v1.8.1-linux-amd64.tar.gz

--- a/addons/velero/1.8.1/install.sh
+++ b/addons/velero/1.8.1/install.sh
@@ -150,7 +150,7 @@ function velero_install() {
         $bslArgs \
         $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --plugins velero/velero-plugin-for-aws:v1.4.1,velero/velero-plugin-for-gcp:v1.4.1,velero/velero-plugin-for-microsoft-azure:v1.4.1,replicated/local-volume-provider:v0.3.5,"$KURL_UTIL_IMAGE" \
+        --plugins velero/velero-plugin-for-aws:v1.4.1,velero/velero-plugin-for-gcp:v1.4.1,velero/velero-plugin-for-microsoft-azure:v1.4.1,replicated/local-volume-provider:v0.3.6,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
         --dry-run -o yaml > "$dst/velero.yaml" 
 

--- a/addons/velero/1.9.0/Manifest
+++ b/addons/velero/1.9.0/Manifest
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v1.9.0
 image velero-aws velero/velero-plugin-for-aws:v1.5.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.0
-image local-volume-provider replicated/local-volume-provider:v0.3.5
+image local-volume-provider replicated/local-volume-provider:v0.3.6
 image s3cmd kurlsh/s3cmd:20220711-9578884
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.0/velero-v1.9.0-linux-amd64.tar.gz

--- a/addons/velero/1.9.0/install.sh
+++ b/addons/velero/1.9.0/install.sh
@@ -150,7 +150,7 @@ function velero_install() {
         $bslArgs \
         $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --plugins velero/velero-plugin-for-aws:v1.5.0,velero/velero-plugin-for-gcp:v1.5.0,velero/velero-plugin-for-microsoft-azure:v1.5.0,replicated/local-volume-provider:v0.3.5,"$KURL_UTIL_IMAGE" \
+        --plugins velero/velero-plugin-for-aws:v1.5.0,velero/velero-plugin-for-gcp:v1.5.0,velero/velero-plugin-for-microsoft-azure:v1.5.0,replicated/local-volume-provider:v0.3.6,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
         --dry-run -o yaml > "$dst/velero.yaml" 
 

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -3,7 +3,7 @@ image restic-restore velero/velero-restic-restore-helper:v__VELERO_VERSION__
 image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
 image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
 image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__
-image local-volume-provider replicated/local-volume-provider:v0.3.5
+image local-volume-provider replicated/local-volume-provider:v0.3.6
 image s3cmd kurlsh/s3cmd:__S3CMD_TAG__
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v__VELERO_VERSION__/velero-v__VELERO_VERSION__-linux-amd64.tar.gz

--- a/addons/velero/template/base/install.sh.tmpl
+++ b/addons/velero/template/base/install.sh.tmpl
@@ -150,7 +150,7 @@ function velero_install() {
         $bslArgs \
         $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --plugins velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__,velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__,velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__,replicated/local-volume-provider:v0.3.5,"$KURL_UTIL_IMAGE" \
+        --plugins velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__,velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__,velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__,replicated/local-volume-provider:v0.3.6,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
         --dry-run -o yaml > "$dst/velero.yaml" 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::chore

#### What this PR does / why we need it:

Updates the local-volume-provider image to v0.3.6

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Updates the local-volume-provider image to address CVE-2021-38561 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE