### PR TITLE
Add external add-on isPrerelease support

### DIFF
--- a/.github/actions/import-external-addons/test/util.js
+++ b/.github/actions/import-external-addons/test/util.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { it } from 'mocha';
 import os from 'os';
 import fs from 'node:fs/promises';
-import { appendVersion, findVersion, generateChecksum } from '../util';
+import { appendVersion, findVersion, generateChecksum, isVersionReleasing } from '../util.js';
 
 describe ('findVersion', () => {
   it('finds version', () => {
@@ -41,5 +41,27 @@ describe ('generateChecksum', () => {
     expect(checksum1).to.have.length(64);
     const checksum2 = await generateChecksum(filename);
     expect(checksum1).to.equal(checksum2);
+  });
+});
+
+describe ('isVersionReleasing', () => {
+  it('is not releasing', () => {
+    const isReleasing = isVersionReleasing({isPrerelease: false}, {isPrerelease: false});
+    expect(isReleasing).to.be.false;
+  });
+
+  it('is releasing', () => {
+    const isReleasing = isVersionReleasing({isPrerelease: true}, {isPrerelease: false});
+    expect(isReleasing).to.be.true;
+  });
+
+  it('undefined', () => {
+    const isReleasing = isVersionReleasing({}, {isPrerelease: false});
+    expect(isReleasing).to.be.false;
+  });
+
+  it('null', () => {
+    const isReleasing = isVersionReleasing(null, {isPrerelease: false});
+    expect(isReleasing).to.be.false;
   });
 });

--- a/.github/actions/import-external-addons/util.js
+++ b/.github/actions/import-external-addons/util.js
@@ -1,4 +1,4 @@
-import * as semver from 'semver';
+import semver from 'semver';
 import fs from 'node:fs';
 import { createHash } from 'node:crypto';
 
@@ -7,6 +7,10 @@ export const findVersion = (kotsAddonVersions, version) => {
     return;
   }
   return kotsAddonVersions.find(el => el.version === version.version);
+};
+
+export const isVersionReleasing = (existing, next) => {
+  return existing && existing.isPrerelease && !next.isPrerelease ?  true : false;
 };
 
 export const appendVersion = (kotsAddonVersions, version) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Right now, an external add-on version becomes available in on kurl.sh as soon as it is added to the versions.json file. However, there may be scenarios where a new version is published, but it is still a pre-release, so we would not want that showing up on kurl.sh.

Add support for an isPrerelease field that would allow filtering out particular add-on versions. This field would be managed by the external add-on.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Related pr https://github.com/replicatedhq/kURL-api/pull/44

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE