### PR TITLE
Fix testgrid full run for k8s 1.25 changes

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -899,7 +899,7 @@
     registry:
       version: 2.7.1
     prometheus:
-      version: "0.53.x"
+      version: latest
     kotsadm:
       version: latest
       disableS3: true
@@ -1026,7 +1026,7 @@
 - name: "K8s 1.25x OpenEBS, disableS3"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.25.x
     containerd:
       version: latest
     weave:
@@ -1040,7 +1040,7 @@
     registry:
       version: 2.7.1
     prometheus:
-      version: "0.53.x"
+      version: latest
     kotsadm:
       version: latest
       disableS3: true
@@ -1128,8 +1128,8 @@
       version: latest
     kotsadm:
       version: latest
-    docker:
-      version: 20.10.x
+    containerd:
+      version: latest
     velero:
       version: 1.8.x
     ekco:
@@ -1149,7 +1149,7 @@
       version: latest
       disableS3: true
     containerd:
-      version: 1.5.x
+      version: latest
     velero:
       version: 1.9.x
     ekco:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:


```
Error: error getting kurl spec url: Prometheus versions less than or equal to 0.59.0 are not compatible with Kubernetes 1.25+
Error: error getting kurl spec url: Docker is not supported with Kubernetes versions 1.24+, please choose Containerd
```