### PR TITLE
Add additional no proxy addresses to the join the command

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -155,7 +155,10 @@ function addon_outro() {
     if [ "$ADDONS_HAVE_HOST_COMPONENTS" = "1" ] && kubernetes_has_remotes; then
         local common_flags
         common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES},${SERVICE_CIDR},${POD_CIDR}")"
+        if [ -n "$ADDITIONAL_NO_PROXY_ADDRESSES" ]; then
+            common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${ADDITIONAL_NO_PROXY_ADDRESSES}")"
+        fi
+        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
         common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
         common_flags="${common_flags}$(get_force_reapply_addons_flag)"
         common_flags="${common_flags}$(get_skip_system_package_install_flag)"

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -155,7 +155,7 @@ function addon_outro() {
     if [ "$ADDONS_HAVE_HOST_COMPONENTS" = "1" ] && kubernetes_has_remotes; then
         local common_flags
         common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
+        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES},${SERVICE_CIDR},${POD_CIDR}")"
         common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
         common_flags="${common_flags}$(get_force_reapply_addons_flag)"
         common_flags="${common_flags}$(get_skip_system_package_install_flag)"

--- a/scripts/common/rke2.sh
+++ b/scripts/common/rke2.sh
@@ -290,7 +290,7 @@ function rke2_outro() {
 
     # local common_flags
     # common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-    # common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
+    # common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES},${SERVICE_CIDR},${POD_CIDR}")"
     # common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
 
     # TODO(dan): move this somewhere into the k8s distro

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -383,7 +383,7 @@ function outro() {
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-    common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
+    common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES},${SERVICE_CIDR},${POD_CIDR}")"
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
     common_flags="${common_flags}$(get_remotes_flags)"
     common_flags="${common_flags}$(get_ipv6_flag)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -367,6 +367,7 @@ function kurl_config() {
         --from-literal=service_cidr="$SERVICE_CIDR" \
         --from-literal=pod_cidr="$POD_CIDR" \
         --from-literal=kurl_install_directory="$KURL_INSTALL_DIRECTORY_FLAG" \
+        --from-literal=additional_no_proxy_addresses="$ADDITIONAL_NO_PROXY_ADDRESSES" \
         --from-literal=kubernetes_cis_compliance="$KUBERNETES_CIS_COMPLIANCE"
 }
 
@@ -383,7 +384,10 @@ function outro() {
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-    common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES},${SERVICE_CIDR},${POD_CIDR}")"
+    if [ -n "$ADDITIONAL_NO_PROXY_ADDRESSES" ]; then
+        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${ADDITIONAL_NO_PROXY_ADDRESSES}")"
+    fi
+    common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
     common_flags="${common_flags}$(get_remotes_flags)"
     common_flags="${common_flags}$(get_ipv6_flag)"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -312,11 +312,15 @@ function join_token() {
 
     local service_cidr=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.service_cidr }')
     local pod_cidr=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.pod_cidr }')
+    local additional_no_proxy_addresses=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.additional_no_proxy_addresses }')
     local kurl_install_directory=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.kurl_install_directory }')
     local docker_registry_ip=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${docker_registry_ip}")"
+    if [ -n "$additional_no_proxy_addresses" ]; then
+        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${ADDITIONAL_NO_PROXY_ADDRESSES}")"
+    fi
     if [ -n "$service_cidr" ] && [ -n "$pod_cidr" ]; then
         common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${service_cidr},${pod_cidr}")"
     fi


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Short cut:  https://app.shortcut.com/replicated/story/24607/inconsistent-join-script-from-cli-vs-ui

#### Special notes for your reviewer:
Currently `ADDITIONAL_NO_PROXY_ADDRESSES` is not added to `common_flags` which is used to generate the join command.


## Steps to reproduce

Create an installer with ADDITIONAL_NO_PROXY_ADDRESSES 
Tested on the DEV environment.

#### Does this PR introduce a user-facing change?
Yes

```release-note
Added missing `additional no proxy addresses` to the join command once installation is complete.

```

#### Does this PR require documentation?
No