### PR TITLE
include why ceph is unhealthy in health status output

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1649,7 +1649,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
+github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/pkg/cli/rook_wait_for_health.go
+++ b/pkg/cli/rook_wait_for_health.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/replicatedhq/kurl/pkg/rook"
 	"github.com/spf13/cobra"
@@ -11,15 +14,29 @@ import (
 
 func NewRookWaitForHealthCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-for-health",
+		Use:   "wait-for-health [TIMEOUT]",
 		Short: "Waits for Rook to report that it is healthy, and prints what it's waiting for",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			k8sConfig := config.GetConfigOrDie()
 			clientSet := kubernetes.NewForConfigOrDie(k8sConfig)
 
 			rook.InitWriter(cmd.OutOrStdout())
 
-			err := rook.WaitForRookHealth(cmd.Context(), clientSet)
+			ctx := cmd.Context()
+
+			if len(args) == 1 {
+				// a timeout was provided, use it
+				timeout, err := strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse %q as an integer number of seconds: %w", args[0], err)
+				}
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(timeout))
+				defer cancel()
+			}
+
+			err := rook.WaitForRookHealth(ctx, clientSet)
 			if err != nil {
 				return fmt.Errorf("failed to check rook health: %w", err)
 			}

--- a/pkg/rook/health_test.go
+++ b/pkg/rook/health_test.go
@@ -36,19 +36,19 @@ func Test_isStatusHealthy(t *testing.T) {
 			name:    "ceph rebalancing",
 			status:  testfiles.RebalanceCephStatus2,
 			health:  false,
-			message: "health is HEALTH_WARN not HEALTH_OK and 1099 bytes are being recovered per second, 0 desired and 0.142857% of PGs are inactive, 0.181073% are degraded, and 64.709807% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 73.739493% complete",
+			message: "health is HEALTH_WARN because \"Degraded data redundancy: 19/10493 objects degraded (0.181%), 17 pgs degraded and Reduced data availability: 1 pg peering\" and 1099 bytes are being recovered per second, 0 desired and 0.142857% of PGs are inactive, 0.181073% are degraded, and 64.709807% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 73.739493% complete",
 		},
 		{
 			name:    "ceph health_err due to full osd", // this message could very much be improved
 			status:  testfiles.RebalanceCephStatusFull,
 			health:  false,
-			message: "health is HEALTH_ERR not HEALTH_OK and 0.000000% of PGs are inactive, 0.516218% are degraded, and 0.000000% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 99.811995% complete",
+			message: "health is HEALTH_ERR because \"1 full osd(s) and 7 pool(s) full and Degraded data redundancy (low space): 2 pgs recovery_toofull and Degraded data redundancy: 388/75162 objects degraded (0.516%), 2 pgs degraded, 2 pgs undersized\" and 0.000000% of PGs are inactive, 0.516218% are degraded, and 0.000000% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 99.811995% complete",
 		},
 		{
 			name:    "ceph rebalancing multinode",
 			status:  testfiles.RebalanceCephStatusMultinode,
 			health:  false,
-			message: "health is HEALTH_WARN not HEALTH_OK and 18863356 bytes are being recovered per second, 0 desired and 0.000000% of PGs are inactive, 42.455066% are degraded, and 2.081463% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 64.823943% complete",
+			message: "health is HEALTH_WARN because \"Degraded data redundancy: 28841/67933 objects degraded (42.455%), 100 pgs degraded, 65 pgs undersized\" and 18863356 bytes are being recovered per second, 0 desired and 0.000000% of PGs are inactive, 42.455066% are degraded, and 2.081463% are misplaced, 0 required for all and 1 tasks in progress, first task \"Rebalancing after osd.0 marked out\" is 64.823943% complete",
 		},
 		{
 			name:    "ceph has too many PGs per OSD",


### PR DESCRIPTION
also allow setting a timeout on the rook wait-for-health command

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improved output when waiting for rook-ceph to become healthy.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
