### PR TITLE
Migrate from Rook to OpenEBS rather than Longhorn if both installed

### DIFF
--- a/addons/longhorn/1.3.1/install.sh
+++ b/addons/longhorn/1.3.1/install.sh
@@ -210,7 +210,8 @@ function longhorn_maybe_init_hosts() {
 
 # if rook-ceph is installed but is not specified in the kURL spec, migrate data from rook-ceph to longhorn
 function longhorn_maybe_migrate_from_rook() {
-    if [ -z "$ROOK_VERSION" ]; then
+    # check that OPENEBS_VERSION is empty as we prefer to migrate to openebs if it is installed
+    if [ -z "$ROOK_VERSION" ] && [ -z "$OPENEBS_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             rook_ceph_to_sc_migration "longhorn"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -210,7 +210,8 @@ function longhorn_maybe_init_hosts() {
 
 # if rook-ceph is installed but is not specified in the kURL spec, migrate data from rook-ceph to longhorn
 function longhorn_maybe_migrate_from_rook() {
-    if [ -z "$ROOK_VERSION" ]; then
+    # check that OPENEBS_VERSION is empty as we prefer to migrate to openebs if it is installed
+    if [ -z "$ROOK_VERSION" ] && [ -z "$OPENEBS_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             rook_ceph_to_sc_migration "longhorn"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

If we have both openebs and longhorn add-ons installed and remove rook the script will attempt to migrate to both. Prefer openebs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
kURL will now prefer to migrate from Rook backed PVCs to OpenEBS Local PV when both OpenEBS and Longhorn add-ons are included in the spec and Rook is removed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE