### PR TITLE
Patch kurlsh/s3cmd for CVE-2022-37434

### DIFF
--- a/addons/registry/2.8.1/Manifest
+++ b/addons/registry/2.8.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.8.1
-image s3cmd kurlsh/s3cmd:20220722-4585dda
+image s3cmd kurlsh/s3cmd:20220825-237c19d

--- a/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20220722-4585dda
+        image: kurlsh/s3cmd:20220825-237c19d
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.8.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.8.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20220722-4585dda
+        image: kurlsh/s3cmd:20220825-237c19d
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20220722-4585dda
+        image: kurlsh/s3cmd:20220825-237c19d
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -200,14 +200,14 @@
       disableS3: true
     containerd:
       version: latest
-- name: registry_airgap_localpathprovisioner
+- name: registry_airgap_longhorn
   airgap: true
   installerSpec:
     kubernetes:
       version: "1.23.x"
     weave:
       version: "latest"
-    localPathProvisioner:
+    longhorn:
       version: "latest"
     minio:
       version: "latest"

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -11,6 +11,8 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker
@@ -42,6 +44,8 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker
@@ -86,6 +90,8 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # wait for the pod to be ready
     sleep 60s
@@ -133,6 +139,8 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # wait for the pod to be ready
     sleep 60s
@@ -216,6 +224,8 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker

--- a/addons/velero/1.9.1/Manifest
+++ b/addons/velero/1.9.1/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.5.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.0
 image local-volume-provider replicated/local-volume-provider:v0.3.7
-image s3cmd kurlsh/s3cmd:20220722-4585dda
+image s3cmd kurlsh/s3cmd:20220825-237c19d
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.1/velero-v1.9.1-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.1/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.1/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20220722-4585dda
+        image: kurlsh/s3cmd:20220825-237c19d
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Patch kurlsh/s3cmd for CVE-2022-37434

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates kurlsh/s3cmd image to tag 20220825-237c19d for latest [Registry](https://kurl.sh/docs/add-ons/registry) and [Velero](https://kurl.sh/docs/add-ons/velero) add-on versions to address the following critical and high severity CVEs: CVE-2022-37434
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE