### PR TITLE
doc/contributing: add export default platform envvar for local env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Testing can be accomplished on systems capable of hosting supported container ru
    ```sh
    export GOOS=linux
    export GOARCH=amd64
+   export DOCKER_DEFAULT_PLATFORM=linux/amd64
    ```
    
     ```bash


### PR DESCRIPTION
#### What this PR does / why we need it:

By default docker will try to get the images used from the platform arch where the build is made.
Therefore, contributors might face issues. In this away the solution to be able to build locally is
to ensure by exporting then env var that the FROM image should be obtained from the arch
that the projects supports. 

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE
## Steps to reproduce
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
