### PR TITLE
Add host preflight check for Docker Addon on Ubuntu 22.04

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -9,6 +9,7 @@ spec:
     - cpu: {}
     - memory: {}
     - hostServices: {}
+    - hostOS: {}
     - diskUsage:
         collectorName: "Ephemeral Disk Usage /var/lib/kubelet"
         path: /var/lib/kubelet
@@ -376,13 +377,20 @@ spec:
                 message: "System clock is not synchronized"
             - warn:
                 when: "ntp == unsynchronized+active"
-                message: System clock not yet synchronized                
+                message: System clock not yet synchronized
             - pass:
                 when: "ntp == synchronized+active"
                 message: "System clock is synchronized"
-            - warn: 
+            - warn:
                 when: "timezone != UTC"
                 message: "Non UTC timezone can interfere with system function"
             - pass:
                 when: "timezone == UTC"
                 message: "Timezone is set to UTC"
+    - hostOS:
+        checkName: "Docker Not Supported Ubuntu 22.04"
+        exclude: '{{kurl not .Installer.Spec.Docker.Version}}'
+        outcomes:
+          - fail:
+              when: "ubuntu = 22.04"
+              message: "docker addon does not support ubuntu 22.04"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -388,9 +388,9 @@ spec:
                 when: "timezone == UTC"
                 message: "Timezone is set to UTC"
     - hostOS:
-        checkName: "Docker Not Supported Ubuntu 22.04"
+        checkName: "Docker Not Supported on Ubuntu 22.04"
         exclude: '{{kurl not .Installer.Spec.Docker.Version}}'
         outcomes:
           - fail:
               when: "ubuntu = 22.04"
-              message: "docker addon does not support ubuntu 22.04"
+              message: "Docker addon does not support ubuntu 22.04"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?


type::feature


#### What this PR does / why we need it:

Current supported kURL versions of Docker are not yet supported on Ubuntu 22.04

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- New preflight check to disallow Docker addon install on Ubuntu 22.04

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
Yes
