### PR TITLE
chore: remove unused go.mod entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -287,5 +287,3 @@ exclude (
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/client-go v9.0.0-invalid+incompatible
 )
-
-replace github.com/replicatedhq/kurl/kurlkinds => ./kurlkinds


### PR DESCRIPTION
#### What this PR does / why we need it:

kurlkinds has been moved to its own repo and this is a left over from the previous implementation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE