### PR TITLE
Fix build-test-success is skipped on failure

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -38,13 +38,6 @@ jobs:
 
       - run: make -C kurl_util deps test build
 
-  test-shell:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - run: sudo apt-get install -y shunit2
-    - run: make test-shell shunit2
-
   build-bin-kurl:
     runs-on: ubuntu-20.04
     steps:
@@ -62,12 +55,29 @@ jobs:
 
       - run: make deps test build/bin/kurl
 
+  test-shell:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: sudo apt-get install -y shunit2
+      - uses: actions/checkout@v3
+      - run: make test-shell shunit2
+
   build-test-success:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs:
-    - validate-go-mod
-    - build-kurl-utils
-    - test-shell
-    - build-bin-kurl
+      - validate-go-mod
+      - build-kurl-utils
+      - build-bin-kurl
+      - test-shell
     steps:
-    - run: echo "::notice ::build test success"
+      - run: |
+          if   [ "${{ needs.validate-go-mod.result }}" = "failure" ] \
+            || [ "${{ needs.build-kurl-utils.result }}" = "failure" ] \
+            || [ "${{ needs.build-bin-kurl.result }}" = "failure" ] \
+            || [ "${{ needs.test-shell.result }}" = "failure" ]
+          then
+            echo "build test failure"
+            exit 1
+          fi
+          echo "build test success"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Branch protections rules are not working because required check build-test-success is skipped on a failure of it's needs.

https://github.com/replicatedhq/kURL/actions/runs/2967656145/jobs/4750952929