### PR TITLE
timeout post-install and post-upgrade scripts after 30m

### DIFF
--- a/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -144,7 +144,7 @@ function run_post_install_script() {
         return # file does not exist
     fi
 
-    bash -euxo pipefail /opt/kurl-testgrid/postinstall.sh
+    timeout 30m bash -euxo pipefail /opt/kurl-testgrid/postinstall.sh
     local exit_status="$?"
 
     send_logs
@@ -162,7 +162,7 @@ function run_post_upgrade_script() {
         return # file does not exist
     fi
 
-    bash -euxo pipefail /opt/kurl-testgrid/postupgrade.sh
+    timeout 30m bash -euxo pipefail /opt/kurl-testgrid/postupgrade.sh
     local exit_status="$?"
 
     send_logs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
The instance timeout is 90m, and we enforce a 30m timeout for install & 40m for upgrades. But we don't enforce any sort of timeout for post-init and post-upgrade scripts, so this limits both to 30m.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
