### PR TITLE
add k8s 1.25, drop 1.21

### DIFF
--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -23,6 +23,7 @@ module.exports.InstallerVersions = {
     "1.17.7",
     "1.17.3",
     "1.16.4",
+    // cron-kubernetes-update-125
     // cron-kubernetes-update-124
     "1.24.4",
     "1.24.3",
@@ -41,7 +42,6 @@ module.exports.InstallerVersions = {
     "1.22.8",
     "1.22.6",
     "1.22.5",
-    // cron-kubernetes-update-121
     "1.21.14",
     "1.21.12",
     "1.21.11",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Adds support for automatic k8s 1.25 PRs, and removes 1.21 PRs.

It does not intrinsically add support for k8s 1.25 - that will come from https://github.com/replicatedhq/kURL/pull/3458.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
