### PR TITLE
:bug: fix docker install steps to build bundle/package/images

### DIFF
--- a/bundles/docker-ubuntu1604/Dockerfile
+++ b/bundles/docker-ubuntu1604/Dockerfile
@@ -1,17 +1,40 @@
+# This image builds the an ubuntu image with the docker version informed.
+# More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:16.04
-RUN apt-get -y update
-RUN apt-get -y upgrade
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN apt-get -y update
 
+# Update the apt package index and install packages to allow apt to use a repository over HTTPS:
+RUN apt-get -y update
+RUN apt-get -y install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# To create directory to export the image to build/packages/docker/${DOCKER_VERSION}/ubuntu-<version>
+# See the build.sh script
 RUN mkdir -p /packages/archives
 
+# Update to be able to get the right pkg with apt-cache madison docker-ce-cli and docker-ce
+# in order to install the specific docker version informed via ARG
+RUN apt-get -y update
+
+# DOCKER_VERSION stores the value informed to via arg to build the image.
+# **Note**: You can test it out with docker build --build-arg DOCKER_VERSION=20.10.17 .
 ARG DOCKER_VERSION
+
+# Installs spefic docker version informed via the ARG DOCKER_VERSION
 RUN apt-get -d -y install --no-install-recommends \
-  docker-ce-cli=$(apt-cache madison 'docker-ce-cli' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  docker-ce=$(apt-cache madison 'docker-ce' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  -oDebug::NoLocking=1 -o=dir::cache=/packages/
+      docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      -oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 CMD cp -r /packages/archives/* /out/

--- a/bundles/docker-ubuntu1804/Dockerfile
+++ b/bundles/docker-ubuntu1804/Dockerfile
@@ -1,17 +1,40 @@
+# This image builds the an ubuntu image with the docker version informed.
+# More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:18.04
-RUN apt-get -y update
-RUN apt-get -y upgrade
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN apt-get -y update
 
+# Update the apt package index and install packages to allow apt to use a repository over HTTPS:
+RUN apt-get -y update
+RUN apt-get -y install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# To create directory to export the image to build/packages/docker/${DOCKER_VERSION}/ubuntu-<version>
+# See the build.sh script
 RUN mkdir -p /packages/archives
 
+# Update to be able to get the right pkg with apt-cache madison docker-ce-cli and docker-ce
+# in order to install the specific docker version informed via ARG
+RUN apt-get -y update
+
+# DOCKER_VERSION stores the value informed to via arg to build the image.
+# **Note**: You can test it out with docker build --build-arg DOCKER_VERSION=20.10.17 .
 ARG DOCKER_VERSION
+
+# Installs spefic docker version informed via the ARG DOCKER_VERSION
 RUN apt-get -d -y install --no-install-recommends \
-  docker-ce-cli=$(apt-cache madison 'docker-ce-cli' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  docker-ce=$(apt-cache madison 'docker-ce' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  -oDebug::NoLocking=1 -o=dir::cache=/packages/
+      docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      -oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 CMD cp -r /packages/archives/* /out/

--- a/bundles/docker-ubuntu2004/Dockerfile
+++ b/bundles/docker-ubuntu2004/Dockerfile
@@ -1,17 +1,40 @@
+# This image builds the an ubuntu image with the docker version informed.
+# More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:20.04
-RUN apt-get -y update
-RUN apt-get -y upgrade
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN apt-get -y update
 
+# Update the apt package index and install packages to allow apt to use a repository over HTTPS:
+RUN apt-get -y update
+RUN apt-get -y install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# To create directory to export the image to build/packages/docker/${DOCKER_VERSION}/ubuntu-<version>
+# See the build.sh script
 RUN mkdir -p /packages/archives
 
+# Update to be able to get the right pkg with apt-cache madison docker-ce-cli and docker-ce
+# in order to install the specific docker version informed via ARG
+RUN apt-get -y update
+
+# DOCKER_VERSION stores the value informed to via arg to build the image.
+# **Note**: You can test it out with docker build --build-arg DOCKER_VERSION=20.10.17 .
 ARG DOCKER_VERSION
+
+# Installs spefic docker version informed via the ARG DOCKER_VERSION
 RUN apt-get -d -y install --no-install-recommends \
-  docker-ce-cli=$(apt-cache madison 'docker-ce-cli' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  docker-ce=$(apt-cache madison 'docker-ce' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  -oDebug::NoLocking=1 -o=dir::cache=/packages/
+      docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      -oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 CMD cp -r /packages/archives/* /out/

--- a/bundles/docker-ubuntu2204/Dockerfile
+++ b/bundles/docker-ubuntu2204/Dockerfile
@@ -1,17 +1,40 @@
+# This image builds the an ubuntu image with the docker version informed.
+# More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:22.04
-RUN apt-get -y update
-RUN apt-get -y upgrade
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN apt-get -y update
 
+# Update the apt package index and install packages to allow apt to use a repository over HTTPS:
+RUN apt-get -y update
+RUN apt-get -y install \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# To create directory to export the image to build/packages/docker/${DOCKER_VERSION}/ubuntu-<version>
+# See the build.sh script
 RUN mkdir -p /packages/archives
 
+# Update to be able to get the right pkg with apt-cache madison docker-ce-cli and docker-ce
+# in order to install the specific docker version informed via ARG
+RUN apt-get -y update
+
+# DOCKER_VERSION stores the value informed to via arg to build the image.
+# **Note**: You can test it out with docker build --build-arg DOCKER_VERSION=20.10.17 .
 ARG DOCKER_VERSION
+
+# Installs spefic docker version informed via the ARG DOCKER_VERSION
 RUN apt-get -d -y install --no-install-recommends \
-  docker-ce-cli=$(apt-cache madison 'docker-ce-cli' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  docker-ce=$(apt-cache madison 'docker-ce' | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
-  -oDebug::NoLocking=1 -o=dir::cache=/packages/
+      docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
+      -oDebug::NoLocking=1 -o=dir::cache=/packages/
 
 CMD cp -r /packages/archives/* /out/


### PR DESCRIPTION
## Description

- Fix commands required to build the image
- Solves tech debt by replacing deprecated command:

```sh
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
```
- Ensure that steps used to build the image follow up the current description into docker docs. [More info](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)

#### What this PR does / why we need it:

- To allow build the images to test the project and contribute with (see the contributing guide and the issue details for further info)
- To solve tech debts and replace deprecated command 

#### Which issue(s) this PR fixes:

Fixes # https://github.com/replicatedhq/kURL/issues/3676

#### Special notes for your reviewer:

## Steps to reproduce
Run `make build/packages/docker/<supported docker version for the image>/ubuntu-[22.04|20.04|18.04|16.04]`

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE

## Local test to check out that is working now:

```sh
make build/packages/docker/20.10.17/ubuntu-22.04                        
./bundles/docker-ubuntu2204/build.sh 20.10.17 `pwd`/build/packages/docker/20.10.17/ubuntu-22.04
+ set -e
+ DOCKER_VERSION=20.10.17
+ OUTPATH=/Users/camilamacedo/go/src/github.com/replicatedhq/kURL/build/packages/docker/20.10.17/ubuntu-22.04
+ SEMVER_COMPARE_RESULT=
+ semverCompare 20.10.17 20.10.17
+ semverParse 20.10.17
+ major=20
+ minor=10.17
+ minor=10
+ patch=17
+ patch=17
+ _a_major=20
+ _a_minor=10
+ _a_patch=17
+ semverParse 20.10.17
+ major=20
+ minor=10.17
+ minor=10
+ patch=17
+ patch=17
+ _b_major=20
+ _b_minor=10
+ _b_patch=17
+ '[' 20 -lt 20 ']'
+ '[' 20 -gt 20 ']'
+ '[' 10 -lt 10 ']'
+ '[' 10 -gt 10 ']'
+ '[' 17 -lt 17 ']'
+ '[' 17 -gt 17 ']'
+ SEMVER_COMPARE_RESULT=0
+ '[' 0 = -1 ']'
+ docker build --build-arg DOCKER_VERSION=20.10.17 -t kurl/ubuntu-2204-docker:20.10.17 -f bundles/docker-ubuntu2204/Dockerfile bundles/docker-ubuntu2204
[+] Building 0.2s (13/13) FINISHED                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                        0.0s
 => => transferring dockerfile: 1.89kB                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                           0.0s
 => => transferring context: 2B                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                             0.0s
 => [1/9] FROM docker.io/library/ubuntu:22.04                                                                                               0.0s
 => CACHED [2/9] RUN apt-get -y update                                                                                                      0.0s
 => CACHED [3/9] RUN apt-get -y install         ca-certificates         curl         gnupg         lsb-release                              0.0s
 => CACHED [4/9] RUN mkdir -p /etc/apt/keyrings                                                                                             0.0s
 => CACHED [5/9] RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg                0.0s
 => CACHED [6/9] RUN echo       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.co  0.0s
 => CACHED [7/9] RUN mkdir -p /packages/archives                                                                                            0.0s
 => CACHED [8/9] RUN apt-get -y update                                                                                                      0.0s
 => CACHED [9/9] RUN apt-get -d -y install --no-install-recommends       docker-ce-cli=$(apt-cache madison docker-ce-cli | grep 20.10.17 |  0.0s
 => exporting to image                                                                                                                      0.0s
 => => exporting layers                                                                                                                     0.0s
 => => writing image sha256:0facb56707405fda4249d5d7f7ad51d88a440b42f44e984aec7a0125974fd3ab                                                0.0s
 => => naming to docker.io/kurl/ubuntu-2204-docker:20.10.17                                                                                 0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
+ docker rm -f docker-ubuntu2204-20.10.17
+ docker create --name docker-ubuntu2204-20.10.17 kurl/ubuntu-2204-docker:20.10.17
74e255e9b956f1689cd98d50985e69f7409944fd555bf28751ad06004ad76da4
+ mkdir -p build/packages/docker/20.10.17/ubuntu-22.04
+ docker cp docker-ubuntu2204-20.10.17:/packages/archives/. /Users/camilamacedo/go/src/github.com/replicatedhq/kURL/build/packages/docker/20.10.17/ubuntu-22.04
+ docker rm docker-ubuntu2204-20.10.17
docker-ubuntu2204-20.10.17
``` 