### PR TITLE
Daily scan images should only fail for vulnerabilities in images we maintain

### DIFF
--- a/.github/workflows/daily-scan-images.yaml
+++ b/.github/workflows/daily-scan-images.yaml
@@ -34,7 +34,9 @@ jobs:
       - name: "Write Trivy ignore file"
         run: if [ -n '${{ matrix.trivyignore }}' ]; then echo '${{ matrix.trivyignore }}' | base64 -d > .trivyignore.rego ; fi
       - name: "Generate artifact"
+        id: trivy
         uses: aquasecurity/trivy-action@0.7.1
+        continue-on-error: ${{ ! matrix.maintainer }}
         with:
           image-ref: ${{ matrix.image }}
           vuln-type: 'os'
@@ -46,13 +48,14 @@ jobs:
           exit-code: '1'
       - name: "Upload artifact"
         uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
+        if: ${{ always() && steps.trivy.outcome == 'failure' }}
         with:
           name: ${{ matrix.addon }}-${{ matrix.version }}-${{ matrix.name }}
           path: trivy.json
       - name: "Display results"
         uses: aquasecurity/trivy-action@0.7.1
-        if: ${{ failure() }}
+        if: ${{ always() && steps.trivy.outcome == 'failure' }}
+        continue-on-error: ${{ ! matrix.maintainer }}
         with:
           image-ref: ${{ matrix.image }}
           vuln-type: 'os'

--- a/bin/scan-images/addons.js
+++ b/bin/scan-images/addons.js
@@ -5,6 +5,15 @@ const skipAddons = [
     "rookupgrade",
 ];
 
+// maintainerImages contains a list of images we maintain.
+// The scan action will only report failures for images in this list.
+const maintainerImages = {
+    ekco: ["ekco", "haproxy"],
+    registry: ["s3cmd"],
+    velero: ["local-volume-provider", "s3cmd"],
+    weave: ["weave-kube", "weave-npc", "weaveexec"],
+};
+
 var getImages = rootDir => {
     const images = [];
     fs.readdirSync(rootDir).forEach((addon) => {
@@ -37,16 +46,22 @@ var getImages = rootDir => {
                 if (parts[0] !== 'image') {
                     return;
                 }
+                const name = parts[1];
                 let imageName = parts[2];
                 if (imageName.split('/').length === 1) {
                     imageName = `library/${imageName}`
                 }
+                let maintainer = false;
+                if (maintainerImages[addon] && maintainerImages[addon].includes(name)) {
+                    maintainer = true;
+                }
                 const image = {
                     addon: addon,
                     version: version,
-                    name: parts[1],
+                    name: name,
                     image: imageName,
                     trivyignore: trivyignore,
+                    maintainer: maintainer,
                 };
                 images.push(image);
             });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

With this change, the daily-scan-images workflow will only fail if an image in the list of ones we maintain contains CVEs.

https://github.com/replicatedhq/kURL/actions/runs/3237215219/jobs/5304001981
