### PR TITLE
Rollback openebs to rook migration prompt

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -13,7 +13,7 @@ function openebs_pre_init() {
     export PREVIOUS_OPENEBS_VERSION="$(openebs_get_running_version)"
 
     openebs_bail_unsupported_upgrade
-    prompt_migrate_from_rook
+    # prompt_migrate_from_rook
 }
 
 function openebs() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

kurl installations failing with 

```
⚙  Host preflights success
2022-10-28 22:27:42+00:00 Using existing weave network: 10.32.0.0/20
Error from server (NotFound): namespaces "rook-ceph" not found
Automatically declining prompt, shell is not interactive
Not migrating
+ KURL_EXIT_STATUS=1
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes kURL to erroneously prompt the end-user for a Rook to OpenEBS Local PV migration.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
