### PR TITLE
Fix longhorn check for default storage class false positive

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -314,4 +314,5 @@ jobs:
             --spec ./testgrid/specs/deploy.yaml \
             --os-spec ./testgrid/specs/os-latest.yaml
         MSG="Testgrid Run(s) Executing @ https://testgrid.kurl.sh/run/${REF}"
+        echo "::set-output name=msg::${MSG}"
         echo "::notice ::${MSG}"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -260,4 +260,5 @@ jobs:
             --spec ./testgrid/specs/deploy.yaml \
             --os-spec ./testgrid/specs/os-latest.yaml
         MSG="Testgrid Run(s) Executing @ https://testgrid.kurl.sh/run/${REF}"
+        echo "::set-output name=msg::${MSG}"
         echo "::notice ::${MSG}"

--- a/addons/longhorn/1.3.1/install.sh
+++ b/addons/longhorn/1.3.1/install.sh
@@ -101,10 +101,7 @@ function longhorn_is_default_storageclass() {
 }
 
 function longhorn_has_default_storageclass() {
-    local hasDefaultStorageClass
-    hasDefaultStorageClass=$(kubectl get sc -o jsonpath='{.items[*].metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')
-
-    if [ "$hasDefaultStorageClass" = "true" ] ; then
+    if kubectl get sc -o jsonpath='{.items[*].metadata.annotations.storageclass\.kubernetes\.io/is-default-class}' | grep -q "true" ; then
         return 0
     fi
     return 1

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -101,10 +101,7 @@ function longhorn_is_default_storageclass() {
 }
 
 function longhorn_has_default_storageclass() {
-    local hasDefaultStorageClass
-    hasDefaultStorageClass=$(kubectl get sc -o jsonpath='{.items[*].metadata.annotations.storageclass\.kubernetes\.io/is-default-class}')
-
-    if [ "$hasDefaultStorageClass" = "true" ] ; then
+    if kubectl get sc -o jsonpath='{.items[*].metadata.annotations.storageclass\.kubernetes\.io/is-default-class}' | grep -q "true" ; then
         return 0
     fi
     return 1

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -99,7 +99,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -113,7 +113,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:

--- a/bin/test-addon-pr.sh
+++ b/bin/test-addon-pr.sh
@@ -141,7 +141,7 @@ function test_addon() {
   ref="${prefix}-${addon}-${version}-$(basename "$test_spec" ".yaml")-$(date --utc +%FT%TZ)"
 
   # Run testgrid plan
-  docker run --rm -e TESTGRID_API_TOKEN -v `pwd`:/wrk -w /wrk \
+  docker run --rm -e TESTGRID_API_TOKEN -v `pwd`:/wrk -v /tmp/test-spec:/tmp/test-spec -w /wrk \
     replicated/tgrun:latest queue --staging \
       --ref "$ref" \
       --spec /tmp/test-spec \

--- a/bin/test-addon-pr.sh
+++ b/bin/test-addon-pr.sh
@@ -166,6 +166,7 @@ function run() {
 
   run_addon "$addon" "$version" "$prefix"
 
+  echo "::set-output name=msg::${MSG}"
   echo "::notice ::${MSG}"
   echo "Run completed."
 }

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -21,17 +21,17 @@ function is_rook_1() {
 }
 
 function rook_ceph_osd_pods_gone() {
-    if kubectl -n rook-ceph get pods -l app=rook-ceph-osd 2>&1 | grep 'rook-ceph-osd' &>/dev/null ; then
+    if kubectl -n rook-ceph get pods -l app=rook-ceph-osd 2>/dev/null | grep 'rook-ceph-osd' &>/dev/null ; then
         return 1
     fi
     return 0
 }
 
 function prometheus_pods_gone() {
-    if kubectl -n monitoring get pods -l app=prometheus 2>&1 | grep 'prometheus' &>/dev/null ; then
+    if kubectl -n monitoring get pods -l app=prometheus 2>/dev/null | grep 'prometheus' &>/dev/null ; then
         return 1
     fi
-    if kubectl -n monitoring get pods -l app.kubernetes.io/name=prometheus 2>&1 | grep 'prometheus' &>/dev/null ; then # the labels changed with prometheus 0.53+
+    if kubectl -n monitoring get pods -l app.kubernetes.io/name=prometheus 2>/dev/null | grep 'prometheus' &>/dev/null ; then # the labels changed with prometheus 0.53+
         return 1
     fi
 
@@ -39,7 +39,7 @@ function prometheus_pods_gone() {
 }
 
 function ekco_pods_gone() {
-    if kubectl -n kurl get pods -l app=ekc-operator 2>&1 | grep 'ekc' &>/dev/null ; then
+    if kubectl -n kurl get pods -l app=ekc-operator 2>/dev/null | grep 'ekc' &>/dev/null ; then
         return 1
     fi
     return 0
@@ -113,7 +113,7 @@ function rook_ceph_to_longhorn() {
 
     # set prometheus scale if it exists
     if kubectl get namespace monitoring &>/dev/null; then
-        if kubectl get prometheus -n monitoring k8s &>/dev/null; then
+        if kubectl -n monitoring get prometheus k8s &>/dev/null; then
             # before scaling down prometheus, scale down ekco as it will otherwise restore the prometheus scale
             if kubernetes_resource_exists kurl deployment ekc-operator; then
                 kubectl -n kurl scale deploy ekc-operator --replicas=0
@@ -121,7 +121,7 @@ function rook_ceph_to_longhorn() {
                 spinner_until 120 ekco_pods_gone
             fi
 
-            kubectl patch prometheus -n monitoring  k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+            kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
             echo "Waiting for prometheus pods to be removed"
             spinner_until 120 prometheus_pods_gone
         fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Migrations from Rook to Longhorn 1.3.1 are failing with the following error:

```
Error from server (Forbidden): error when creating "./kustomize/minio/": persistentvolumeclaims "minio-pv-claim" is forbidden: Internal error occurred: 2 default StorageClasses were found
```

Longhorn 1.3.1 code sets annotation to false rather than unset. The result of the conditional to check if there is a default storage class is "false true" which evaluates to false.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue that causes migrations from Rook to Longhorn 1.3.1 to fail with 2 conflicting default storage classes.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE