### PR TITLE
Update GHA workflows to ubuntu-20.04 [sc-56448]

### DIFF
--- a/.github/workflows/build-package-prod.yaml
+++ b/.github/workflows/build-package-prod.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/build-package-staging.yaml
+++ b/.github/workflows/build-package-staging.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
 
   validate-go-mod:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -22,7 +22,7 @@ jobs:
       - run: go mod tidy -compat=1.17
 
   build-kurl-utils:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -39,7 +39,7 @@ jobs:
       - run: make -C kurl_util deps test build
 
   build-web:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -50,14 +50,14 @@ jobs:
       - run: make -C web deps test build
 
   test-shell:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - run: sudo apt-get install -y shunit2
     - run: make test-shell shunit2
 
   build-kurlkinds:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -75,7 +75,7 @@ jobs:
           make -C kurlkinds deps test manager
 
   build-bin-kurl:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -92,7 +92,7 @@ jobs:
       - run: make deps test build/bin/kurl
 
   build-testgrid:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: validate-go-mod
     steps:
     - uses: actions/setup-go@v3

--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -22,7 +22,7 @@ jobs:
 
   build-upload-packages:
     needs: build-matrix
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix: ${{fromJSON(needs.build-matrix.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -24,7 +24,7 @@ jobs:
 
   build-upload-packages:
     needs: build-matrix
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix: ${{fromJSON(needs.build-matrix.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production-docker-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
         docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl:${VERSION_TAG}-${GITHUB_SHA:0:7}
 
   kurl-util-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: docker/login-action@v2
@@ -58,7 +58,7 @@ jobs:
         make -C kurl_util build-and-push-kurl-util-image
 
   build-matrix:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - production-docker-image
     - kurl-util-image
@@ -77,7 +77,7 @@ jobs:
         echo "::set-output name=matrix::$OUTPUT"
 
   build-upload-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - build-matrix
     strategy:
@@ -113,7 +113,7 @@ jobs:
         AWS_REGION: "us-east-1"
 
   build-addons:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - production-docker-image
     - kurl-util-image
@@ -135,7 +135,7 @@ jobs:
         DIST_FOLDER: "dist"
 
   deploy-production-eks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - production-docker-image
     - kurl-util-image
@@ -180,7 +180,7 @@ jobs:
           git push origin release
 
   github-release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - production-docker-image
     - kurl-util-image
@@ -266,7 +266,7 @@ jobs:
 
 
   testgrid-run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - deploy-production-eks
     steps:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   get-tag:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       version_tag: ${{ steps.set-tag.outputs.version_tag }}
     steps:
@@ -22,7 +22,7 @@ jobs:
         echo "::set-output name=version_tag::${VERSION_TAG}"
 
   kurl-util-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     steps:
@@ -44,7 +44,7 @@ jobs:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   build-matrix:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     - kurl-util-image
@@ -65,7 +65,7 @@ jobs:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   build-upload-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     - build-matrix
@@ -119,7 +119,7 @@ jobs:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   build-addons:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     - kurl-util-image
@@ -140,7 +140,7 @@ jobs:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   staging-docker-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     steps:
@@ -184,7 +184,7 @@ jobs:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
   deploy-staging-eks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     - staging-docker-image
@@ -232,7 +232,7 @@ jobs:
           git push origin main
 
   testgrid-run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
     - get-tag
     - deploy-staging-eks

--- a/.github/workflows/deploy-testgrid.yaml
+++ b/.github/workflows/deploy-testgrid.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   staging-docker-image-tgapi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 
@@ -31,7 +31,7 @@ jobs:
     - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/tgapi:${GITHUB_SHA:0:7}
 
   deploy-staging-eks-tgapi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: staging-docker-image-tgapi
     steps:
     - uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
           git push origin main
 
   production-docker-image-tgapi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 
@@ -93,7 +93,7 @@ jobs:
     - run: docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/tgapi:${GITHUB_SHA:0:7}
 
   docker-image-tgrun:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: tgrun-build
@@ -115,7 +115,7 @@ jobs:
           docker push replicated/tgrun:${GITHUB_SHA:0:7}
 
   deploy-production-eks-tgapi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: production-docker-image-tgapi
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-containerd.yaml
+++ b/.github/workflows/update-containerd.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-containerd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-contour.yaml
+++ b/.github/workflows/update-contour.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-contour:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-ekco.yaml
+++ b/.github/workflows/update-ekco.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-ekco:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-goldpinger.yaml
+++ b/.github/workflows/update-goldpinger.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-goldpinger:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-kubernetes:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-local-path-provisioner.yaml
+++ b/.github/workflows/update-local-path-provisioner.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-local-path-provisioner:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/update-longhorn.yaml
+++ b/.github/workflows/update-longhorn.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-longhorn:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-openebs.yaml
+++ b/.github/workflows/update-openebs.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-openebs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-prometheus.yaml
+++ b/.github/workflows/update-prometheus.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-prometheus:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-registry.yaml
+++ b/.github/workflows/update-registry.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-registry:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-sonobuoy.yaml
+++ b/.github/workflows/update-sonobuoy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-sonobuoy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/update-velero.yaml
+++ b/.github/workflows/update-velero.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-pr-velero:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -689,7 +689,7 @@ build/bin: build/bin/kurl
 
 build/bin/kurl:
 	CGO_ENABLED=0 go build $(LDFLAGS) -o build/bin/kurl $(BUILDFLAGS) ./cmd/kurl
-	[ -n "${SKIP_LDD_CHECK}" ] || ldd build/bin/kurl | grep -q "not a dynamic executable" # confirm that there are no linked libs
+	[ -n "${SKIP_LDD_CHECK}" ] || ldd build/bin/kurl 2>&1 | grep -q "not a dynamic executable" # confirm that there are no linked libs
 
 .PHONY: code
 code: build/kustomize build/addons


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
GitHub actions is deprecating Ubuntu-18.04 runners. Brownouts have started this morning ([ref](https://github.com/actions/runner-images/issues/6002)); images will be removed on 12/1/22

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE