### PR TITLE
Do not toggle off ekco internal load balancer on upgrade

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -256,7 +256,7 @@ function kubernetes_get_conformance_packages_online() {
 }
 
 function kubernetes_masters() {
-    kubectl get nodes --no-headers --selector="node-role.kubernetes.io/master"
+    kubectl get nodes --no-headers --selector="node-role.kubernetes.io/master" 2>/dev/null
 }
 
 function kubernetes_remote_masters() {

--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -243,6 +243,11 @@ function prompt_for_load_balancer_address() {
         LOAD_BALANCER_PORT=6443
     fi
 
+    # localhost:6444 is the address of the internal load balancer
+    if [ "$LOAD_BALANCER_ADDRESS" = "localhost" ] && [ "$LOAD_BALANCER_PORT" = "6444" ]; then
+        EKCO_ENABLE_INTERNAL_LOAD_BALANCER=1
+    fi
+
     if [ -n "$LOAD_BALANCER_ADDRESS" ]; then
         $BIN_BASHTOYAML -c "$MERGED_YAML_SPEC" -f "load-balancer-address=${LOAD_BALANCER_ADDRESS}:${LOAD_BALANCER_PORT}"
     fi

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -315,9 +315,15 @@ function apply_iptables_config() {
 }
 
 function is_ha() {
-    local master_count=$(kubectl get node --selector='node-role.kubernetes.io/master' 2>/dev/null | grep 'master' | wc -l) #get nodes with the 'master' role, and then search for 'master' to remove the column labels row
+    local master_count=
+    master_count="$(kubernetes_masters | wc -l)"
     if [ "$master_count" -gt 1 ]; then
         HA_CLUSTER=1
+    fi
+    if kubeadm_cluster_configuration >/dev/null 2>&1 ; then
+        if [ -n "$(kubeadm_cluster_configuration | grep 'controlPlaneEndpoint:' | sed 's/controlPlaneEndpoint: \|"//g')" ]; then
+            HA_CLUSTER=1
+        fi
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When upgrading without explicitly enabling the internal load balancer via a flag or in the spec, the property will not get set to 1 by the kurl script, as it is on initial installation, toggling off ekco management of the load balancer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Press enter when prompted for internal load balancer address without inputting anything.

```
curl https://kurl.sh/ba2ea78 | sudo bash -s ha
curl https://kurl.sh/6aadba7 | sudo bash -s ha
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that can cause the kURL installer to disable EKCO management of the [Internal Load Balancer](https://kurl.sh/docs/add-ons/ekco#internal-load-balancer) upon upgrade.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE