### PR TITLE
test combined rook and kubernetes upgrades

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -551,13 +551,13 @@ function main() {
     install_host_dependencies
     get_common
     setup_kubeadm_kustomize
+    maybe_report_upgrade_rook_10_to_14
     ${K8S_DISTRO}_addon_for_each addon_pre_init
     discover_pod_subnet
     discover_service_subnet
     configure_no_proxy
     install_cri
     get_shared
-    maybe_report_upgrade_rook_10_to_14
     report_upgrade_kubernetes
     report_kubernetes_install
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1652,7 +1652,7 @@
     weave:
       version: "latest"
     rook:
-      version: "1.4.9"
+      version: "1.5.12"
     prometheus:
       version: "latest"
     minio:
@@ -1675,7 +1675,7 @@
     validate_read_write_object_store postupgrade minioupgrade.txt
 
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
-    echo $operatorVersion | grep 1.4.9
+    echo $operatorVersion | grep 1.5.12
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1676,16 +1676,6 @@
 
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep 1.4.9
-    is149=$?
-    if [ $ is149 -ne 0 ]; then
-      echo "Rook operator was running $operatorVersion not 1.4.9"
-      return 1 #failure
-    fi
 
-    k8sversion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
+    k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
-    is120=$?
-    if [ $ is120 -ne 0 ]; then
-      echo "Kubernetes was still running $k8sVersion not 1.20.x"
-      return 1 #failure
-    fi

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1629,3 +1629,63 @@
       version: "0.53.x"
     metricsServer:
       version: "0.4.x"
+- name: rook-upgrade-to-1.4
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    minio:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: 1.20.x
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: "1.4.9"
+    prometheus:
+      version: "latest"
+    minio:
+      version: "latest"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ecph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+    minio_object_store_info
+    validate_read_write_object_store rwtest minio.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ecph_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+
+    minio_object_store_info
+    validate_testfile rwtest minio.txt
+    validate_read_write_object_store postupgrade minioupgrade.txt
+
+    operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
+    echo $operatorVersion | grep 1.4.9
+    is149=$?
+    if [ $ is149 -ne 0 ]; then
+      echo "Rook operator was running $operatorVersion not 1.4.9"
+      return 1 #failure
+    fi
+
+    k8sversion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
+    echo $k8sVersion | grep 1.20
+    is120=$?
+    if [ $ is120 -ne 0 ]; then
+      echo "Kubernetes was still running $k8sVersion not 1.20.x"
+      return 1 #failure
+    fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
This adds a testgrid test that upgrades from Rook 1.0.4 to 1.4.9, and then upgrades k8s from 1.19 to 1.20 and Rook from 1.4.9 to 1.5.12.

It also fixes a problem where k8s and Rook would not be upgraded further from 1.19/1.4.9 until running the upgrade script again. (as in, you would run the installer and Rook would go from 1.0.4 to 1.4.9, but k8s would be untouched. Running the same installer again would bring Rook to 1.5 and k8s to your desired version)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
