### PR TITLE
Add flags for EKCO restart failed envoy pods

### DIFF
--- a/addons/ekco/0.21.0/Manifest
+++ b/addons/ekco/0.21.0/Manifest
@@ -1,0 +1,2 @@
+image ekco docker.io/replicated/ekco:v0.21.0
+image haproxy haproxy:2.6.5-alpine3.16

--- a/addons/ekco/0.21.0/README.md
+++ b/addons/ekco/0.21.0/README.md
@@ -1,0 +1,4 @@
+
+[Embedded Kurl cluster operator (EKCO)](https://github.com/replicatedhq/ekco) is responsible for performing various operations to maintain the health of a Kurl cluster. For more information see the documentation [here](https://github.com/replicatedhq/ekco).
+
+This addon deploys it to the `kurl` namespace.

--- a/addons/ekco/0.21.0/deployment.yaml
+++ b/addons/ekco/0.21.0/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ekc-operator
+spec:
+  selector:
+    matchLabels:
+      app: ekc-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ekc-operator
+    spec:
+      serviceAccountName: ekco
+      restartPolicy: Always
+      affinity: 
+        nodeAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution: 
+            nodeSelectorTerms: 
+            - matchExpressions: 
+              - key: node-role.kubernetes.io/control-plane 
+                operator: Exists 
+            - matchExpressions: 
+              - key: node-role.kubernetes.io/master 
+                operator: Exists
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+      containers:
+        - name: ekc-operator
+          image: replicated/ekco:v0.21.0
+          imagePullPolicy: IfNotPresent
+          command: [ /usr/bin/ekco, operator ]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: ekco-config
+              mountPath: /etc/ekco
+              readOnly: true
+            - name: certificates-dir
+              mountPath: /etc/kubernetes/pki
+              readOnly: true
+      volumes:
+        - name: ekco-config
+          configMap:
+            name: ekco-config
+        - name: certificates-dir
+          hostPath:
+            path: /etc/kubernetes/pki
+            type: Directory

--- a/addons/ekco/0.21.0/ekco-purge-node.sh
+++ b/addons/ekco/0.21.0/ekco-purge-node.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+export KUBECONFIG="${KUBECONFIG:-/etc/kubernetes/admin.conf}"
+
+namespace=kurl
+pod="$(kubectl get pods -n "$namespace" -l app=ekc-operator --field-selector=status.phase=Running --no-headers 2>/dev/null | awk 'NR == 1 {print $1}')"
+
+if [ -z "$pod" ]; then
+    printf "[error] no running EKCO pods found\n\n" 1>&2
+    (set -x; kubectl get pods -n "$namespace" -l app=ekc-operator 1>&2)
+    exit 1
+fi
+
+kubectl exec -n "$namespace" -it "$pod" -- ekco purge-node $@

--- a/addons/ekco/0.21.0/install.sh
+++ b/addons/ekco/0.21.0/install.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+
+EKCO_HAPROXY_IMAGE=haproxy:2.6.5-alpine3.16
+
+function ekco_pre_init() {
+    if [ -z "$EKCO_NODE_UNREACHABLE_TOLERATION_DURATION" ]; then
+        EKCO_NODE_UNREACHABLE_TOLERATION_DURATION=5m
+    fi
+    if [ -z "$EKCO_MIN_READY_MASTER_NODE_COUNT" ]; then
+        EKCO_MIN_READY_MASTER_NODE_COUNT=2
+    fi
+    if [ -z "$EKCO_MIN_READY_WORKER_NODE_COUNT" ]; then
+        EKCO_MIN_READY_WORKER_NODE_COUNT=0
+    fi
+    EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=true
+    if [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ]; then
+        EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
+    fi
+    EKCO_RECONCILE_ROOK_MDS_PLACEMENT=true
+    if [ "$EKCO_ROOK_SHOULD_DISABLE_RECONCILE_MDS_PLACEMENT" = "1" ]; then
+        EKCO_RECONCILE_ROOK_MDS_PLACEMENT=false
+    fi
+    EKCO_SHOULD_INSTALL_REBOOT_SERVICE=1
+    if [ "$EKCO_SHOULD_DISABLE_REBOOT_SERVICE" = "1" ]; then
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+    EKCO_PURGE_DEAD_NODES=false
+    if [ "$EKCO_SHOULD_ENABLE_PURGE_NODES" = "1" ]; then
+        EKCO_PURGE_DEAD_NODES=true
+    fi
+    EKCO_CLEAR_DEAD_NODES=true
+    if [ "$EKCO_SHOULD_DISABLE_CLEAR_NODES" = "1" ]; then
+        EKCO_CLEAR_DEAD_NODES=false
+    fi
+    if [ "$ROOK_VERSION" = "1.0.4" ]; then
+        EKCO_ROOK_PRIORITY_CLASS="node-critical"
+    fi
+    EKCO_RESTART_FAILED_ENVOY_PODS=true
+    if [ "$EKCO_SHOULD_DISABLE_RESTART_FAILED_ENVOY_PODS" = "1" ]; then
+        EKCO_RESTART_FAILED_ENVOY_PODS=false
+    fi
+    if [ -z "$EKCO_ENVOY_PODS_NOT_READY_DURATION" ]; then
+        EKCO_ENVOY_PODS_NOT_READY_DURATION="5m"
+    fi
+
+    EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=false
+    if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
+        EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=true
+        HA_CLUSTER=1
+        LOAD_BALANCER_ADDRESS=localhost
+        LOAD_BALANCER_PORT="6444"
+    fi
+}
+
+function ekco() {
+    local src="$DIR/addons/ekco/$EKCO_VERSION"
+    local dst="$DIR/kustomize/ekco"
+
+    ekco_create_deployment "$src" "$dst"
+
+    if [ "$EKCO_SHOULD_INSTALL_REBOOT_SERVICE" = "1" ]; then
+        ekco_install_reboot_service "$src"
+    fi
+
+    ekco_install_purge_node_command "$src"
+
+    # Wait for the pod image override mutating webhook to be created so when other add-ons are
+    # installed they will get their overridden image
+    if [ -n "$EKCO_POD_IMAGE_OVERRIDES" ]; then
+        ekco_load_images
+        echo "Waiting up to 5 minutes for pod-image-overrides mutating webhook config to be created"
+        if ! spinner_until 300 kubernetes_resource_exists kurl mutatingwebhookconfigurations pod-image-overrides.kurl.sh; then
+            bail "EKCO failed to deploy the pod-image-overrides.kurl.sh mutating webhook configuration"
+        fi
+    fi
+}
+
+function ekco_join() {
+    local src="$DIR/addons/ekco/$EKCO_VERSION"
+
+    EKCO_SHOULD_INSTALL_REBOOT_SERVICE=1
+    if [ "$EKCO_SHOULD_DISABLE_REBOOT_SERVICE" = "1" ]; then
+        EKCO_SHOULD_INSTALL_REBOOT_SERVICE=0
+    fi
+
+    if [ "$EKCO_SHOULD_INSTALL_REBOOT_SERVICE" = "1" ]; then
+        ekco_install_reboot_service "$src"
+    fi
+
+    if kubernetes_is_master; then
+        ekco_install_purge_node_command "$src"
+    fi
+
+    if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
+        ekco_bootstrap_internal_lb
+    fi
+
+    ekco_load_images
+}
+
+function ekco_already_applied() {
+    local src="$DIR/addons/ekco/$EKCO_VERSION"
+    local dst="$DIR/kustomize/ekco"
+
+    # if rook-ceph has been removed, ekco should be redeployed to not attempt to manage it
+    if [ "$DID_MIGRATE_ROOK_PVCS" == "1" ]; then
+        ekco_create_deployment "$src" "$dst"
+    fi
+}
+
+function ekco_install_reboot_service() {
+    local src="$1"
+
+    mkdir -p /opt/ekco
+    cp "$src/reboot/startup.sh" /opt/ekco/startup.sh
+    cp "$src/reboot/shutdown.sh" /opt/ekco/shutdown.sh
+    if [ -n "$DOCKER_VERSION" ]; then
+        cp "$src/reboot/ekco-reboot.service" /etc/systemd/system/ekco-reboot.service
+    else
+        cp "$src/reboot/ekco-reboot-containerd.service" /etc/systemd/system/ekco-reboot.service
+    fi
+    chmod u+x /opt/ekco/startup.sh
+    chmod u+x /opt/ekco/shutdown.sh
+
+    systemctl daemon-reload
+    systemctl enable ekco-reboot.service
+    systemctl start ekco-reboot.service
+}
+
+function ekco_install_purge_node_command() {
+    local src="$1"
+
+    cp "$src/ekco-purge-node.sh" /usr/local/bin/ekco-purge-node
+    chmod u+x /usr/local/bin/ekco-purge-node
+}
+
+function ekco_handle_load_balancer_address_change_pre_init() {
+    if [ -z "$1" ] || [ -z "$2" ]; then
+        return 0
+    fi
+
+    splitHostPort $1
+    local oldLoadBalancerHost=$HOST
+    splitHostPort $2
+    local newLoadBalancerHost=$HOST
+
+    if [ "$oldLoadBalancerHost" = "$newLoadBalancerHost" ]; then
+        return 0
+    fi
+
+    local ARG=--add-alt-names=$newLoadBalancerHost
+
+    for NODE in "${KUBERNETES_REMOTE_PRIMARIES[@]}"; do
+        echo "Adding new load balancer $newLoadBalancerHost to API server certificate on node $NODE"
+        local podName=regen-cert-$NODE
+        kubectl delete pod $podName --force --grace-period=0 2>/dev/null || true
+        render_yaml_file "$DIR/addons/ekco/$EKCO_VERSION/regen-cert-pod.yaml" | kubectl apply -f -
+        spinner_until 120 kubernetes_pod_started $podName default
+        kubectl logs -f $podName
+        spinner_until 10 kubernetes_pod_completed $podName default
+        local phase=$(kubectl get pod $podName -ojsonpath='{ .status.phase }')
+        if [ "$phase" != "Succeeded" ]; then
+            bail "Pod $podName phase: $phase"
+        fi
+        kubectl delete pod $podName --force --grace-period=0
+    done
+
+    # Wait for the servers to pick up the new certs
+    for NODE in "${KUBERNETES_REMOTE_PRIMARIES[@]}"; do
+        local nodeIP=$(kubectl get node $NODE -owide  --no-headers | awk '{ print $6 }')
+        echo "Waiting for $NODE to begin serving certificate signed for $newLoadBalancerHost"
+        local addr=$($DIR/bin/kurl format-address $nodeIP)
+        if ! spinner_until 120 cert_has_san "$addr:6443" "$newLoadBalancerHost"; then
+            printf "${YELLOW}$NODE is not serving certificate signed for $newLoadBalancerHost${NC}\n"
+        fi
+    done
+}
+
+function ekco_handle_load_balancer_address_change_post_init() {
+    if [ -z "$1" ] || [ -z "$2" ]; then
+        return 0
+    fi
+
+    splitHostPort $1
+    local oldLoadBalancerHost=$HOST
+    splitHostPort $2
+    local newLoadBalancerHost=$HOST
+
+    if [ "$oldLoadBalancerHost" = "$newLoadBalancerHost" ]; then
+        return 0
+    fi
+
+    local ARG=--drop-alt-names=$oldLoadBalancerHost
+
+    for NODE in "${KUBERNETES_REMOTE_PRIMARIES[@]}"; do
+        echo "Removing old load balancer address $oldLoadBalancerHost from API server certificate on node $NODE"
+        local podName=regen-cert-$NODE
+        kubectl delete pod $podName --force --grace-period=0 2>/dev/null || true
+        render_yaml_file "$DIR/addons/ekco/$EKCO_VERSION/regen-cert-pod.yaml" | kubectl apply -f -
+        spinner_until 120 kubernetes_pod_started $podName default
+        kubectl logs -f $podName
+        spinner_until 10 kubernetes_pod_completed $podName default
+        local phase=$(kubectl get pod $podName -ojsonpath='{ .status.phase }')
+        if [ "$phase" != "Succeeded" ]; then
+            bail "Pod $podName phase: $phase"
+        fi
+        kubectl delete pod $podName --force --grace-period=0
+    done
+}
+
+# The internal load balancer is a static pod running haproxy on every node. When joining, kubeadm
+# needs to connect to the Kubernetes API before starting kubelet. To workaround this problem,
+# temporarily run haproxy as a container directly with docker or containerd.
+function ekco_bootstrap_internal_lb() {
+    local backends="$PRIMARY_HOST"
+    if [ -z "$backends" ]; then
+        backends="$PRIVATE_ADDRESS"
+    fi
+
+    # Always regenerate the manifests to account for updates.
+    # Note: this could cause downtime when kublet syncs the manifests for a new haproxy version
+    if commandExists docker; then
+        mkdir -p /etc/kubernetes/manifests
+        docker run --rm \
+            --entrypoint="/usr/bin/ekco" \
+            --volume '/etc:/host/etc' \
+            replicated/ekco:v$EKCO_VERSION \
+            generate-haproxy-manifest \
+                --primary-host=${backends} \
+                --file=/host/etc/kubernetes/manifests/haproxy.yaml \
+                --image="${EKCO_HAPROXY_IMAGE}"
+    else
+        mkdir -p /etc/kubernetes/manifests
+        ctr --namespace k8s.io run --rm \
+            --mount "type=bind,src=/etc,dst=/host/etc,options=rbind:rw" \
+            docker.io/replicated/ekco:v$EKCO_VERSION \
+            haproxy-manifest \
+            ekco generate-haproxy-manifest \
+                --primary-host=${backends} \
+                --file=/host/etc/kubernetes/manifests/haproxy.yaml \
+                --image="${EKCO_HAPROXY_IMAGE}"
+    fi
+
+    # Check if load balancer is already bootstrapped
+    if curl -skf "https://localhost:6444/healthz"; then
+        return 0
+    fi
+
+    if commandExists docker; then
+        mkdir -p /etc/haproxy
+        docker run --rm \
+            --entrypoint="/usr/bin/ekco" \
+            replicated/ekco:v$EKCO_VERSION \
+            generate-haproxy-config --primary-host=${backends} \
+            > /etc/haproxy/haproxy.cfg
+
+        docker rm -f bootstrap-lb &>/dev/null || true
+        docker run -d -p "6444:6444" -v /etc/haproxy:/usr/local/etc/haproxy --name bootstrap-lb "${EKCO_HAPROXY_IMAGE}"
+    else
+        mkdir -p /etc/haproxy
+        ctr --namespace k8s.io run --rm \
+            docker.io/replicated/ekco:v$EKCO_VERSION \
+            haproxy-cfg \
+            ekco generate-haproxy-config --primary-host=${backends} \
+            > /etc/haproxy/haproxy.cfg
+
+        ctr --namespace k8s.io task kill -s SIGKILL bootstrap-lb &>/dev/null || true
+        ctr --namespace k8s.io containers delete bootstrap-lb &>/dev/null || true
+        ctr --namespace k8s.io run --rm \
+            --mount "type=bind,src=/etc/haproxy,dst=/usr/local/etc/haproxy,options=rbind:ro" \
+            --net-host \
+            --detach \
+            "$(canonical_image_name "${EKCO_HAPROXY_IMAGE}")" \
+            bootstrap-lb
+    fi
+}
+
+function ekco_cleanup_bootstrap_internal_lb() {
+    if commandExists docker; then
+        docker rm -f bootstrap-lb &>/dev/null || true
+    else
+        ctr --namespace k8s.io task kill -s SIGKILL bootstrap-lb &>/dev/null || true
+        ctr --namespace k8s.io containers delete bootstrap-lb &>/dev/null || true
+    fi
+}
+
+function ekco_handle_load_balancer_address_change_kubeconfigs() {
+    # The change-load-balancer command will restart kubelet on all remote nodes after updating
+    # kubeconfigs. When kubelet restarts on the node where the ekco pod is scheduled, the connection
+    # to the change-load-balancer output stream will break, but the command will continue running
+    # in the pod to completion. Therefore the command output has to be redirected to a file in the
+    # pod and then we have to poll that file to determine when the command is finished and if it was
+    # successful
+    exclude=$(hostname | tr '[:upper:]' '[:lower:]')
+    if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
+        kubectl -n kurl exec deploy/ekc-operator -- /bin/bash -c "ekco change-load-balancer --exclude=${exclude} --internal --server=https://localhost:6444 &>/tmp/change-lb-log"
+    else
+        kubectl -n kurl exec deploy/ekc-operator -- /bin/bash -c "ekco change-load-balancer --exclude=${exclude} --server=https://${API_SERVICE_ADDRESS} &>/tmp/change-lb-log"
+    fi
+
+    echo "Waiting up to 10 minutes for kubeconfigs on remote nodes to begin using new load balancer address"
+    spinner_until 600 ekco_change_lb_completed
+
+    logs=$(kubectl -n kurl exec -i deploy/ekc-operator -- cat /tmp/change-lb-log)
+    if ! echo "$logs" | grep -q "Result: success"; then
+        echo "$logs"
+        bail "Failed to update server address in kubeconfigs on remote ndoes"
+    fi
+}
+
+function ekco_change_lb_completed() {
+    2>/dev/null kubectl -n kurl exec -i deploy/ekc-operator -- grep -q "Result:" /tmp/change-lb-log
+}
+
+function ekco_create_deployment() {
+    cp "$src/kustomization.yaml" "$dst/kustomization.yaml"
+    cp "$src/namespace.yaml" "$dst/namespace.yaml"
+    cp "$src/rbac.yaml" "$dst/rbac.yaml"
+    cp "$src/rolebinding.yaml" "$dst/rolebinding.yaml"
+    cp "$src/deployment.yaml" "$dst/deployment.yaml"
+    cp "$src/rotate-certs-rbac.yaml" "$dst/rotate-certs-rbac.yaml"
+
+    # is rook enabled
+    if kubectl get ns | grep -q rook-ceph; then
+        cp "$src/rbac-rook.yaml" "$dst/rbac-rook.yaml"
+        insert_resources "$dst/kustomization.yaml" rbac-rook.yaml
+        cat "$src/rolebinding-rook.yaml" >> "$dst/rolebinding.yaml"
+
+        if [ -n "$EKCO_ROOK_PRIORITY_CLASS" ]; then
+            kubectl label namespace rook-ceph rook-priority.kurl.sh="" --overwrite
+        fi
+    else
+        EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
+    fi
+
+    render_yaml_file "$src/tmpl-configmap.yaml" > "$dst/configmap.yaml"
+    insert_resources "$dst/kustomization.yaml" configmap.yaml
+
+    kubectl apply -k "$dst"
+    # apply rolebindings separately so as not to override the namespace
+    kubectl apply -f "$dst/rolebinding.yaml"
+
+    # delete pod to re-read the config map
+    kubectl -n kurl delete pod -l app=ekc-operator 2>/dev/null || true
+}
+
+function ekco_load_images() {
+    if [ -z "$EKCO_POD_IMAGE_OVERRIDES" ] || [ "$AIRGAP" != "1" ]; then
+        return 0
+    fi
+
+    if [ -n "$DOCKER_VERSION" ]; then
+        find "$DIR/image-overrides" -type f | xargs -I {} bash -c "docker load < {}"
+    else
+        find "$DIR/image-overrides" -type f | xargs -I {} bash -c "cat {} | ctr -a $(${K8S_DISTRO}_get_containerd_sock) -n=k8s.io images import -"
+    fi
+}

--- a/addons/ekco/0.21.0/kustomization.yaml
+++ b/addons/ekco/0.21.0/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: kurl
+
+resources:
+- namespace.yaml
+- rbac.yaml
+- deployment.yaml
+- rotate-certs-rbac.yaml

--- a/addons/ekco/0.21.0/namespace.yaml
+++ b/addons/ekco/0.21.0/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kurl

--- a/addons/ekco/0.21.0/rbac-rook.yaml
+++ b/addons/ekco/0.21.0/rbac-rook.yaml
@@ -1,0 +1,35 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-rook-ceph
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - delete
+      - get
+      - update
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephclusters
+      - cephblockpools
+      - cephfilesystems
+      - cephobjectstores
+    verbs:
+      - get
+      - update
+      - patch

--- a/addons/ekco/0.21.0/rbac.yaml
+++ b/addons/ekco/0.21.0/rbac.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ekco
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-cluster
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+    verbs:
+      - get
+      - list
+      - delete
+      - deletecollection
+      - update
+      - create
+      - watch
+  - apiGroups: ["scheduling.k8s.io"]
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - create
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheuses
+      - alertmanagers
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+    - certificatesigningrequests
+    verbs:
+    - list
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+    - certificatesigningrequests/approval
+    verbs:
+    - update
+  - apiGroups:
+    - certificates.k8s.io
+    resourceNames:
+    - kubernetes.io/kubelet-serving
+    resources:
+    - signers
+    verbs:
+    - approve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ekco-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-cluster
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/addons/ekco/0.21.0/reboot/ekco-reboot-containerd.service
+++ b/addons/ekco/0.21.0/reboot/ekco-reboot-containerd.service
@@ -1,0 +1,12 @@
+[Unit]
+After=kubelet.service
+After=containerd.service
+
+[Service]
+ExecStart=/opt/ekco/startup.sh
+ExecStop=/opt/ekco/shutdown.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/addons/ekco/0.21.0/reboot/ekco-reboot.service
+++ b/addons/ekco/0.21.0/reboot/ekco-reboot.service
@@ -1,0 +1,12 @@
+[Unit]
+After=kubelet.service
+After=docker.service
+
+[Service]
+ExecStart=/opt/ekco/startup.sh
+ExecStop=/opt/ekco/shutdown.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/addons/ekco/0.21.0/reboot/shutdown.sh
+++ b/addons/ekco/0.21.0/reboot/shutdown.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export KUBECONFIG=/etc/kubernetes/kubelet.conf
+
+kubectl cordon "$(hostname | tr '[:upper:]' '[:lower:]')"
+
+allPodUIDs=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' )
+
+# delete local pods with PVCs
+while read -r dev; do
+    uid=$(echo "$dev" | grep -Eo "pods\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | sed 's/pods\///')
+    pod=$(echo "${allPodUIDs[*]}" | grep "$uid")
+    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+done < <(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")
+
+# delete local pods using the Ceph filesystem
+while read -r uid; do
+    pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
+    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
+
+# while there are still pods with PVCs mounted
+while [ -n "$(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")" ]; do
+    echo "Waiting for pods to unmount PVCs"
+    sleep 1
+done
+
+while grep -q ':6789:/' /proc/mounts; do
+    echo "Waiting for Ceph shared filesystems to unmount"
+    sleep 1
+done
+
+# remove ceph-operator and mds pods from this node so they can continue to service the cluster
+thisHost=$(hostname | tr '[:upper:]' '[:lower:]')
+while read -r row; do
+    podName=$(echo "$row" | awk '{ print $1 }')
+    ns=$(echo "$row" | awk '{ print $2 }')
+
+    if echo "$podName" | grep -q "rook-ceph-operator"; then
+        kubectl -n "$ns" delete pod "$podName"
+    fi
+    if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
+        kubectl -n "$ns" delete pod "$podName"
+    fi
+done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")

--- a/addons/ekco/0.21.0/reboot/startup.sh
+++ b/addons/ekco/0.21.0/reboot/startup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# On first install on additional nodes the node is not yet joined to the cluster
+if [ ! -e /etc/kubernetes/kubelet.conf ]; then
+    exit 0
+fi
+
+export KUBECONFIG=/etc/kubernetes/kubelet.conf
+
+# wait for Kubernetes API
+master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
+while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
+        sleep 1
+done
+
+kubectl uncordon $(hostname | tr '[:upper:]' '[:lower:]')

--- a/addons/ekco/0.21.0/regen-cert-pod.yaml
+++ b/addons/ekco/0.21.0/regen-cert-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regen-cert-$NODE
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    kubernetes.io/hostname: $NODE
+  containers:
+  - name: regen
+    image: replicated/ekco:v$EKCO_VERSION
+    command:
+    - ekco
+    - regen-cert
+    - $ARG
+    volumeMounts:
+    - name: etc-k8s
+      mountPath: /etc/kubernetes
+  volumes:
+  - name: etc-k8s
+    hostPath:
+      path: /etc/kubernetes
+

--- a/addons/ekco/0.21.0/rolebinding-rook.yaml
+++ b/addons/ekco/0.21.0/rolebinding-rook.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ekco-rook-ceph
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-rook-ceph
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl

--- a/addons/ekco/0.21.0/rolebinding.yaml
+++ b/addons/ekco/0.21.0/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ekco-kube-system
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-kube-system
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl

--- a/addons/ekco/0.21.0/rotate-certs-rbac.yaml
+++ b/addons/ekco/0.21.0/rotate-certs-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kurl
+  name: ekco-rotate-certs
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - pods/log
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - delete
+  - create
+  - update
+  - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ekco-rotate-certs
+  namespace: kurl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ekco-rotate-certs
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl

--- a/addons/ekco/0.21.0/tmpl-configmap.yaml
+++ b/addons/ekco/0.21.0/tmpl-configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ekco-config
+data:
+  config.yaml: |
+    node_unreachable_toleration: $EKCO_NODE_UNREACHABLE_TOLERATION_DURATION
+    clear_dead_nodes: $EKCO_CLEAR_DEAD_NODES
+    purge_dead_nodes: $EKCO_PURGE_DEAD_NODES
+    min_ready_master_nodes: $EKCO_MIN_READY_MASTER_NODE_COUNT
+    min_ready_worker_nodes: $EKCO_MIN_READY_WORKER_NODE_COUNT
+    maintain_rook_storage_nodes: $EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES
+    reconcile_rook_mds_placement: $EKCO_RECONCILE_ROOK_MDS_PLACEMENT
+    ceph_block_pool: replicapool
+    ceph_filesystem: rook-shared-fs
+    ceph_object_store: rook-ceph-store
+    min_ceph_pool_replication: 1
+    max_ceph_pool_replication: 3
+    certificates_dir: /etc/kubernetes/pki
+    reconcile_interval: 1m
+    rook_version: $ROOK_VERSION
+    rotate_certs_image: replicated/ekco:v$EKCO_VERSION
+    rotate_certs_namespace: kurl
+    rotate_certs_ttl: 720h
+    rotate_certs_check_interval: 24h
+    rotate_certs: true
+    registry_cert_namespace: kurl
+    registry_cert_secret: registry-pki
+    kurl_proxy_cert_namespace: default
+    kurl_proxy_cert_secret: kotsadm-tls
+    kotsadm_kubelet_cert_namespace: default
+    kotsadm_kubelet_cert_secret: kubelet-client-cert
+    contour_cert_namespace: projectcontour
+    contour_cert_secret: contourcert
+    envoy_cert_secret: envoycert
+    rook_priority_class: \"$EKCO_ROOK_PRIORITY_CLASS\"
+    host_task_image: replicated/ekco:v$EKCO_VERSION
+    host_task_namespace: kurl
+    enable_internal_load_balancer: $EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL
+    internal_load_balancer_haproxy_image: $EKCO_HAPROXY_IMAGE
+    pod_image_overrides: \"$EKCO_POD_IMAGE_OVERRIDES\"
+    auto_approve_kubelet_csrs: true
+    restart_failed_envoy_pods: $EKCO_RESTART_FAILED_ENVOY_PODS
+    envoy_pods_not_ready_duration: $EKCO_ENVOY_PODS_NOT_READY_DURATION

--- a/addons/ekco/template/base/README.md
+++ b/addons/ekco/template/base/README.md
@@ -2,23 +2,3 @@
 [Embedded Kurl cluster operator (EKCO)](https://github.com/replicatedhq/ekco) is responsible for performing various operations to maintain the health of a Kurl cluster. For more information see the documentation [here](https://github.com/replicatedhq/ekco).
 
 This addon deploys it to the `kurl` namespace.
-
-## Options
-
-- `ekco-node-unreachable-toleration-duration`: How long a Node must be unreachable before considered dead (default 5m).
-- `ekco-should-enable-purge-nodes`: Watch the cluster for dead nodes and remove them
-- `ekco-min-ready-master-node-count`: Don't purge the node if it will result in less than this many ready masters.
-   Only applicable if node purging is enabled.
-- `ekco-min-ready-worker-node-count`: Don't purge the node if it will result in less than this many ready workers
-   Only applicable if node purging is enabled.
-- `ekco-should-disable-clear-nodes`: Don't force delete pods on unreachable stuck in the terminating state
-- `ekco-disable-should-maintain-rook-storage-nodes`: Whether to maintain the list of nodes to use in the CephCluster config.
-   This also enables control of the replication factor of ceph pools, scaling up and down with the number of nodes in the cluster.
-- `ekco-disable-should-install-reboot-service`: Whether to disable the reboot service, responsible for graceful node termination.
-- `rook-version`: Version of Rook to manage
-- `rook-priority-class`: Name of priority class to add to Rook 1.0 Deployments and DaemonSets. Will be created if not found.
-- `enable-internal-load-balancer`: Run haproxy on all nodes and forward to all Kubernetes API server pods
-- `host-task-image`: The image to use for host tasks, such as updating the haproxy configuration on all nodes.
-- `host-task-namespace`: The namespace host task pods will run in.
-- `pod-image-overrides`: List of images to be replaced in pod specs
-- `auto-approve-kubelet-csrs`: Enable automatic approval of kubelet-serving csrs

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -35,6 +35,13 @@ function ekco_pre_init() {
     if [ "$ROOK_VERSION" = "1.0.4" ]; then
         EKCO_ROOK_PRIORITY_CLASS="node-critical"
     fi
+    EKCO_RESTART_FAILED_ENVOY_PODS=true
+    if [ "$EKCO_SHOULD_DISABLE_RESTART_FAILED_ENVOY_PODS" = "1" ]; then
+        EKCO_RESTART_FAILED_ENVOY_PODS=false
+    fi
+    if [ -z "$EKCO_ENVOY_PODS_NOT_READY_DURATION" ]; then
+        EKCO_ENVOY_PODS_NOT_READY_DURATION="5m"
+    fi
 
     EKCO_ENABLE_INTERNAL_LOAD_BALANCER_BOOL=false
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then

--- a/addons/ekco/template/base/tmpl-configmap.yaml
+++ b/addons/ekco/template/base/tmpl-configmap.yaml
@@ -40,3 +40,5 @@ data:
     internal_load_balancer_haproxy_image: $EKCO_HAPROXY_IMAGE
     pod_image_overrides: \"$EKCO_POD_IMAGE_OVERRIDES\"
     auto_approve_kubelet_csrs: true
+    restart_failed_envoy_pods: $EKCO_RESTART_FAILED_ENVOY_PODS
+    envoy_pods_not_ready_duration: $EKCO_ENVOY_PODS_NOT_READY_DURATION

--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -182,6 +182,8 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 		"Ekco.AutoUpgradeSchedule":                    "EKCO_AUTO_UPGRADE_SCHEDULE", // no longer supported
 		"Ekco.EnableInternalLoadBalancer":             "EKCO_ENABLE_INTERNAL_LOAD_BALANCER",
 		"Ekco.PodImageOverrides":                      "EKCO_POD_IMAGE_OVERRIDES",
+		"Ekco.ShouldDisableRestartFailedEnvoyPods":    "EKCO_SHOULD_DISABLE_RESTART_FAILED_ENVOY_PODS",
+		"Ekco.EnvoyPodsNotReadyDuration":              "EKCO_ENVOY_PODS_NOT_READY_DURATION",
 		"FirewalldConfig.BypassFirewalldWarning":      "BYPASS_FIREWALLD_WARNING",
 		"FirewalldConfig.DisableFirewalld":            "DISABLE_FIREWALLD",
 		"FirewalldConfig.HardFailOnFirewalld":         "HARD_FAIL_ON_FIREWALLD",

--- a/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/kurlkinds/pkg/apis/cluster/v1beta1/installer_types.go
@@ -256,6 +256,8 @@ type Ekco struct {
 	AutoUpgradeSchedule                    string   `json:"autoUpgradeSchedule,omitempty" yaml:"autoUpgradeSchedule,omitempty"` // no longer supported
 	EnableInternalLoadBalancer             bool     `json:"enableInternalLoadBalancer,omitempty" yaml:"enableInternalLoadBalancer,omitempty"`
 	PodImageOverrides                      []string `json:"podImageOverrides,omitempty" yaml:"podImageOverrides,omitempty"`
+	ShouldDisableRestartFailedEnvoyPods    bool     `json:"shouldDisableRestartFailedEnvoyPods,omitempty" yaml:"shouldDisableRestartFailedEnvoyPods,omitempty"`
+	EnvoyPodsNotReadyDuration              string   `json:"envoyPodsNotReadyDuration,omitempty" yaml:"envoyPodsNotReadyDuration,omitempty"`
 }
 
 type Calico struct {

--- a/kurlkinds/schemas/installer-cluster-v1beta1.json
+++ b/kurlkinds/schemas/installer-cluster-v1beta1.json
@@ -185,6 +185,9 @@
             "enableInternalLoadBalancer": {
               "type": "boolean"
             },
+            "envoyPodsNotReadyDuration": {
+              "type": "string"
+            },
             "minReadyMasterNodeCount": {
               "type": "integer"
             },
@@ -213,6 +216,9 @@
               "type": "boolean"
             },
             "shouldDisableRebootServices": {
+              "type": "boolean"
+            },
+            "shouldDisableRestartFailedEnvoyPods": {
               "type": "boolean"
             },
             "shouldEnablePurgeNodes": {

--- a/kurlkinds/schemas/installer-kurl-v1beta1.json
+++ b/kurlkinds/schemas/installer-kurl-v1beta1.json
@@ -185,6 +185,9 @@
             "enableInternalLoadBalancer": {
               "type": "boolean"
             },
+            "envoyPodsNotReadyDuration": {
+              "type": "string"
+            },
             "minReadyMasterNodeCount": {
               "type": "integer"
             },
@@ -213,6 +216,9 @@
               "type": "boolean"
             },
             "shouldDisableRebootServices": {
+              "type": "boolean"
+            },
+            "shouldDisableRestartFailedEnvoyPods": {
               "type": "boolean"
             },
             "shouldEnablePurgeNodes": {

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1525,6 +1525,8 @@
       shouldDisableRebootServices: false
       shouldDisableClearNodes: false
       shouldEnablePurgeNodes: false
+      shouldDisableRestartFailedEnvoyPods: false
+      envoyPodsNotReadyDuration: "5m"
   upgradeSpec:
     kubernetes:
       version: "1.21.9"
@@ -1566,6 +1568,8 @@
       shouldDisableRebootServices: false
       shouldDisableClearNodes: false
       shouldEnablePurgeNodes: false
+      shouldDisableRestartFailedEnvoyPods: false
+      envoyPodsNotReadyDuration: "5m"
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: less_command

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -377,6 +377,7 @@ module.exports.InstallerVersions = {
   ],
   ekco: [
     // cron-ekco-update
+    "0.21.0",
     "0.20.0",
     "0.19.9",
     "0.19.6",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Adds flags for new EKCO option to reconcile restart failed envoy pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- [FEATURE] Adds [EKCO add-on](https://kurl.sh/docs/add-ons/ekco) version 0.21.0
- [BUG] [EKCO add-on](https://kurl.sh/docs/add-ons/ekco) versions 0.21.0 or greater will now forcefully delete Envoy pods that change from a ready state to one where the Envoy container is not ready and have been in that state for at least 5 minutes. This has been added to work around a [known issue](https://github.com/projectcontour/contour/issues/3192) that may be caused by resource contention.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
https://github.com/replicatedhq/kurl.sh/pull/863