### PR TITLE
wipe prometheus CRD last-applied-configuration before update

### DIFF
--- a/addons/prometheus/template/base/install.sh
+++ b/addons/prometheus/template/base/install.sh
@@ -17,6 +17,8 @@ function prometheus() {
 
     # Server-side apply is needed here because the CRDs are too large to keep in metadata
     # https://github.com/prometheus-community/helm-charts/issues/1500
+    # Also delete any existing last-applied-configuration annotations for pre-122 clusters
+    kubectl get crd | grep coreos.com | awk '{ print $1 }' | xargs -I {} kubectl patch crd {} --type=json -p='[{"op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration"}]' 2>/dev/null
     kubectl apply --server-side --force-conflicts -k "$crdsdst/"
     spinner_until -1 prometheus_crd_ready
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This deletes last-applied-configuration annotations for prometheus CRDs before updating them, preventing them from exceeding the size limit.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix CRD errors when updating from Prometheus 0.49.0-17.1.3 on Kubernetes versions that do not support server-side apply
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
