### PR TITLE
Use two different github tokens for testgrid checker action permissions

### DIFF
--- a/.github/actions/testgrid-checker/action.yml
+++ b/.github/actions/testgrid-checker/action.yml
@@ -3,7 +3,10 @@ description: 'Check the TestGrid status for pull requests'
 inputs:
   GITHUB_TOKEN:
     required: true
-    description: GitHub token
+    description: GitHub token. Can be secrets.GITHUB_TOKEN.
+  AUTOMERGE_GITHUB_TOKEN:
+    required: true
+    description: GitHub token to perform auto-merge action. Likely a PAT.
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/.github/actions/testgrid-checker/dist/index.js
+++ b/.github/actions/testgrid-checker/dist/index.js
@@ -10310,9 +10310,9 @@ var dist_node = __nccwpck_require__(8467);
 
 
 
-const octokit = (0,github.getOctokit)(core.getInput('GITHUB_TOKEN'));
-
 const enablePullRequestAutomerge = async (pullRequestId) => {
+  const octokit = (0,github.getOctokit)(core.getInput('AUTOMERGE_GITHUB_TOKEN') || core.getInput('GITHUB_TOKEN'));
+
   const params = {
     pullRequestId: pullRequestId,
   };
@@ -10362,7 +10362,7 @@ var request_error_dist_node = __nccwpck_require__(537);
 
 
 
-const pullrequests_octokit = (0,github.getOctokit)(core.getInput('GITHUB_TOKEN'));
+const octokit = (0,github.getOctokit)(core.getInput('GITHUB_TOKEN'));
 const { owner, repo } = github.context.repo
 
 const httpClient = new lib.HttpClient();
@@ -10372,7 +10372,7 @@ const checkPullRequest = async pullRequest => {
   const prTitle = pullRequest.title;
   console.log(`PR "${prTitle}" #${prNumber}: checking`);
 
-  const thisPrComments = await pullrequests_octokit.rest.issues.listComments({ owner, repo, issue_number: prNumber });
+  const thisPrComments = await octokit.rest.issues.listComments({ owner, repo, issue_number: prNumber });
 
   let lastTestgridCommentID = 0;
   let lastTestgridCommentPrefix = "";
@@ -10416,7 +10416,7 @@ const checkPullRequest = async pullRequest => {
         break;
       }
     }
-    await pullrequests_octokit.rest.checks.create({
+    await octokit.rest.checks.create({
       owner,
       repo,
       name: 'testgrid-checker',
@@ -10455,8 +10455,8 @@ const approvePullRequest = async (pullRequest, reviewMessage) => {
 
   try {
     const [login, { data: reviews }] = await Promise.all([
-      getLoginForToken(pullrequests_octokit),
-      pullrequests_octokit.rest.pulls.listReviews({ owner, repo, pull_number: prNumber }),
+      getLoginForToken(octokit),
+      octokit.rest.pulls.listReviews({ owner, repo, pull_number: prNumber }),
     ]);
 
     const prHead = pullRequest.head.sha;
@@ -10474,7 +10474,7 @@ const approvePullRequest = async (pullRequest, reviewMessage) => {
     }
 
     console.log(`PR "${prTitle}" #${prNumber}: has not been approved yet, creating approving review`);
-    await pullrequests_octokit.rest.pulls.createReview({
+    await octokit.rest.pulls.createReview({
       owner: owner,
       repo: repo,
       pull_number: prNumber,
@@ -10527,7 +10527,7 @@ const approvePullRequest = async (pullRequest, reviewMessage) => {
 
 async function getLoginForToken() {
   try {
-    const { data: user } = await pullrequests_octokit.rest.users.getAuthenticated();
+    const { data: user } = await octokit.rest.users.getAuthenticated();
     return user.login;
   } catch (error) {
     if (error instanceof request_error_dist_node.RequestError) {

--- a/.github/actions/testgrid-checker/github.js
+++ b/.github/actions/testgrid-checker/github.js
@@ -2,9 +2,9 @@ import { GraphqlResponseError } from '@octokit/graphql';
 import * as core from '@actions/core';
 import { getOctokit } from '@actions/github'
 
-const octokit = getOctokit(core.getInput('GITHUB_TOKEN'));
-
 export const enablePullRequestAutomerge = async (pullRequestId) => {
+  const octokit = getOctokit(core.getInput('AUTOMERGE_GITHUB_TOKEN') || core.getInput('GITHUB_TOKEN'));
+
   const params = {
     pullRequestId: pullRequestId,
   };

--- a/.github/workflows/test-testgrid-results.yaml
+++ b/.github/workflows/test-testgrid-results.yaml
@@ -18,4 +18,5 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/testgrid-checker
         with:
-          GITHUB_TOKEN: ${{ secrets.TESTGRID_CHECKER_GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOMERGE_GITHUB_TOKEN: ${{ secrets.TESTGRID_CHECKER_GH_PAT }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Workflow is failing with error `Error: You must authenticate via a GitHub App.`.

Using a PAT and the secret for enough permissions for now.

We may be able to solve this with a single token from a github app only used for its permissions.