### PR TITLE
Remove deploy-prod testgrid-run needs deploy-production-eks

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -227,7 +227,6 @@ jobs:
   testgrid-run:
     runs-on: ubuntu-20.04
     needs:
-    - deploy-production-eks
     - set-current-version
     steps:
 


### PR DESCRIPTION
Workflow was edited when we move web to its own project. The dependent step no longer exists. Fixes workflow error:

```
The workflow is not valid. .github/workflows/deploy-prod.yaml (Line: 230, Col: 7): Job 'testgrid-run' depends on unknown job 'deploy-production-eks'.
```