### PR TITLE
Remove unsupported osid ubuntu-22.04  from addon testgrid specs

### DIFF
--- a/addons/ekco/template/testgrid/k8s-docker.yaml
+++ b/addons/ekco/template/testgrid/k8s-docker.yaml
@@ -11,8 +11,6 @@
     ekco:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
 - name: Kubernetes 1.23, Internal LB, Rook, Multi node
   installerSpec:
     kubernetes:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -128,5 +128,3 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-    - ubuntu-2204

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -11,8 +11,6 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker
@@ -44,8 +42,6 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker
@@ -90,8 +86,6 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # wait for the pod to be ready
     sleep 60s
@@ -139,8 +133,6 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # wait for the pod to be ready
     sleep 60s
@@ -224,8 +216,6 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
   postInstallScript: |
     # setup docker config
     mkdir -p ~/.docker

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -23,8 +23,6 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
-  unsupportedOSIDs:
-    - ubuntu-2204
 
 - name: Upgrade from 1.4.3
   installerSpec:
@@ -77,8 +75,6 @@
     minio_object_store_info
     validate_testfile rwtest minio.txt
     validate_read_write_object_store postupgrade minioupgrade.txt
-  unsupportedOSIDs:
-    - ubuntu-2204
 
 - name: Upgrade from 1.5.10
   installerSpec:
@@ -210,8 +206,6 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
-  unsupportedOSIDs:
-    - ubuntu-2204
 
 - name: Upgrade from 1.0.4
   installerSpec:
@@ -262,5 +256,3 @@
     minio_object_store_info
     validate_testfile rwtest minio.txt
     validate_read_write_object_store postupgrade minioupgrade.txt
-  unsupportedOSIDs:
-    - ubuntu-2204

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -11,8 +11,6 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
 - name: "Velero Minimal Airgap"
   airgap: true
   installerSpec:
@@ -27,8 +25,6 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-  - ubuntu-2204 # docker is not available on ubuntu 22.04
 - name: "Velero DisableS3 - Rook"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove  unsupported osid ubuntu-22.04 from the addon testgrid specs since it supports latest docker version 
