### PR TITLE
chore: migrating testgrid to k8s 1.24.x

### DIFF
--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -47,7 +47,7 @@
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
       isEncryptionDisabled: true
@@ -64,7 +64,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
       isEncryptionDisabled: true
@@ -83,7 +83,7 @@
 - name: "Migrate from Docker to Containerd airgap"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
       isEncryptionDisabled: true
@@ -100,7 +100,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
       isEncryptionDisabled: true

--- a/addons/ekco/template/testgrid/k8s-docker.yaml
+++ b/addons/ekco/template/testgrid/k8s-docker.yaml
@@ -11,10 +11,10 @@
     ekco:
       version: "__testver__"
       s3Override: "__testdist__"
-- name: Kubernetes 1.23, Internal LB, Rook, Multi node
+- name: Kubernetes 1.24, Internal LB, Rook, Multi node
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: "latest"
     rook:
@@ -47,7 +47,7 @@
 - name: podImageOverrides
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     containerd:
       version: "latest"
     weave:

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -1,7 +1,7 @@
 - name: fresh-install
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -21,7 +21,7 @@
 - name: upgrade-from-latest-longhorn
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -32,7 +32,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -99,7 +99,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -113,7 +113,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -176,7 +176,7 @@
 - name: upgrade-from-oldest-longhorn-1.2.x
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -187,7 +187,7 @@
       version: "1.2.2"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -213,7 +213,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -1,7 +1,7 @@
 - name: basic localpv
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -38,7 +38,7 @@
       version: "2.6.0"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -67,7 +67,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     containerd:
@@ -104,7 +104,7 @@
       version: "1.12.0"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     docker:

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -204,7 +204,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     weave:
       version: "latest"
     longhorn:

--- a/addons/sonobuoy/template/testgrid/k8s-docker.yaml
+++ b/addons/sonobuoy/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
 - name: latest
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     containerd:
       version: latest
     weave:
@@ -16,7 +16,7 @@
 - name: latest-airgap
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     containerd:
       version: latest
     weave:

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -7,7 +7,7 @@
     ekco:
       version: latest
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
       containerLogMaxSize: "5Mi"
       containerLogMaxFiles: 5
     prometheus:
@@ -61,10 +61,10 @@
       version: latest
   unsupportedOSIDs:
     - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-- name: k8s123-minimal
+- name: k8s124-minimal
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     docker:
       version: 20.10.x
     weave:
@@ -155,18 +155,18 @@
     ekco:
       version: latest
   airgap: true
-- name: minimal-123
+- name: minimal-124
   installerSpec:
     containerd:
       version: latest
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
-- name: k8s123x_cis_benchmarks_checks
+- name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
       cisCompliance: true
     containerd:
       version: "latest"
@@ -179,10 +179,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-- name: k8s123x_reserved_resources
+- name: k8s124x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -847,7 +847,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -936,7 +936,7 @@
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -952,7 +952,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -969,7 +969,7 @@
 - name: "Migrate from Docker to Containerd airgap"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -985,7 +985,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -1081,10 +1081,10 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-- name: "K8s 1.23x Rook"
+- name: "K8s 1.24x Rook"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     containerd:
       version: 1.4.x
     antrea:
@@ -1106,10 +1106,10 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: "K8s 1.23x Longhorn, disableS3"
+- name: "K8s 1.24x Longhorn, disableS3"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     containerd:
       version: 1.4.x
     weave:
@@ -1131,10 +1131,10 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: "K8s 1.23x Airgap"
+- name: "K8s 1.24x Airgap"
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     containerd:
       version: 1.4.x
     antrea:
@@ -1157,7 +1157,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: "Upgrade to 1.23"
+- name: "Upgrade to 1.24"
   cpu: 6
   installerSpec:
     kubernetes:
@@ -1179,7 +1179,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -1197,7 +1197,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: "Upgrade to 1.23 airgap"
+- name: "Upgrade to 1.24 airgap"
   cpu: 6
   installerSpec:
     kubernetes:
@@ -1219,7 +1219,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -1238,24 +1238,8 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.x is not supported on ubuntu 22.04
-- name: "Upgrade to 1.23 minimal"
+- name: "Upgrade to 1.24 minimal"
   installerSpec:
