### PR TITLE
Added missing env for version tag

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -40,7 +40,9 @@ jobs:
         username: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
         password: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
 
-    - run: docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl:${VERSION_TAG}-${GITHUB_SHA:0:7}
+    - run: |
+        export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
+        docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl:${VERSION_TAG}-${GITHUB_SHA:0:7}
 
   kurl-util-image:
     runs-on: ubuntu-18.04

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -178,7 +178,10 @@ jobs:
         username: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
         password: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
 
-    - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${VERSION_TAG}-${GITHUB_SHA:0:7}
+    - run: |
+        docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/kurl:${VERSION_TAG}-${GITHUB_SHA:0:7}
+      env:
+        VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   deploy-staging-eks:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Added missing env for version tag

Fixes #

https://app.shortcut.com/replicated/story/55090/use-release-git-tag-for-image-tags-in-kurl

