### PR TITLE
Fix addon-testgrid-tester action when called from remote repo

### DIFF
--- a/.github/actions/addon-testgrid-tester/action.yml
+++ b/.github/actions/addon-testgrid-tester/action.yml
@@ -43,6 +43,7 @@ runs:
           "${{ inputs.version }}" \
           "${{ inputs.package-url }}" \
           "${{ inputs.testgrid-spec-path }}" \
+          "${{ github.action_path }}/../../../testgrid/specs/os-firstlast.yaml" \
           "${{ inputs.testgrid-run-prefix }}" \
           "${{ inputs.priority }}"
       env:


### PR DESCRIPTION
When called from kots the path is wrong to the testgrid os spec and the action is failing.