### PR TITLE
report_status_update failed after report_failure cluster_not_ready

### DIFF
--- a/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -483,8 +483,10 @@ function wait_for_cluster_ready() {
         echo "cluster is not ready"
         i=$((i+1))
         if [ $i -gt 20 ]; then
+            send_logs
             report_failure "cluster_not_ready"
-            exit 0
+            report_status_update "failed"
+            exit 1
         fi
         sleep 60
     done
@@ -507,10 +509,10 @@ function main() {
     
     if [ $KURL_EXIT_STATUS -ne 0 ]; then
         echo "kurl install failed"
+        send_logs
         report_failure "kurl_install"
         report_status_update "failed"
         collect_support_bundle
-        send_logs
         exit 1
     fi
 
@@ -531,10 +533,10 @@ function main() {
 
         if [ $KURL_EXIT_STATUS -ne 0 ]; then
             echo "kurl upgrade failed"
+            send_logs
             report_failure "kurl_upgrade"
             report_status_update "failed"
             collect_support_bundle
-            send_logs
             exit 1
         fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Testgrid ui shows running after cluster_not_ready failures
