### PR TITLE
Sonobuoy conformance image is now hosted at registry.k8s.io

### DIFF
--- a/addons/sonobuoy/0.56.8/install.sh
+++ b/addons/sonobuoy/0.56.8/install.sh
@@ -1,10 +1,14 @@
 
 function sonobuoy() {
     sonobuoy_binary
+
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_join() {
     sonobuoy_binary
+
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_binary() {
@@ -20,4 +24,43 @@ function sonobuoy_binary() {
     fi
 
     tar xzf "${src}/assets/sonobuoy.tar.gz" -C /usr/local/bin
+}
+
+function sonobuoy_airgap_maybe_tag_image() {
+    if [ "$AIRGAP" != "1" ]; then
+        return
+    fi
+    if [ -n "$DOCKER_VERSION" ]; then
+        sonobuoy_docker_maybe_tag_image "$@"
+    else
+        sonobuoy_ctr_maybe_tag_image "$@"
+    fi
+}
+
+function sonobuoy_docker_maybe_tag_image() {
+    local src="$1"
+    local dst="$2"
+    if ! docker image inspect "$src" >/dev/null 2>&1 ; then
+        # source image does not exist, will not tag
+        return
+    fi
+    if docker image inspect "$dst" >/dev/null 2>&1 ; then
+        # destination image exists, will not tag
+        return
+    fi
+    docker image tag "$src" "$dst"
+}
+
+function sonobuoy_ctr_maybe_tag_image() {
+    local src="$1"
+    local dst="$2"
+    if [ "$(ctr -n=k8s.io images list -q name=="$src" 2>/dev/null | wc -l)" = "0" ] ; then
+        # source image does not exist, will not tag
+        return
+    fi
+    if [ "$(ctr -n=k8s.io images list -q name=="$dst" 2>/dev/null | wc -l)" = "1" ] ; then
+        # destination image exists, will not tag
+        return
+    fi
+    ctr -n=k8s.io images tag "$src" "$dst"
 }

--- a/addons/sonobuoy/template/base/install.sh
+++ b/addons/sonobuoy/template/base/install.sh
@@ -1,10 +1,14 @@
 
 function sonobuoy() {
     sonobuoy_binary
+
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_join() {
     sonobuoy_binary
+
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_binary() {
@@ -20,4 +24,43 @@ function sonobuoy_binary() {
     fi
 
     tar xzf "${src}/assets/sonobuoy.tar.gz" -C /usr/local/bin
+}
+
+function sonobuoy_airgap_maybe_tag_image() {
+    if [ "$AIRGAP" != "1" ]; then
+        return
+    fi
+    if [ -n "$DOCKER_VERSION" ]; then
+        sonobuoy_docker_maybe_tag_image "$@"
+    else
+        sonobuoy_ctr_maybe_tag_image "$@"
+    fi
+}
+
+function sonobuoy_docker_maybe_tag_image() {
+    local src="$1"
+    local dst="$2"
+    if ! docker image inspect "$src" >/dev/null 2>&1 ; then
+        # source image does not exist, will not tag
+        return
+    fi
+    if docker image inspect "$dst" >/dev/null 2>&1 ; then
+        # destination image exists, will not tag
+        return
+    fi
+    docker image tag "$src" "$dst"
+}
+
+function sonobuoy_ctr_maybe_tag_image() {
+    local src="$1"
+    local dst="$2"
+    if [ "$(ctr -n=k8s.io images list -q name=="$src" 2>/dev/null | wc -l)" = "0" ] ; then
+        # source image does not exist, will not tag
+        return
+    fi
+    if [ "$(ctr -n=k8s.io images list -q name=="$dst" 2>/dev/null | wc -l)" = "1" ] ; then
+        # destination image exists, will not tag
+        return
+    fi
+    ctr -n=k8s.io images tag "$src" "$dst"
 }

--- a/addons/sonobuoy/template/generate.sh
+++ b/addons/sonobuoy/template/generate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 VERSION=""
 function get_latest_release_version() {
-    VERSION=$(curl -I https://github.com/vmware-tanzu/sonobuoy/releases/latest | \
+    VERSION=$(curl -sI https://github.com/vmware-tanzu/sonobuoy/releases/latest | \
         grep -i "^location" | \
         grep -Eo "0\.[0-9]+\.[0-9]+")
 }
@@ -18,9 +18,9 @@ function generate() {
     # insert images into manifest
     local tmpdir=
     tmpdir="$(mktemp -d)"
-    curl -L -o "${tmpdir}/sonobuoy.tar.gz" https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_linux_amd64.tar.gz && \
-        tar xzvf "${tmpdir}/sonobuoy.tar.gz" -C "${tmpdir}"
-    "${tmpdir}/sonobuoy" gen --kube-conformance-image-version latest | \
+    curl -sL -o "${tmpdir}/sonobuoy.tar.gz" https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_linux_amd64.tar.gz && \
+        tar xzf "${tmpdir}/sonobuoy.tar.gz" -C "${tmpdir}"
+    "${tmpdir}/sonobuoy" gen --kubernetes-version latest | \
         grep ' image: ' | \
         grep -v conformance | \
         sed 's/ *image: "*\(.*\)\/\(.*\):\([^"]*\)"*/image \2 \1\/\2:\3/' >> "../${VERSION}/Manifest"
@@ -37,6 +37,7 @@ function main() {
     get_latest_release_version
 
     if [ -d "../${VERSION}" ]; then
+        echo "Sonobuoy ${VERSION} add-on already exists"
         exit 0
     fi
 

--- a/addons/sonobuoy/template/testgrid/k8s-docker.yaml
+++ b/addons/sonobuoy/template/testgrid/k8s-docker.yaml
@@ -1,12 +1,31 @@
-- installerSpec:
+- name: latest
+  installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
+    containerd:
+      version: latest
     weave:
-      version: "latest"
-    rook:
-      version: "latest"
-    docker:
-      version: "latest"
+      version: "2.8.x"
+    longhorn:
+      version: latest
+    ekco:
+      version: latest
     sonobuoy:
       version: "__testver__"
       s3Override: "__testdist__"
+- name: latest-airgap
+  installerSpec:
+    kubernetes:
+      version: "1.23.x"
+    containerd:
+      version: latest
+    weave:
+      version: "2.8.x"
+    longhorn:
+      version: latest
+    ekco:
+      version: latest
+    sonobuoy:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

k8s project is in the process of moving from k8s.gcr.io to registry.k8s.io. Looks like sonobuoy is already looking at the latter for conformance image. [This](https://github.com/replicatedhq/kURL/blob/4585dda32f7add58fc248e6cd7f302b843f94e53/packages/kubernetes/template/script.sh#L84) along with other references to k8s.gcr.io should be changed once 1.25 ships.

https://github.com/vmware-tanzu/sonobuoy/issues/1734
