### PR TITLE
ensure build with the latest built image version for weave and waveexec patches

### DIFF
--- a/addons/weave/2.8.1-20221122/Manifest
+++ b/addons/weave/2.8.1-20221122/Manifest
@@ -1,3 +1,3 @@
 image weave-kube kurlsh/weave-kube:2.8.1-20221122-d71f0cb
-image weave-npc kurlsh/weave-npc:2.8.1-20221025-5520311
-image weaveexec kurlsh/weaveexec:2.8.1-20221025-5520311
+image weave-npc kurlsh/weave-npc:2.8.1-20221122-59bb72b
+image weaveexec kurlsh/weaveexec:2.8.1-20221122-59bb72b

--- a/addons/weave/2.8.1-20221122/patch-daemonset.yaml
+++ b/addons/weave/2.8.1-20221122/patch-daemonset.yaml
@@ -19,6 +19,6 @@ spec:
             - name: CHECKPOINT_DISABLE
               value: "1"
             - name: EXEC_IMAGE
-              value: "kurlsh/weaveexec:2.8.1-20221025-5520311"
+              value: "kurlsh/weaveexec:2.8.1-20221122-59bb72b"
         - name: weave-npc
           args: ["--log-level", "info"] # default log level is debug

--- a/addons/weave/2.8.1-20221122/weave-daemonset-k8s-1.11.yaml
+++ b/addons/weave/2.8.1-20221122/weave-daemonset-k8s-1.11.yaml
@@ -180,7 +180,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'kurlsh/weave-npc:2.8.1-20221025-5520311'
+              image: 'kurlsh/weave-npc:2.8.1-20221122-59bb72b'
 #npc-args
               resources:
                 requests:


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow up of https://github.com/replicatedhq/kURL/pull/3763
We need also ensure the fix patch for weave-npc and weaveexec images

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
The release note was added into https://github.com/replicatedhq/kURL/pull/3763 already.
See the scan in: https://github.com/replicatedhq/kURL/actions/runs/3522873998

## Steps to reproduce

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?

