### PR TITLE
NO_PROXY environment variable can have empty address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,6 +678,8 @@ test-shell:
 	./scripts/common/common-test.sh
 	./scripts/common/docker-test.sh
 	./scripts/common/kubernetes-test.sh
+	./scripts/common/proxy-test.sh
+	./scripts/common/yaml-test.sh
 	./addons/rook/template/test/install.sh
 
 .PHONY: kurl-util-image

--- a/addons/velero/1.9.2/tmpl-restic-daemonset-proxy.yaml
+++ b/addons/velero/1.9.2/tmpl-restic-daemonset-proxy.yaml
@@ -10,8 +10,8 @@ spec:
         - name: restic
           env:
           - name: HTTP_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: NO_PROXY
-            value: ${NO_PROXY_ADDRESSES}
+            value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/1.9.2/tmpl-velero-deployment-proxy.yaml
+++ b/addons/velero/1.9.2/tmpl-velero-deployment-proxy.yaml
@@ -10,8 +10,8 @@ spec:
         - name: velero
           env:
           - name: HTTP_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: NO_PROXY
-            value: ${NO_PROXY_ADDRESSES}
+            value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/template/base/install.tmpl.sh
+++ b/addons/velero/template/base/install.tmpl.sh
@@ -285,12 +285,12 @@ function velero_patch_http_proxy() {
     local dst="$2"
 
     if [ -n "$PROXY_ADDRESS" ]; then
-        render_yaml_file "$src/tmpl-velero-deployment-proxy.yaml" > "$dst/velero-deployment-proxy.yaml"
+        render_yaml_file_2 "$src/tmpl-velero-deployment-proxy.yaml" > "$dst/velero-deployment-proxy.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" velero-deployment-proxy.yaml
     fi
 
     if [ -n "$PROXY_ADDRESS" ] && [ "$VELERO_DISABLE_RESTIC" != "1" ]; then
-        render_yaml_file "$src/tmpl-restic-daemonset-proxy.yaml" > "$dst/restic-daemonset-proxy.yaml"
+        render_yaml_file_2 "$src/tmpl-restic-daemonset-proxy.yaml" > "$dst/restic-daemonset-proxy.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" restic-daemonset-proxy.yaml
     fi
 }

--- a/addons/velero/template/base/tmpl-restic-daemonset-proxy.yaml
+++ b/addons/velero/template/base/tmpl-restic-daemonset-proxy.yaml
@@ -10,8 +10,8 @@ spec:
         - name: restic
           env:
           - name: HTTP_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: NO_PROXY
-            value: ${NO_PROXY_ADDRESSES}
+            value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/template/base/tmpl-velero-deployment-proxy.yaml
+++ b/addons/velero/template/base/tmpl-velero-deployment-proxy.yaml
@@ -10,8 +10,8 @@ spec:
         - name: velero
           env:
           - name: HTTP_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: ${PROXY_ADDRESS}
+            value: "${PROXY_ADDRESS}"
           - name: NO_PROXY
-            value: ${NO_PROXY_ADDRESSES}
+            value: "${NO_PROXY_ADDRESSES}"

--- a/scripts/common/proxy-test.sh
+++ b/scripts/common/proxy-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+. ./scripts/common/proxy.sh
+
+function test_unique_no_proxy_addresses() {
+    assertEquals "basic" "a,b,c" "$(unique_no_proxy_addresses "a,b,b,a,c,a,b")"
+    assertEquals "empty" "a,b,c" "$(unique_no_proxy_addresses "a,b,b, ,a,c,a, ,b")"
+}
+
+. shunit2

--- a/scripts/common/proxy.sh
+++ b/scripts/common/proxy.sh
@@ -101,7 +101,7 @@ function configure_no_proxy_preinstall() {
     fi
 
     # filter duplicates
-    addresses=$(echo "$addresses" | sed 's/,/\n/g' | sort | uniq | paste -s --delimiters=",")
+    addresses=$(unique_no_proxy_addresses "$addresses")
 
     # kubeadm requires this in the environment to reach K8s masters
     export no_proxy="$addresses"
@@ -161,10 +161,14 @@ function configure_no_proxy() {
     fi
 
     # filter duplicates
-    addresses=$(echo "$addresses" | sed 's/,/\n/g' | sort | uniq | paste -s --delimiters=",")
+    addresses=$(unique_no_proxy_addresses "$addresses")
 
     # kubeadm requires this in the environment to reach K8s masters
     export no_proxy="$addresses"
     NO_PROXY_ADDRESSES="$addresses"
     echo "Exported no_proxy: $no_proxy"
+}
+
+function unique_no_proxy_addresses() {
+    echo "$1" | sed 's/,/\n/g' | sed '/^\s*$/d' | sort | uniq | paste -s --delimiters=","
 }

--- a/scripts/common/yaml-test.sh
+++ b/scripts/common/yaml-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+. ./scripts/common/yaml.sh
+
+function test_render_yaml_file_2() {
+    local PROXY_ADDRESS=a
+    local NO_PROXY_ADDRESSES=b
+    local expects="apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: velero
+  namespace: 
+spec:
+  template:
+    spec:
+      containers:
+        - name: velero
+          env:
+          - name: HTTP_PROXY
+            value: \"a\"
+          - name: HTTPS_PROXY
+            value: \"a\"
+          - name: NO_PROXY
+            value: \"b\""
+    assertEquals "preserves quotes" "$expects" "$(render_yaml_file_2 "./addons/velero/template/base/tmpl-velero-deployment-proxy.yaml")"
+}
+
+. shunit2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When $addresses value contains a space it produces a list that begins with a comma. This is invalid yaml when not quoted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause installations to fail with error "yaml: did not find expected node content" when installing behind an HTTP_PROXY.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE