### PR TITLE
quote integer env var values

### DIFF
--- a/addons/kotsadm/alpha/postgres.yaml
+++ b/addons/kotsadm/alpha/postgres.yaml
@@ -153,7 +153,7 @@ spec:
           mountPath: /scripts
         env:
         - name: PGPORT
-          value: 50432 # run on different port to avoid unintended client connections.
+          value: "50432" # run on different port to avoid unintended client connections.
         - name: PGDATA
           value: /var/lib/postgresql/data/pg14data
         - name: POSTGRES_USER

--- a/addons/kotsadm/nightly/postgres.yaml
+++ b/addons/kotsadm/nightly/postgres.yaml
@@ -153,7 +153,7 @@ spec:
           mountPath: /scripts
         env:
         - name: PGPORT
-          value: 50432 # run on different port to avoid unintended client connections.
+          value: "50432" # run on different port to avoid unintended client connections.
         - name: PGDATA
           value: /var/lib/postgresql/data/pg14data
         - name: POSTGRES_USER


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::tests

#### What this PR does / why we need it:

This PR fixes an issue where integer environment variable values were not quoted for the kotsadm `nightly` and `alpha` add-ons and resulted in:

```
Error from server (BadRequest): error when creating "./kustomize/kotsadm/": StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.InitContainers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 5, error found in #10 byte of ...|,"value":50432},{"na|..., bigger context ...|de-postgres.sh"],"env":[{"name":"PGPORT","value":50432},{"name":"PGDATA","value":"/var/lib/postgresq|...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE