### PR TITLE
Fix registry testgrid post install and upgrade scripts to use ctr

### DIFF
--- a/addons/registry/2.8.1/service.yaml
+++ b/addons/registry/2.8.1/service.yaml
@@ -14,3 +14,4 @@ spec:
     protocol: TCP
   selector:
     app: registry
+

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -12,22 +12,23 @@
       version: "__testver__"
       s3Override: "__testdist__"
   postInstallScript: |
-    # setup docker config
-    mkdir -p ~/.docker
-    kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode > ~/.docker/config.json
-    
-    # the registry image with the local registry address
+
+    # get the registry address and credentials
     DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
-    docker tag registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # push this to the registry
-    docker push $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # remove this image from the registry, so that the pull is real
-    docker rmi $DOCKER_REGISTRY_IP/registry:testtag
-    
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # tag and push this to the registry
+    ctr -n k8s.io images tag docker.io/library/registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images push --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
     # pull it from the registry
-    docker pull $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
 
 - name: registry_latest_longhorn
   installerSpec:
@@ -43,22 +44,23 @@
       version: "__testver__"
       s3Override: "__testdist__"
   postInstallScript: |
-    # setup docker config
-    mkdir -p ~/.docker
-    kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode > ~/.docker/config.json
-    
-    # the registry image with the local registry address
+
+    # get the registry address and credentials
     DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
-    docker tag registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # push this to the registry
-    docker push $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # remove this image from the registry, so that the pull is real
-    docker rmi $DOCKER_REGISTRY_IP/registry:testtag
-    
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # tag and push this to the registry
+    ctr -n k8s.io images tag docker.io/library/registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images push --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
     # pull it from the registry
-    docker pull $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
 
 - name: registry_latest_upgrade
   installerSpec:
@@ -91,27 +93,41 @@
       version: "__testver__"
       s3Override: "__testdist__"
   postInstallScript: |
+
     # wait for the pod to be ready
     sleep 60s
     kubectl get pods -n kurl
-    
-    # setup docker config
-    mkdir -p ~/.docker
-    kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode > ~/.docker/config.json
-    
-    # the test image with the local registry address
+
+    # get the registry address and credentials
     DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
-    docker tag bloomberg/goldpinger:v3.5.1 $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # push this to the registry
-    docker push $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # remove this image from the registry, so that the pull is real
-    docker rmi $DOCKER_REGISTRY_IP/registry:testtag
-  postUpgradeScript: |
-    DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # tag and push this to the registry
+    ctr -n k8s.io images tag docker.io/bloomberg/goldpinger:v3.5.1 $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images push --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
     # pull it from the registry
-    docker pull $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+  postUpgradeScript: |
+
+    # get the registry address and credentials
+    DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
+    # pull it from the registry
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
 
 - name: registry_oldest_upgrade
   installerSpec:
@@ -138,27 +154,41 @@
       version: "__testver__"
       s3Override: "__testdist__"
   postInstallScript: |
+
     # wait for the pod to be ready
     sleep 60s
     kubectl get pods -n kurl
-    
-    # setup docker config
-    mkdir -p ~/.docker
-    kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode > ~/.docker/config.json
-    
-    # the registry image with the local registry address
+
+    # get the registry address and credentials
     DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
-    docker tag registry:2.7.1 $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # push this to the registry
-    docker push $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # remove this image from the registry, so that the pull is real
-    docker rmi $DOCKER_REGISTRY_IP/registry:testtag
-  postUpgradeScript: |
-    DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # tag and push this to the registry
+    ctr -n k8s.io images tag docker.io/library/registry:2.7.1 $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images push --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
     # pull it from the registry
-    docker pull $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+  postUpgradeScript: |
+
+    # get the registry address and credentials
+    DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
+    # pull it from the registry
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
 
 - name: registry_publish_port
   installerSpec:
@@ -225,19 +255,24 @@
       version: "__testver__"
       s3Override: "__testdist__"
   postInstallScript: |
-    # setup docker config
-    mkdir -p ~/.docker
-    kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode > ~/.docker/config.json
-    
-    # the registry image with the local registry address
+
+    # wait for the pod to be ready
+    sleep 60s
+    kubectl get pods -n kurl
+
+    # get the registry address and credentials
     DOCKER_REGISTRY_IP=$(kubectl -n kurl get service registry -o=jsonpath='{@.spec.clusterIP}' 2>/dev/null || echo "")
-    docker tag registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # push this to the registry
-    docker push $DOCKER_REGISTRY_IP/registry:testtag
-    
-    # remove this image from the registry, so that the pull is real
-    docker rmi $DOCKER_REGISTRY_IP/registry:testtag
-    
+    DOCKER_AUTH=$(kubectl get secret registry-creds -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode | sed 's|.*"auth":"\([^"]*\)".*|\1|')
+
+    # tag and push this to the registry
+    ctr -n k8s.io images tag docker.io/library/registry:__testver__ $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images push --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+
+    # remove this image from the local filesystem, so that the pull is real
+    IMAGE_DIGEST=$(ctr -n k8s.io images ls | grep -F "$DOCKER_REGISTRY_IP/registry:testtag" | awk '{ print $3 }')
+    if [ -n "$IMAGE_DIGEST" ]; then
+      ctr -n k8s.io images ls | grep -F "$IMAGE_DIGEST" | awk '{ print $1 }' | xargs ctr -n k8s.io images delete --sync
+    fi
+
     # pull it from the registry
-    docker pull $DOCKER_REGISTRY_IP/registry:testtag
+    ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes

```
/opt/kurl-testgrid/postinstall.sh: line 7: docker: command not found
```

https://testgrid.kurl.sh/run/pr-3544-cb8d4be-registry-2.8.1-k8s-docker-registry-2.8.1-k8s-docker-2022-10-06T18:26:16Z