### PR TITLE
Enable containerd 1.6.x to be latest

### DIFF
--- a/addons/containerd/template/script.sh
+++ b/addons/containerd/template/script.sh
@@ -195,16 +195,6 @@ function find_common_versions() {
     VERSIONS+=("1.2.13")
 
     export GREATEST_VERSION="${VERSIONS[0]}"
-
-    # Move 1.6.x to the back so it's not the latest
-    local V6=()
-    for v in ${VERSIONS[@]}; do
-        if [[ $v == 1\.6\.* ]]; then
-            VERSIONS=("${VERSIONS[@]/$v}")
-            V6+=("${v}")
-        fi
-    done
-    VERSIONS=("${VERSIONS[@]}" "${V6[@]}")
 }
 
 function generate_version() {

--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -1,8 +1,8 @@
-- name: basic containerd and antrea
+- name: basic containerd and weave
   installerSpec:
     kubernetes:
       version: "latest"
-    antrea:
+    weave:
       version: "latest"
       isEncryptionDisabled: true
     containerd:
@@ -14,10 +14,11 @@
       version: "latest"
     rook:
       version: "latest"
-- installerSpec:
+- name: "Upgrade Containerd from current to __testver__"
+  installerSpec:
     kubernetes:
       version: "latest"
-    antrea:
+    weave:
       version: "latest"
       isEncryptionDisabled: true
     containerd:
@@ -31,7 +32,7 @@
   upgradeSpec:
     kubernetes:
       version: "latest"
-    antrea:
+    weave:
       version: "latest"
       isEncryptionDisabled: true
     containerd:
@@ -47,7 +48,7 @@
   installerSpec:
     kubernetes:
       version: 1.23.x
-    antrea:
+    weave:
       version: latest
       isEncryptionDisabled: true
     longhorn:
@@ -64,7 +65,7 @@
   upgradeSpec:
     kubernetes:
       version: 1.23.x
-    antrea:
+    weave:
       version: latest
       isEncryptionDisabled: true
     longhorn:
@@ -83,7 +84,7 @@
   installerSpec:
     kubernetes:
       version: 1.23.x
-    antrea:
+    weave:
       version: latest
       isEncryptionDisabled: true
     longhorn:
@@ -100,7 +101,7 @@
   upgradeSpec:
     kubernetes:
       version: 1.23.x
-    antrea:
+    weave:
       version: latest
       isEncryptionDisabled: true
     longhorn:

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -401,3 +401,10 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "Docker versions < 20.10.17 not supported on ubuntu 22.04"
+    # hijack hostOS analyzer in order to analyze the kURL Installer spec
+    - hostOS:
+        checkName: "Containerd and Weave Compatibility"
+        exclude: '{{kurl or (not .Installer.Spec.Weave.Version) (not .Installer.Spec.Containerd.Version) (semverCompare "1.6.0 - 1.6.4" .Installer.Spec.Containerd.Version | not) }}'
+        outcomes:
+          - fail:
+              message: "Weave is not compatible with containerd versions 1.6.0 - 1.6.4"

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -169,13 +169,11 @@
       version: "1.23.x"
       cisCompliance: true
     containerd:
-      version: "1.4.x"
+      version: "latest"
     weave:
       version: "latest"
     ekco:
       version: "latest"
-  unsupportedOSIDs:
-    - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   postInstallScript: |
     echo "running CIS Kubernetes Benchmark Checks"
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
@@ -230,7 +228,7 @@
     kubernetes:
       version: 1.24.x
     containerd:
-      version: 1.5.x
+      version: latest
     weave:
       version: 2.8.x
     contour:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1679,17 +1679,17 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
-- name: "k8s_latest containerd 1.5.x upgrade to latest"
+- name: "k8s_124x containerd 1.5.x upgrade to latest"
   installerSpec:
     kubernetes:
-      version: latest
+      version: 1.24.x
     weave:
       version: latest
     containerd:
       version: 1.5.x
   upgradeSpec:
     kubernetes:
-      version: latest
+      version: 1.24.x
     weave:
       version: latest
     containerd:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1586,7 +1586,7 @@
     weave:
       version: "2.6.5"
     containerd:
-      version: "1.5.11"
+      version: "latest"
   numPrimaryNodes: 1
   numSecondaryNodes: 2
 - name: "weave 2.8.1 multinode"
@@ -1596,7 +1596,7 @@
     weave:
       version: "2.8.1"
     containerd:
-      version: "1.5.11"
+      version: "latest"
   numPrimaryNodes: 1
   numSecondaryNodes: 2
 - name: k8s121x_openebs_containerd
@@ -1608,7 +1608,7 @@
     contour:
       version: "1.21.x"
     containerd:
-      version: "1.5.x"
+      version: "latest"
     velero:
       version: "1.8.x"
     kotsadm:
@@ -1679,3 +1679,18 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
+- name: "k8s_latest containerd 1.5.x upgrade to latest"
+  installerSpec:
+    kubernetes:
+      version: latest
+    weave:
+      version: latest
+    containerd:
+      version: 1.5.x
+  upgradeSpec:
+    kubernetes:
+      version: latest
+    weave:
+      version: latest
+    containerd:
+      version: latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This changes marks containerd `1.6.x` as `latest`.

The latest version, `1.6.8` is in this PR: https://github.com/replicatedhq/kURL/pull/3371

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/56980/make-containerd-1-6-x-latest

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

containerd-1.6.8 is now the most recent version and has been designated as 'latest'

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE