### PR TITLE
uninstall docker-scan-plugin package during docker uninstall

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -112,6 +112,9 @@ function uninstall_docker() {
             if rpm -qa | grep -q 'docker-ce-rootless-extras'; then
                 dockerPackages+=("docker-ce-rootless-extras")
             fi
+            if rpm -qa | grep -q 'docker-scan-plugin'; then
+                dockerPackages+=("docker-scan-plugin")
+            fi
             rpm --erase ${dockerPackages[@]}
             ;;
     esac


### PR DESCRIPTION
#### What this PR does / why we need it:

During docker->containerd migration, `docker-scan-plugin` package is not uninstalled which is looking for docker-ce-cli.

#### Which issue(s) this PR fixes:
During docker->containerd migration, remove `docker-scan-plugin` package in rhel, amazon, centos and ol.

#### Special notes for your reviewer:
Reproduced and verified the fix on the Dev envt.


## Steps to reproduce
Install with a spec that has docker latest 20.10.17
Upgrade - Replace docker with containerd.

#### Does this PR introduce a user-facing change?
No

```release-note
Fixed a bug that caused docker to containerd upgrade failure. `docker-scan-plugin` package was not uninstalled as part of docker uninstall. 

```

#### Does this PR require documentation?
No
