### PR TITLE
improve health checks, watch for the right ceph when upgrading, set autoscale after updating to 1.4 and add a tasks.sh call for rook 1.0 to 1.4

### DIFF
--- a/pkg/rook/health_test.go
+++ b/pkg/rook/health_test.go
@@ -29,32 +29,44 @@ func Test_isStatusHealthy(t *testing.T) {
 		{
 			name:    "ceph finished rebalancing",
 			status:  testfiles.RebalanceCephStatus1,
-			health:  true,
-			message: "",
+			health:  false,
+			message: "1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 0.000000% complete",
 		},
 		{
 			name:    "ceph rebalancing",
 			status:  testfiles.RebalanceCephStatus2,
 			health:  false,
-			message: "health is HEALTH_WARN not HEALTH_OK and 1099 bytes are being recovered per second, 0 desired and 0.142857% of PGs are inactive, 0.181073% are degraded, and 64.709807% are misplaced, 0 required for all",
+			message: "health is HEALTH_WARN not HEALTH_OK and 1099 bytes are being recovered per second, 0 desired and 0.142857% of PGs are inactive, 0.181073% are degraded, and 64.709807% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 0.737395% complete",
 		},
 		{
 			name:    "ceph health_err due to full osd", // this message could very much be improved
 			status:  testfiles.RebalanceCephStatusFull,
 			health:  false,
-			message: "health is HEALTH_ERR not HEALTH_OK and 0.000000% of PGs are inactive, 0.516218% are degraded, and 0.000000% are misplaced, 0 required for all",
+			message: "health is HEALTH_ERR not HEALTH_OK and 0.000000% of PGs are inactive, 0.516218% are degraded, and 0.000000% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 0.998120% complete",
 		},
 		{
 			name:    "ceph rebalancing multinode",
 			status:  testfiles.RebalanceCephStatusMultinode,
 			health:  false,
-			message: "health is HEALTH_WARN not HEALTH_OK and 18863356 bytes are being recovered per second, 0 desired and 0.000000% of PGs are inactive, 42.455066% are degraded, and 2.081463% are misplaced, 0 required for all",
+			message: "health is HEALTH_WARN not HEALTH_OK and 18863356 bytes are being recovered per second, 0 desired and 0.000000% of PGs are inactive, 42.455066% are degraded, and 2.081463% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 0.648239% complete",
 		},
 		{
 			name:    "ceph has too many PGs per OSD",
 			status:  testfiles.TooManyPGSPerOSD,
 			health:  true,
 			message: "",
+		},
+		{
+			name:    "ceph has no replicas",
+			status:  testfiles.NoReplicasCephStatus,
+			health:  true,
+			message: "",
+		},
+		{
+			name:    "ceph is in the process of scaling PGs",
+			status:  testfiles.AutoscalerInProgressCephStatus,
+			health:  false,
+			message: "706767 bytes are being recovered per second, 0 desired and 7 tasks in progress, first task \"PG autoscaler decreasing pool 7 PGs from 100 to 32 (60s)      [===.........................] (remaining: 7m)\" is 0.117647% complete",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/rook/testfiles/autoscalerCephStatus.json
+++ b/pkg/rook/testfiles/autoscalerCephStatus.json
@@ -1,0 +1,168 @@
+{
+  "fsid": "79d8caa6-3023-4754-9bac-ba8dee7cd6bb",
+  "health": {
+    "status": "HEALTH_WARN",
+    "checks": {
+      "POOL_NO_REDUNDANCY": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "9 pool(s) have no replicas configured",
+          "count": 9
+        },
+        "muted": false
+      },
+      "TOO_MANY_PGS": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "too many PGs per OSD (623 > max 250)",
+          "count": 373
+        },
+        "muted": false
+      }
+    },
+    "mutes": []
+  },
+  "election_epoch": 17,
+  "quorum": [
+    0
+  ],
+  "quorum_names": [
+    "a"
+  ],
+  "quorum_age": 271,
+  "monmap": {
+    "epoch": 2,
+    "min_mon_release_name": "octopus",
+    "num_mons": 1
+  },
+  "osdmap": {
+    "epoch": 175,
+    "num_osds": 1,
+    "num_up_osds": 1,
+    "osd_up_since": 1660921258,
+    "num_in_osds": 1,
+    "osd_in_since": 1660920042,
+    "num_remapped_pgs": 0
+  },
+  "pgmap": {
+    "pgs_by_state": [
+      {
+        "state_name": "active+clean",
+        "count": 623
+      }
+    ],
+    "num_pgs": 623,
+    "num_pools": 9,
+    "num_objects": 442,
+    "data_bytes": 663156793,
+    "bytes_used": 1743863808,
+    "bytes_avail": 104556576768,
+    "bytes_total": 106300440576,
+    "recovering_objects_per_sec": 0,
+    "recovering_bytes_per_sec": 706767,
+    "recovering_keys_per_sec": 0,
+    "num_objects_recovered": 2,
+    "num_bytes_recovered": 4194304,
+    "num_keys_recovered": 0,
+    "read_bytes_sec": 17082,
+    "write_bytes_sec": 795975,
+    "read_op_per_sec": 17,
+    "write_op_per_sec": 24
+  },
+  "fsmap": {
+    "epoch": 1,
+    "by_rank": [],
+    "up:standby": 0
+  },
+  "mgrmap": {
+    "available": true,
+    "num_standbys": 0,
+    "modules": [
+      "dashboard",
+      "iostat",
+      "prometheus",
+      "restful",
+      "rook"
+    ],
+    "services": {
+      "dashboard": "http://rook-ceph-mgr-a-78cb9698bf-rxqq6:7000/",
+      "prometheus": "http://rook-ceph-mgr-a-78cb9698bf-rxqq6:9283/"
+    }
+  },
+  "servicemap": {
+    "epoch": 16,
+    "modified": "2022-08-19T15:02:19.897807+0000",
+    "services": {
+      "rgw": {
+        "daemons": {
+          "summary": "",
+          "rook.ceph.store.a": {
+            "start_epoch": 15,
+            "start_stamp": "2022-08-19T15:01:00.193033+0000",
+            "gid": 74255,
+            "addr": "10.32.0.7:0/2642159149",
+            "metadata": {
+              "arch": "x86_64",
+              "ceph_release": "octopus",
+              "ceph_version": "ceph version 15.2.8 (bdf3eebcd22d7d0b3dd4d5501bee5bac354d5b55) octopus (stable)",
+              "ceph_version_short": "15.2.8",
+              "container_hostname": "rook-ceph-rgw-rook-ceph-store-a-7b5f8677d9-d7vr2",
+              "container_image": "ceph/ceph:v15.2.8-20201217",
+              "cpu": "Intel(R) Xeon(R) CPU @ 2.20GHz",
+              "distro": "centos",
+              "distro_description": "CentOS Linux 8",
+              "distro_version": "8",
+              "frontend_config#0": "beast port=8080",
+              "frontend_type#0": "beast",
+              "hostname": "laverya-singlenode-rook-demo",
+              "kernel_description": "#21-Ubuntu SMP Fri Aug 5 12:17:08 UTC 2022",
+              "kernel_version": "5.15.0-1016-gcp",
+              "mem_swap_kb": "0",
+              "mem_total_kb": "16382208",
+              "num_handles": "1",
+              "os": "Linux",
+              "pid": "1",
+              "pod_name": "rook-ceph-rgw-rook-ceph-store-a-7b5f8677d9-d7vr2",
+              "pod_namespace": "rook-ceph",
+              "zone_id": "bab00533-5315-45d1-8d6d-9160480dafc0",
+              "zone_name": "rook-ceph-store",
+              "zonegroup_id": "ff0846e2-c328-40ec-9456-9e78ecfad9d1",
+              "zonegroup_name": "rook-ceph-store"
+            },
+            "task_status": {}
+          }
+        }
+      }
+    }
+  },
+  "progress_events": {
+    "24dcf5c3-de17-487b-9884-e9a917f1befd": {
+      "message": "PG autoscaler decreasing pool 7 PGs from 100 to 32 (60s)\n      [===.........................] (remaining: 7m)",
+      "progress": 0.11764705926179886
+    },
+    "3aa321cc-d306-4072-abf8-262aa9c38c7e": {
+      "message": "PG autoscaler decreasing pool 4 PGs from 100 to 8 (63s)\n      [===.........................] (remaining: 8m)",
+      "progress": 0.10869564861059189
+    },
+    "69cdf6be-6a13-40a0-8dc2-55c403453d0c": {
+      "message": "PG autoscaler decreasing pool 6 PGs from 100 to 8 (61s)\n      [===.........................] (remaining: 8m)",
+      "progress": 0.10869564861059189
+    },
+    "a1167470-88b2-4792-af0d-34703d4cdefa": {
+      "message": "PG autoscaler decreasing pool 1 PGs from 100 to 32 (66s)\n      [====........................] (remaining: 5m)",
+      "progress": 0.17647059261798859
+    },
+    "a34ca027-bc13-4b9c-9f21-05c2517525c5": {
+      "message": "PG autoscaler decreasing pool 2 PGs from 100 to 8 (65s)\n      [===.........................] (remaining: 7m)",
+      "progress": 0.1304347813129425
+    },
+    "b0bec4ac-0d5a-424b-b86f-27e63c0e7c82": {
+      "message": "PG autoscaler decreasing pool 5 PGs from 100 to 8 (62s)\n      [===.........................] (remaining: 8m)",
+      "progress": 0.10869564861059189
+    },
+    "c5f21c17-982c-48c3-a04b-857403fd284e": {
+      "message": "PG autoscaler decreasing pool 3 PGs from 100 to 8 (64s)\n      [===.........................] (remaining: 8m)",
+      "progress": 0.10869564861059189
+    }
+  }
+}

