### PR TITLE
Fix airgap sonobuoy upgrade kubernetes

### DIFF
--- a/addons/sonobuoy/0.56.10/install.sh
+++ b/addons/sonobuoy/0.56.10/install.sh
@@ -5,6 +5,10 @@ function sonobuoy() {
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
+function sonobuoy_already_applied() {
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+}
+
 function sonobuoy_join() {
     sonobuoy_binary
 

--- a/addons/sonobuoy/0.56.8/install.sh
+++ b/addons/sonobuoy/0.56.8/install.sh
@@ -5,6 +5,10 @@ function sonobuoy() {
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
+function sonobuoy_already_applied() {
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+}
+
 function sonobuoy_join() {
     sonobuoy_binary
 

--- a/addons/sonobuoy/template/base/install.sh
+++ b/addons/sonobuoy/template/base/install.sh
@@ -5,6 +5,10 @@ function sonobuoy() {
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
 }
 
+function sonobuoy_already_applied() {
+    sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+}
+
 function sonobuoy_join() {
     sonobuoy_binary
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

After upgrades of kubernetes we don't re tag the sonobuoy image for newer versions of kubernetes using conformance image registry registry.k8s.io.

https://testgrid.kurl.sh/run/PROD-daily-2022-09-19T05:33:38Z?sonobuoyResultsInstanceId=qfvikkqmbmluorkq

```
Failed to pull image registry.k8s.io/conformance:v1.24.5 for container e2e within 5m0s. Container is in state ImagePullBackOff
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause airgapped Kuberentes upgrades to fail Sonobuoy tests with a missing image.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
