### PR TITLE
fix: ignore PDB on single node upgrades

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -316,26 +316,26 @@ function spinner_kubernetes_api_stable() {
 }
 
 function kubernetes_drain() {
-  if kubernetes_has_remotes ; then
-    kubectl drain "$1" \
-      --delete-local-data \
-      --ignore-daemonsets \
-      --force \
-      --grace-period=30 \
-      --timeout=120s \
-      --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
-  else
-    # On single node installs force drain to delete pods or
-    # else the command will timeout when evicting pods with pod disruption budgets
-    kubectl drain "$1" \
-      --delete-local-data \
-      --ignore-daemonsets \
-      --force \
-      --grace-period=30 \
-      --timeout=120s \
-      --disable-eviction \
-      --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
-  fi
+    if kubernetes_has_remotes ; then
+        kubectl drain "$1" \
+            --delete-local-data \
+            --ignore-daemonsets \
+            --force \
+            --grace-period=30 \
+            --timeout=120s \
+            --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
+    else
+        # On single node installs force drain to delete pods or
+        # else the command will timeout when evicting pods with pod disruption budgets
+        kubectl drain "$1" \
+            --delete-local-data \
+            --ignore-daemonsets \
+            --force \
+            --grace-period=30 \
+            --timeout=120s \
+            --disable-eviction \
+            --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
+    fi
 }
 
 function kubernetes_node_has_version() {

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -316,17 +316,26 @@ function spinner_kubernetes_api_stable() {
 }
 
 function kubernetes_drain() {
-    # Respect pod disruption budgets for applications running on the node but
-    # if we can't evict the pod(s) after --skip-wait-for-delete-timeout seconds then
-    # force delete the pod(s) to allow the node to be drained.
+  if kubernetes_has_remotes ; then
     kubectl drain "$1" \
       --delete-local-data \
       --ignore-daemonsets \
       --force \
       --grace-period=30 \
-      --skip-wait-for-delete-timeout=90 \
       --timeout=120s \
       --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
+  else
+    # On single node installs force drain to delete pods or
+    # else the command will timeout when evicting pods with pod disruption budgets
+    kubectl drain "$1" \
+      --delete-local-data \
+      --ignore-daemonsets \
+      --force \
+      --grace-period=30 \
+      --timeout=120s \
+      --disable-eviction \
+      --pod-selector 'app notin (rook-ceph-mon,rook-ceph-osd,rook-ceph-osd-prepare,rook-ceph-operator,rook-ceph-agent),k8s-app!=kube-dns, name notin (restic)' || true
+  fi
 }
 
 function kubernetes_node_has_version() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
This PR adds the [disable-eviction](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain) flag to the `kubectl drain` command during a Kubernetes upgrade which allows longhorn instance-manager pods to be restarted and therefore allows statefulset pods to be recreated.

**Background**

When upgrading Kubernetes with the `longhorn` add-on installed, the existing `kubectl drain` command never completes because of the podDisruptionBudget for the `instance-manager` pods:
```
error when evicting pods/"instance-manager-r-78f51205" -n "longhorn-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod longhorn-system/instance-manager-e-8a5dd362
evicting pod longhorn-system/instance-manager-r-78f51205
There are pending pods in node "rafael-sc55652-k8s121-122-and-kots-upgrade" when an error occurred: [error when evicting pods/"instance-manager-e-8a5dd362" -n "longhorn-system": global timeout reached: 2m0s, error when evicting pods/"instance-manager-r-78f51205" -n "longhorn-system": global timeout reached: 2m0s]
pod/instance-manager-e-8a5dd362
pod/instance-manager-r-78f51205
error: unable to drain node "rafael-sc55652-k8s121-122-and-kots-upgrade", aborting command...
```

This caused statefulset pods such as `kotsadm-postgres` to never rollout successfully as the pod stayed stuck in `Terminating` status due to mount volume failures like the ones below:
```
MountVolume.WaitForAttach failed for volume "pvc-7d821e41-7c9f-46db-9498-387b47922cfb" : volume pvc-7d821e41-7c9f-46db-9498-387b47922cfb has GET error for volume attachment csi-3fd98854818e88981e49ebd22a7dbb054b5056e0123647ec1e044483e80ab5e6: volumeattachments.storage.k8s.io "csi-3fd98854818e88981e49ebd22a7dbb054b5056e0123647ec1e044483e80ab5e6" is forbidden: User "system:node:rafael-sc55652-k8s121-122-and-kots-upgrade" cannot get resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope: no relationship found between node 'rafael-sc55652-k8s121-122-and-kots-upgrade' and this object
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[sc-55652]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Install Kubernetes via this kURL spec: https://kurl.sh/8d91156
2. Deploy the app as described in https://app.shortcut.com/replicated/story/55652/kurl-upgrade-to-kots-1-79-0-fails-and-kills-the-application-too
3. Perform an upgrade of Kubernetes to `1.22.13` and kots to `1.79.0`.
4. See the kURL install script fail when waiting for `kotsadm` rollout to finish 
 
kURL upgrade spec:
```yaml
apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: a11f243
spec:
  kubernetes:
    version: 1.22.13
  docker:
    version: 20.10.5
  weave:
    version: 2.6.5
  minio:
    version: 2020-01-25T02-50-51Z
  contour:
    version: 1.20.1
  registry:
    version: 2.7.1
  prometheus:
    version: 0.53.1-30.1.0
  kotsadm:
    applicationSlug: jama-k8s/cguzman-2-kots
    version: 1.79.0
  velero:
    version: 1.7.1
  ekco:
    version: 0.13.0
  kurl:
    additionalNoProxyAddresses: []
    installerVersion: v2022.09.08-1
  certManager:
    version: 1.9.1
  metricsServer:
    version: 0.3.7
  longhorn:
    version: 1.2.4
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
