### PR TITLE
containerd-1.2.13 not supported on OL7 and CentOS7

### DIFF
--- a/addons/containerd/1.2.13/host-preflight.yaml
+++ b/addons/containerd/1.2.13/host-preflight.yaml
@@ -14,3 +14,6 @@ spec:
           - fail:
               when: "ol = 7"
               message: "containerd-1.2.13 is not supported on Oracle Linux 7"
+          - fail:
+              when: "ubuntu = 22.04"
+              message: "containerd-1.2.13 is not supported on Ubuntu 22.04"

--- a/addons/containerd/1.2.13/host-preflight.yaml
+++ b/addons/containerd/1.2.13/host-preflight.yaml
@@ -5,15 +5,58 @@ metadata:
 spec:
   hostCollectors:
     - hostOS: {}
+    - systemPackages:
+        collectorName: system-packages
+        ubuntu:
+          - docker-ce
+        centos:
+          - docker-ce
   analyzers:
+    - systemPackages:
+        collectorName: "System Packages"
+        outcomes:
+        - fail:
+            when: '{{ .IsInstalled }}'
+            message: "Docker ({{ .Name }}) to containerd-1.2.13 migration is not supported"
     - hostOS:
+        checkName: "Containerd-1.2.13 Support"
         outcomes:
           - fail:
-              when: "centos = 7"
-              message: "containerd-1.2.13 is not supported on CentOS 7"
+              when: "centos = 7.4"
+              message: "containerd-1.2.13 is not supported on CentOS 7.4"
           - fail:
-              when: "ol = 7"
-              message: "containerd-1.2.13 is not supported on Oracle Linux 7"
+              when: "centos = 7.5"
+              message: "containerd-1.2.13 is not supported on CentOS 7.5"
+          - fail:
+              when: "centos = 7.6"
+              message: "containerd-1.2.13 is not supported on CentOS 7.6"
+          - fail:
+              when: "centos = 7.7"
+              message: "containerd-1.2.13 is not supported on CentOS 7.7"
+          - fail:
+              when: "centos = 7.8"
+              message: "containerd-1.2.13 is not supported on CentOS 7.8"
+          - fail:
+              when: "centos = 7.9"
+              message: "containerd-1.2.13 is not supported on CentOS 7.9"
+          - fail:
+              when: "ol = 7.4"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.4"
+          - fail:
+              when: "ol = 7.5"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.5"
+          - fail:
+              when: "ol = 7.6"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.6"
+          - fail:
+              when: "ol = 7.7"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.7"
+          - fail:
+              when: "ol = 7.8"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.8"
+          - fail:
+              when: "ol = 7.9"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7.9"
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd-1.2.13 is not supported on Ubuntu 22.04"

--- a/addons/containerd/1.2.13/host-preflight.yaml
+++ b/addons/containerd/1.2.13/host-preflight.yaml
@@ -1,0 +1,16 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: kurl-builtin
+spec:
+  hostCollectors:
+    - hostOS: {}
+  analyzers:
+    - hostOS:
+        outcomes:
+          - fail:
+              when: "centos = 7"
+              message: "containerd-1.2.13 is not supported on CentOS 7"
+          - fail:
+              when: "ol = 7"
+              message: "containerd-1.2.13 is not supported on Oracle Linux 7"

--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -80,6 +80,7 @@
     - centos-78
     - centos-79
     - ol-79
+    - ubuntu-2204
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:

--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -14,7 +14,8 @@
       version: "latest"
     rook:
       version: "latest"
-- installerSpec:
+- name: "Upgrade Containerd from latest to __testver__"
+  installerSpec:
     kubernetes:
       version: "latest"
     antrea:
@@ -43,6 +44,42 @@
       version: "latest"
     rook:
       version: "latest"
+- name: "Upgrade Containerd from oldest (1.2.13) to __testver__"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    antrea:
+      version: "latest"
+      isEncryptionDisabled: true
+    containerd:
+      version: "1.2.13"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    rook:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    antrea:
+      version: "latest"
+      isEncryptionDisabled: true
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    rook:
+      version: "latest"
+  unsupportedOSIDs:
+    # containerd-1.2.13 not supported on CentOS7 and Oracle Linux 7
+    - centos-74
+    - centos-78
+    - centos-79
+    - ol-79
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
While testing https://github.com/replicatedhq/kURL/pull/3371 I discovered that containerd-1.2.13 (oldest) does not work on CentOS7 and OL7.

Per [this](https://github.com/containerd/containerd/issues/4008#issuecomment-584322019) comment, OL7 and CentOS7 only provide libseccomp-2.3.1 but containerd-1.2.13 requires libseccomp >= 2.4.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
Maybe.