### PR TITLE
Testgrid save sysctl settings with higher precidence when reloaded

### DIFF
--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -1,7 +1,7 @@
 - id: amzn-20
   name: Amazon Linux
   version: "2.0"
-  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20200917.0/kvm/amzn2-kvm-2.0.20200917.0-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20220606.1/kvm/amzn2-kvm-2.0.20220606.1-x86_64.xfs.gpt.qcow2
   preinit: ""
 - id: centos-79
   name: CentOS

--- a/testgrid/specs/os.yaml
+++ b/testgrid/specs/os.yaml
@@ -1,7 +1,7 @@
 - id: amzn-20
   name: Amazon Linux
   version: "2.0"
-  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20200917.0/kvm/amzn2-kvm-2.0.20200917.0-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20220606.1/kvm/amzn2-kvm-2.0.20220606.1-x86_64.xfs.gpt.qcow2
   preinit: ""
 - id: centos-74
   name: CentOS

--- a/testgrid/tgrun/hack/os-spec.yaml
+++ b/testgrid/tgrun/hack/os-spec.yaml
@@ -1,7 +1,7 @@
 - id: amzn-20
   name: Amazon Linux
   version: "2.0"
-  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20200917.0/kvm/amzn2-kvm-2.0.20200917.0-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/os-images/2.0.20220606.1/kvm/amzn2-kvm-2.0.20220606.1-x86_64.xfs.gpt.qcow2
   preinit: ""
 - id: centos-74
   name: CentOS

--- a/testgrid/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/common.sh
@@ -16,9 +16,11 @@ function command_exists()
 function setup_runner()
 {
     setenforce 0 || true # rhel variants
-    sysctl vm.overcommit_memory=1
-    sysctl kernel.panic=10
-    sysctl kernel.panic_on_oops=1
+
+    echo "vm.overcommit_memory = 1" > /etc/sysctl.d/99-custom.conf
+    echo "kernel.panic = 10" >> /etc/sysctl.d/99-custom.conf
+    echo "kernel.panic_on_oops = 1" >> /etc/sysctl.d/99-custom.conf
+    sysctl -p /etc/sysctl.d/99-custom.conf
 
     echo "$TEST_ID" > /tmp/testgrid-id
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::tests

#### What this PR does / why we need it:

CIS benchmark checks are failing on amazon linux. This is because the kernel settings set at the beginning of the testgrid script are overridden later by the kurl script and kubelet fails to start.


```
+ cat install.sh
+ timeout 30m bash -s
...
2022-07-29 16:53:24+00:00 * Applying /etc/sysctl.d/00-defaults.conf ...
2022-07-29 16:53:24+00:00 kernel.printk = 8 4 1 7
2022-07-29 16:53:24+00:00 kernel.panic = 30
2022-07-29 16:53:24+00:00 net.ipv4.neigh.default.gc_thresh1 = 0
2022-07-29 16:53:24+00:00 net.ipv6.neigh.default.gc_thresh1 = 0
...
error execution phase wait-control-plane: couldn't initialize a Kubernetes cluster
To see the stack trace of this error execute with --v=5 or higher
2022-07-29 16:56:36+00:00 [kubelet-check] It seems like the kubelet isn't running or healthy.
2022-07-29 16:56:36+00:00 [kubelet-check] The HTTP call equal to 'curl -sSL http://localhost:10248/healthz' failed with error: Get "http://localhost:10248/healthz": dial tcp 127.0.0.1:10248: connect: connection refused.
2022-07-29 16:56:36+00:00 
2022-07-29 16:56:36+00:00 	Unfortunately, an error has occurred:
2022-07-29 16:56:36+00:00 		timed out waiting for the condition
2022-07-29 16:56:36+00:00 
2022-07-29 16:56:36+00:00 	This error is likely caused by:
2022-07-29 16:56:36+00:00 		- The kubelet is not running
2022-07-29 16:56:36+00:00 		- The kubelet is unhealthy due to a misconfiguration of the node in some way (required cgroups disabled)
```

```
+ journalctl -xeu kubelet
...
2022-07-29 16:56:37+00:00 Jul 29 16:54:58 njarnpsdurfexnzl-initialprimary kubelet[13820]: E0729 16:54:58.938075   13820 kubelet.go:1431] "Failed to start ContainerManager" err="invalid kernel flag: kernel/panic, expected value: 10, actual value: 30"
```