### PR TITLE
Fix cron rook update missing version

### DIFF
--- a/addons/rook/template/generate.sh
+++ b/addons/rook/template/generate.sh
@@ -3,10 +3,12 @@
 set -euo pipefail
 
 function get_latest_19x_version() {
-    curl -s https://api.github.com/repos/rook/rook/releases | \
-        grep '"tag_name": ' | \
-        grep -Eo "1\.9\.[0-9]+" | \
-        head -1
+    helm repo add rook-release https://charts.rook.io/release
+    helm repo update
+    helm search repo rook-release/rook-ceph --version '< 1.10.0' 2>/dev/null | \
+        grep -F 'rook-release/rook-ceph ' | \
+        awk '{ print $2 }' | \
+        grep -Eo "1\.9\.[0-9]+"
 }
 
 function generate() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Automation is failing with the following error. Rather than check the repo for the latest rook version get the version from helm.

```
Update Complete. ⎈Happy Helming!⎈
Error: chart "rook-ceph" matching 1.9.13 not found in rook-release index. (try 'helm repo update'): no chart version found for rook-ceph-1.9.13
Error: Process completed with exit code 1.
```
