### PR TITLE
doc/contributing: update and remove make target not found

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,12 @@ Testing can be accomplished on systems capable of hosting supported container ru
    export GOOS=linux
    export GOARCH=amd64
    ```
-   
+
     ```bash
     # Local workstation
-    make build/packages/kubernetes/1.19.3/ubuntu-18.04
-    make build/packages/kubernetes/1.19.3/images
-    make build/packages/docker/19.03.10/ubuntu-18.04
-    make build/packages/docker/19.03.10/images
+    make build/packages/kubernetes/1.25.3/ubuntu-22.04
+    make build/packages/kubernetes/1.25.3/images
+    make build/packages/docker/20.10.17/ubuntu-22.04
     ```
    
 1. Rsync local packages to remote test server.


### PR DESCRIPTION
#### What this PR does / why we need it:

I can check the version but we have not have the target build/packages/docker/%/images on the makefile: https://github.com/replicatedhq/kURL/blob/main/Makefile, see:

) make build/packages/docker/19.03.10/images
make: *** No rule to make target `build/packages/docker/19.03.10/images'. Stop.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

NONE

## Steps to reproduce

NONE
#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE