### PR TITLE
fix storageClass provisioner extraction when migrating from Rook to OpenEBS

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -104,10 +104,11 @@ function remove_rook_ceph() {
 # Supported storage class migrations from ceph are: 'longhorn' and 'openebs'
 function rook_ceph_to_sc_migration() {
     local destStorageClass=$1
-    local scProvisioner="$(kubectl get $destStorageClass -ojsonpath='{.provisioner}')"
+    local scProvisioner
+    scProvisioner=$(kubectl get sc "$destStorageClass" -ojsonpath='{.provisioner}')
 
     # we only support migrating to 'longhorn' and 'openebs' storage classes
-    if [ "$scProvisioner" != *"longhorn"* ] && [ "$scProvisioner" != *"openebs"* ]; then
+    if [[ "$scProvisioner" != *"longhorn"* ]] && [[ "$scProvisioner" != *"openebs"* ]]; then
         bail "Ceph to $scProvisioner migration is not supported"
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fix the following error when rook to opebebs migration is triggered:
```
error: the server doesn't have a resource type "openebs"
Ceph to  migration is not supported
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
