### PR TITLE
Trigger PVC Migration when Removing Rook and Installing OpenEBS

### DIFF
--- a/addons/longhorn/1.1.2/install.sh
+++ b/addons/longhorn/1.1.2/install.sh
@@ -234,7 +234,7 @@ function maybe_init_hosts() {
 function maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
-            rook_ceph_to_longhorn
+            rook_ceph_to_sc_migration "longhorn"
             export DID_MIGRATE_ROOK_PVCS="1" # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi

--- a/addons/longhorn/1.2.2/install.sh
+++ b/addons/longhorn/1.2.2/install.sh
@@ -196,7 +196,7 @@ function maybe_init_hosts() {
 function maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
-            rook_ceph_to_longhorn
+            rook_ceph_to_sc_migration "longhorn"
             export DID_MIGRATE_ROOK_PVCS="1" # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi

--- a/addons/longhorn/1.2.4/install.sh
+++ b/addons/longhorn/1.2.4/install.sh
@@ -191,7 +191,7 @@ function maybe_init_hosts() {
 function maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
-            rook_ceph_to_longhorn
+            rook_ceph_to_sc_migration "longhorn"
             export DID_MIGRATE_ROOK_PVCS="1" # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi

--- a/addons/longhorn/1.3.1/install.sh
+++ b/addons/longhorn/1.3.1/install.sh
@@ -212,7 +212,7 @@ function longhorn_maybe_init_hosts() {
 function longhorn_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
-            rook_ceph_to_longhorn
+            rook_ceph_to_sc_migration "longhorn"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -212,7 +212,7 @@ function longhorn_maybe_init_hosts() {
 function longhorn_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
-            rook_ceph_to_longhorn
+            rook_ceph_to_sc_migration "longhorn"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -35,6 +35,20 @@ function openebs() {
 
     # if there is a validatingWebhookConfiguration, wait for the service to be ready
     openebs_await_admissionserver
+
+    # migrate from Rook/Ceph storage if applicable
+    openebs_maybe_migrate_from_rook
+}
+
+# if rook-ceph is installed but is not specified in the kURL spec, migrate data from
+# rook-ceph to OpenEBS local pv hostpath
+function openebs_maybe_migrate_from_rook() {
+    if [ -z "$ROOK_VERSION" ]; then
+        if kubectl get ns | grep -q rook-ceph; then
+            rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS"
+            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+        fi
+    fi
 }
 
 function openebs_apply_crds() {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kurlkinds v1.0.1
-	github.com/replicatedhq/pvmigrate v0.5.0
+	github.com/replicatedhq/pvmigrate v0.6.0
 	github.com/replicatedhq/troubleshoot v0.45.0
 	github.com/rook/rook v1.7.11
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1709,8 +1709,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/replicatedhq/kurlkinds v1.0.1 h1:fkiOlZ3KJUrt/Nr/IPovBZW7pSWzq3GA/Jonec59sbQ=
 github.com/replicatedhq/kurlkinds v1.0.1/go.mod h1:ipRic9PDO6+GXPDvO3zGBAMpkg5iPun987VQqQK5S+E=
-github.com/replicatedhq/pvmigrate v0.5.0 h1:nIseRkPw+4/7LUAv7UsmdmaJZfeh7HydTNK9wNPxlg4=
-github.com/replicatedhq/pvmigrate v0.5.0/go.mod h1:GVPgShsnL8Oksp3eP75qZvd7Xx4T2JiEhFmicRs1BI0=
+github.com/replicatedhq/pvmigrate v0.6.0 h1:vj26q3KBYP3D2yKMoEU9+ZE7mP38lDhzA260ZDBbLSY=
+github.com/replicatedhq/pvmigrate v0.6.0/go.mod h1:kCyzLWCfD7jnm7As+g/3jFdXdHWCdFnp5ekh5LfAebs=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.45.0 h1:2NLxS1lF+BiWp0ZX5xfO7QIa5s11jqg26KmnkslHQBA=

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -100,9 +100,16 @@ function remove_rook_ceph() {
     printf "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed.\n"
 }
 
-# scale down prometheus, move all 'rook-ceph' PVCs to 'longhorn', scale up prometheus
-function rook_ceph_to_longhorn() {
-    report_addon_start "rook-ceph-to-longhorn" "v1"
+# scale down prometheus, move all 'rook-ceph' PVCs to provided storage class, scale up prometheus
+# Supported storage class migrations from ceph are 'longhorn' and 'openebs'
+function rook_ceph_to_sc_migration() {
+    local destStorageClass=$1
+    report_addon_start "rook-ceph-to-${destStorageClass}-migration" "v2"
+
+    # we only support migrating to 'longhonr' and 'openebs' storage classes
+    if [ "$destStorageClass" != "longhorn" ] && [ "$destStorageClass" != "openebs" ]; then
+        bail "Ceph to $destStorageClass migration is not supported"
+    fi
 
     # patch ceph so that it does not consume new devices that longhorn creates
     echo "Patching CephCluster storage.useAllDevices=false"
@@ -134,13 +141,13 @@ function rook_ceph_to_longhorn() {
     for rook_sc in $rook_scs
     do
         # run the migration (without setting defaults)
-        $BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc longhorn --rsync-image "$KURL_UTIL_IMAGE"
+        $BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE"
     done
 
     for rook_sc in $rook_default_sc
     do
         # run the migration (setting defaults)
-        $BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc longhorn --rsync-image "$KURL_UTIL_IMAGE" --set-defaults
+        $BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE" --set-defaults
     done
 
     # reset prometheus (and ekco) scale
@@ -155,8 +162,8 @@ function rook_ceph_to_longhorn() {
     fi
 
     # print success message
-    printf "${GREEN}Migration from rook-ceph to longhorn completed successfully!\n${NC}"
-    report_addon_success "rook-ceph-to-longhorn" "v1"
+    printf "${GREEN}Migration from rook-ceph to %s completed successfully!\n${NC}" "$destStorageClass"
+    report_addon_success "rook-ceph-to-$destStorageClass-migration" "v2"
 }
 
 # if PVCs and object store data have both been migrated from rook-ceph and rook-ceph is no longer specified in the kURL spec, remove rook-ceph

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -104,12 +104,14 @@ function remove_rook_ceph() {
 # Supported storage class migrations from ceph are: 'longhorn' and 'openebs'
 function rook_ceph_to_sc_migration() {
     local destStorageClass=$1
-    report_addon_start "rook-ceph-to-${destStorageClass}-migration" "v2"
+    local scProvisioner="$(kubectl get $destStorageClass -ojsonpath='{.provisioner}')"
 
     # we only support migrating to 'longhorn' and 'openebs' storage classes
-    if [ "$destStorageClass" != "longhorn" ] && [[ "$destStorageClass" != *"openebs"* ]]; then
-        bail "Ceph to $destStorageClass migration is not supported"
+    if [ "$scProvisioner" != *"longhorn"* ] && [ "$scProvisioner" != *"openebs"* ]; then
+        bail "Ceph to $scProvisioner migration is not supported"
     fi
+
+    report_addon_start "rook-ceph-to-${scProvisioner}-migration" "v2"
 
     # patch ceph so that it does not consume new devices that longhorn creates
     echo "Patching CephCluster storage.useAllDevices=false"
@@ -162,8 +164,8 @@ function rook_ceph_to_sc_migration() {
     fi
 
     # print success message
-    printf "${GREEN}Migration from rook-ceph to %s completed successfully!\n${NC}" "$destStorageClass"
-    report_addon_success "rook-ceph-to-$destStorageClass-migration" "v2"
+    printf "${GREEN}Migration from rook-ceph to %s completed successfully!\n${NC}" "$scProvisioner"
+    report_addon_success "rook-ceph-to-$scProvisioner-migration" "v2"
 }
 
 # if PVCs and object store data have both been migrated from rook-ceph and rook-ceph is no longer specified in the kURL spec, remove rook-ceph

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -101,12 +101,12 @@ function remove_rook_ceph() {
 }
 
 # scale down prometheus, move all 'rook-ceph' PVCs to provided storage class, scale up prometheus
-# Supported storage class migrations from ceph are 'longhorn' and 'openebs'
+# Supported storage class migrations from ceph are: 'longhorn' and 'openebs'
 function rook_ceph_to_sc_migration() {
     local destStorageClass=$1
     report_addon_start "rook-ceph-to-${destStorageClass}-migration" "v2"
 
-    # we only support migrating to 'longhonr' and 'openebs' storage classes
+    # we only support migrating to 'longhorn' and 'openebs' storage classes
     if [ "$destStorageClass" != "longhorn" ] && [[ "$destStorageClass" != *"openebs"* ]]; then
         bail "Ceph to $destStorageClass migration is not supported"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -107,7 +107,7 @@ function rook_ceph_to_sc_migration() {
     report_addon_start "rook-ceph-to-${destStorageClass}-migration" "v2"
 
     # we only support migrating to 'longhonr' and 'openebs' storage classes
-    if [ "$destStorageClass" != "longhorn" ] && [ "$destStorageClass" != "openebs" ]; then
+    if [ "$destStorageClass" != "longhorn" ] && [[ "$destStorageClass" != *"openebs"* ]]; then
         bail "Ceph to $destStorageClass migration is not supported"
     fi
 

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR=./kurl
+DIR=.
 
 # Magic begin: scripts are inlined for distribution. See "make build/tasks.sh"
 . $DIR/scripts/Manifest

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -592,9 +592,9 @@ function migrate_pvcs() {
     elif kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner &>/dev/null; then
         non_ceph_storage_class_detected=$(kubectl get storageclass | grep openebs | awk '{ print $1}')
 
-        # check OpenEBS localpv-hostpath provisioner is installed
-        if ! kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner &>/dev/null; then
-            echo "The OpenEBS Local PV provisioner is not runnning"
+        # check OpenEBS localpv-provisioner is actually running and ready
+        if [[ -z $(kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner --field-selector=status.phase=Running 2>/dev/null | grep '1/1' | grep 'Running') ]]; then
+            echo "The OpenEBS Local PV provisioner pod is not running and/or not ready"
             return 1
         fi
     fi

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -593,7 +593,7 @@ function migrate_pvcs() {
         non_ceph_storage_class_detected=$(kubectl get storageclass | grep openebs | awk '{ print $1}')
 
         # check OpenEBS localpv-provisioner is actually running and ready
-        if [[ -z $(kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner --field-selector=status.phase=Running 2>/dev/null | grep '1/1' | grep 'Running') ]]; then
+        if kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner --field-selector=status.phase=Running 2>/dev/null | grep '1/1' | grep -q 'Running' ; then
             echo "The OpenEBS Local PV provisioner pod is not running and/or not ready"
             return 1
         fi

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR=.
+DIR=./kurl
 
 # Magic begin: scripts are inlined for distribution. See "make build/tasks.sh"
 . $DIR/scripts/Manifest
@@ -590,8 +590,13 @@ function migrate_pvcs() {
             fi
         fi
     elif kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner &>/dev/null; then
-        non_ceph_storage_class_detected="openebs"
-        # TODO: check openebs storage class is installed
+        non_ceph_storage_class_detected=$(kubectl get storageclass | grep openebs | awk '{ print $1}')
+
+        # check OpenEBS localpv-hostpath provisioner is installed
+        if ! kubectl get pods -A -l openebs.io/component-name=openebs-localpv-provisioner &>/dev/null; then
+            echo "The OpenEBS Local PV provisioner is not runnning"
+            return 1
+        fi
     fi
 
     # provide large warning that this will stop the app


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Triggers PVC migration from Rook/Ceph to OpenEBS when installing a kURL spec where the Rook add-on is being replaced by the OpenEBS add-on. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [sc-58504]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
See changes to pvmigrate: https://github.com/replicatedhq/pvmigrate/pull/131

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
OpenEBS add-on versions 3.3.0 and later will automatically migrate Rook-backed PVCs to OpenEBS Local PV if Rook is installed but no longer included in the kURL spec.
```

#### Does this PR require documentation?
<!--
Yes.
-->
