### PR TITLE
improve testgrid log reporting

### DIFF
--- a/testgrid/tgapi/pkg/testinstance/testinstance.go
+++ b/testgrid/tgapi/pkg/testinstance/testinstance.go
@@ -140,12 +140,9 @@ func SetInstanceFinishedAndSuccess(id string, isSuccess bool, failureReason stri
 	db := persistence.MustGetPGSession()
 
 	var query string
-	if isSuccess {
-		// Failure cannot change to success.
+	if isSuccess || failureReason == "timeout" {
+		// Failure cannot change to success, and timeout cannot change anything.
 		query = `update testinstance set is_success = $2, finished_at = now(), failure_reason = $3 where id = $1 and finished_at is null`
-	} else if failureReason == "timeout" {
-		// Timeout cannot change success to failure.
-		query = `update testinstance set is_success = $2, finished_at = now(), failure_reason = $3 where id = $1 and is_success != true`
 	} else {
 		// Success can change to failure unless timeout.
 		query = `update testinstance set is_success = $2, finished_at = now(), failure_reason = $3 where id = $1`

--- a/testgrid/tgrun/pkg/runner/cleanup.go
+++ b/testgrid/tgrun/pkg/runner/cleanup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kurl/testgrid/tgrun/pkg/runner/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -16,7 +17,7 @@ import (
 
 // CleanUpVMIs deletes "Succeeded" VMIs
 func CleanUpVMIs() error {
-	virtClient, err := GetKubevirtClientset()
+	virtClient, err := helpers.GetKubevirtClientset()
 	if err != nil {
 		return errors.Wrap(err, "failed to get clientset")
 	}
@@ -58,6 +59,8 @@ func CleanUpVMIs() error {
 			} else {
 				fmt.Printf("Delete long-running vmi %s\n", vmi.Name)
 			}
+
+			// get the
 		}
 	}
 
@@ -66,7 +69,7 @@ func CleanUpVMIs() error {
 
 // CleanUpData cleans stale PV/PVC/Secrets and localpath to reclaim space
 func CleanUpData() error {
-	clientset, err := GetClientset()
+	clientset, err := helpers.GetClientset()
 	if err != nil {
 		return errors.Wrap(err, "failed to get clientset")
 	}

--- a/testgrid/tgrun/pkg/runner/cleanup.go
+++ b/testgrid/tgrun/pkg/runner/cleanup.go
@@ -44,7 +44,7 @@ func CleanUpVMIs() error {
 		// the in-script timeout for install is 30m, upgrade is 45m
 		if vmi.Status.Phase == kubevirtv1.Running && time.Since(vmi.CreationTimestamp.Time).Minutes() > 90 {
 			if apiEndpoint := vmi.Annotations[runnerVmi.ApiEndpointAnnotation]; apiEndpoint != "" {
-				url := fmt.Sprintf("%s/v1/instance/%s/finish", apiEndpoint, vmi.Annotations[runnerVmi.RunIDAnnotation])
+				url := fmt.Sprintf("%s/v1/instance/%s/finish", apiEndpoint, vmi.Annotations[runnerVmi.TestIDAnnotation])
 				data := `{"success": false, "failureReason": "timeout"}`
 				resp, err := http.Post(url, "application/json", strings.NewReader(data))
 				if err != nil {

--- a/testgrid/tgrun/pkg/runner/helpers/config.go
+++ b/testgrid/tgrun/pkg/runner/helpers/config.go
@@ -1,0 +1,62 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"kubevirt.io/client-go/kubecli"
+)
+
+func GetRestConfig() (*rest.Config, error) {
+	kubeconfig := filepath.Join(homeDir(), ".kube", "config")
+
+	if os.Getenv("KUBECONFIG") != "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build config")
+	}
+	return config, nil
+}
+
+func GetClientset() (*kubernetes.Clientset, error) {
+	config, err := GetRestConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get restconfig")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create clientset")
+	}
+
+	return clientset, nil
+}
+
+func GetKubevirtClientset() (kubecli.KubevirtClient, error) {
+	config, err := GetRestConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get restconfig")
+	}
+
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kubevirt clientset")
+	}
+
+	return virtClient, nil
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}

--- a/testgrid/tgrun/pkg/runner/loop.go
+++ b/testgrid/tgrun/pkg/runner/loop.go
@@ -98,7 +98,7 @@ func MainRunLoop(runnerOptions types.RunnerOptions) error {
 				OperatingSystemImage:   dequeuedInstance.OperatingSystemImage,
 				OperatingSystemPreInit: dequeuedInstance.OperatingSystemPreInit,
 
-				PVCName: fmt.Sprintf("%s-disk", dequeuedInstance.ID),
+				PVCName: dequeuedInstance.ID,
 
 				KurlYAML:          dequeuedInstance.KurlYAML,
 				KurlURL:           dequeuedInstance.KurlURL,

--- a/testgrid/tgrun/pkg/runner/metrics.go
+++ b/testgrid/tgrun/pkg/runner/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	tghandlers "github.com/replicatedhq/kurl/testgrid/tgapi/pkg/handlers"
+	"github.com/replicatedhq/kurl/testgrid/tgrun/pkg/runner/helpers"
 	"github.com/replicatedhq/kurl/testgrid/tgrun/pkg/runner/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -52,7 +53,7 @@ func ReportMetrics(runnerOptions types.RunnerOptions) error {
 
 // countRunningVMIs gets a count of the number of running VMIs
 func countRunningVMIs() (int, error) {
-	virtClient, err := GetKubevirtClientset()
+	virtClient, err := helpers.GetKubevirtClientset()
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get clientset")
 	}
@@ -73,7 +74,7 @@ func countRunningVMIs() (int, error) {
 }
 
 func getFreeResources() (float64, float64, error) {
-	clientset, err := GetClientset()
+	clientset, err := helpers.GetClientset()
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to get clientset")
 	}

--- a/testgrid/tgrun/pkg/runner/vmi/embed.go
+++ b/testgrid/tgrun/pkg/runner/vmi/embed.go
@@ -5,19 +5,22 @@ import (
 )
 
 //go:embed embed/runcmd.sh
-var runcmdSh string
+var runcmdSh []byte
 
 //go:embed embed/common.sh
-var commonSh string
+var commonSh []byte
 
 //go:embed embed/secondarynodecmd.sh
-var secondarynodecmd string
+var secondarynodecmd []byte
 
 //go:embed embed/primarynodecmd.sh
-var primarynodecmd string
+var primarynodecmd []byte
 
 //go:embed embed/mainscript.sh
-var mainscript string
+var mainscript []byte
 
 //go:embed embed/testhelpers.sh
-var testHelpers string
+var testHelpers []byte
+
+//go:embed embed/finalizelogs.sh
+var finalizeLogs []byte

--- a/testgrid/tgrun/pkg/runner/vmi/embed/finalizelogs.sh
+++ b/testgrid/tgrun/pkg/runner/vmi/embed/finalizelogs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function send_logs()
+{
+  cat /var/log/cloud-init-output.log | grep -v '"__CURSOR" :' > /tmp/testgrid-node-logs # strip junk
+  curl -X PUT -f --data-binary "@/tmp/testgrid-node-logs" "$TESTGRID_APIENDPOINT/v1/instance/$NODE_ID/node-logs"
+}
+
+send_logs

--- a/testgrid/tgrun/pkg/runner/vmi/vmi.go
+++ b/testgrid/tgrun/pkg/runner/vmi/vmi.go
@@ -34,7 +34,7 @@ const (
 	OSImageAnnotation     = "testgrid.kurl.sh/osimage"
 	OSVersionAnnotation   = "testgrid.kurl.sh/osversion"
 	OSNameAnnotation      = "testgrid.kurl.sh/osname"
-	RunIDAnnotation       = "testgrid.kurl.sh/runid"
+	TestIDAnnotation      = "testgrid.kurl.sh/testid"
 )
 
 var zero = int64(0)
@@ -311,7 +311,7 @@ func createK8sNode(singleTest types.SingleRun, nodeName string) error {
 				OSImageAnnotation:     singleTest.OperatingSystemImage,
 				KurlURLAnnotation:     singleTest.KurlURL,
 				ApiEndpointAnnotation: singleTest.TestGridAPIEndpoint,
-				RunIDAnnotation:       singleTest.ID,
+				TestIDAnnotation:      singleTest.ID,
 			},
 		},
 		Spec: kubevirtv1.VirtualMachineInstanceSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

If a VM is killed due to a timeout, this starts a new VM that sends the saved logfile to the server.

This also does a lot of code cleanup, and reduces the usage of direct execs.

It also allows things to be marked as having timed out.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
