### PR TITLE
chore: fix testgrid (incompatible velero 1.6.x k8s 1.23.x)

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -842,7 +842,7 @@
     containerd:
       version: latest
     velero:
-      version: 1.6.x
+      version: 1.8.x
     ekco:
       version: latest
   upgradeSpec:
@@ -860,7 +860,7 @@
     containerd:
       version: latest
     velero:
-      version: 1.7.x
+      version: 1.9.x
     ekco:
       version: latest
 - name: "K8s 1.22x Rook"
@@ -1174,7 +1174,7 @@
     docker:
       version: 20.10.x
     velero:
-      version: 1.6.x
+      version: 1.8.x
     ekco:
       version: latest
   upgradeSpec:
@@ -1192,7 +1192,7 @@
     containerd:
       version: 1.4.x
     velero:
-      version: 1.7.x
+      version: 1.9.x
     ekco:
       version: latest
   unsupportedOSIDs:
@@ -1214,7 +1214,7 @@
     docker:
       version: 20.10.x
     velero:
-      version: 1.6.x
+      version: 1.8.x
     ekco:
       version: latest
   upgradeSpec:
@@ -1232,7 +1232,7 @@
     containerd:
       version: 1.5.x
     velero:
-      version: 1.7.x
+      version: 1.9.x
     ekco:
       version: latest
   airgap: true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

According to velero github [compatibility matrix](https://github.com/vmware-tanzu/velero#velero-compatibility-matrix) velero 1.6.2 works in Kubernetes 1.21, for testing with Kubernetes >= 1.21.x we need to use a newer velero version.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #54878

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
