### PR TITLE
bug: verify if port 9090 is available (rook)

### DIFF
--- a/addons/rook/1.9.12/host-preflight.yaml
+++ b/addons/rook/1.9.12/host-preflight.yaml
@@ -6,6 +6,10 @@ spec:
   collectors:
   - blockDevices:
       exclude: '{{kurl .IsUpgrade }}'
+  - tcpPortStatus:
+      collectorName: "Pod csi-rbdplugin Host Port"
+      port: 9090
+      exclude: '{{kurl .IsUpgrade }}'
 
   analyzers:
   - blockDevices:
@@ -21,3 +25,16 @@ spec:
           message: Multiple available block devices
       - fail:
           message: No available block devices
+  - tcpPortStatus:
+      checkName: "Pod csi-rbdplugin Host Port Status"
+      collectorName: "Pod csi-rbdplugin Host Port"
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "connected"
+          message: "Port 9090 is available for use."
+      - fail:
+          when: "address-in-use"
+          message: "Another process is listening on port 9090."
+      - fail:
+          message: "Unexpected error connecting to port 9090."

--- a/addons/rook/template/base/host-preflight.yaml
+++ b/addons/rook/template/base/host-preflight.yaml
@@ -6,6 +6,10 @@ spec:
   collectors:
   - blockDevices:
       exclude: '{{kurl .IsUpgrade }}'
+  - tcpPortStatus:
+      collectorName: "Pod csi-rbdplugin Host Port"
+      port: 9090
+      exclude: '{{kurl .IsUpgrade }}'
 
   analyzers:
   - blockDevices:
@@ -21,3 +25,16 @@ spec:
           message: Multiple available block devices
       - fail:
           message: No available block devices
+  - tcpPortStatus:
+      checkName: "Pod csi-rbdplugin Host Port Status"
+      collectorName: "Pod csi-rbdplugin Host Port"
+      exclude: '{{kurl .IsUpgrade }}'
+      outcomes:
+      - pass:
+          when: "connected"
+          message: "Port 9090 is available for use."
+      - fail:
+          when: "address-in-use"
+          message: "Another process is listening on port 9090."
+      - fail:
+          message: "Unexpected error connecting to port 9090."


### PR DESCRIPTION
#### What this PR does / why we need it:

rook's csi-rbdplugin pod uses host port 9090, we need to check if it is available prior to installing the add-on. upon installing in a node where the port 9090 is in use the pod never cames up, remains as:

```
NAME                   READY   STATUS             RESTARTS        AGE
csi-rbdplugin-w5jz4    1/2     CrashLoopBackOff   7 (3m52s ago)   14m
```

this pr adds a host-preflight check that validates if the port 9090 is available in the node.

#### Which issue(s) this PR fixes:
Fixes #62345

## Steps to reproduce

To reproduce the problem:
- Create a VM with RedHat 8
- Install and start cockpit service
  - `dnf install -y cockpit`
  - `dnf start cockpit.socket`
- Attempt to install a cluster with rook enabled

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE