### PR TITLE
Host Preflight Check for Collectd on Ubuntu 22.04 

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -388,14 +388,14 @@ spec:
                 when: "timezone == UTC"
                 message: "Timezone is set to UTC"
     - hostOS:
-        checkName: "Docker Not Supported on Ubuntu 22.04"
+        checkName: "Docker Support"
         exclude: '{{kurl not .Installer.Spec.Docker.Version}}'
         outcomes:
           - fail:
               when: "ubuntu = 22.04"
               message: "Docker addon does not support ubuntu 22.04"
     - hostOS:
-        checkName: "Collectd Not Supported on Ubuntu 22.04"
+        checkName: "Collectd Support"
         exclude: '{{kurl not .Installer.Spec.Collectd.Version}}'
         outcomes:
           - fail:

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -394,3 +394,10 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "Docker addon does not support ubuntu 22.04"
+    - hostOS:
+        checkName: "Collectd Not Supported on Ubuntu 22.04"
+        exclude: '{{kurl not .Installer.Spec.Collectd.Version}}'
+        outcomes:
+          - fail:
+              when: "ubuntu = 22.04"
+              message: "Collectd addon not supported on ubuntu 22.04"

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -89,6 +89,8 @@
       version: 1.2.0
     ekco:
       version: 0.6.0
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
 - name: k8s119_containerd149
   installerSpec:
     kubernetes:
@@ -111,6 +113,8 @@
       version: 0.6.0
     containerd:
       version: 1.4.9
+  unsupportedOSIDs:
+  - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
 - name: k8s120x_openebs_minio
   installerSpec:
     kubernetes:
@@ -553,6 +557,8 @@
                   nodePort: 30080
                 httpsPort:
                   nodePort: 30443
+  unsupportedOSIDs:
+  - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: k8s120_minimal_containerd1411
   installerSpec:
     kubernetes:
@@ -587,7 +593,7 @@
     collectd:
       version: v5
   unsupportedOSIDs:
-  - ubuntu-2204 # docker 19.x is not supported on ubuntu 22.04
+  - ubuntu-2204 # docker 19.x and collectd-v5 are not supported on ubuntu 22.04
 - name: k8s119_selinux
   installerSpec:
     kubernetes:
@@ -969,6 +975,8 @@
       disableS3: true
     containerd:
       version: latest
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker latest (20.10.5) is not supported on ubuntu 22.04
 - name: "Migrate from Docker to Containerd airgap"
   installerSpec:
     kubernetes:
@@ -1003,6 +1011,8 @@
     containerd:
       version: latest
   airgap: true
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker latest (20.10.5) is not available on ubuntu 22.04
 - name: "Upgrade to 1.22"
   cpu: 6
   installerSpec:
@@ -1082,6 +1092,8 @@
     ekco:
       version: latest
   airgap: true
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
 - name: "K8s 1.23x Rook"
   installerSpec:
     kubernetes:
@@ -1237,6 +1249,8 @@
     ekco:
       version: latest
   airgap: true
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker 20.10.x is not supported on ubuntu 22.04
 - name: "Upgrade to 1.23 minimal"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::chore


#### What this PR does / why we need it:
1. Collectd v5 is [not available](https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1971093) for Ubuntu 22.04 so this update **fails** the kURL installation if the collectd addon is selected and the target OS is Ubuntu 22.04.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Collectd v5 not supported on Ubuntu 22.04
```

#### Does this PR require documentation?
Yes. Link to doc updates for collectd addon is forthcoming.
