### PR TITLE
Patch critical CVE-2022-40674 in kurlsh/s3cmd:20220825-237c19d

### DIFF
--- a/addons/registry/2.8.1/Manifest
+++ b/addons/registry/2.8.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.8.1
-image s3cmd kurlsh/s3cmd:20220825-237c19d
+image s3cmd kurlsh/s3cmd:20221006-27d5371

--- a/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20220825-237c19d
+        image: kurlsh/s3cmd:20221006-27d5371
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.8.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.8.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20220825-237c19d
+        image: kurlsh/s3cmd:20221006-27d5371
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20220825-237c19d
+        image: kurlsh/s3cmd:20221006-27d5371
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/velero/1.9.2/Manifest
+++ b/addons/velero/1.9.2/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.5.1
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.1
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.1
 image local-volume-provider replicated/local-volume-provider:v0.3.8
-image s3cmd kurlsh/s3cmd:20220825-237c19d
+image s3cmd kurlsh/s3cmd:20221006-27d5371
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.2/velero-v1.9.2-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.2/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.2/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20220825-237c19d
+        image: kurlsh/s3cmd:20221006-27d5371
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Patch critical cve

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates kurlsh/s3cmd image to tag 20221006-27d5371 for latest [Registry](https://kurl.sh/docs/add-ons/registry) and [Velero](https://kurl.sh/docs/add-ons/velero) add-on versions to address the following critical CVE: CVE-2022-40674
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE