### PR TITLE
add kotsadm-rqlite to no_proxy list

### DIFF
--- a/scripts/common/proxy.sh
+++ b/scripts/common/proxy.sh
@@ -120,7 +120,7 @@ function configure_no_proxy() {
         addresses="${addresses},${ENV_NO_PROXY}"
     fi
     if [ -n "$KOTSADM_VERSION" ]; then
-        addresses="${addresses},kotsadm-api-node"
+        addresses="${addresses},kotsadm-rqlite,kotsadm-api-node"
     fi
     if [ -n "$ROOK_VERSION" ]; then
         addresses="${addresses},.rook-ceph"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes an issue where [KOTS add-on](https://kurl.sh/docs/add-ons/kotsadm) version 1.89.0+ fails to install when a proxy is configured.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
[SC-61862](https://app.shortcut.com/replicated/story/61862/kots-1-90-0-fails-to-install-on-embedded-clusters-that-have-a-proxy-configured)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where [KOTS add-on](https://kurl.sh/docs/add-ons/kotsadm) version 1.89.0+ fails to install when a proxy is configured.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE