### PR TITLE
patch the hostname in addition to the cluster ip

### DIFF
--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -146,7 +146,7 @@ EOF
         rm config.yml
     fi
     if kubernetes_resource_exists kurl secret registry-s3-secret; then
-        kubectl -n kurl patch secret registry-s3-secret -p "{\"stringData\":{\"access-key-id\":\"${MINIO_ACCESS_KEY_ID}\",\"secret-access-key\":\"${MINIO_ACCESS_KEY_SECRET}\",\"object-store-cluster-ip\":\"${MINIO_CLUSTER_IP}\"}}"
+        kubectl -n kurl patch secret registry-s3-secret -p "{\"stringData\":{\"access-key-id\":\"${MINIO_ACCESS_KEY_ID}\",\"secret-access-key\":\"${MINIO_ACCESS_KEY_SECRET}\",\"object-store-cluster-ip\":\"${MINIO_CLUSTER_IP}\",\"object-store-hostname\":\"http://${MINIO_HOST}\"}}"
     fi
     if kubernetes_resource_exists kurl deployment registry; then
         kubectl -n kurl rollout restart deployment registry


### PR DESCRIPTION
#### What this PR does / why we need it:

During the Migration from rook-ceph to Minio, One of the fields in registry-s3-secret was missing. This PR just fixes that. Tested after the change and able to do Snapshots now.

#### Which issue(s) this PR fixes:
Fixes https://app.shortcut.com/replicated/story/53258/snapshots-fail-after-migration-from-rook-to-minio

type::bug
bug::normal

## Steps to reproduce
Run the Installer and the Upgrade spec specified in the ticket 

#### Does this PR introduce a user-facing change?
No

```release-note

Fixes a bug where the registry secret has an older cluster name before migration.

```

#### Does this PR require documentation?
No