### PR TITLE
Only switch mirror to vault.centos.org if centos 8

### DIFF
--- a/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -297,7 +297,10 @@ function check_airgap() {
 
 function disable_internet() {
     echo "disabling internet"
-    if [[ "$OS_NAME" == "CentOS" ]]; then
+
+    local os_id="$(. /etc/os-release && echo "$ID")"
+    local os_version_id="$(. /etc/os-release && echo "$VERSION_ID")"
+    if [ "$OS_NAME" = "CentOS" ] && [ "$os_id" = "centos" ] && [ "$os_version_id" = "8" ]; then
       ##
       # Centos 8 has reached to EOL, It means that CentOS 8 will no longer receive development resources from the official CentOS project. 
       # After Dec 31st, 2021, if you need to update your CentOS, you need to change the mirrors to vault.centos.org where they will be archived permanently
@@ -305,6 +308,7 @@ function disable_internet() {
       sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
       sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
     fi
+
     # get the list of testgrid API IPs
     command -v dig >/dev/null 2>&1 || { yum -y install bind-utils; }
     command -v iptables >/dev/null 2>&1 || { yum -y install iptables; }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Testgrid centos 7 is hanging. I think this change is likely due to https://github.com/replicatedhq/kURL/pull/3117
