### PR TITLE
Testgrid use ekco latest with rook 1.9.x

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -436,7 +436,7 @@
     kotsadm:
       version: 1.25.2
     ekco:
-      version: 0.7.0
+      version: latest
     containerd:
       version: 1.4.10
     certManager:
@@ -589,6 +589,8 @@
       nameserver: 8.8.8.8
     collectd:
       version: v5
+    ekco:
+      version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x and collectd-v5 are not supported on ubuntu 22.04
 - name: k8s119_selinux


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes https://testgrid.kurl.sh/run/PROD-daily-2022-10-19T05:34:01Z?kurlLogsInstanceId=sakacnaavcerzvbe&nodeId=sakacnaavcerzvbe-initialprimary#L302

```
Rook Pre-init: Rook 1.9.12 is only compatible with EKCO add-on version 0.23.0 and above.
Rook 1.9.12 will not be installed due to failed preflight checks.
```