### PR TITLE
Remove Makefile Target for Building Docker on Ubuntu-22.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ dist/docker-%.tar.gz:
 	${MAKE} build/packages/docker/$*/ubuntu-16.04
 	${MAKE} build/packages/docker/$*/ubuntu-18.04
 	${MAKE} build/packages/docker/$*/ubuntu-20.04
-	${MAKE} build/packages/docker/$*/ubuntu-22.04
 	${MAKE} build/packages/docker/$*/rhel-7
 	${MAKE} build/packages/docker/$*/amzn-force
 	${MAKE} build/packages/docker/$*/rhel-8
@@ -471,9 +470,6 @@ build/packages/docker/%/ubuntu-18.04:
 
 build/packages/docker/%/ubuntu-20.04:
 	./bundles/docker-ubuntu2004/build.sh $* `pwd`/build/packages/docker/$*/ubuntu-20.04
-
-build/packages/docker/%/ubuntu-22.04:
-	./bundles/docker-ubuntu2204/build.sh $* `pwd`/build/packages/docker/$*/ubuntu-22.04
 
 build/packages/docker/%/rhel-7:
 	docker build \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::feature


#### What this PR does / why we need it:

This a follow up to https://github.com/replicatedhq/kURL/pull/3248. Removes support for building kURL supported versions of Docker on Ubuntu 22.04.
#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE