### PR TITLE
Prompt to load images before running Rook 1.0 to 1.4 migration

### DIFF
--- a/pkg/cli/cluster.go
+++ b/pkg/cli/cluster.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewClusterCmd(cli CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Perform operations on the kURL cluster",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.PersistentFlags())
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.Flags())
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/cluster_images.go
+++ b/pkg/cli/cluster_images.go
@@ -36,7 +36,7 @@ func NewClusterNodesMissingImageCmd(cli CLI) *cobra.Command {
 				}
 			}
 
-			fmt.Printf("%s\n", strings.Join(nodesMissingImages, " "))
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", strings.Join(nodesMissingImages, " "))
 			return nil
 		},
 		SilenceUsage: true,

--- a/pkg/cli/cluster_images.go
+++ b/pkg/cli/cluster_images.go
@@ -14,7 +14,7 @@ func NewClusterNodesMissingImageCmd(cli CLI) *cobra.Command {
 	var excludeHost string
 
 	cmd := &cobra.Command{
-		Use:   "nodes-missing-images image...",
+		Use:   "nodes-missing-images IMAGE...",
 		Short: "Lists nodes missing the provided image(s). If a node is missing multiple images, it is only returned once.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/cluster_images.go
+++ b/pkg/cli/cluster_images.go
@@ -11,6 +11,8 @@ import (
 )
 
 func NewClusterNodesMissingImageCmd(cli CLI) *cobra.Command {
+	var excludeHost string
+
 	cmd := &cobra.Command{
 		Use:   "nodes-missing-images image...",
 		Short: "Lists nodes missing the provided image(s). If a node is missing multiple images, it is only returned once.",
@@ -24,10 +26,23 @@ func NewClusterNodesMissingImageCmd(cli CLI) *cobra.Command {
 				return fmt.Errorf("failed to determine what nodes were missing images: %w", err)
 			}
 
+			if excludeHost != "" {
+				for idx, item := range nodesMissingImages {
+					if item == excludeHost {
+						// exclude this index from nodesMissingImages
+						nodesMissingImages = append(nodesMissingImages[:idx], nodesMissingImages[idx+1:]...)
+						break
+					}
+				}
+			}
+
 			fmt.Printf("%s\n", strings.Join(nodesMissingImages, " "))
 			return nil
 		},
 		SilenceUsage: true,
 	}
+
+	cmd.Flags().StringVar(&excludeHost, "exclude_host", "", "A hostname that will be excluded from the output")
+
 	return cmd
 }

--- a/pkg/cli/cluster_images.go
+++ b/pkg/cli/cluster_images.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/replicatedhq/kurl/pkg/cluster"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func NewClusterNodesMissingImageCmd(cli CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nodes-missing-images image...",
+		Short: "Lists nodes missing the provided image(s). If a node is missing multiple images, it is only returned once.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8sConfig := config.GetConfigOrDie()
+			clientSet := kubernetes.NewForConfigOrDie(k8sConfig)
+
+			nodesMissingImages, err := cluster.NodesMissingImages(cmd.Context(), clientSet, args)
+			if err != nil {
+				return fmt.Errorf("failed to determine what nodes were missing images: %w", err)
+			}
+
+			fmt.Printf("%s\n", strings.Join(nodesMissingImages, " "))
+			return nil
+		},
+		SilenceUsage: true,
+	}
+	return cmd
+}

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -19,6 +19,10 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	rookCmd.AddCommand(NewRookHasSufficientBlockDevicesCmd(cli))
 	cmd.AddCommand(rookCmd)
 
+	clusterCmd := NewClusterCmd(cli)
+	clusterCmd.AddCommand(NewClusterNodesMissingImageCmd(cli))
+	cmd.AddCommand(clusterCmd)
+
 	cmd.AddCommand(NewSyncObjectStoreCmd(cli))
 
 	cmd.AddCommand(NewFormatAddressCmd(cli))

--- a/pkg/cli/rook_wait_for_version.go
+++ b/pkg/cli/rook_wait_for_version.go
@@ -11,7 +11,7 @@ import (
 
 func NewRookWaitForRookVersionCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-for-rook-version version",
+		Use:   "wait-for-rook-version VERSION",
 		Short: "Waits for all deployments to be using the specified rook version, and prints deployments that are still on an old version",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,7 +36,7 @@ func NewRookWaitForRookVersionCmd(cli CLI) *cobra.Command {
 }
 func NewRookWaitForCephVersionCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-for-ceph-version version",
+		Use:   "wait-for-ceph-version VERSION",
 		Short: "Waits for all deployments to be using the specified ceph version, and prints deployments that are still on an old version",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/rook_wait_for_version.go
+++ b/pkg/cli/rook_wait_for_version.go
@@ -11,7 +11,7 @@ import (
 
 func NewRookWaitForRookVersionCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-for-rook-version",
+		Use:   "wait-for-rook-version version",
 		Short: "Waits for all deployments to be using the specified rook version, and prints deployments that are still on an old version",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,7 +36,7 @@ func NewRookWaitForRookVersionCmd(cli CLI) *cobra.Command {
 }
 func NewRookWaitForCephVersionCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-for-ceph-version",
+		Use:   "wait-for-ceph-version version",
 		Short: "Waits for all deployments to be using the specified ceph version, and prints deployments that are still on an old version",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cluster/nodes.go
+++ b/pkg/cluster/nodes.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NodeImages returns a map of node names to maps of images present on that node
+func NodeImages(ctx context.Context, client kubernetes.Interface) (map[string]map[string]struct{}, error) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list nodes: %w", err)
+	}
+
+	nodeImages := map[string]map[string]struct{}{}
+
+	for _, node := range nodes.Items {
+		thisNodeImages := map[string]struct{}{}
+		for _, image := range node.Status.Images {
+			for _, name := range image.Names {
+				thisNodeImages[name] = struct{}{}
+			}
+		}
+		nodeImages[node.Name] = thisNodeImages
+	}
+
+	return nodeImages, nil
+}
+
+// NodesMissingImages returns the list of nodes missing any one of the images in the provided list
+func NodesMissingImages(ctx context.Context, client kubernetes.Interface, images []string) ([]string, error) {
+	nodesImages, err := NodeImages(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find what nodes have what images: %w", err)
+	}
+
+	missingNodes := map[string]struct{}{}
+	for _, image := range images {
+		for node, nodeImages := range nodesImages {
+			_, foundImage := nodeImages[image]
+			if !foundImage {
+				missingNodes[node] = struct{}{}
+			}
+		}
+	}
+
+	missingNodesList := []string{}
+	for missingNode := range missingNodes {
+		missingNodesList = append(missingNodesList, missingNode)
+	}
+
+	return missingNodesList, nil
+}

--- a/pkg/cluster/nodes_test.go
+++ b/pkg/cluster/nodes_test.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/replicatedhq/kurl/pkg/rook/testfiles"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// test function only, contains panics
+func runtimeFromNodesJson(nodeListJson []byte) []runtime.Object {
+	podList := corev1.NodeList{}
+	err := json.Unmarshal(nodeListJson, &podList)
+	if err != nil {
+		panic(err) // this is only called for unit tests, not at runtime
+	}
+
+	runtimeObjects := []runtime.Object{}
+	for idx, _ := range podList.Items {
+		runtimeObjects = append(runtimeObjects, &podList.Items[idx])
+	}
+	return runtimeObjects
+}
+
+func Test_countRookOSDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []runtime.Object
+		images    []string
+		wantNodes []string
+	}{
+		{
+			name:      "an image that does not exist should return the node",
+			resources: runtimeFromNodesJson(testfiles.UpgradedNode),
+			images:    []string{"doesnotexist"},
+			wantNodes: []string{"laverya-rook-kubernetes-upgrade"},
+		},
+		{
+			name:      "an image that does exist should not return the node",
+			resources: runtimeFromNodesJson(testfiles.UpgradedNode),
+			images:    []string{"registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0"},
+			wantNodes: []string{},
+		},
+		{
+			name:      "an image that does exist and one that does should return the node",
+			resources: runtimeFromNodesJson(testfiles.UpgradedNode),
+			images:    []string{"registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0", "doesnotexist"},
+			wantNodes: []string{"laverya-rook-kubernetes-upgrade"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			clientset := fake.NewSimpleClientset(tt.resources...)
+
+			gotNodes, err := NodesMissingImages(context.Background(), clientset, tt.images)
+			req.NoError(err)
+			req.ElementsMatch(tt.wantNodes, gotNodes)
+		})
+	}
+}

