### PR TITLE
Preflight check for supported docker versions on ubuntu 22.04

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -394,3 +394,11 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "Collectd addon not supported on ubuntu 22.04"
+    - hostOS:
+        checkName: "Docker Support"
+        exclude: '{{kurl and .Installer.Spec.Docker.Version (semverCompare "< 20.10.17" .Installer.Spec.Docker.Version) | not }}'
+        outcomes:
+          - fail:
+              when: "ubuntu = 22.04"
+              message: "Docker version < 20.10.17 not supported on ubuntu 22.04"
+

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -400,5 +400,4 @@ spec:
         outcomes:
           - fail:
               when: "ubuntu = 22.04"
-              message: "Docker version < 20.10.17 not supported on ubuntu 22.04"
-
+              message: "Docker versions < 20.10.17 not supported on ubuntu 22.04"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -396,7 +396,7 @@ spec:
               message: "Collectd addon not supported on ubuntu 22.04"
     - hostOS:
         checkName: "Docker Support"
-        exclude: '{{kurl and .Installer.Spec.Docker.Version (semverCompare "< 20.10.17" .Installer.Spec.Docker.Version) | not }}'
+        exclude: '{{kurl or (not .Installer.Spec.Docker.Version) (semverCompare ">= 20.10.17" .Installer.Spec.Docker.Version) }}'
         outcomes:
           - fail:
               when: "ubuntu = 22.04"

--- a/pkg/preflight/builtin_test.go
+++ b/pkg/preflight/builtin_test.go
@@ -212,7 +212,7 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 			spec: clusterv1beta1.Installer{
 				Spec: clusterv1beta1.InstallerSpec{
 					Docker: &clusterv1beta1.Docker{
-						Version: "latest",
+						Version: "20.10.17",
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
Ubuntu 22.04 does not support docker versions less than 20.10.17. 
Added Host built in preflight check so that the Install bails early on.

#### Which issue(s) this PR fixes:
sc-57514 https://app.shortcut.com/replicated/story/57514/write-a-preflight-check-that-does-not-allow-any-docker-versions-less-than-20-10-17-on-ubuntu-22-04

#### Special notes for your reviewer:
Did basic testing. 
. Without docker version in the spec.
. With docker version in the spec.
. semvers like 20.01.06 (prefixed with 0's on Minor/Patch numbers

## Steps to reproduce
Install kurl with Docker version say 20.10.5 on Ubuntu 22.04 

#### Does this PR introduce a user-facing change?
No
```release-note
Added Host Preflight check for supported docker versions on Ubuntu 22.04
```

#### Does this PR require documentation?
No
