### PR TITLE
When checking for CRI we should not use "commandExists docker"

### DIFF
--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -236,7 +236,7 @@ function ekco_bootstrap_internal_lb() {
 
     # Always regenerate the manifests to account for updates.
     # Note: this could cause downtime when kublet syncs the manifests for a new haproxy version
-    if commandExists docker; then
+    if [ -n "$DOCKER_VERSION" ]; then
         mkdir -p /etc/kubernetes/manifests
         docker run --rm \
             --entrypoint="/usr/bin/ekco" \
@@ -261,7 +261,7 @@ function ekco_bootstrap_internal_lb() {
         return 0
     fi
 
-    if commandExists docker; then
+    if [ -n "$DOCKER_VERSION" ]; then
         mkdir -p /etc/haproxy
         docker run --rm \
             --entrypoint="/usr/bin/ekco" \

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -311,7 +311,7 @@ function require_cri() {
     fi
 
     if [ -z "$DOCKER_VERSION" ] && [ -z "$CONTAINERD_VERSION" ]; then
-            force_docker
+        force_docker
     fi
 
     return 0

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -36,11 +36,12 @@ function join() {
         # this will stop all the control plane pods except etcd
         rm -f /etc/kubernetes/manifests/kube-*
         if commandExists docker ; then
-            while docker ps | grep -q kube-apiserver ; do
+            while docker ps 2>/dev/null | grep -q kube-apiserver ; do
                 sleep 2
             done
-        elif commandExists crictl ; then
-            while crictl ps | grep -q kube-apiserver ; do
+        fi
+        if commandExists crictl ; then
+            while crictl ps 2>/dev/null | grep -q kube-apiserver ; do
                 sleep 2
             done
         fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When migrating from docker to containerd we load these images with containerd and run the containers with docker.

I am not certain of the impact.

```
unpacking docker.io/library/haproxy:2.6.5-alpine3.16 (sha256:be6e78a6cec816639cb4e918255b624ba6c51e16c3978024ebd2eeee5a23edf0)...done
unpacking docker.io/replicated/ekco:v0.21.0 (sha256:9f3b98d0b0d555648cddf037ad2a87def1fbbe115f7fb1e092e807f4655dbe65)...done
⚙  Addon ekco 0.21.0
Unable to find image 'replicated/ekco:v0.21.0' locally
v0.21.0: Pulling from replicated/ekco
2238450926aa: Pull complete
668359300dbd: Pull complete
4be50ed4ede1: Pull complete
Digest: sha256:5f4b51223a1091f9422b16109fa3ad83904e128c418693972b44aa37132d69a0
Status: Downloaded newer image for replicated/ekco:v0.21.0
Unable to find image 'haproxy:2.6.5-alpine3.16' locally
2.6.5-alpine3.16: Pulling from library/haproxy
213ec9aee27d: Pull complete
22c292e26e36: Pull complete
6e247ab2c68e: Pull complete
583f6dbef993: Pull complete
Digest: sha256:c6095270479e2c08f47cdf194961a70b68dbeac084e79e7bd50423ff42ea1cac
Status: Downloaded newer image for haproxy:2.6.5-alpine3.16
d62ebd2b93aae61dc6e154dbdee0f4db8ca68d84c50904f0dddce3dfe74cf2e4
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE