### PR TITLE
test rook-ceph 1.0 to 1.4 (or 1.5) upgrade in airgap

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -251,7 +251,7 @@ function addon_fetch_airgap() {
 
         if ! prompts_can_prompt; then
             # we can't ask the user to give us the file because there are no prompts, but we can say where to put it for a future run
-            printf "Please move this file to %s before rerunning the installer.\n" "$(package_filepath "${package}")"
+            printf "Please move this file to /var/lib/kurl/%s before rerunning the installer.\n" "$(package_filepath "${package}")"
             return 1
         fi
 

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1679,6 +1679,62 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
+- name: rook-upgrade-to-1.5-airgap
+  flags: "yes"
+  airgap: true
+  installerSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: "1.0.4"
+    prometheus:
+      version: "latest"
+    minio:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    rook:
+      version: "1.5.12"
+    prometheus:
+      version: "latest"
+    minio:
+      version: "latest"
+  preInstallScript: |
+    # download the file that the airgap upgrade requires, and place it in the correct location
+    curl -LO https://kurl-sh.s3.amazonaws.com/staging/rookupgrade-10to14.tar.gz
+    mkdir -p /var/lib/kurl/assets
+    mv rookupgrade-10to14.tar.gz /var/lib/kurl/assets
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ecph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+    minio_object_store_info
+    validate_read_write_object_store rwtest minio.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ecph_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+
+    minio_object_store_info
+    validate_testfile rwtest minio.txt
+    validate_read_write_object_store postupgrade minioupgrade.txt
+
+    operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
+    echo $operatorVersion | grep 1.5.12
+
+    k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
+    echo $k8sVersion | grep 1.19
 - name: "k8s_124x containerd 1.5.x upgrade to latest"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
This adds a daily testgrid test to make sure we don't inadvertently break airgap rook 1.0 to 1.4 upgrades. The run can be seen here: https://testgrid.kurl.sh/run/laverya%20rook%201.0.4%20to%201.4%20airgap%20nok8s%20allos.

This partially reincludes things reverted in https://github.com/replicatedhq/kURL/pull/3456.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
