### PR TITLE
Testgrid additional nodes must wait until test is done

### DIFF
--- a/testgrid/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/common.sh
@@ -84,6 +84,32 @@ function wait_for_join_commandready()
   done
 }
 
+function wait_for_initprimary_done()
+{
+  i=0
+  while true; do
+    primaryNodeStatus=$(get_initprimary_status)
+    if [[ "$primaryNodeStatus" = "success" ]]; then
+      echo "initprimary status finsihed the test"
+      break
+    elif [[ "$primaryNodeStatus" = "failed" ]] ; then
+      echo "primaryNodeStatus failed"
+      report_status_update "failed"
+      send_logs
+      exit 1
+    fi
+    echo "initprimary not ready"
+    i=$((i+1))
+    if [ $i -gt 20 ]; then
+      echo "wait_for_initprimary_done timeout"
+      report_status_update "failed"
+      send_logs
+      exit 1
+    fi
+    sleep 60
+  done
+}
+
 function is_airgap()
 {
   airgap=0

--- a/testgrid/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
@@ -2,7 +2,7 @@
 
 source /opt/kurl-testgrid/common.sh
 
-function runJoinCommand() 
+function runJoinCommand()
 {
   joinCommand=$(get_join_command)
   primaryJoin=$(echo "$joinCommand" | sed 's/{.*primaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)
@@ -30,21 +30,28 @@ function main()
 
   green "wait for join command"
   wait_for_join_commandready
-  
+
   green "run join command"
   if [ "$(is_airgap)" = "1" ]; then
-    runAirgapJoinCommand 
+    runAirgapJoinCommand
   else
     runJoinCommand
   fi
-  
+
   if [ $KURL_EXIT_STATUS -ne 0 ]; then
     report_status_update "failed"
     send_logs
     exit 1
   fi
-  
+
   green "report success join"
+  report_status_update "joined"
+  send_logs
+
+  # must stick around as part of the cluster until the test is complete
+  green "wait for initprimary done"
+  wait_for_initprimary_done
+
   report_status_update "success"
   send_logs
 }

--- a/testgrid/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
@@ -2,7 +2,7 @@
 
 source /opt/kurl-testgrid/common.sh
 
-function runJoinCommand() 
+function runJoinCommand()
 {
   joinCommand=$(get_join_command)
   secondaryJoin=$(echo "$joinCommand" | sed 's/{.*secondaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)
@@ -20,21 +20,21 @@ function runAirgapJoinCommand()
   KURL_EXIT_STATUS=$?
 }
 
-function main() 
+function main()
 {
   green "setup runner"
   setup_runner
-  
+
   green "report node in waiting for join command"
   report_status_update "waiting_join_command"
 
   green "wait for join command"
   secondaryJoin=$(wait_for_join_commandready)
   green "$secondaryJoin"
-  
+
   green "run join command"
   if [ "$(is_airgap)" = "1" ]; then
-    runAirgapJoinCommand 
+    runAirgapJoinCommand
   else
     runJoinCommand
   fi
@@ -45,6 +45,13 @@ function main()
   fi
 
   green "report success join"
+  report_status_update "joined"
+  send_logs
+
+  # must stick around as part of the cluster until the test is complete
+  green "wait for initprimary done"
+  wait_for_initprimary_done
+
   report_status_update "success"
   send_logs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::tests

#### What this PR does / why we need it:

Additional nodes must stick around as part of the cluster until the test is complete otherwise multi node tests fail