### PR TITLE
the existence of 'global recovery event' does not make ceph unhealthy

### DIFF
--- a/pkg/rook/health.go
+++ b/pkg/rook/health.go
@@ -135,7 +135,22 @@ func progressEventsString(status cephtypes.CephStatus) string {
 			eventKeys = append(eventKeys, key)
 		}
 		sort.Strings(eventKeys)
-		firstEvent := status.ProgressEvents[eventKeys[0]]
+
+		var firstEvent struct {
+			Message  string  `json:"message"`
+			Progress float64 `json:"progress"`
+		}
+		for _, event := range eventKeys {
+			// we do not consider a global recovery event to be enough to make ceph be 'unhealthy'
+			if !strings.Contains(status.ProgressEvents[event].Message, "Global Recovery Event") {
+				firstEvent = status.ProgressEvents[event]
+				break
+			}
+		}
+
+		if firstEvent.Message == "" {
+			return ""
+		}
 
 		firstEvent.Message = strings.ReplaceAll(firstEvent.Message, "\n", "")
 

--- a/pkg/rook/health_test.go
+++ b/pkg/rook/health_test.go
@@ -74,6 +74,12 @@ func Test_isStatusHealthy(t *testing.T) {
 			health:  true,
 			message: "",
 		},
+		{
+			name:    "Global recovery event is not unhealthy",
+			status:  testfiles.GlobalRecoveryEventStatus,
+			health:  true,
+			message: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/rook/testfiles/globalRecoveryEventCephStatus.json
+++ b/pkg/rook/testfiles/globalRecoveryEventCephStatus.json
@@ -1,0 +1,153 @@
+{
+  "fsid": "9d7018dc-721a-4229-90ab-bb63ae1d5d1e",
+  "health": {
+    "status": "HEALTH_WARN",
+    "checks": {
+      "POOL_NO_REDUNDANCY": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "11 pool(s) have no replicas configured",
+          "count": 11
+        },
+        "muted": false
+      }
+    },
+    "mutes": []
+  },
+  "election_epoch": 5,
+  "quorum": [
+    0
+  ],
+  "quorum_names": [
+    "a"
+  ],
+  "quorum_age": 579,
+  "monmap": {
+    "epoch": 1,
+    "min_mon_release_name": "pacific",
+    "num_mons": 1
+  },
+  "osdmap": {
+    "epoch": 133,
+    "num_osds": 1,
+    "num_up_osds": 1,
+    "osd_up_since": 1664340482,
+    "num_in_osds": 1,
+    "osd_in_since": 1664338986,
+    "num_remapped_pgs": 0
+  },
+  "pgmap": {
+    "pgs_by_state": [
+      {
+        "state_name": "active+clean",
+        "count": 177
+      }
+    ],
+    "num_pgs": 177,
+    "num_pools": 11,
+    "num_objects": 540,
+    "data_bytes": 288443880,
+    "bytes_used": 294387712,
+    "bytes_avail": 53388509184,
+    "bytes_total": 53682896896,
+    "read_bytes_sec": 2388,
+    "write_bytes_sec": 6908,
+    "read_op_per_sec": 3,
+    "write_op_per_sec": 0
+  },
+  "fsmap": {
+    "epoch": 28,
+    "id": 1,
+    "up": 1,
+    "in": 1,
+    "max": 1,
+    "by_rank": [
+      {
+        "filesystem_id": 1,
+        "rank": 0,
+        "name": "rook-shared-fs-b",
+        "status": "up:active",
+        "gid": 14278
+      },
+      {
+        "filesystem_id": 1,
+        "rank": 0,
+        "name": "rook-shared-fs-a",
+        "status": "up:standby-replay",
+        "gid": 14444
+      }
+    ],
+    "up:standby": 0
+  },
+  "mgrmap": {
+    "available": true,
+    "num_standbys": 0,
+    "modules": [
+      "dashboard",
+      "iostat",
+      "nfs",
+      "prometheus",
+      "restful"
+    ],
+    "services": {
+      "dashboard": "https://***HIDDEN***:8443/",
+      "prometheus": "http://***HIDDEN***:9283/"
+    }
+  },
+  "servicemap": {
+    "epoch": 14,
+    "modified": "2022-09-28T04:51:41.638280+0000",
+    "services": {
+      "rgw": {
+        "daemons": {
+          "summary": "",
+          "14390": {
+            "start_epoch": 10,
+            "start_stamp": "2022-09-28T04:48:29.402492+0000",
+            "gid": 14390,
+            "addr": "***HIDDEN***:0/2146332328",
+            "metadata": {
+              "arch": "x86_64",
+              "ceph_release": "pacific",
+              "ceph_version": "ceph version 16.2.9 (4c3647a322c0ff5a1dd2344e039859dcbd28c830) pacific (stable)",
+              "ceph_version_short": "16.2.9",
+              "container_hostname": "rook-ceph-rgw-rook-ceph-store-a-848d9884-g4wxc",
+              "container_image": "quay.io/ceph/ceph:v16.2.9",
+              "cpu": "AMD EPYC Processor (with IBPB)",
+              "distro": "centos",
+              "distro_description": "CentOS Stream 8",
+              "distro_version": "8",
+              "frontend_config#0": "beast port=8080",
+              "frontend_type#0": "beast",
+              "hostname": "laffpxovptdabkpm-initialprimary",
+              "id": "rook.ceph.store.a",
+              "kernel_description": "#1 SMP Tue Mar 31 23:36:51 UTC 2020",
+              "kernel_version": "3.10.0-1127.el7.x86_64",
+              "mem_swap_kb": "0",
+              "mem_total_kb": "16266188",
+              "num_handles": "1",
+              "os": "Linux",
+              "pid": "1",
+              "pod_name": "rook-ceph-rgw-rook-ceph-store-a-848d9884-g4wxc",
+              "pod_namespace": "rook-ceph",
+              "realm_id": "fcb25ba7-1782-412d-9b7e-e7677b210c09",
+              "realm_name": "rook-ceph-store",
+              "zone_id": "5dc03d73-94a4-4f90-be58-379a36c8df6b",
+              "zone_name": "rook-ceph-store",
+              "zonegroup_id": "2f176f8e-32bf-41e4-aef2-7c8bc10bbd68",
+              "zonegroup_name": "rook-ceph-store"
+            },
+            "task_status": {}
+          }
+        }
+      }
+    }
+  },
+  "progress_events": {
+    "892b0e95-7768-4a40-ae05-79c7091984dc": {
+      "message": "Global Recovery Event (0s)\n      [............................] ",
+      "progress": 0,
+      "add_to_ceph_s": true
+    }
+  }
+}

--- a/pkg/rook/testfiles/static.go
+++ b/pkg/rook/testfiles/static.go
@@ -31,6 +31,9 @@ var NoReplicasCephStatus []byte
 //go:embed recentCrashCephStatus.json
 var RecentCrashCephStatus []byte
 
+//go:embed globalRecoveryEventCephStatus.json
+var GlobalRecoveryEventStatus []byte
+
 // lists of pods to use in migrate unit tests
 
 //go:embed "6 blockdevice pods.json"


### PR DESCRIPTION
Co-authored-by: Rafael Polanco <rafael@replicated.com>>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This PR allows the rook-ceph health check to not fail when there is a `GLOBAL RECOVERY EVENT` in progress.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
