### PR TITLE
Fix sleep spinner exits with syntax error

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -511,7 +511,7 @@ function spinner_until() {
     local spinstr='|/-\'
 
     while ! $cmd $args; do
-        elapsed=$(($elapsed + $delay))
+        elapsed=$((elapsed + delay))
         if [ "$timeoutSeconds" -ge 0 ] && [ "$elapsed" -gt "$timeoutSeconds" ]; then
             return 1
         fi
@@ -531,7 +531,7 @@ function sleep_spinner() {
     local spinstr='|/-\'
 
     while true ; do
-        elapsed=$(("$elapsed" + "$delay"))
+        elapsed=$((elapsed + delay))
         if [ "$elapsed" -gt "$sleepSeconds" ]; then
             return 0
         fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When running an upgrade we encountered the error:

```
"0" + "1": syntax error: operand expected (error token is ""0" + "1"")
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause installations or upgrades to fail with error "syntax error: operand expected (error token is ""0" + "1"")" for older bash versions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE