### PR TITLE
Omit v2022.09.04 when generating changelog

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -204,7 +204,7 @@ jobs:
     - name: Generate Changelog
       run: |
         git fetch --tags -f
-        lastTag=$(git tag | grep '^v20' | grep -v "$GIT_TAG" | sort | tail -1)
+        lastTag=$(git tag | grep '^v20' | grep -v 'v2022\.09\.04' | grep -v "$GIT_TAG" | sort | tail -1)
         docker run --rm \
           --env CHANGELOG_GITHUB_TOKEN \
           -v `pwd`:/usr/local/src/your-app \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::chore

#### What this PR does / why we need it:

Changelog is always diffed from highest tag alphabetically which will match erroneous tag.
