### PR TITLE
add help to allow we doc the makefile targets and a few clean ups

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - run: make deps test build/bin/kurl
+      - run: make test build/bin/kurl
 
   test-shell:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
#### What this PR does / why we need it:

- To help us begin to doc the targets. It is an small/silly addition 

Extra: (small clean up)
- We are also pinning the lint version so that we avoid break ci (when it be added on the ci)
- We are unifying the shell tests 

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
See: 

<img width="1190" alt="Screenshot 2022-11-08 at 11 23 09" src="https://user-images.githubusercontent.com/7708031/200551956-7ad22b5d-7265-4044-b48e-1fbe086d1b47.png">

## Steps to reproduce
run make only

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
