### PR TITLE
Run Node Disk and Volume Validation Checks when Upgrading from Rook to OpenEBS

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -60,6 +60,8 @@ function openebs_maybe_migrate_from_rook() {
 function openebs_maybe_rook_migration_checks() {
 
     # get the list of StorageClasses that use rook-ceph
+    local rook_scs
+    local rook_default_sc
     rook_scs=$(kubectl get storageclass | grep rook | grep -v '(default)' | awk '{ print $1}') # any non-default rook StorageClasses
     rook_default_sc=$(kubectl get storageclass | grep rook | grep '(default)' | awk '{ print $1}') # any default rook StorageClasses
 
@@ -74,6 +76,9 @@ function openebs_maybe_rook_migration_checks() {
     do
         # run validation checks for non default Rook storage classes
         rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
+        if [ $? -ne 0 ]; then
+            break
+        fi
     done
 
     if [ -n "$rook_default_sc" ] ; then

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -15,7 +15,7 @@ function openebs_pre_init() {
     export PREVIOUS_OPENEBS_VERSION="$(openebs_get_running_version)"
 
     openebs_bail_unsupported_upgrade
-    prompt_migrate_from_rook
+    openebs_prompt_migrate_from_rook
 }
 
 function openebs() {
@@ -49,58 +49,47 @@ function openebs_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             # show validation errors from pvmigrate
-            # if there are errors, maybe_prompt_migrate_from_rook_dryrun_errors() will bail
-            maybe_prompt_migrate_from_rook_dryrun_errors
-            rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS"
+            # if there are errors, maybe_rook_to_openebs_migration_checks() will bail
+            maybe_rook_to_openebs_migration_checks
+            rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS" "1"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
 }
 
-function maybe_prompt_migrate_from_rook_dryrun_errors() {
-    echo "Running Rook to OpenEBS Migration Checks ..."
+function maybe_rook_to_openebs_migration_checks() {
 
     # get the list of StorageClasses that use rook-ceph
     rook_scs=$(kubectl get storageclass | grep rook | grep -v '(default)' | awk '{ print $1}') # any non-default rook StorageClasses
     rook_default_sc=$(kubectl get storageclass | grep rook | grep '(default)' | awk '{ print $1}') # any default rook StorageClasses
 
+    # Ensure openebs-localpv-provisioner deployment is ready
+    printf "awaiting openebs-localpv-provisioner deployment\n"
+    spinner_until 120 deployment_fully_updated openebs openebs-localpv-provisioner
+
+    echo "Running Rook to OpenEBS Migration Checks ..."
     local rook_scs_pvmigrate_dryrun_output
     local rook_default_sc_pvmigrate_dryrun_output
     for rook_sc in $rook_scs
     do
         # run validation checks for non default Rook storage classes
-        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>/dev/null || true)
     done
 
     if [ -n "$rook_default_sc" ] ; then
         # run validation checks for Rook default storage class
-        rook_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+        rook_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>/dev/null || true)
     fi
 
-    if { [ -n "$rook_scs_pvmigrate_dryrun_output" ] && [[ "$rook_scs_pvmigrate_dryrun_output" != *"ProvisioningFailed"* ]]; } || { [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] && [[ "$rook_default_sc_pvmigrate_dryrun_output" != *"ProvisioningFailed"* ]]; }; then
-        printf "${YELLOW}"
-        printf "\n"
-        printf "$rook_scs_pvmigrate_dryrun_output"
-        printf "\n"
-        printf "$rook_default_sc_pvmigrate_dryrun_output"
-        printf "\n"
-        printf "${NC}"
-        printf "\n"
-        return
-    else
-        printf "${RED}"
-        printf "\n"
-        printf "$rook_scs_pvmigrate_dryrun_output"
-        printf "\n"
-        printf "$rook_default_sc_pvmigrate_dryrun_output"
-        printf "\n"
-        printf "${NC}"
-        printf "\n"
-    fi
+    if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
+        logFail "$rook_scs_pvmigrate_dryrun_output"
+        logFail "$rook_default_sc_pvmigrate_dryrun_output"
+        
         bail "Cannot upgrade from Rook to OpenEBS due to previous errors."
+    fi
 }
 
-function prompt_migrate_from_rook() {
+function openebs_prompt_migrate_from_rook() {
     local ceph_disk_usage_total
     local rook_ceph_exec_deploy=rook-ceph-operator
 

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -75,8 +75,7 @@ function openebs_maybe_rook_migration_checks() {
     for rook_sc in $rook_scs
     do
         # run validation checks for non default Rook storage classes
-        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
-        if [ $? -ne 0 ]; then
+        if ! rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
             break
         fi
     done

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -48,10 +48,56 @@ function openebs() {
 function openebs_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
+            # show validation errors from pvmigrate
+            # if there are errors, maybe_prompt_migrate_from_rook_dryrun_errors() will bail
+            maybe_prompt_migrate_from_rook_dryrun_errors
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
+}
+
+function maybe_prompt_migrate_from_rook_dryrun_errors() {
+    echo "Running Rook to OpenEBS Migration Checks ..."
+
+    # get the list of StorageClasses that use rook-ceph
+    rook_scs=$(kubectl get storageclass | grep rook | grep -v '(default)' | awk '{ print $1}') # any non-default rook StorageClasses
+    rook_default_sc=$(kubectl get storageclass | grep rook | grep '(default)' | awk '{ print $1}') # any default rook StorageClasses
+
+    local rook_scs_pvmigrate_dryrun_output
+    local rook_default_sc_pvmigrate_dryrun_output
+    for rook_sc in $rook_scs
+    do
+        # run validation checks for non default Rook storage classes
+        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+    done
+
+    if [ -n "$rook_default_sc" ] ; then
+        # run validation checks for Rook default storage class
+        rook_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+    fi
+
+    if { [ -n "$rook_scs_pvmigrate_dryrun_output" ] && [[ "$rook_scs_pvmigrate_dryrun_output" != *"ProvisioningFailed"* ]]; } || { [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] && [[ "$rook_default_sc_pvmigrate_dryrun_output" != *"ProvisioningFailed"* ]]; }; then
+        printf "${YELLOW}"
+        printf "\n"
+        printf "$rook_scs_pvmigrate_dryrun_output"
+        printf "\n"
+        printf "$rook_default_sc_pvmigrate_dryrun_output"
+        printf "\n"
+        printf "${NC}"
+        printf "\n"
+        return
+    else
+        printf "${RED}"
+        printf "\n"
+        printf "$rook_scs_pvmigrate_dryrun_output"
+        printf "\n"
+        printf "$rook_default_sc_pvmigrate_dryrun_output"
+        printf "\n"
+        printf "${NC}"
+        printf "\n"
+    fi
+        bail "Cannot upgrade from Rook to OpenEBS due to previous errors."
 }
 
 function prompt_migrate_from_rook() {

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -48,9 +48,58 @@ function openebs() {
 function openebs_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
+            # show validation errors from pvmigrate
+            # if there are errors, maybe_prompt_migrate_from_rook_dryrun_errors() will bail
+            maybe_prompt_migrate_from_rook_dryrun_errors
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS"
             DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
         fi
+    fi
+}
+
+function maybe_prompt_migrate_from_rook_dryrun_errors() {
+    echo "Running Rook to OpenEBS Migration Checks ..."
+
+    # get the list of StorageClasses that use rook-ceph
+    rook_scs=$(kubectl get storageclass | grep rook | grep -v '(default)' | awk '{ print $1}') # any non-default rook StorageClasses
+    rook_default_sc=$(kubectl get storageclass | grep rook | grep '(default)' | awk '{ print $1}') # any default rook StorageClasses
+
+    local rook_scs_pvmigrate_dryrun_output
+    local rook_default_sc_pvmigrate_dryrun_output
+    for rook_sc in $rook_scs
+    do
+        # run validation checks for non default Rook storage classes
+        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+    done
+
+    if [ -n "$rook_default_sc" ] ; then
+        # run validation checks for Rook default storage class
+        rook_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --dry-run 2>/dev/null)
+    fi
+
+    if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
+        # print warn messages in different color
+        if [[ "$rook_scs_pvmigrate_dryrun_output" != *"------"* ]] || [[ "$rook_default_sc_pvmigrate_dryrun_output" != *"------"* ]] ; then
+            printf "${YELLOW}"
+            printf "\n"
+            printf "$rook_scs_pvmigrate_dryrun_output"
+            printf "\n"
+            printf "$rook_default_sc_pvmigrate_dryrun_output"
+            printf "\n"
+            printf "${NC}"
+            printf "\n"
+            return
+        else
+            printf "${RED}"
+            printf "\n"
+            printf "$rook_scs_pvmigrate_dryrun_output"
+            printf "\n"
+            printf "$rook_default_sc_pvmigrate_dryrun_output"
+            printf "\n"
+            printf "${NC}"
+            printf "\n"
+        fi
+        bail "Cannot upgrade from Rook to OpenEBS due to previous errors."
     fi
 }
 

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -60,6 +60,8 @@ function openebs_maybe_migrate_from_rook() {
 function openebs_maybe_rook_migration_checks() {
 
     # get the list of StorageClasses that use rook-ceph
+    local rook_scs
+    local rook_default_sc
     rook_scs=$(kubectl get storageclass | grep rook | grep -v '(default)' | awk '{ print $1}') # any non-default rook StorageClasses
     rook_default_sc=$(kubectl get storageclass | grep rook | grep '(default)' | awk '{ print $1}') # any default rook StorageClasses
 
@@ -74,6 +76,9 @@ function openebs_maybe_rook_migration_checks() {
     do
         # run validation checks for non default Rook storage classes
         rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
+        if [ $? -ne 0 ]; then
+            break
+        fi
     done
 
     if [ -n "$rook_default_sc" ] ; then

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -75,8 +75,7 @@ function openebs_maybe_rook_migration_checks() {
     for rook_sc in $rook_scs
     do
         # run validation checks for non default Rook storage classes
-        rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
-        if [ $? -ne 0 ]; then
+        if ! rook_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$rook_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
             break
         fi
     done

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -22,6 +22,7 @@
     validate_read_write_object_store rwtest testfile.txt
 
 - name: localpv upgrade from 2.6.0
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.21.x" # this is the latest version of k8s that supports openebs 2.6
@@ -88,6 +89,7 @@
     validate_read_write_object_store rwtest testfile.txt
 
 - name: localpv upgrade from 1.12.0
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
@@ -170,6 +172,7 @@
     validate_read_write_object_store postupgrade upgradefile.txt
 
 - name: localpv upgrade from latest
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.25.x"

--- a/go.mod
+++ b/go.mod
@@ -215,6 +215,7 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
+	github.com/vmware/govmomi v0.20.3 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kurlkinds v1.0.8
 	github.com/replicatedhq/kurlkinds v1.0.7
+	github.com/replicatedhq/pvmigrate v0.7.0
 	github.com/replicatedhq/troubleshoot v0.49.1
 	github.com/rook/rook v1.10.6
-	github.com/replicatedhq/pvmigrate v0.7.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kurlkinds v1.0.8
-	github.com/replicatedhq/kurlkinds v1.0.7
 	github.com/replicatedhq/pvmigrate v0.7.0
 	github.com/replicatedhq/troubleshoot v0.49.1
 	github.com/rook/rook v1.10.6

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,10 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/kurlkinds v1.0.8
-	github.com/replicatedhq/pvmigrate v0.6.0
+	github.com/replicatedhq/kurlkinds v1.0.7
 	github.com/replicatedhq/troubleshoot v0.49.1
 	github.com/rook/rook v1.10.6
+	github.com/replicatedhq/pvmigrate v0.7.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.6.1
@@ -215,7 +216,6 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
-	github.com/vmware/govmomi v0.20.3 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
@@ -242,6 +242,7 @@ require (
 	k8s.io/cli-runtime v0.25.4 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
+	k8s.io/kubernetes v1.25.4 // indirect
 	oras.land/oras-go v1.2.1 // indirect
 	periph.io/x/host/v3 v3.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1656,9 +1656,10 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware-tanzu/velero v1.9.3 h1:sZqUbkXrqqOLOYYETcp2CLTHp7j5gH7+IlEM4RcS2Gw=
-github.com/vmware-tanzu/velero v1.9.3/go.mod h1:XRQ9aiZKQDqZ+QqL34B6i6xjMiH8gzBuz86NfCwljIQ=
-github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
+github.com/vmware-tanzu/velero v1.9.2 h1:J02VxeHevIJ6D3r+wSGrjw6hGvMawb2Ty+j8wc+Owp8=
+github.com/vmware-tanzu/velero v1.9.2/go.mod h1:75v4RUMzs8RK6Kqmrg6jgIOBaHUgAWwWAFiWERw2l4U=
+github.com/vmware/govmomi v0.20.3 h1:gpw/0Ku+6RgF3jsi7fnCLmlcikBHfKBCUcu1qgc16OU=
+github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/go.sum
+++ b/go.sum
@@ -1494,8 +1494,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/replicatedhq/kurlkinds v1.0.8 h1:1HyAh7MScP93CQR1r6r5ujEuRXWMRIsxTf+KYl8N8F4=
 github.com/replicatedhq/kurlkinds v1.0.8/go.mod h1:El1ZyCyGLD/fxM0cbNCtMIozUUBC7BI0rMGdiDu6T2E=
-github.com/replicatedhq/pvmigrate v0.6.0 h1:vj26q3KBYP3D2yKMoEU9+ZE7mP38lDhzA260ZDBbLSY=
-github.com/replicatedhq/pvmigrate v0.6.0/go.mod h1:kCyzLWCfD7jnm7As+g/3jFdXdHWCdFnp5ekh5LfAebs=
+github.com/replicatedhq/pvmigrate v0.7.0 h1:5GEmYaw0P+9T76HyMlQ2xtKznafTBg++PSMCclpFjh4=
+github.com/replicatedhq/pvmigrate v0.7.0/go.mod h1:pSh7a3xQvpZijtfrZR8ol2t92xQw1d/aMMq1pFIiSu8=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.49.1 h1:oThE8v7SZ2sNUXq4ECsHeJfFYjTS7wjhJUvXya+gVVw=
@@ -1659,7 +1659,6 @@ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1
 github.com/vmware-tanzu/velero v1.9.2 h1:J02VxeHevIJ6D3r+wSGrjw6hGvMawb2Ty+j8wc+Owp8=
 github.com/vmware-tanzu/velero v1.9.2/go.mod h1:75v4RUMzs8RK6Kqmrg6jgIOBaHUgAWwWAFiWERw2l4U=
 github.com/vmware/govmomi v0.20.3 h1:gpw/0Ku+6RgF3jsi7fnCLmlcikBHfKBCUcu1qgc16OU=
-github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -2527,6 +2526,8 @@ k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lV
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.25.4 h1:M1+MR8IxE64zHhSSDn30twChLaOI+p0Kt77pvyQMKwU=
+k8s.io/kubernetes v1.25.4/go.mod h1:lvEY+3iJhh+sGIK1LorGkI56rW0eLGsfalnp68wQwYU=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/go.sum
+++ b/go.sum
@@ -1656,8 +1656,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware-tanzu/velero v1.9.2 h1:J02VxeHevIJ6D3r+wSGrjw6hGvMawb2Ty+j8wc+Owp8=
-github.com/vmware-tanzu/velero v1.9.2/go.mod h1:75v4RUMzs8RK6Kqmrg6jgIOBaHUgAWwWAFiWERw2l4U=
+github.com/vmware-tanzu/velero v1.9.3 h1:sZqUbkXrqqOLOYYETcp2CLTHp7j5gH7+IlEM4RcS2Gw=
+github.com/vmware-tanzu/velero v1.9.3/go.mod h1:XRQ9aiZKQDqZ+QqL34B6i6xjMiH8gzBuz86NfCwljIQ=
 github.com/vmware/govmomi v0.20.3 h1:gpw/0Ku+6RgF3jsi7fnCLmlcikBHfKBCUcu1qgc16OU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=

--- a/kurl_util/cmd/pvmigrate/main.go
+++ b/kurl_util/cmd/pvmigrate/main.go
@@ -50,9 +50,11 @@ func main() {
 
 	flag.Parse()
 
+	fmt.Printf("Running pvmigrate build:\n")
+	version.Print()
+
+	// if --version flag is set, exit
 	if printVersion {
-		fmt.Printf("Running pvmigrate build:\n")
-		version.Print()
 		os.Exit(0)
 	}
 

--- a/kurl_util/cmd/pvmigrate/main.go
+++ b/kurl_util/cmd/pvmigrate/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"time"
 
 	clusterspace "github.com/replicatedhq/kurl/pkg/cluster/space"
 	"github.com/replicatedhq/kurl/pkg/version"
@@ -39,7 +40,7 @@ func main() {
 	flag.BoolVar(&opts.SkipSourceValidation, "skip-source-validation", false, "migrate from PVCs using a particular StorageClass name, even if that StorageClass does not exist")
 	flag.BoolVar(&skipFreeSpaceCheck, "skip-free-space-check", false, "skips the check for storage free space prior to running the migrations")
 	flag.BoolVar(&printVersion, "version", false, "Print the version of the client")
-	flag.IntVar(&opts.PodReadyTimeout, "pod-ready-timeout", 60, "length of time to wait (in seconds) for volume validation pod(s) to go into Ready phase")
+	flag.DurationVar(&opts.PodReadyTimeout, "pod-ready-timeout", 60*time.Second, "length of time to wait (in seconds) for volume validation pod(s) to go into Ready phase")
 	flag.BoolVar(&skipPreflightValidation, "skip-preflight-validation", false, "skips pre-migration validation")
 	flag.BoolVar(&preflightValidationOnly, "preflight-validation-only", false, "skip the migration and run preflight validation only")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Apply node disk validation introduced in https://github.com/replicatedhq/kURL/pull/3674 and volume access modes validation introduced in https://github.com/replicatedhq/pvmigrate/pull/139 when upgrading from Rook to OpenEBS.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
Internal tracker ref: [sc-61144]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Unfortunately, the volume access modes validation cannot run at pre-init time because it requires the `openebs` storage class to be installed.


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Disk and Volume validation checks will be run prior to migrating from Rook to OpenEBS. A failed validation check will abort the upgrade.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
