### PR TITLE
Output table rather than sarif for daily-scan-images workflow

### DIFF
--- a/.github/workflows/daily-scan-images.yaml
+++ b/.github/workflows/daily-scan-images.yaml
@@ -30,8 +30,6 @@ jobs:
       fail-fast: false
       max-parallel: 5
     steps:
-      - uses: actions/setup-node@v3
-      - uses: actions/checkout@v3
       - name: "${{ matrix.addon }}:${{ matrix.version }} - ${{ matrix.name }} : Write Trivy ignore file"
         run: if [ -n '${{ matrix.trivyignore }}' ]; then echo '${{ matrix.trivyignore }}' | base64 -d > .trivyignore.rego ; fi
       - name: "${{ matrix.addon }}:${{ matrix.version }} - ${{ matrix.name }} : Scan image"
@@ -39,13 +37,9 @@ jobs:
         uses: aquasecurity/trivy-action@0.7.1
         with:
           image-ref: ${{ matrix.image }}
-          format: 'sarif'
-          output: 'scan-output.sarif'
+          exit-code: '1'
           vuln-type: 'os'
+          format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           ignore-policy: ${{ matrix.trivyignore && '.trivyignore.rego' }}
-      - name: Upload SARIF report
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: scan-output.sarif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Sarif results are inputs to github security code scanning alerts. Because there is no file and line number to associate with the images we are scanning, the alerts never go away and must be manually dismissed. Because of this limitation this pr will output the alerts in human readable format until we find a better platform.