--- a/pkg/rook/migrate_test.go
+++ b/pkg/rook/migrate_test.go
@@ -3,12 +3,13 @@ package rook
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/replicatedhq/kurl/pkg/rook/testfiles"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 // test function only, contains panics

--- a/pkg/rook/testfiles/static.go
+++ b/pkg/rook/testfiles/static.go
@@ -3,6 +3,7 @@ package testfiles
 import _ "embed"
 
 // for health unit tests
+
 //go:embed healthyCephStatus1.json
 var HealthyCephStatus1 []byte
 
@@ -31,6 +32,7 @@ var NoReplicasCephStatus []byte
 var RecentCrashCephStatus []byte
 
 // lists of pods to use in migrate unit tests
+
 //go:embed "6 blockdevice pods.json"
 var SixBlockDevicePods []byte
 
@@ -38,8 +40,14 @@ var SixBlockDevicePods []byte
 var HostpathPods []byte
 
 // lists of deployments to be used in toolbox unit tests
+
 //go:embed "rook-6osd-deployments.json"
 var Rook6OSDDeployments []byte
 
 //go:embed "rook-hostpath-deployments.json"
 var RookHostpathDeployments []byte
+
+// lists of nodes to be used in unit tests
+
+//go:embed "upgradedNode.json"
+var UpgradedNode []byte

--- a/pkg/rook/testfiles/upgradedNode.json
+++ b/pkg/rook/testfiles/upgradedNode.json
@@ -1,0 +1,598 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Node",
+      "metadata": {
+        "annotations": {
+          "csi.volume.kubernetes.io/nodeid": "{\"rook-ceph.cephfs.csi.ceph.com\":\"laverya-rook-kubernetes-upgrade\",\"rook-ceph.rbd.csi.ceph.com\":\"laverya-rook-kubernetes-upgrade\"}",
+          "kubeadm.alpha.kubernetes.io/cri-socket": "/run/containerd/containerd.sock",
+          "node.alpha.kubernetes.io/ttl": "0",
+          "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        },
+        "creationTimestamp": "2022-08-31T17:20:36Z",
+        "labels": {
+          "beta.kubernetes.io/arch": "amd64",
+          "beta.kubernetes.io/os": "linux",
+          "kubernetes.io/arch": "amd64",
+          "kubernetes.io/hostname": "laverya-rook-kubernetes-upgrade",
+          "kubernetes.io/os": "linux",
+          "kurl.sh/cluster": "true",
+          "node-role.kubernetes.io/control-plane": "",
+          "node-role.kubernetes.io/master": ""
+        },
+        "managedFields": [
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"NetworkUnavailable\"}": {
+                    ".": {},
+                    "f:lastHeartbeatTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                }
+              }
+            },
+            "manager": "kube-utils",
+            "operation": "Update",
+            "time": "2022-08-31T17:21:01Z"
+          },
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:csi.volume.kubernetes.io/nodeid": {},
+                  "f:volumes.kubernetes.io/controller-managed-attach-detach": {}
+                },
+                "f:labels": {
+                  ".": {},
+                  "f:beta.kubernetes.io/arch": {},
+                  "f:beta.kubernetes.io/os": {},
+                  "f:kubernetes.io/arch": {},
+                  "f:kubernetes.io/hostname": {},
+                  "f:kubernetes.io/os": {},
+                  "f:kurl.sh/cluster": {}
+                }
+              },
+              "f:status": {
+                "f:addresses": {
+                  ".": {},
+                  "k:{\"type\":\"Hostname\"}": {
+                    ".": {},
+                    "f:address": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"InternalIP\"}": {
+                    ".": {},
+                    "f:address": {},
+                    "f:type": {}
+                  }
+                },
+                "f:allocatable": {
+                  ".": {},
+                  "f:cpu": {},
+                  "f:ephemeral-storage": {},
+                  "f:hugepages-1Gi": {},
+                  "f:hugepages-2Mi": {},
+                  "f:memory": {},
+                  "f:pods": {}
+                },
+                "f:capacity": {
+                  ".": {},
+                  "f:cpu": {},
+                  "f:ephemeral-storage": {},
+                  "f:hugepages-1Gi": {},
+                  "f:hugepages-2Mi": {},
+                  "f:memory": {},
+                  "f:pods": {}
+                },
+                "f:conditions": {
+                  ".": {},
+                  "k:{\"type\":\"DiskPressure\"}": {
+                    ".": {},
+                    "f:lastHeartbeatTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"MemoryPressure\"}": {
+                    ".": {},
+                    "f:lastHeartbeatTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"PIDPressure\"}": {
+                    ".": {},
+                    "f:lastHeartbeatTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastHeartbeatTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:daemonEndpoints": {
+                  "f:kubeletEndpoint": {
+                    "f:Port": {}
+                  }
+                },
+                "f:images": {},
+                "f:nodeInfo": {
+                  "f:architecture": {},
+                  "f:bootID": {},
+                  "f:containerRuntimeVersion": {},
+                  "f:kernelVersion": {},
+                  "f:kubeProxyVersion": {},
+                  "f:kubeletVersion": {},
+                  "f:machineID": {},
+                  "f:operatingSystem": {},
+                  "f:osImage": {},
+                  "f:systemUUID": {}
+                }
+              }
+            },
+            "manager": "kubelet",
+            "operation": "Update",
+            "time": "2022-08-31T17:43:05Z"
+          },
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  "f:kubeadm.alpha.kubernetes.io/cri-socket": {}
+                },
+                "f:labels": {
+                  "f:node-role.kubernetes.io/control-plane": {},
+                  "f:node-role.kubernetes.io/master": {}
+                }
+              }
+            },
+            "manager": "kubeadm",
+            "operation": "Update",
+            "time": "2022-08-31T18:08:14Z"
+          },
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  "f:node.alpha.kubernetes.io/ttl": {}
+                }
+              }
+            },
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "time": "2022-08-31T18:13:20Z"
+          }
+        ],
+        "name": "laverya-rook-kubernetes-upgrade",
+        "resourceVersion": "485847",
+        "uid": "c576c750-26ff-4866-8592-c17e1917d7f3"
+      },
+      "spec": {},
+      "status": {
+        "addresses": [
+          {
+            "address": "10.128.0.67",
+            "type": "InternalIP"
+          },
+          {
+            "address": "laverya-rook-kubernetes-upgrade",
+            "type": "Hostname"
+          }
+        ],
+        "allocatable": {
+          "cpu": "4",
+          "ephemeral-storage": "93478772582",
+          "hugepages-1Gi": "0",
+          "hugepages-2Mi": "0",
+          "memory": "16279808Ki",
+          "pods": "110"
+        },
+        "capacity": {
+          "cpu": "4",
+          "ephemeral-storage": "101430960Ki",
+          "hugepages-1Gi": "0",
+          "hugepages-2Mi": "0",
+          "memory": "16382208Ki",
+          "pods": "110"
+        },
+        "conditions": [
+          {
+            "lastHeartbeatTime": "2022-08-31T17:21:01Z",
+            "lastTransitionTime": "2022-08-31T17:21:01Z",
+            "message": "Weave pod has set this",
+            "reason": "WeaveIsUp",
+            "status": "False",
+            "type": "NetworkUnavailable"
+          },
+          {
+            "lastHeartbeatTime": "2022-09-02T15:52:16Z",
+            "lastTransitionTime": "2022-08-31T17:20:32Z",
+            "message": "kubelet has sufficient memory available",
+            "reason": "KubeletHasSufficientMemory",
+            "status": "False",
+            "type": "MemoryPressure"
+          },
+          {
+            "lastHeartbeatTime": "2022-09-02T15:52:16Z",
+            "lastTransitionTime": "2022-08-31T17:20:32Z",
+            "message": "kubelet has no disk pressure",
+            "reason": "KubeletHasNoDiskPressure",
+            "status": "False",
+            "type": "DiskPressure"
+          },
+          {
+            "lastHeartbeatTime": "2022-09-02T15:52:16Z",
+            "lastTransitionTime": "2022-08-31T17:20:32Z",
+            "message": "kubelet has sufficient PID available",
+            "reason": "KubeletHasSufficientPID",
+            "status": "False",
+            "type": "PIDPressure"
+          },
+          {
+            "lastHeartbeatTime": "2022-09-02T15:52:16Z",
+            "lastTransitionTime": "2022-08-31T18:13:30Z",
+            "message": "kubelet is posting ready status. AppArmor enabled",
+            "reason": "KubeletReady",
+            "status": "True",
+            "type": "Ready"
+          }
+        ],
+        "daemonEndpoints": {
+          "kubeletEndpoint": {
+            "Port": 10250
+          }
+        },
+        "images": [
+          {
+            "names": [
+              "docker.io/rook/ceph:v1.5.12"
+            ],
+            "sizeBytes": 1207092147
+          },
+          {
+            "names": [
+              "quay.io/cephcsi/cephcsi:v3.2.2"
+            ],
+            "sizeBytes": 1164659951
+          },
+          {
+            "names": [
+              "docker.io/ceph/ceph:v15.2.11"
+            ],
+            "sizeBytes": 1118098593
+          },
+          {
+            "names": [
+              "docker.io/kurlsh/rook-ceph:v1.0.4-9065b09-20210625"
+            ],
+            "sizeBytes": 1057682027
+          },
+          {
+            "names": [
+              "docker.io/rook/ceph:v1.4.9"
+            ],
+            "sizeBytes": 1053472661
+          },
+          {
+            "names": [
+              "quay.io/cephcsi/cephcsi:v3.1.1"
+            ],
+            "sizeBytes": 1048444382
+          },
+          {
+            "names": [
+              "quay.io/cephcsi/cephcsi:v1.2.2"
+            ],
+            "sizeBytes": 1011347710
+          },
+          {
+            "names": [
+              "docker.io/rook/ceph:v1.1.9"
+            ],
+            "sizeBytes": 1001768797
+          },
+          {
+            "names": [
+              "docker.io/kurlsh/ceph:v14.2.0-9065b09-20210625"
+            ],
+            "sizeBytes": 987206644
+          },
+          {
+            "names": [
+              "docker.io/ceph/ceph@sha256:37939a3739e4e037dcf1b1f5828058d721d8c6de958212609f9e7d920b9c62bf",
+              "docker.io/ceph/ceph:v15.2.8",
+              "docker.io/ceph/ceph:v15.2.8-20201217"
+            ],
+            "sizeBytes": 965200807
+          },
+          {
+            "names": [
+              "docker.io/rook/ceph:v1.3.11"
+            ],
+            "sizeBytes": 940068931
+          },
+          {
+            "names": [
+              "docker.io/rook/ceph:v1.2.7"
+            ],
+            "sizeBytes": 939977280
+          },
+          {
+            "names": [
+              "quay.io/cephcsi/cephcsi:v2.1.2"
+            ],
+            "sizeBytes": 864132576
+          },
+          {
+            "names": [
+              "docker.io/ceph/ceph:v14.2.5"
+            ],
+            "sizeBytes": 819591352
+          },
+          {
+            "names": [
+              "docker.io/replicated/kurl-util:v2022.08.25-0-dirty"
+            ],
+            "sizeBytes": 463964208
+          },
+          {
+            "names": [
+              "docker.io/grafana/grafana:9.0.5"
+            ],
+            "sizeBytes": 294570330
+          },
+          {
+            "names": [
+              "docker.io/ceph/ceph@sha256:8c86fc6acf47edb6c3e38777b72c3fea2bad5be18c7e88553673205b378d0121",
+              "docker.io/ceph/ceph:v14.2.5-20191210"
+            ],
+            "sizeBytes": 289364517
+          },
+          {
+            "names": [
+              "k8s.gcr.io/etcd:3.4.13-0"
+            ],
+            "sizeBytes": 254659286
+          },
+          {
+            "names": [
+              "quay.io/prometheus/prometheus:v2.37.0"
+            ],
+            "sizeBytes": 215409668
+          },
+          {
+            "names": [
+              "docker.io/kurlsh/weaveexec:2.6.5-20220825-237c19d"
+            ],
+            "sizeBytes": 148574378
+          },
+          {
+            "names": [
+              "docker.io/replicated/ekco:v0.20.0"
+            ],
+            "sizeBytes": 134121639
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-apiserver:v1.20.15"
+            ],
+            "sizeBytes": 123119938
+          },
+          {
+            "names": [
+              "docker.io/kurlsh/weave-kube:2.6.5-20220825-237c19d"
+            ],
+            "sizeBytes": 122801082
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-apiserver:v1.19.16"
+            ],
+            "sizeBytes": 120150332
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-controller-manager:v1.20.15"
+            ],
+            "sizeBytes": 117639508
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-controller-manager:v1.19.16"
+            ],
+            "sizeBytes": 112122180
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-proxy:v1.20.15"
+            ],
+            "sizeBytes": 101481064
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-proxy:v1.19.16"
+            ],
+            "sizeBytes": 100748383
+          },
+          {
+            "names": [
+              "docker.io/bloomberg/goldpinger:v3.5.1"
+            ],
+            "sizeBytes": 80970429
+          },
+          {
+            "names": [
+              "quay.io/kiwigrid/k8s-sidecar:1.19.2"
+            ],
+            "sizeBytes": 80525437
+          },
+          {
+            "names": [
+              "k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.10.0"
+            ],
+            "sizeBytes": 70135207
+          },
+          {
+            "names": [
+              "docker.io/kurlsh/s3cmd:20220825-237c19d"
+            ],
+            "sizeBytes": 65266747
+          },
+          {
+            "names": [
+              "quay.io/prometheus/alertmanager:v0.24.0"
+            ],
+            "sizeBytes": 61142380
+          },
+          {
+            "names": [
+              "k8s.gcr.io/metrics-server/metrics-server:v0.3.7"
+            ],
+            "sizeBytes": 56610121
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-provisioner:v1.4.0"
+            ],
+            "sizeBytes": 55701441
+          },
+          {
+            "names": [
+              "quay.io/prometheus-operator/prometheus-operator:v0.58.0"
+            ],
+            "sizeBytes": 51267340
+          },
+          {
+            "names": [
+              "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4"
+            ],
+            "sizeBytes": 51113966
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-provisioner:v1.6.0"
+            ],
+            "sizeBytes": 49524681
+          },
+          {
+            "names": [
+              "k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2"
+            ],
+            "sizeBytes": 49070085
+          },
+          {
+            "names": [
+              "k8s.gcr.io/sig-storage/csi-attacher:v3.0.2"
+            ],
+            "sizeBytes": 48925146
+          },
+          {
+            "names": [
+              "k8s.gcr.io/sig-storage/csi-resizer:v1.0.1"
+            ],
+            "sizeBytes": 48905182
+          },
+          {
+            "names": null,
+            "sizeBytes": 48892869
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-scheduler:v1.20.15"
+            ],
+            "sizeBytes": 48535873
+          },
+          {
+            "names": [
+              "k8s.gcr.io/kube-scheduler:v1.19.16"
+            ],
+            "sizeBytes": 47741243
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-snapshotter:v2.1.1"
+            ],
+            "sizeBytes": 47570909
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-attacher:v1.2.0"
+            ],
+            "sizeBytes": 47472035
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-attacher:v2.1.0"
+            ],
+            "sizeBytes": 47374255
+          },
+          {
+            "names": [
+              "quay.io/k8scsi/csi-resizer:v0.4.0"
+            ],
+            "sizeBytes": 47308195
+          },
+          {
+            "names": [
+              "k8s.gcr.io/coredns:1.7.0"
+            ],
+            "sizeBytes": 45355497
+          },
+          {
+            "names": [
+              "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0"
+            ],
+            "sizeBytes": 39610629
+          }
+        ],
+        "nodeInfo": {
+          "architecture": "amd64",
+          "bootID": "5d1f8e56-b06f-4418-9e52-63920dec1579",
+          "containerRuntimeVersion": "containerd://1.5.11",
+          "kernelVersion": "5.15.0-1016-gcp",
+          "kubeProxyVersion": "v1.20.15",
+          "kubeletVersion": "v1.20.15",
+          "machineID": "7e4c7af7f8d64fe9ef8757306777e262",
+          "operatingSystem": "linux",
+          "osImage": "Ubuntu 22.04.1 LTS",
+          "systemUUID": "7e4c7af7-f8d6-4fe9-ef87-57306777e262"
+        }
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": "",
+    "selfLink": ""
+  }
+}

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -260,8 +260,11 @@ function rook_10_to_14() {
     echo "This may take some time"
     rook_10_to_14_images
 
+    local thisHostname=
+    thisHostname=$(hostname)
+
     local nodesMissingImages=
-    nodesMissingImages=$($DIR/bin/kurl cluster nodes-missing-images docker.io/rook/ceph:v1.1.9 docker.io/rook/ceph:v1.2.7 docker.io/rook/ceph:v1.3.11 docker.io/rook/ceph:v1.4.9)
+    nodesMissingImages=$($DIR/bin/kurl cluster nodes-missing-images docker.io/rook/ceph:v1.1.9 docker.io/rook/ceph:v1.2.7 docker.io/rook/ceph:v1.3.11 docker.io/rook/ceph:v1.4.9 --exclude_host $thisHostname)
     if [ -n "$nodesMissingImages" ]; then
         local prefix=
         prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -260,6 +260,19 @@ function rook_10_to_14() {
     echo "This may take some time"
     rook_10_to_14_images
 
+    local nodesMissingImages=
+    nodesMissingImages=$($DIR/bin/kurl cluster nodes-missing-images docker.io/rook/ceph:v1.1.9 docker.io/rook/ceph:v1.2.7 docker.io/rook/ceph:v1.3.11 docker.io/rook/ceph:v1.4.9)
+    if [ -n "$nodesMissingImages" ]; then
+        local prefix=
+        prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+
+        echo "The nodes $nodesMissingImages appear to be missing images required for the Rook 1.0 to 1.4 migration."
+        echo "Please run the following on each of these nodes before continuing:"
+        printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s rook_10_to_14_images${NC}\n\n"
+        printf "Are you ready to continue? "
+        confirmY
+    fi
+
     $DIR/bin/kurl rook hostpath-to-block
 
     local upgrade_files_path="$DIR/addons/rookupgrade/10to14"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The Rook 1.0 to 1.4 migration will now prompt the user to load images used by the migration on other nodes before starting.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