--- a/pkg/rook/testfiles/noreplicasCephStatus.json
+++ b/pkg/rook/testfiles/noreplicasCephStatus.json
@@ -1,0 +1,125 @@
+{
+  "fsid": "79d8caa6-3023-4754-9bac-ba8dee7cd6bb",
+  "health": {
+    "status": "HEALTH_WARN",
+    "checks": {
+      "POOL_NO_REDUNDANCY": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "9 pool(s) have no replicas configured",
+          "count": 9
+        },
+        "muted": false
+      }
+    },
+    "mutes": []
+  },
+  "election_epoch": 17,
+  "quorum": [
+    0
+  ],
+  "quorum_names": [
+    "a"
+  ],
+  "quorum_age": 1253,
+  "monmap": {
+    "epoch": 2,
+    "min_mon_release_name": "octopus",
+    "num_mons": 1
+  },
+  "osdmap": {
+    "epoch": 562,
+    "num_osds": 1,
+    "num_up_osds": 1,
+    "osd_up_since": 1660921258,
+    "num_in_osds": 1,
+    "osd_in_since": 1660920042,
+    "num_remapped_pgs": 0
+  },
+  "pgmap": {
+    "pgs_by_state": [
+      {
+        "state_name": "active+clean",
+        "count": 113
+      }
+    ],
+    "num_pgs": 113,
+    "num_pools": 9,
+    "num_objects": 442,
+    "data_bytes": 663156793,
+    "bytes_used": 1756561408,
+    "bytes_avail": 104543879168,
+    "bytes_total": 106300440576,
+    "read_bytes_sec": 341,
+    "write_bytes_sec": 2047,
+    "read_op_per_sec": 0,
+    "write_op_per_sec": 0
+  },
+  "fsmap": {
+    "epoch": 1,
+    "by_rank": [],
+    "up:standby": 0
+  },
+  "mgrmap": {
+    "available": true,
+    "num_standbys": 0,
+    "modules": [
+      "dashboard",
+      "iostat",
+      "prometheus",
+      "restful",
+      "rook"
+    ],
+    "services": {
+      "dashboard": "http://rook-ceph-mgr-a-78cb9698bf-rxqq6:7000/",
+      "prometheus": "http://rook-ceph-mgr-a-78cb9698bf-rxqq6:9283/"
+    }
+  },
+  "servicemap": {
+    "epoch": 17,
+    "modified": "2022-08-19T15:17:20.746691+0000",
+    "services": {
+      "rgw": {
+        "daemons": {
+          "summary": "",
+          "rook.ceph.store.a": {
+            "start_epoch": 15,
+            "start_stamp": "2022-08-19T15:01:00.193033+0000",
+            "gid": 74255,
+            "addr": "10.32.0.7:0/2642159149",
+            "metadata": {
+              "arch": "x86_64",
+              "ceph_release": "octopus",
+              "ceph_version": "ceph version 15.2.8 (bdf3eebcd22d7d0b3dd4d5501bee5bac354d5b55) octopus (stable)",
+              "ceph_version_short": "15.2.8",
+              "container_hostname": "rook-ceph-rgw-rook-ceph-store-a-7b5f8677d9-d7vr2",
+              "container_image": "ceph/ceph:v15.2.8-20201217",
+              "cpu": "Intel(R) Xeon(R) CPU @ 2.20GHz",
+              "distro": "centos",
+              "distro_description": "CentOS Linux 8",
+              "distro_version": "8",
+              "frontend_config#0": "beast port=8080",
+              "frontend_type#0": "beast",
+              "hostname": "laverya-singlenode-rook-demo",
+              "kernel_description": "#21-Ubuntu SMP Fri Aug 5 12:17:08 UTC 2022",
+              "kernel_version": "5.15.0-1016-gcp",
+              "mem_swap_kb": "0",
+              "mem_total_kb": "16382208",
+              "num_handles": "1",
+              "os": "Linux",
+              "pid": "1",
+              "pod_name": "rook-ceph-rgw-rook-ceph-store-a-7b5f8677d9-d7vr2",
+              "pod_namespace": "rook-ceph",
+              "zone_id": "bab00533-5315-45d1-8d6d-9160480dafc0",
+              "zone_name": "rook-ceph-store",
+              "zonegroup_id": "ff0846e2-c328-40ec-9456-9e78ecfad9d1",
+              "zonegroup_name": "rook-ceph-store"
+            },
+            "task_status": {}
+          }
+        }
+      }
+    }
+  },
+  "progress_events": {}
+}

