### PR TITLE
Increase testgrid timeout

### DIFF
--- a/testgrid/tgrun/pkg/runner/cleanup.go
+++ b/testgrid/tgrun/pkg/runner/cleanup.go
@@ -38,8 +38,9 @@ func CleanUpVMIs() error {
 			}
 		}
 
-		// cleanup VMIs that have been running for more than one hour - the in-script timeout is 30m
-		if vmi.Status.Phase == kubevirtv1.Running && time.Since(vmi.CreationTimestamp.Time).Minutes() > 60 {
+		// cleanup VMIs that have been running for more than 1.5 hours
+		// the in-script timeout for install is 30m, upgrade is 45m
+		if vmi.Status.Phase == kubevirtv1.Running && time.Since(vmi.CreationTimestamp.Time).Minutes() > 90 {
 			if apiEndpoint := vmi.Annotations["testgrid.kurl.sh/apiendpoint"]; apiEndpoint != "" {
 				url := fmt.Sprintf("%s/v1/instance/%s/finish", apiEndpoint, vmi.Name)
 				data := `{"success": false, "failureReason": "timeout"}`

--- a/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -119,7 +119,7 @@ function run_upgrade() {
     echo "running kurl upgrade at '$(date)'"
     send_logs
 
-    cat install.sh | timeout 30m bash -s $AIRGAP_UPGRADE_FLAG ${KURL_FLAGS[@]}
+    cat install.sh | timeout 45m bash -s $AIRGAP_UPGRADE_FLAG ${KURL_FLAGS[@]}
     KURL_EXIT_STATUS=$?
 
     if [ "$KURL_EXIT_STATUS" -eq 0 ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

Upgrade is taking too long and getting killed by timeout

```
Cloud-init v. 18.5 running 'modules:config' at Wed, 20 Jul 2022 22:26:31 +0000. Up 7.50 seconds.
```

```
+ echo 'running kurl upgrade at '\''Wed Jul 20 22:38:44 UTC 2022'\'''
```

```
2022-07-20 23:07:53+00:00 awaiting minio readiness
+ KURL_EXIT_STATUS=124
+ '[' 124 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 124'
+ collect_debug_info_after_kurl
+ '[' 124 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
2022-07-20 23:08:44+00:00 
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE