### PR TITLE
(addon/containerd): replace apt-key which is deprecated.

### DIFF
--- a/addons/containerd/template/Dockerfile.ubuntu16
+++ b/addons/containerd/template/Dockerfile.ubuntu16
@@ -6,8 +6,15 @@ ENV VERSION=${VERSION}
 RUN apt-get -y update
 RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \

--- a/addons/containerd/template/Dockerfile.ubuntu18
+++ b/addons/containerd/template/Dockerfile.ubuntu18
@@ -6,8 +6,15 @@ ENV VERSION=${VERSION}
 RUN apt-get -y update
 RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \

--- a/addons/containerd/template/Dockerfile.ubuntu20
+++ b/addons/containerd/template/Dockerfile.ubuntu20
@@ -6,8 +6,15 @@ ENV VERSION=${VERSION}
 RUN apt-get -y update
 RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \

--- a/addons/containerd/template/Dockerfile.ubuntu22
+++ b/addons/containerd/template/Dockerfile.ubuntu22
@@ -6,8 +6,15 @@ ENV VERSION=${VERSION}
 RUN apt-get -y update
 RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+# Add Docker’s official GPG key:
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Use the following command to set up the repository:
+RUN echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR replaces the `apt-key` which is deprecated ([More info](https://sites.google.com/site/installationubuntu/home/ubuntu-22-04/apt-key-is-deprecated)) for security reasons ([More info](https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key)) and will no longer work on ubuntu >= 22.04.

Also, It usage does not allow us to build the images from mac os x to do the tests in a remote sever and seems not either work in some linux distributions such as Jammy Jellyfish (Ubuntu 22.04).  

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

You can check that apt-key does not work for builds done on mac by runing the image (`docker run -i -t ubuntu:22.04 bin/bash`) and performing the steps. You will see that `apt-cache madison 'containerd.io'` is not found. 

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
