### PR TITLE
Testgrid longhorn should use k8s 1.23.x

### DIFF
--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -54,7 +54,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
-- name: upgrade-from-latest-rook
+- name: upgrade-from-rook-1.0.x
   cpu: 6
   installerSpec:
     kubernetes:
@@ -71,7 +71,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.19.x"
     weave:
       version: "latest"
     containerd:
@@ -140,7 +140,7 @@
 - name: upgrade-from-oldest-longhorn
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.21.x" # 1.1.2 does not support versions higher than 1.21
     weave:
       version: "latest"
     containerd:
@@ -151,7 +151,7 @@
       version: "1.1.2" # 1.1.0 is failing in testgrid
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.21.x"
     weave:
       version: "latest"
     containerd:

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -1,7 +1,7 @@
 - name: fresh-install
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -21,7 +21,7 @@
 - name: upgrade-from-latest-longhorn
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -32,7 +32,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -58,7 +58,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.19.x"
     weave:
       version: "latest"
     containerd:
@@ -66,12 +66,12 @@
     kotsadm:
       version: "latest"
     rook:
-      version: "latest"
+      version: "1.0.x"
     ekco:
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -140,7 +140,7 @@
 - name: upgrade-from-oldest-longhorn
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -151,7 +151,7 @@
       version: "1.1.2" # 1.1.0 is failing in testgrid
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -176,7 +176,7 @@
 - name: upgrade-from-oldest-longhorn-1.2.x
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -187,7 +187,7 @@
       version: "1.2.2"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -213,7 +213,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -847,7 +847,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.21.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:

--- a/testgrid/specs/latest.yaml
+++ b/testgrid/specs/latest.yaml
@@ -27,7 +27,7 @@
     ekco:
       version: latest
     kubernetes:
-      version: latest
+      version: 1.23.x
     prometheus:
       version: latest
     registry:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

No need to pin longhorn to k8s latest (1.19.x) since that is only for rook.
