### PR TITLE
yumol lvm2 missing from Rook version 1.0.4-14.2.21

### DIFF
--- a/addons/rook/1.0.4-14.2.21/Manifest
+++ b/addons/rook/1.0.4-14.2.21/Manifest
@@ -2,4 +2,5 @@ image rook kurlsh/rook-ceph:v1.0.4-14.2.21-9065b09-20210625
 image ceph kurlsh/ceph:v14.2.21-9065b09-20210625
 
 yum lvm2
+yumol lvm2
 apt lvm2

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
 - name: Rook minimal
   installerSpec:
     kubernetes:
-      version: "1.19.x"
+      version: "1.25.x"
     weave:
       version: "latest"
     containerd:
@@ -15,6 +15,8 @@
     rook:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ecph_object_store_info
@@ -53,10 +55,96 @@
     kubectl -n default get pvc cephfs-pvc | grep Bound
     kubectl -n default delete pvc cephfs-pvc default-pvc
 
+- name: Upgrade from 1.8.10
+  installerSpec:
+    kubernetes:
+      version: "1.24.x"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    ekco:
+      version: "latest"
+    rook:
+      version: "1.8.10"
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    ekco:
+      version: "latest"
+    rook:
+      version: "__testver__"
+      s3Override: "__testdist__"
+      bypassUpgradeWarning: true
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ecph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+    minio_object_store_info
+    validate_read_write_object_store rwtest minio.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+
+    operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
+    echo $operatorVersion | grep __testver__
+
+    rook_ecph_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+
+    minio_object_store_info
+    validate_testfile rwtest minio.txt
+    validate_read_write_object_store postupgrade minioupgrade.txt
+
+    # validate data pools
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: cephfs-pvc
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: rook-cephfs
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: default-pvc
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+    EOF
+    sleep 10
+    kubectl -n default get pvc default-pvc | grep Bound
+    kubectl -n default get pvc cephfs-pvc | grep Bound
+    kubectl -n default delete pvc cephfs-pvc default-pvc
+
 - name: Disable shared filesystem
   installerSpec:
     kubernetes:
-      version: "1.19.x"
+      version: "1.25.x"
     weave:
       version: "latest"
     containerd:
@@ -71,6 +159,8 @@
       version: "__testver__"
       s3Override: "__testdist__"
       isSharedFilesystemDisabled: true
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ecph_object_store_info

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
 - name: Rook minimal
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.19.x"
     weave:
       version: "latest"
     containerd:
@@ -15,8 +15,6 @@
     rook:
       version: "__testver__"
       s3Override: "__testdist__"
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ecph_object_store_info
@@ -24,92 +22,6 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
-
-    # validate data pools
-    cat <<EOF | kubectl apply -f -
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: cephfs-pvc
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: 1Gi
-      storageClassName: rook-cephfs
-    ---
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: default-pvc
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
-    EOF
-    sleep 10
-    kubectl -n default get pvc default-pvc | grep Bound
-    kubectl -n default get pvc cephfs-pvc | grep Bound
-    kubectl -n default delete pvc cephfs-pvc default-pvc
-
-- name: Upgrade from 1.8.10
-  installerSpec:
-    kubernetes:
-      version: "1.24.x"
-    weave:
-      version: "latest"
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    ekco:
-      version: "latest"
-    rook:
-      version: "1.8.10"
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    weave:
-      version: "latest"
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    ekco:
-      version: "latest"
-    rook:
-      version: "__testver__"
-      s3Override: "__testdist__"
-      bypassUpgradeWarning: true
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-
-    minio_object_store_info
-    validate_read_write_object_store rwtest minio.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-
-    operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
-    echo $operatorVersion | grep __testver__
-
-    rook_ecph_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-
-    minio_object_store_info
-    validate_testfile rwtest minio.txt
-    validate_read_write_object_store postupgrade minioupgrade.txt
 
     # validate data pools
     cat <<EOF | kubectl apply -f -
@@ -144,7 +56,7 @@
 - name: Disable shared filesystem
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.19.x"
     weave:
       version: "latest"
     containerd:
@@ -159,8 +71,6 @@
       version: "__testver__"
       s3Override: "__testdist__"
       isSharedFilesystemDisabled: true
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ecph_object_store_info


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Installs on ol7 are failing with error

https://testgrid.kurl.sh/run/pr-3661-000eebb-openebs-3.3.0-k8s-docker-localpv-2022-11-02T14:10:24Z?kurlLogsInstanceId=wozxwzllxazlrhem&nodeId=wozxwzllxazlrhem-initialprimary#L0

```
-> Processing Dependency: device-mapper = 7:1.02.170-6.el7_9.5 for package: 7:device-mapper-event-1.02.170-6.el7_9.5.x86_64
--> Finished Dependency Resolution
Error: Package: 7:device-mapper-event-1.02.170-6.el7_9.5.x86_64 (kurl.local)
           Requires: device-mapper = 7:1.02.170-6.el7_9.5
           Installed: 7:device-mapper-1.02.170-6.0.5.el7_9.5.x86_64 (@ol7_latest/$releasever)
               device-mapper = 7:1.02.170-6.0.5.el7_9.5
           Available: 7:device-mapper-1.02.170-6.el7_9.5.x86_64 (kurl.local)
               device-mapper = 7:1.02.170-6.el7_9.5
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes Rook add-on version 1.0.4-14.2.21 to fail to install on Oracle Linux 7 with host dependency resolution errors.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE