### PR TITLE
addons/weave: patch release 2.6.5-20221122 to address cve

### DIFF
--- a/addons/weave/2.6.5-20221122/Manifest
+++ b/addons/weave/2.6.5-20221122/Manifest
@@ -1,0 +1,3 @@
+image weave-kube kurlsh/weave-kube:2.6.5-20221122-96e898a
+image weave-npc kurlsh/weave-npc:2.6.5-20221122-96e898a
+image weaveexec kurlsh/weaveexec:2.6.5-20221122-96e898a

--- a/addons/weave/2.6.5-20221122/host-preflight.yaml
+++ b/addons/weave/2.6.5-20221122/host-preflight.yaml
@@ -1,0 +1,112 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: weave
+spec:
+  collectors:
+    - tcpPortStatus:
+        collectorName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        port: 6781
+        exclude: '{{kurl .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        port: 6782
+        exclude: '{{kurl .IsUpgrade }}'
+    - tcpPortStatus:
+        collectorName: "Weave Net Control TCP Port Status"
+        port: 6783
+        exclude: '{{kurl .IsUpgrade }}'
+{{kurl- if and .IsJoin (not .IsUpgrade)}}
+  {{kurl- range .RemoteHosts}}
+    - tcpConnect:
+        collectorName: "weave {{kurl . }}"
+        address: '{{kurl . }}:6783'
+        timeout: 5s
+  {{kurl- end}}
+{{kurl- end}}
+
+  analyzers:
+    - tcpPortStatus:
+        checkName: "Weave Network Policy Controller Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6781 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - fail:
+              when: "address-in-use"
+              message: Another process was already listening on port 6781.
+          - pass:
+              when: "connection-timeout"
+              message: Port 6781 is available
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6781 is available
+    - tcpPortStatus:
+        checkName: "Weave Net Metrics Server TCP Port Status"
+        collectorName: "Weave Net Metrics Server TCP Port Status"
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6782 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - fail:
+              when: "address-in-use"
+              message: Another process was already listening on port 6782.
+          - pass:
+              when: "connection-timeout"
+              message: Port 6782 is available
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6782 is available
+    - tcpPortStatus:
+        checkName: "Weave Net Control TCP Port Status"
+        collectorName: "Weave Net Control TCP Port Status"
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - fail:
+              when: "connection-refused"
+              message: Connection to port 6783 was refused. This is likely to be a routing problem since this preflight configures a test server to listen on this port.
+          - warn:
+              when: "address-in-use"
+              message: Another process was already listening on port 6783.
+          - fail:
+              when: "connection-timeout"
+              message: Timed out connecting to port 6783. Check your firewall.
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port 6783 is open
+          - warn:
+              message: Unexpected port status
+{{kurl- if and .IsJoin (not .IsUpgrade)}}
+  {{kurl- range .RemoteHosts}}
+    - tcpConnect:
+        checkName: "weave {{kurl . }}:6783 TCP connection status"
+        collectorName: "weave {{kurl . }}"
+        outcomes:
+          - warn:
+              when: "connection-refused"
+              message: Connection to weave {{kurl . }}:6783 was refused
+          - warn:
+              when: "connection-timeout"
+              message: Timed out connecting to weave {{kurl . }}:6783
+          - warn:
+              when: "error"
+              message: Unexpected error connecting to weave {{kurl . }}:6783
+          - pass:
+              when: "connected"
+              message: Successfully connected to weave {{kurl . }}:6783
+          - warn:
+              message: Unexpected TCP connection status for weave {{kurl . }}:6783
+  {{kurl- end}}
+{{kurl- end}}

