### PR TITLE
Update to kurlsh/s3cmd:20221029-37473ee image

### DIFF
--- a/addons/registry/2.8.1/Manifest
+++ b/addons/registry/2.8.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.8.1
-image s3cmd kurlsh/s3cmd:20221006-27d5371
+image s3cmd kurlsh/s3cmd:20221029-37473ee

--- a/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20221006-27d5371
+        image: kurlsh/s3cmd:20221029-37473ee
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.8.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.8.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20221006-27d5371
+        image: kurlsh/s3cmd:20221029-37473ee
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20221006-27d5371
+        image: kurlsh/s3cmd:20221029-37473ee
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/registry/2.8.1/service.yaml
+++ b/addons/registry/2.8.1/service.yaml
@@ -14,4 +14,3 @@ spec:
     protocol: TCP
   selector:
     app: registry
-

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -207,6 +207,7 @@
       version: "__testver__"
       s3Override: "__testdist__"
 - name: registry_remove_all_object_storage
+  cpu: 5
   installerSpec:
     kubernetes:
       version: 1.24.x


### PR DESCRIPTION

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the kurlsh/s3cmd image to tag 20221029-37473ee for the latest [Registry](https://kurl.sh/docs/add-ons/registry) add-on version, to address the following high severity CVE: CVE-2022-43680
```
