### PR TITLE
Add comment for rook_osd_phase_ready unsupported on Rook 1.0.4

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -119,6 +119,7 @@ function rook_ceph_to_sc_migration() {
     kubectl -n rook-ceph patch cephcluster rook-ceph --type json --patch '[{"op": "replace", "path": "/spec/storage/useAllDevices", value: false}]'
     sleep 1
     echo "Waiting for CephCluster to update"
+    # this will fail for Rook 1.0.4 since '{.status.phase}' is not supported by the CRD
     spinner_until 300 rook_osd_phase_ready || true # don't fail
 
     # set prometheus scale if it exists
@@ -181,6 +182,7 @@ function maybe_cleanup_rook() {
 }
 
 function rook_osd_phase_ready() {
+    # this will fail for Rook 1.0.4 since '{.status.phase}' is not supported by the CRD
     [ "$(kubectl -n rook-ceph get cephcluster rook-ceph --template '{{.status.phase}}')" = 'Ready' ]
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Justify ignoring the failure