--- a/addons/weave/2.6.5-20221122/install.sh
+++ b/addons/weave/2.6.5-20221122/install.sh
@@ -1,0 +1,98 @@
+
+function weave_pre_init() {
+    weave_use_existing_network
+}
+
+function weave() {
+    local src="${DIR}/addons/weave/${WEAVE_VERSION}"
+    local dst="${DIR}/kustomize/weave"
+
+    cp "${src}/kustomization.yaml" "${dst}/kustomization.yaml"
+    cp "${src}/weave-daemonset-k8s-1.11.yaml" "${dst}/weave-daemonset-k8s-1.11.yaml"
+    cp "${src}/patch-daemonset.yaml" "${dst}/patch-daemonset.yaml"
+
+    if [ "$ENCRYPT_NETWORK" != "0" ]; then
+        # don't change existing secrets because pods that start after will have a different value
+        if ! kubernetes_resource_exists kube-system secret weave-passwd; then
+            weave_resource_secret
+        fi
+        weave_patch_encrypt
+        weave_warn_if_sleeve
+    fi
+
+    if [ -n "$POD_CIDR" ]; then
+        weave_patch_ip_alloc_range
+    fi
+
+    if [ -n "$NO_MASQ_LOCAL" ]; then
+      weave_patch_no_masq_local
+    fi
+
+    kubectl apply -k "${dst}/"
+    weave_ready_spinner
+    check_network
+}
+
+function weave_resource_secret() {
+    local src="${DIR}/addons/weave/${WEAVE_VERSION}"
+    local dst="${DIR}/kustomize/weave"
+
+    insert_resources "${dst}/kustomization.yaml" secret.yaml
+
+    WEAVE_PASSWORD=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c9)
+    render_yaml_file_2 "${src}/tmpl-secret.yaml" > "${dst}/secret.yaml"
+}
+
+function weave_patch_encrypt() {
+    local src="${DIR}/addons/weave/${WEAVE_VERSION}"
+    local dst="${DIR}/kustomize/weave"
+
+    insert_patches_strategic_merge "${dst}/kustomization.yaml" patch-encrypt.yaml
+    cp "${src}/patch-encrypt.yaml" "${dst}/patch-encrypt.yaml"
+}
+
+function weave_patch_ip_alloc_range() {
+    local src="${DIR}/addons/weave/${WEAVE_VERSION}"
+    local dst="${DIR}/kustomize/weave"
+
+    insert_patches_strategic_merge "${dst}/kustomization.yaml" patch-ip-alloc-range.yaml
+    render_yaml_file_2 "${src}/tmpl-patch-ip-alloc-range.yaml" > "${dst}/patch-ip-alloc-range.yaml"
+}
+
+function weave_patch_no_masq_local() {
+    local src="${DIR}/addons/weave/${WEAVE_VERSION}"
+    local dst="${DIR}/kustomize/weave"
+
+    insert_patches_strategic_merge "${dst}/kustomization.yaml" patch-no-masq-local.yaml
+    render_yaml_file_2 "${src}/tmpl-patch-no-masq-local.yaml" > "${dst}/patch-no-masq-local.yaml"
+}
+
+function weave_warn_if_sleeve() {
+    local kernel_major=$(uname -r | cut -d'.' -f1)
+    local kernel_minor=$(uname -r | cut -d'.' -f2)
+    if [ "$kernel_major" -lt "4" ] || ([ "$kernel_major" -lt "5" ] && [ "$kernel_minor" -lt "3" ]); then
+        printf "${YELLOW}This host will not be able to establish optimized network connections with other peers in the Kubernetes cluster.\nRefer to the Replicated networking guide for help.\n\nhttp://help.replicated.com/docs/kubernetes/customer-installations/networking/${NC}\n"
+    fi
+}
+
+function weave_use_existing_network() {
+    if weaveDev=$(ip route show dev weave 2>/dev/null); then
+        EXISTING_POD_CIDR=$(echo $weaveDev | awk '{ print $1 }')
+        echo "Using existing weave network: $EXISTING_POD_CIDR"
+    fi
+}
+
+function weave_health_check() {
+    local health="$(kubectl get pods -n kube-system -l name=weave-net -o jsonpath="{range .items[*]}{range .status.conditions[*]}{ .type }={ .status }{'\n'}{end}{end}" 2>/dev/null)"
+    if [ -z "$health" ] || echo "$health" | grep -q '^Ready=False' ; then
+        return 1
+    fi
+    return 0
+}
+
+function weave_ready_spinner() {
+    if ! spinner_until 180 weave_health_check; then
+        kubectl logs -n kube-system -l name=weave-net --all-containers --tail 10
+        bail "The weave addon failed to deploy successfully."
+    fi
+}

--- a/addons/weave/2.6.5-20221122/kustomization.yaml
+++ b/addons/weave/2.6.5-20221122/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- weave-daemonset-k8s-1.11.yaml
+
+patchesStrategicMerge:
+- patch-daemonset.yaml

