### PR TITLE
fix: rebase issue makefile / duplication of generate-mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -668,11 +668,6 @@ test-shell: ## Run tests for code in shell. (Requires shUnit2 to be installed).
 generate-addons:
 	node bin/generate-addons.js
 
-.PHONY: generate-mocks
-generate-mocks:
-	mockgen -source=pkg/cli/cli.go -destination=pkg/cli/mock/mock_cli.go
-	mockgen -source=pkg/preflight/runner.go -destination=pkg/preflight/mock/mock_runner.go
-
 .PHONY: init-sbom
 init-sbom:
 	mkdir -p sbom/spdx sbom/assets


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix generate-mocks target duplication caused in rebasing https://github.com/replicatedhq/kURL/pull/3692 with changes made on main.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

NONE

## Steps to reproduce
 
Run make generate-mocks

#### Does this PR introduce a user-facing change?

NONE

#### Does this PR require documentation?
NONE