--- a/pkg/rook/testfiles/static.go
+++ b/pkg/rook/testfiles/static.go
@@ -21,6 +21,12 @@ var RebalanceCephStatusMultinode []byte
 //go:embed tooManyPgsPerOsd.json
 var TooManyPGSPerOSD []byte
 
+//go:embed autoscalerCephStatus.json
+var AutoscalerInProgressCephStatus []byte
+
+//go:embed noreplicasCephStatus.json
+var NoReplicasCephStatus []byte
+
 // lists of pods to use in migrate unit tests
 //go:embed "6 blockdevice pods.json"
 var SixBlockDevicePods []byte

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -240,18 +240,21 @@ function rook_ceph_tools_exec() {
     return 1
 }
 
+function rook_10_to_14_images() {
+    logStep "Downloading images required for this upgrade"
+    addon_fetch rookupgrade 10to14
+    addon_load rookupgrade 10to14
+    logSuccess "Images loaded for Rook 1.1.9, 1.2.7, 1.3.11 and 1.4.9"
+}
+
 # upgrades Rook progressively from 1.0.x to 1.4.x
 function rook_10_to_14() {
     logStep "Upgrading Rook-Ceph from 1.0.x to 1.4.x"
     echo "This involves upgrading from 1.0.x to 1.1, 1.1 to 1.2, 1.2 to 1.3, and 1.3 to 1.4"
     echo "This may take some time"
+    rook_10_to_14_images
 
     $DIR/bin/kurl rook hostpath-to-block
-
-    logStep "Downloading images required for this upgrade"
-    addon_fetch rookupgrade 10to14
-    addon_load rookupgrade 10to14
-    logSuccess "Images loaded for Rook 1.1.9, 1.2.7, 1.3.11 and 1.4.9"
 
     local upgrade_files_path="$DIR/addons/rookupgrade/10to14"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -557,7 +557,7 @@ function main() {
     configure_no_proxy
     install_cri
     get_shared
-    # report_upgrade_rook
+#    maybe_report_upgrade_rook
     report_upgrade_kubernetes
     report_kubernetes_install
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -19,6 +19,7 @@ DIR=.
 . $DIR/scripts/distro/interface.sh
 . $DIR/scripts/distro/kubeadm/distro.sh
 . $DIR/scripts/distro/rke2/distro.sh
+. $DIR/scripts/distro/rke2/addon.sh
 # Magic end
 
 K8S_DISTRO=
@@ -71,6 +72,9 @@ function tasks() {
             ;;
         longhorn-node-initilize|longhorn_node_initilize)
             install_host_dependencies_longhorn $@
+            ;;
+        rook-10-to-14|rook_10_to_14)
+            rook_tasks_10_to_14
             ;;
         *)
             bail "Unknown task: $1"
@@ -684,6 +688,17 @@ function install_host_dependencies_longhorn() {
     pushd_install_directory
 
     longhorn_host_init_common "${DIR}/packages/host/longhorn"
+}
+
+function rook_tasks_10_to_14() {
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+
+    export ROOK_VERSION=v1.4.9
+    if should_upgrade_rook_10_to_14; then
+        report_upgrade_rook_10_to_14
+    else
+        echo "Not upgrading rook because it is not installed or the currently installed version is not 1.0.x"
+    fi
 }
 
 tasks "$@"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -693,6 +693,8 @@ function install_host_dependencies_longhorn() {
 function rook_tasks_10_to_14() {
     export KUBECONFIG=/etc/kubernetes/admin.conf
 
+    download_util_binaries
+
     export ROOK_VERSION=v1.4.9
     if should_upgrade_rook_10_to_14; then
         report_upgrade_rook_10_to_14


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Add a new tasks.sh endpoint, `rook-10-to-14`, that upgrades Rook 1.0 installations to Rook 1.4.9. This command only works in online installations at the moment.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