--- a/addons/weave/2.6.5-20221122/patch-daemonset.yaml
+++ b/addons/weave/2.6.5-20221122/patch-daemonset.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: weave
+          command:
+            - /bin/sh
+            - -c
+            - sed '/ipset destroy weave-kube-test$/ i sleep 1' /home/weave/launch.sh | /bin/sh
+          env:
+            - name: EXTRA_ARGS
+              value: "--log-level=info" # default log level is debug
+            - name: CHECKPOINT_DISABLE
+              value: "1"
+            - name: EXEC_IMAGE
+              value: "kurlsh/weaveexec:2.6.5-20221122-96e898a"
+        - name: weave-npc
+          args: ["--log-level", "info"] # default log level is debug

--- a/addons/weave/2.6.5-20221122/patch-encrypt.yaml
+++ b/addons/weave/2.6.5-20221122/patch-encrypt.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: weave
+        env:
+        - name: WEAVE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: weave-passwd
+              key: weave-passwd

--- a/addons/weave/2.6.5-20221122/tmpl-patch-ip-alloc-range.yaml
+++ b/addons/weave/2.6.5-20221122/tmpl-patch-ip-alloc-range.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: weave
+          env:
+          - name: IPALLOC_RANGE
+            value: $POD_CIDR

--- a/addons/weave/2.6.5-20221122/tmpl-patch-no-masq-local.yaml
+++ b/addons/weave/2.6.5-20221122/tmpl-patch-no-masq-local.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: weave
+          env:
+          - name: NO_MASQ_LOCAL
+            value: "$NO_MASQ_LOCAL"

--- a/addons/weave/2.6.5-20221122/tmpl-secret.yaml
+++ b/addons/weave/2.6.5-20221122/tmpl-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: weave-passwd
+  namespace: kube-system
+stringData:
+  weave-passwd: $WEAVE_PASSWORD

--- a/addons/weave/2.6.5-20221122/weave-daemonset-k8s-1.11.yaml
+++ b/addons/weave/2.6.5-20221122/weave-daemonset-k8s-1.11.yaml
@@ -1,0 +1,213 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+      namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - 'networking.k8s.io'
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes/status
+        verbs:
+        - patch
+        - update
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    roleRef:
+      kind: ClusterRole
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: weave-net
+      namespace: kube-system
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        resourceNames:
+          - weave-net
+        verbs:
+          - get
+          - update
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        verbs:
+          - create
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: weave-net
+      namespace: kube-system
+      labels:
+        name: weave-net
+    roleRef:
+      kind: Role
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+      namespace: kube-system
+    spec:
+      # Wait 5 seconds to let pod connect before rolling next pod
+      selector:
+        matchLabels:
+          name: weave-net
+      minReadySeconds: 5
+      template:
+        metadata:
+          labels:
+            name: weave-net
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'kurlsh/weave-kube:2.6.5-20221122-96e898a'
+              readinessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+              resources:
+                requests:
+                  cpu: 50m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+            - name: weave-npc
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'kurlsh/weave-npc:2.6.5-20221122-96e898a'
+#npc-args
+              resources:
+                requests:
+                  cpu: 50m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+          hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
+          hostPID: true
+          restartPolicy: Always
+          securityContext:
+            seLinuxOptions: {}
+          serviceAccountName: weave-net
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
+          volumes:
+            - name: weavedb
+              hostPath:
+                path: /var/lib/weave
+            - name: cni-bin
+              hostPath:
+                path: /opt
+            - name: cni-bin2
+              hostPath:
+                path: /home
+            - name: cni-conf
+              hostPath:
+                path: /etc
+            - name: dbus
+              hostPath:
+                path: /var/lib/dbus
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+          priorityClassName: system-node-critical
+      updateStrategy:
+        type: RollingUpdate

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -97,6 +97,7 @@ module.exports.InstallerVersions = {
   ],
   weave: [
     // cron-weave-update-265
+    "2.6.5-20221122",
     "2.6.5-20221025",
     "2.6.5-20221006",
     "2.6.5-20220825",


### PR DESCRIPTION
#### What this PR does / why we need it:

Address CVEs

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

## Steps to reproduce
Scan the images: https://github.com/replicatedhq/kURL/actions/runs/3521359488/jobs/5903133316

#### Does this PR introduce a user-facing change?

```release-note
Adds [Weave add-on](https://kurl.sh/docs/add-ons/weave) version 2.6.5-20221122 to address the critical CVEs
 (CVE-2022-42915, CVE-2022-42915) and the high CVEs (CVE-2022-42916, CVE-2022-42916)
```

#### Does this PR require documentation?

