### PR TITLE
chore: fix testgrid for k8s 1.24 docker incompatibility

### DIFF
--- a/addons/cert-manager/template/testgrid/k8s-docker.yaml
+++ b/addons/cert-manager/template/testgrid/k8s-docker.yaml
@@ -20,7 +20,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     certManager:
       version: "1.0.3"
@@ -29,7 +29,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     certManager:
       version: "__testver__"

--- a/addons/collectd/template/testgrid/k8s-docker.yaml
+++ b/addons/collectd/template/testgrid/k8s-docker.yaml
@@ -3,7 +3,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     collectd:
       version: "__testver__"

--- a/addons/containerd/template/testgrid/k8s-docker.yaml
+++ b/addons/containerd/template/testgrid/k8s-docker.yaml
@@ -47,7 +47,7 @@
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
       isEncryptionDisabled: true
@@ -83,7 +83,7 @@
 - name: "Migrate from Docker to Containerd airgap"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
       isEncryptionDisabled: true

--- a/addons/contour/template/testgrid/k8s-docker.yaml
+++ b/addons/contour/template/testgrid/k8s-docker.yaml
@@ -3,7 +3,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     contour:
       version: "latest"
@@ -12,7 +12,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     contour:
       version: "__testver__"
@@ -43,7 +43,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     contour:
       version: "__testver__"

--- a/addons/ekco/template/testgrid/k8s-docker.yaml
+++ b/addons/ekco/template/testgrid/k8s-docker.yaml
@@ -6,7 +6,7 @@
       version: "latest"
     rook:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     ekco:
       version: "__testver__"

--- a/addons/fluentd/template/testgrid/k8s-docker.yaml
+++ b/addons/fluentd/template/testgrid/k8s-docker.yaml
@@ -5,7 +5,7 @@
       version: "latest"
     rook:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     fluentd:
       version: "__testver__"

--- a/addons/metrics-server/template/testgrid/k8s-docker.yaml
+++ b/addons/metrics-server/template/testgrid/k8s-docker.yaml
@@ -5,7 +5,7 @@
       version: "latest"
     rook:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     metricsServer:
       version: "__testver__"

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -10,7 +10,7 @@
       localPVStorageClassName: default
       namespace: openebs
       version: "3.2.x"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "__testver__"

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -24,7 +24,7 @@
 - name: localpv upgrade from 2.6.0
   installerSpec:
     kubernetes:
-      version: "1.21.x"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -104,7 +104,7 @@
       version: "1.12.0"
   upgradeSpec:
     kubernetes:
-      version: "1.24.x"
+      version: "1.21.x"
     weave:
       version: "latest"
     containerd:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -107,7 +107,7 @@
       version: "1.24.x"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "latest"

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -107,7 +107,7 @@
       version: "1.21.x"
     weave:
       version: "latest"
-    containerd:
+    docker:
       version: "latest"
     minio:
       version: "latest"

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -7,7 +7,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "__testver__"
@@ -21,7 +21,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "0.33.0"
@@ -33,7 +33,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "__testver__"
@@ -47,7 +47,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "latest"
@@ -59,7 +59,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "__testver__"
@@ -86,7 +86,7 @@
     rook:
       version: "1.7.x"
       isBlockStorageEnabled: true
-    docker:
+    containerd:
       version: "latest"
     prometheus:
       version: "__testver__"

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -211,7 +211,7 @@
       version: "latest"
     minio:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "__testver__"

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -6,7 +6,7 @@
       version: "latest"
     rook:
       version: 1.7.x
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "__testver__"
@@ -37,7 +37,7 @@
       version: "latest"
     longhorn:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "__testver__"
@@ -68,7 +68,7 @@
       version: "latest"
     longhorn:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "latest"
@@ -81,7 +81,7 @@
       version: "latest"
     longhorn:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "__testver__"
@@ -117,7 +117,7 @@
       version: "latest"
     longhorn:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "2.7.1"
@@ -128,7 +128,7 @@
       version: "latest"
     longhorn:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     registry:
       version: "__testver__"

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -210,7 +210,7 @@
 - name: Upgrade from 1.0.4
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.19.x"
     weave:
       version: "latest"
     docker:
@@ -225,7 +225,7 @@
       version: "1.0.4"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.19.x"
     weave:
       version: "latest"
     docker:

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -4,7 +4,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "latest"
@@ -30,7 +30,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "latest"
@@ -46,7 +46,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "latest"
@@ -186,7 +186,7 @@
       version: "latest"
     weave:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     minio:
       version: "latest"

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -6,7 +6,7 @@
       version: "latest"
     rook:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     velero:
       version: "__testver__"
@@ -20,7 +20,7 @@
       version: "latest"
     rook:
       version: "latest"
-    docker:
+    containerd:
       version: "latest"
     velero:
       version: "__testver__"

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -65,8 +65,8 @@
   installerSpec:
     kubernetes:
       version: 1.24.x
-    docker:
-      version: 20.10.x
+    containerd:
+      version: latest
     weave:
       version: latest
 - name: k8s121

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -936,7 +936,7 @@
 - name: "Migrate from Docker to Containerd"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:
@@ -952,7 +952,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:
@@ -969,7 +969,7 @@
 - name: "Migrate from Docker to Containerd airgap"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:
@@ -985,7 +985,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.23.x
     weave:
       version: latest
     longhorn:
@@ -1572,7 +1572,7 @@
   installerSpec:
     kubernetes:
       version: "1.24.x"
-    docker:
+    containerd:
       version: latest
     weave:
       version: "2.6.5"

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -829,7 +829,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.20.x
+      version: 1.23.x
     weave:
       version: latest
     rook:
@@ -1161,7 +1161,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.21.x
+      version: 1.23.x
     weave:
       version: latest
     rook:
@@ -1201,7 +1201,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.21.x
+      version: 1.23.x
     weave:
       version: latest
     rook:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1694,3 +1694,36 @@
       version: latest
     containerd:
       version: latest
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.24"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.24.x
+    weave:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest

--- a/testgrid/specs/latest.yaml
+++ b/testgrid/specs/latest.yaml
@@ -2,7 +2,7 @@
   installerSpec:
     kubernetes:
       version: latest
-    docker:
+    containerd:
       version: latest
     weave:
       version: latest


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR makes a series of changes in the test grids:

- As Kubernetes 1.24.x does not support Docker, all references to `kubernetes:latest` are now using `containerd`
- Ensures that we never try to run OpenEBS 1.12 on Kubernetes newer than 1.21
- Ensures we never attempt to skip more than one version when upgrading Kubernetes
- Creates an extra test to verify if we can migrate from Docker to Containerd while moving also from Kubernetes `1.23` to `1.24`
- Ensures we never try to run Rook `1.0.x` in any Kubernetes newer than `1.19.x`


#### Which issue(s) this PR fixes:
Fixes #54878

#### Special notes for your reviewer:

To review this one can be a little bit overwhelming but please take special care while doing it. The whole process of changing and verifying this is error prone therefore I passed through the whole test grid more than once.

## Steps to reproduce

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE