### PR TITLE
Allow passing testgrid os spec path to action

### DIFF
--- a/.github/actions/addon-testgrid-tester/action.yml
+++ b/.github/actions/addon-testgrid-tester/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: true
     description: 'Path to directory where *.yaml testgrid specs reside.'
     type: string
+  testgrid-os-spec-path:
+    description: 'Path to testgrid os spec yaml file.'
+    type: string
   testgrid-run-prefix:
     description: 'Prefix for testgrid ref (for identification).'
     type: string
@@ -38,12 +41,16 @@ runs:
   steps:
     - id: test-addon
       run: |
+        testgrid_os_spec_path="${{ inputs.testgrid-os-spec-path }}"
+        if [ -z "$testgrid_os_spec_path" ]; then
+          testgrid_os_spec_path="${{ github.action_path }}/../../../testgrid/specs/os-firstlast.yaml"
+        fi
         ${{ github.action_path }}/../../../bin/test-addon.sh \
           "${{ inputs.addon }}" \
           "${{ inputs.version }}" \
           "${{ inputs.package-url }}" \
           "${{ inputs.testgrid-spec-path }}" \
-          "${{ github.action_path }}/../../../testgrid/specs/os-firstlast.yaml" \
+          "$testgrid_os_spec_path" \
           "${{ inputs.testgrid-run-prefix }}" \
           "${{ inputs.priority }}"
       env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Allow kots kurl add-on test to only test a single os