### PR TITLE
Do not auth_allow_insecure_global_id_reclaim on initial installation

### DIFF
--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -421,6 +421,11 @@ function rook_clients_secure {
 function rook_maybe_auth_allow_insecure_global_id_reclaim() {
     local dst="${DIR}/kustomize/rook/operator"
 
+    if ! kubectl -n rook-ceph get cephcluster rook-ceph >/dev/null 2>&1 ; then
+        # rook ceph not deployed, do not allow since not upgrading
+        return
+    fi
+
     local ceph_version="$(rook_detect_ceph_version)"
     if rook_should_auth_allow_insecure_global_id_reclaim "$ceph_version" ; then
         sed -i 's/auth_allow_insecure_global_id_reclaim = false/auth_allow_insecure_global_id_reclaim = true/' "$dst/configmap-rook-config-override.yaml"
@@ -432,8 +437,8 @@ function rook_should_auth_allow_insecure_global_id_reclaim() {
     local ceph_version="$1"
 
     if [ -z "$ceph_version" ]; then
-        # rook ceph not deployed, allow since not upgrading
-        return 0
+        # rook ceph not deployed, do not allow since not upgrading
+        return 1
     fi
 
     # https://docs.ceph.com/en/latest/security/CVE-2021-20288/

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -463,6 +463,11 @@ function rook_should_skip_rook_install() {
 function rook_maybe_auth_allow_insecure_global_id_reclaim() {
     local dst="${DIR}/kustomize/rook/operator"
 
+    if ! kubectl -n rook-ceph get cephcluster rook-ceph >/dev/null 2>&1 ; then
+        # rook ceph not deployed, do not allow since not upgrading
+        return
+    fi
+
     local ceph_version="$(rook_detect_ceph_version)"
     if rook_should_auth_allow_insecure_global_id_reclaim "$ceph_version" ; then
         sed -i 's/auth_allow_insecure_global_id_reclaim = false/auth_allow_insecure_global_id_reclaim = true/' "$dst/configmap-rook-config-override.yaml"
@@ -474,8 +479,8 @@ function rook_should_auth_allow_insecure_global_id_reclaim() {
     local ceph_version="$1"
 
     if [ -z "$ceph_version" ]; then
-        # rook ceph not deployed, allow since not upgrading
-        return 0
+        # rook ceph not deployed, do not allow since not upgrading
+        return 1
     fi
 
     # https://docs.ceph.com/en/latest/security/CVE-2021-20288/

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -463,6 +463,11 @@ function rook_should_skip_rook_install() {
 function rook_maybe_auth_allow_insecure_global_id_reclaim() {
     local dst="${DIR}/kustomize/rook/operator"
 
+    if ! kubectl -n rook-ceph get cephcluster rook-ceph >/dev/null 2>&1 ; then
+        # rook ceph not deployed, do not allow since not upgrading
+        return
+    fi
+
     local ceph_version="$(rook_detect_ceph_version)"
     if rook_should_auth_allow_insecure_global_id_reclaim "$ceph_version" ; then
         sed -i 's/auth_allow_insecure_global_id_reclaim = false/auth_allow_insecure_global_id_reclaim = true/' "$dst/configmap-rook-config-override.yaml"
@@ -474,8 +479,8 @@ function rook_should_auth_allow_insecure_global_id_reclaim() {
     local ceph_version="$1"
 
     if [ -z "$ceph_version" ]; then
-        # rook ceph not deployed, allow since not upgrading
-        return 0
+        # rook ceph not deployed, do not allow since not upgrading
+        return 1
     fi
 
     # https://docs.ceph.com/en/latest/security/CVE-2021-20288/

--- a/addons/rook/template/test/install.sh
+++ b/addons/rook/template/test/install.sh
@@ -17,7 +17,7 @@ function test_rook_should_skip_rook_install() {
 }
 
 function test_rook_should_auth_allow_insecure_global_id_reclaim() {
-    assertEquals 'rook_should_auth_allow_insecure_global_id_reclaim ""' "0" "$(rook_should_auth_allow_insecure_global_id_reclaim "" >/dev/null; echo $?)"
+    assertEquals 'rook_should_auth_allow_insecure_global_id_reclaim ""' "1" "$(rook_should_auth_allow_insecure_global_id_reclaim "" >/dev/null; echo $?)"
     assertEquals 'rook_should_auth_allow_insecure_global_id_reclaim "16.2.0"' "0" "$(rook_should_auth_allow_insecure_global_id_reclaim "16.2.0" >/dev/null; echo $?)"
     assertEquals 'rook_should_auth_allow_insecure_global_id_reclaim "16.2.1"' "1" "$(rook_should_auth_allow_insecure_global_id_reclaim "16.2.1" >/dev/null; echo $?)"
     assertEquals 'rook_should_auth_allow_insecure_global_id_reclaim "15.2.10"' "0" "$(rook_should_auth_allow_insecure_global_id_reclaim "15.2.10" >/dev/null; echo $?)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

Fixes an issue as of kURL version v2022.08.03-0 that improperly sets auth_allow_insecure_global_id_reclaim to true for new installations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue as of kURL version v2022.08.03-0 that improperly sets auth_allow_insecure_global_id_reclaim to true for new installations.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE