### PR TITLE
Retry package download on failure

### DIFF
--- a/scripts/common/common-test.sh
+++ b/scripts/common/common-test.sh
@@ -10,4 +10,13 @@ function test_get_kurl_install_directory_flag() {
     assertEquals "get_kurl_install_directory_flag KURL_INSTALL_DIRECTORY ." " kurl-install-directory=." "$(get_kurl_install_directory_flag .)"
 }
 
+function test_package_download_url_with_retry() {
+    local tmpdir="$(mktemp -d)"
+
+    assertEquals "package_download_url_with_retry 404" "22" "$(package_download_url_with_retry "https://api.replicated.com/404" "${tmpdir}/fail" || echo $?)"
+    assertEquals "package_download_url_with_retry success" "" "$(package_download_url_with_retry "https://kurl-sh.s3.amazonaws.com/dist/v2022.07.29-0/addons-gen.json" "${tmpdir}/success" "2" || echo $?)"
+
+    rm -rf "$tmpdir"
+}
+
 . shunit2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::feature

#### What this PR does / why we need it:

I see a lot of testgrid failures due to connection failures when downloading packages. We can retry to make the script more resilient.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- The installer will now retry add-on package downloads for some failure scenarios.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE