### PR TITLE
bundles/k8s: replace apt-key which is deprecated to use gpg

### DIFF
--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -1,17 +1,20 @@
 FROM ubuntu:16.04
-ARG KUBERNETES_VERSION
+
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get -y install curl apt-transport-https
-RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-COPY ./kubernetes.list /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
+RUN apt-get -y install curl apt-transport-https gnupg
 
-RUN mkdir -p /packages
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update
+RUN mkdir -p /packages/archives
+
+ARG KUBERNETES_VERSION
 RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubernetes-cni \
-	git \	
+	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 
+CMD cp -r /packages/archives/* /out/

--- a/bundles/k8s-ubuntu1804/Dockerfile
+++ b/bundles/k8s-ubuntu1804/Dockerfile
@@ -1,13 +1,15 @@
 FROM ubuntu:18.04
-ARG KUBERNETES_VERSION
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg
-RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-COPY ./kubernetes.list /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
 
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+
+RUN apt-get update
 RUN mkdir -p /packages/archives
+
+ARG KUBERNETES_VERSION
 RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \

--- a/bundles/k8s-ubuntu2004/Dockerfile
+++ b/bundles/k8s-ubuntu2004/Dockerfile
@@ -1,13 +1,15 @@
 FROM ubuntu:20.04
-ARG KUBERNETES_VERSION
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg
-RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-COPY ./kubernetes.list /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
 
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+
+RUN apt-get update
 RUN mkdir -p /packages/archives
+
+ARG KUBERNETES_VERSION
 RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \

--- a/bundles/k8s-ubuntu2204/Dockerfile
+++ b/bundles/k8s-ubuntu2204/Dockerfile
@@ -1,13 +1,16 @@
 FROM ubuntu:22.04
-ARG KUBERNETES_VERSION
+
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg
-RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-COPY ./kubernetes.list /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
 
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+
+RUN apt-get update
 RUN mkdir -p /packages/archives
+
+ARG KUBERNETES_VERSION
 RUN apt-get install -d -y \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \

--- a/packages/kubernetes/template/Dockerfile
+++ b/packages/kubernetes/template/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get -y install curl apt-transport-https gnupg
-RUN  curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR replaces the `apt-key` which is deprecated ([More info](https://sites.google.com/site/installationubuntu/home/ubuntu-22-04/apt-key-is-deprecated)) for security reasons ([More info](https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key)) and will no longer work on ubuntu >= 22.04.

Also, It usage does not allow us to build the images from mac os x to do the tests in a remote sever and seems not either work in some linux distributions such as Jammy Jellyfish (Ubuntu 22.04).  

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
