### PR TITLE
fix openebs testgrid specs

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -24,7 +24,7 @@
 - name: localpv upgrade from 2.6.0
   installerSpec:
     kubernetes:
-      version: "1.23.x"
+      version: "1.22.x" # this is the latest version of k8s that supports openebs 2.6
     weave:
       version: "latest"
     containerd:
@@ -38,7 +38,7 @@
       version: "2.6.0"
   upgradeSpec:
     kubernetes:
-      version: "1.24.x"
+      version: "1.23.x"
     weave:
       version: "latest"
     containerd:
@@ -90,7 +90,7 @@
 - name: localpv upgrade from 1.12.0
   installerSpec:
     kubernetes:
-      version: "1.21.x"
+      version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
     weave:
       version: "latest"
     docker:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Openebs on-pr tests are currently failing because Openebs 2.x is not supported on k8s 1.23.x, see https://github.com/replicatedhq/kURL/pull/3415.
This reverts that test to use k8s 1.22.x.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
