### PR TITLE
Validate version tag in CI and bail if necessary

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -6,6 +6,21 @@ on:
     - "v*.*.*"
 
 jobs:
+  verify-tag:
+    runs-on: ubuntu-20.04
+    outputs:
+        result: ${{ steps.verify-tag-id.outputs.result }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - id: verify-tag-id
+      name: Verify version tag
+      run: |
+          export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
+          OUTPUT=`bin/verify_tag.sh "${VERSION_TAG}"`
+          echo "::set-output name=result::$OUTPUT"
+
   generate-kurl-release-notes-pr:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -18,7 +18,7 @@ jobs:
       name: Verify version tag
       run: |
           export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
-          OUTPUT=`bin/verify_tag.sh "${VERSION_TAG}"`
+          OUTPUT=`bin/verify-tag.sh "${VERSION_TAG}"`
           echo "::set-output name=result::$OUTPUT"
 
   generate-kurl-release-notes-pr:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Verify version tag
       run: |
         export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
-        OUTPUT=`bin/verify-tag.sh "${VERSION_TAG}"`
+        ./bin/verify-tag.sh "${VERSION_TAG}"
 
   generate-kurl-release-notes-pr:
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -8,21 +8,19 @@ on:
 jobs:
   verify-tag:
     runs-on: ubuntu-20.04
-    outputs:
-        result: ${{ steps.verify-tag-id.outputs.result }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - id: verify-tag-id
-      name: Verify version tag
+    - name: Verify version tag
       run: |
-          export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
-          OUTPUT=`bin/verify-tag.sh "${VERSION_TAG}"`
-          echo "::set-output name=result::$OUTPUT"
+        export VERSION_TAG=$(echo $GITHUB_REF | awk -F'/' '{ print $NF }')
+        OUTPUT=`bin/verify-tag.sh "${VERSION_TAG}"`
 
   generate-kurl-release-notes-pr:
     runs-on: ubuntu-20.04
+    needs:
+    - verify-tag
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -39,6 +37,8 @@ jobs:
 
   production-docker-image:
     runs-on: ubuntu-20.04
+    needs:
+    - verify-tag
     steps:
     - uses: actions/checkout@v3
 
@@ -77,6 +77,8 @@ jobs:
 
   kurl-util-image:
     runs-on: ubuntu-20.04
+    needs:
+    - verify-tag
     steps:
     - uses: actions/checkout@v3
     - uses: docker/login-action@v2

--- a/bin/verify-tag.sh
+++ b/bin/verify-tag.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function log() {
+    echo "$1" 1>&2
+}
+
+function bail() {
+    log "$1"
+    exit 1
+}          
+
+function main() {
+    VERSION_TAG=$1
+    tag_arr=(${VERSION_TAG//-/ })
+    todays_date=$(date +'v%Y.%m.%d')
+    if [ "${todays_date}" != "${tag_arr[0]}" ]; then
+        bail "Tag must have today's date suffixed with a running number, <vYYYY.MM.DD-[0..n]>"
+    fi
+}
+
+main "$@"

--- a/bin/verify-tag.sh
+++ b/bin/verify-tag.sh
@@ -14,9 +14,12 @@ function bail() {
 function main() {
     VERSION_TAG=$1
     tag_arr=(${VERSION_TAG//-/ })
+    if [ "${#tag_arr[@]}" != 2 ]; then
+        bail "Tag must have a release sequence, <vYYYY.MM.DD-[0..n]>"
+    fi
     todays_date=$(date +'v%Y.%m.%d')
     if [ "${todays_date}" != "${tag_arr[0]}" ]; then
-        bail "Tag must have today's date suffixed with a running number, <vYYYY.MM.DD-[0..n]>"
+        bail "Tag must have today's date suffixed with a release sequence, <vYYYY.MM.DD-[0..n]>"
     fi
 }
 

--- a/bin/verify-tag.sh
+++ b/bin/verify-tag.sh
@@ -17,7 +17,7 @@ function main() {
     if [ "${#tag_arr[@]}" != 2 ]; then
         bail "Tag must have a release sequence, <vYYYY.MM.DD-[0..n]>"
     fi
-    todays_date=$(date +'v%Y.%m.%d')
+    todays_date=$(date -u +'v%Y.%m.%d')
     if [ "${todays_date}" != "${tag_arr[0]}" ]; then
         bail "Tag must have today's date suffixed with a release sequence, <vYYYY.MM.DD-[0..n]>"
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:
 If the Version tag is incorrect (say by accidentally pushing a wrong tag) or does not follow the convention of `<vYYYY.MM.DD-[0..n]>` ,  fail CI to avoid storing images with incorrect tags.

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/55228/ci-should-fail-for-tags-with-dates-in-the-future

#### Special notes for your reviewer:
Verified this on private repo. Need to verify this during Release. I will do a kURL release to verify. 

## Steps to reproduce
Push a tag that has future or past dated. 

#### Does this PR introduce a user-facing change?
No

#### Does this PR require documentation?
No