### PR TITLE
cis: remove apiserver --insecure-port command line flag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,9 +115,15 @@ function init() {
             $kustomize_kubeadm_init/kustomization.yaml \
             patch-kubelet-cis-compliance.yaml
         
-        insert_patches_strategic_merge \
-            $kustomize_kubeadm_init/kustomization.yaml \
-            patch-cluster-config-cis-compliance.yaml
+        if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge "20" ]; then
+            insert_patches_strategic_merge \
+                $kustomize_kubeadm_init/kustomization.yaml \
+                patch-cluster-config-cis-compliance.yaml
+	else
+            insert_patches_strategic_merge \
+                $kustomize_kubeadm_init/kustomization.yaml \
+                patch-cluster-config-cis-compliance-insecure-port.yaml
+	fi
     fi
 
     if [ "$KUBE_RESERVED" == "1" ]; then

--- a/scripts/kustomize/kubeadm/init-orig/patch-cluster-config-cis-compliance-insecure-port.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/patch-cluster-config-cis-compliance-insecure-port.yaml
@@ -5,4 +5,5 @@ metadata:
 apiServer:
   extraArgs:
     enable-admission-plugins: NodeRestriction
+    insecure-port: '"0"'
     kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt


### PR DESCRIPTION
#### What this PR does / why we need it:

From kubernetes v1.24 onwards the kubeapi flag --insecure-port has been removed. In CIS compliant environment this flag was in use, with it the apiserver does not come up.

This flag is a no-op since kubernetes [v1.20](https://github.com/kubernetes/kubeadm/issues/2156)

#### Which issue(s) this PR fixes:

Fixes #54878

#### Special notes for your reviewer:

Please pay special attention to my shell script foo as it is quite rusty.

## Steps to reproduce

Install any cluster with kubernetes v1.24  and `cisCompliance` enabled.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE