### PR TITLE
fix enabling pg autoscale

### DIFF
--- a/pkg/rook/health.go
+++ b/pkg/rook/health.go
@@ -130,7 +130,7 @@ func progressEventsString(status cephtypes.CephStatus) string {
 
 		firstEvent.Message = strings.ReplaceAll(firstEvent.Message, "\n", "")
 
-		return fmt.Sprintf("%d tasks in progress, first task %q is %f%% complete", len(status.ProgressEvents), firstEvent.Message, firstEvent.Progress)
+		return fmt.Sprintf("%d tasks in progress, first task %q is %f%% complete", len(status.ProgressEvents), firstEvent.Message, firstEvent.Progress*100)
 	}
 
 	return ""
@@ -206,7 +206,7 @@ func waitForOkToRemoveOSD(ctx context.Context, client kubernetes.Interface, osdT
 					if isOkToRemove {
 						return nil
 					}
-					spinLine(fmt.Sprintf("Waiting for %d PGs to be moved off of osd.%d before removing it", offendingPgs, osdToRemove))
+					updatedLine(fmt.Sprintf("Waiting for %d PGs to be moved off of osd.%d before removing it", offendingPgs, osdToRemove))
 				}
 			} else {
 				// print a status message

--- a/pkg/rook/migrate.go
+++ b/pkg/rook/migrate.go
@@ -281,7 +281,7 @@ func waitForBlockOSDs(ctx context.Context, client kubernetes.Interface) error {
 			}
 		}
 
-		spinLine(fmt.Sprintf("Waiting for %d block device OSDs to be added to the cluster, have %d", desiredBlockCount, blockOSDCount))
+		updatedLine(fmt.Sprintf("Waiting for %d block device OSDs to be added to the cluster, have %d", desiredBlockCount, blockOSDCount))
 		select {
 		case <-time.After(loopSleep):
 		case <-ctx.Done():

--- a/pkg/rook/output.go
+++ b/pkg/rook/output.go
@@ -14,6 +14,7 @@ const (
 	rewriteNone = iota
 	rewriteSpinner
 	rewriteLine
+	rewriteNewline
 )
 
 func InitWriter(wr io.Writer) {
@@ -44,6 +45,23 @@ func spinLine(newLine string) {
 	} else {
 		rewriteType = rewriteLine
 		fmt.Fprintf(outputWriter, "%s", newLine)
+	}
+}
+
+var previousUpdatedLine string
+
+// when first called, writes a new line with the provided string.
+// on second+ consecutive calls in a row, writes a new line if the content has changed.
+// useful for "waiting for X, Y and Z to complete" style messages.
+func updatedLine(newLine string) {
+	if outputWriter == nil || newLine == "" {
+		return
+	}
+
+	if rewriteType != rewriteNewline || newLine != previousUpdatedLine {
+		rewriteType = rewriteNewline
+		previousUpdatedLine = newLine
+		fmt.Fprintf(outputWriter, "%s\n", newLine)
 	}
 }
 

--- a/pkg/rook/upgrade.go
+++ b/pkg/rook/upgrade.go
@@ -48,7 +48,7 @@ func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, 
 				versionMessages = append(versionMessages, fmt.Sprintf("deployments %s still running %s", strings.Join(names, ", "), ver))
 			}
 
-			spinLine(strings.Join(versionMessages, " and "))
+			updatedLine(strings.Join(versionMessages, " and "))
 		}
 
 		select {

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -76,6 +76,9 @@ function tasks() {
         rook-10-to-14|rook_10_to_14)
             rook_tasks_10_to_14
             ;;
+        rook-10-to-14-images|rook_10_to_14_images)
+            rook_tasks_10_to_14_images
+            ;;
         *)
             bail "Unknown task: $1"
             ;;
@@ -701,6 +704,13 @@ function rook_tasks_10_to_14() {
     else
         echo "Not upgrading rook because it is not installed or the currently installed version is not 1.0.x"
     fi
+}
+
+function rook_tasks_10_to_14_images() {
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+
+    download_util_binaries
+    rook_10_to_14_images
 }
 
 tasks "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
This properly sets pg autoscale behavior in the rook upgrade script (previously on single-node installs it would stall waiting for pgs to scale down)
It also improves the output of some spinners during this process, by printing a new line for each change.
Finally, a new task has been added, `rook_10_to_14_images`, which loads images for the migration process. (useful for additional nodes, will eventually have a prompt to run it if images are not present)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix an issue in the Rook 1.0 to 1.4 script that would cause a stall on single-node installations.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE