### PR TITLE
Fix testgrid daily run needs more cpu with Rook 1.9.x

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -419,6 +419,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: k8s119_containerd_rook_block
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.19.3
@@ -825,7 +826,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: remove_all_object_storage
-  cpu: 6
+  cpu: 7
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -862,6 +863,7 @@
     ekco:
       version: latest
 - name: "K8s 1.22x Rook"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.22.x
@@ -885,6 +887,7 @@
     ekco:
       version: latest
 - name: "K8s 1.22x Rook, disableS3"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.22.x
@@ -898,8 +901,6 @@
       version: 1.9.x
     registry:
       version: 2.7.1
-    prometheus:
-      version: latest
     kotsadm:
       version: latest
       disableS3: true
@@ -908,6 +909,7 @@
     ekco:
       version: latest
 - name: "K8s 1.22x Airgap"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.22.x
@@ -999,6 +1001,7 @@
       version: latest
   airgap: true
 - name: "K8s 1.24x Rook"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -1024,6 +1027,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: "K8s 1.25x Rook, disableS3"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.25.x
@@ -1047,6 +1051,7 @@
     ekco:
       version: latest
 - name: "K8s 1.24x Airgap"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -1073,7 +1078,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
 - name: "Upgrade to 1.24"
-  cpu: 6
+  cpu: 7
   installerSpec:
     kubernetes:
       version: 1.23.x


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Testgrid runs with rook 1.9.x are failing with pending pods because of not enough cpus