-    kubernetes:
-      version: 1.22.x
-    weave:
-      version: latest
-    longhorn:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-      disableS3: true
-    containerd:
-      version: latest
-    ekco:
-      version: latest
-  upgradeSpec:
     kubernetes:
       version: 1.23.x
     weave:
@@ -1271,10 +1255,26 @@
       version: latest
     ekco:
       version: latest
-- name: "Upgrade to 1.23 minimal airgap"
+  upgradeSpec:
+    kubernetes:
+      version: 1.24.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest
+    ekco:
+      version: latest
+- name: "Upgrade to 1.24 minimal airgap"
   installerSpec:
     kubernetes:
-      version: 1.22.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:
@@ -1290,7 +1290,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     weave:
       version: latest
     longhorn:
@@ -1349,10 +1349,10 @@
     ekco:
       version: latest
   flags: "labels=disktype=ssd,gpu=enabled"
-- name: k8s123-with-flags
+- name: k8s124-with-flags
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     containerd:
       version: latest
     weave:
@@ -1371,10 +1371,10 @@
     ekco:
       version: latest
   flags: "labels=disktype=ssd,gpu=enabled"
-- name: k8s123-all-the-flags
+- name: k8s124-all-the-flags
   installerSpec:
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     containerd:
       version: latest
     weave:
@@ -1392,7 +1392,7 @@
 - name: ekco-podimageoverrides
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
     containerd:
       version: "latest"
     weave:
@@ -1415,10 +1415,10 @@
     fi
 
     echo "Pod image override success: $pod_image"
-- name: k8s123x_cis_benchmarks_checks
+- name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
       cisCompliance: true
     containerd:
       version: "latest"
@@ -1431,10 +1431,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-- name: k8s122x_123x_upgrade_cis_benchmarks_checks
+- name: k8s123x_124x_upgrade_cis_benchmarks_checks
   installerSpec:
     kubernetes:
-      version: "1.22.x"
+      version: "1.23.x"
     containerd:
       version: "latest"
     weave:
@@ -1443,7 +1443,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
       cisCompliance: true
     containerd:
       version: "latest"
@@ -1456,10 +1456,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-- name: k8s123x_reserved_resources
+- name: k8s124x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.24.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
@@ -1571,7 +1571,7 @@
 - name: less_command
   installerSpec:
     kubernetes:
-      version: "1.23.5"
+      version: "1.24.x"
     docker:
       version: latest
     weave:
@@ -1582,7 +1582,7 @@
 - name: "weave 2.6.5 multinode"
   installerSpec:
     kubernetes:
-      version: "1.23.6"
+      version: "1.24.x"
     weave:
       version: "2.6.5"
     containerd:
@@ -1592,7 +1592,7 @@
 - name: "weave 2.8.1 multinode"
   installerSpec:
     kubernetes:
-      version: "1.23.6"
+      version: "1.24.x"
     weave:
       version: "2.8.1"
     containerd:

--- a/testgrid/specs/latest.yaml
+++ b/testgrid/specs/latest.yaml
@@ -27,7 +27,7 @@
     ekco:
       version: latest
     kubernetes:
-      version: 1.23.x
+      version: 1.24.x
     prometheus:
       version: latest
     registry:

--- a/web/src/installers/index.ts
+++ b/web/src/installers/index.ts
@@ -819,7 +819,7 @@ export class Installer {
     const installerVersions = await getInstallerVersions(distUrl, kurlVersion);
 
     i.id = "latest";
-    i.spec.kubernetes = { version: "1.23.x" };
+    i.spec.kubernetes = { version: "1.24.x" };
     i.spec.containerd = { version: this.toDotXVersion(installerVersions.containerd[0]) };
     i.spec.weave = { version: this.toDotXVersion(installerVersions.weave[0]) };
     i.spec.longhorn = { version: this.toDotXVersion(installerVersions.longhorn[0]) };


### PR DESCRIPTION
#### What this PR does / why we need it:

This pull request migrates references to kubernetes 1.23.x to kubernetes 1.24.x in our testgrid files.

#### Which issue(s) this PR fixes:

This pull request is part of issue #54878, there may be extra pull requests coming in next before we can close the issue.

#### Special notes for your reviewer:

Please pay special attention as in some cases I created new "test cases" (like in upgrade tests for instance).


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE