### PR TITLE
Deploy workflow to set current version in s3

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -297,11 +297,28 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: sbom/assets/*
 
+  set-current-version:
+    runs-on: ubuntu-20.04
+    needs:
+    - build-addons
+    - build-upload-packages
+    steps:
+    - name: Set VERSION file in s3
+      run: |
+        export VERSION_TAG=$GITHUB_REF_NAME
+        echo "$VERSION_TAG" | aws s3 cp - s3://$S3_BUCKET/$DIST_FOLDER/VERSION
+      env:
+        S3_BUCKET: kurl-sh
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "us-east-1"
+        DIST_FOLDER: "dist"
 
   testgrid-run:
     runs-on: ubuntu-20.04
     needs:
     - deploy-production-eks
+    - set-current-version
     steps:
 
     - name: Sleep for 3 minutes

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -231,11 +231,30 @@ jobs:
         git commit --allow-empty -m "https://github.com/replicatedhq/kURL/actions/runs/${GITHUB_RUN_ID}" && \
           git push origin main
 
+  set-current-version:
+    runs-on: ubuntu-20.04
+    needs:
+    - get-tag
+    - build-addons
+    - build-upload-packages
+    steps:
+    - name: Set VERSION file in s3
+      run: |
+        echo "$VERSION_TAG" | aws s3 cp - s3://$S3_BUCKET/$DIST_FOLDER/VERSION
+      env:
+        S3_BUCKET: kurl-sh
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "us-east-1"
+        DIST_FOLDER: "staging"
+        VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+
   testgrid-run:
     runs-on: ubuntu-20.04
     needs:
     - get-tag
     - deploy-staging-eks
+    - set-current-version
     steps:
 
     - name: Sleep for 3 minutes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Since we will be moving the kurl api to a separate repo we can no longer pin the version in the kurl release workflow. I will use this file in s3 to identify the current version from the api.