### PR TITLE
Separate openebs 2.x and 3.x automation into separate pull requests

### DIFF
--- a/.github/workflows/update-openebs.yaml
+++ b/.github/workflows/update-openebs.yaml
@@ -29,7 +29,7 @@ jobs:
         token: ${{ secrets.AUTOMATED_PR_GH_PAT }}
         commit-message: Create new OpenEBS version
         title: 'Automated OpenEBS version update ${{ steps.update.outputs.openebs_version }}'
-        branch: automation/update-openebs
+        branch: automation/update-openebs-2
         delete-branch: true
         labels: |
           automated-pr

--- a/.github/workflows/update-openebs.yaml
+++ b/.github/workflows/update-openebs.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-pr-openebs:
+  build-pr-openebs-2:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -18,12 +18,9 @@ jobs:
         go-version: 1.19
 
     - name: Create OpenEBS 2.x Update
+      id: update
       working-directory: ./addons/openebs/template
       run: ./generate.sh --version=^2.0.0
-
-    - name: Create OpenEBS 3.x Update
-      working-directory: ./addons/openebs/template
-      run: ./generate.sh
 
     - name: Create Pull Request # creates a PR if there are differences
       uses: peter-evans/create-pull-request@v4.1.1
@@ -31,7 +28,7 @@ jobs:
       with:
         token: ${{ secrets.AUTOMATED_PR_GH_PAT }}
         commit-message: Create new OpenEBS version
-        title: 'Automated OpenEBS version update ${{ steps.update.outputs.openebs_version_2 }} ${{ steps.update.outputs.openebs_version_3 }}'
+        title: 'Automated OpenEBS version update ${{ steps.update.outputs.openebs_version }}'
         branch: automation/update-openebs
         delete-branch: true
         labels: |
@@ -42,7 +39,50 @@ jobs:
         base: "main"
         body: |
           Automated changes by the [cron-openebs-update](https://github.com/replicatedhq/kURL/blob/main/.github/workflows/update-openebs.yaml) GitHub action
-          
+
+          ```release-note
+            Adds [OpenEBS add-on](https://kurl.sh/docs/add-ons/openebs) version ${{ steps.update.outputs.openebs_version }}.
+          ```
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+  build-pr-openebs-3:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    # for installing github.com/go-ksplit/ksplit
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Create OpenEBS 3.x Update
+      id: update
+      working-directory: ./addons/openebs/template
+      run: ./generate.sh
+
+    - name: Create Pull Request # creates a PR if there are differences
+      uses: peter-evans/create-pull-request@v4.1.1
+      id: cpr
+      with:
+        token: ${{ secrets.AUTOMATED_PR_GH_PAT }}
+        commit-message: Create new OpenEBS version
+        title: 'Automated OpenEBS version update ${{ steps.update.outputs.openebs_version }}'
+        branch: automation/update-openebs
+        delete-branch: true
+        labels: |
+          automated-pr
+          openebs
+          type::chore
+        draft: false
+        base: "main"
+        body: |
+          Automated changes by the [cron-openebs-update](https://github.com/replicatedhq/kURL/blob/main/.github/workflows/update-openebs.yaml) GitHub action
+
           ```release-note
             Adds [OpenEBS add-on](https://kurl.sh/docs/add-ons/openebs) version ${{ steps.update.outputs.openebs_version }}.
           ```

--- a/addons/openebs/template/generate.sh
+++ b/addons/openebs/template/generate.sh
@@ -116,7 +116,7 @@ function main() {
     generate
     add_as_latest
 
-    echo "::set-output name=openebs_version_$version_major::$chart_version"
+    echo "::set-output name=openebs_version::$chart_version"
 }
 
 main "$@"


### PR DESCRIPTION
Makes two separate prs to fix pr title and release notes. See image below is missing version

![Screen Shot 2022-09-12 at 11 50 05 AM](https://user-images.githubusercontent.com/371319/189732701-725182b1-917d-4b2b-a68a-c78d2644018b.png)
