### PR TITLE
Use fixed-strings grep in kubeadm_registry_containerd_configure

### DIFF
--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -180,7 +180,7 @@ function kubeadm_registry_containerd_configure() {
         echo "$registry_ip $server" >> /etc/hosts
     fi
 
-    if grep -q "plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"${server}\".tls" /etc/containerd/config.toml; then
+    if grep -Fq "plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"${server}\".tls" /etc/containerd/config.toml; then
         echo "Registry ${server} TLS already configured for containerd"
         return 0
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Use --fixed-strings grep as this is not a regex. This does not fix a bug but is an optimization.