### PR TITLE
OpenEBS add-on not supported for disableS3

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -882,20 +882,18 @@
       version: 1.7.x
     ekco:
       version: latest
-- name: "K8s 1.22x OpenEBS, disableS3"
+- name: "K8s 1.22x Rook, disableS3"
   installerSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.22.x
     containerd:
       version: 1.5.x
     weave:
       version: latest
     contour:
       version: 1.19.1
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
+    rook:
+      version: 1.9.x
     registry:
       version: 2.7.1
     prometheus:
@@ -904,7 +902,7 @@
       version: latest
       disableS3: true
     velero:
-      version: 1.7.x
+      version: latest
     ekco:
       version: latest
 - name: "K8s 1.22x Airgap"
@@ -1023,7 +1021,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: "K8s 1.25x OpenEBS, disableS3"
+- name: "K8s 1.25x Rook, disableS3"
   installerSpec:
     kubernetes:
       version: 1.25.x
@@ -1033,10 +1031,8 @@
       version: latest
     contour:
       version: 1.19.1
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
+    rook:
+      version: 1.9.x
     registry:
       version: 2.7.1
     prometheus:
@@ -1045,7 +1041,7 @@
       version: latest
       disableS3: true
     velero:
-      version: 1.7.x
+      version: latest
     ekco:
       version: latest
 - name: "K8s 1.24x Airgap"
@@ -1143,11 +1139,12 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
     velero:
@@ -1165,11 +1162,12 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
     ekco:
@@ -1187,7 +1185,6 @@
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
     ekco:
@@ -1202,11 +1199,12 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
     ekco:
@@ -1220,11 +1218,12 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
     ekco:
@@ -1305,11 +1304,12 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     ekco:
       version: latest
   flags: "labels=disktype=ssd,gpu=enabled exclude-builtin-host-preflights" # TODO: add more flags here
@@ -1696,13 +1696,14 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     ekco:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     docker:
       version: latest
   upgradeSpec:
@@ -1714,12 +1715,13 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio:
+      version: latest
     registry:
       version: latest
     ekco:
       version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes

https://testgrid.kurl.sh/run/PROD-daily-2022-10-19T05:34:01Z?kurlLogsInstanceId=zjlbvxyjmdbxlinl&nodeId=zjlbvxyjmdbxlinl-initialprimary#L305

```
Only Rook and Longhorn are supported for Velero Internal backup storage.
```