### PR TITLE
Fix name collisions nodes.v1.core with longhorn crd name 'nodes'

### DIFF
--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -78,8 +78,8 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
     fi
 }
 

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -78,8 +78,9 @@ function containerd_install() {
         # If using the internal load balancer the Kubernetes API server will be unavailable until
         # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
         # is available before proceeeding.
-        # ".." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes..
+        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+
     fi
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Longhorn has its own CRD names like `nodes.longhorn.io`. And its short name is `nodes`.
This causes trouble listing `kubectl get nodes`. 
Using long hand name like "nodes.v1." fixes it.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

## Steps to reproduce

#### Does this PR introduce a user-facing change?

```release-note

Fixed a bug where migration to containerd from docker will fail due to incorrectly listing node using incorrect Group. 

```

#### Does this PR require documentation?
No
