### PR TITLE
Fix erroneously remove --network-plugin flag prior to 1.24

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -311,7 +311,7 @@ function maybe_patch_node_cri_socket_annotation() {
 # will remove the erroneous flag from the file.
 function upgrade_maybe_remove_kubeadm_network_plugin_flag() {
     local k8sVersion=$1
-    if [ "$(kubernetes_version_minor)" -lt "24" ]; then
+    if [ "$(kubernetes_version_minor "$k8sVersion")" -lt "24" ]; then
         return
     fi
     sed -i 's/ \?--network-plugin \?[^ "]*//' /var/lib/kubelet/kubeadm-flags.env


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The kubernetes_version_minor function requires an argument that is missing.

TBH I dont know if there is any impact here.
