### PR TITLE
fix ubuntu dockerfiles to not requires dialog interaction

### DIFF
--- a/addons/containerd/template/Dockerfile.ubuntu16
+++ b/addons/containerd/template/Dockerfile.ubuntu16
@@ -2,9 +2,10 @@ FROM ubuntu:16.04
 
 ARG VERSION
 ENV VERSION=${VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
+RUN apt-get -y update && \
+    apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -18,7 +19,7 @@ RUN echo \
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \
-    apt-get -d -y install \
+    apt-get -d -y install tzdata \
     containerd.io=$(apt-cache madison 'containerd.io' | grep ${VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
     -oDebug::NoLocking=1 -o=dir::cache=/packages/ && \
     cp -r /packages/archives/* /out/

--- a/addons/containerd/template/Dockerfile.ubuntu18
+++ b/addons/containerd/template/Dockerfile.ubuntu18
@@ -2,9 +2,10 @@ FROM ubuntu:18.04
 
 ARG VERSION
 ENV VERSION=${VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
+RUN apt-get -y update && \
+    apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -18,7 +19,7 @@ RUN echo \
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \
-    apt-get -d -y install \
+    apt-get -d -y install tzdata \
     containerd.io=$(apt-cache madison 'containerd.io' | grep ${VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
     -oDebug::NoLocking=1 -o=dir::cache=/packages/ && \
     cp -r /packages/archives/* /out/

--- a/addons/containerd/template/Dockerfile.ubuntu20
+++ b/addons/containerd/template/Dockerfile.ubuntu20
@@ -2,9 +2,10 @@ FROM ubuntu:20.04
 
 ARG VERSION
 ENV VERSION=${VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
+RUN apt-get -y update && \
+    apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -18,7 +19,8 @@ RUN echo \
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \
-    apt-get -d -y install \
+    apt-get -d -y install tzdata \
     containerd.io=$(apt-cache madison 'containerd.io' | grep ${VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
     -oDebug::NoLocking=1 -o=dir::cache=/packages/ && \
     cp -r /packages/archives/* /out/
+

--- a/addons/containerd/template/Dockerfile.ubuntu22
+++ b/addons/containerd/template/Dockerfile.ubuntu22
@@ -1,10 +1,12 @@
 FROM ubuntu:22.04
 
+
 ARG VERSION
 ENV VERSION=${VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common
+RUN apt-get -y update && \
+    apt-get -y install apt-utils apt-transport-https ca-certificates curl software-properties-common tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -18,7 +20,7 @@ RUN echo \
 RUN apt-get -y update
 
 CMD mkdir -p /packages/archives && \
-    apt-get -d -y install \
+    apt-get -d -y install tzdata \
     containerd.io=$(apt-cache madison 'containerd.io' | grep ${VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
     -oDebug::NoLocking=1 -o=dir::cache=/packages/ && \
     cp -r /packages/archives/* /out/

--- a/bundles/docker-ubuntu1604/Dockerfile
+++ b/bundles/docker-ubuntu1604/Dockerfile
@@ -2,13 +2,14 @@
 # More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:16.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 # Update the apt package index and install packages to allow apt to use a repository over HTTPS:
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && \
+    apt-get -y install \
         ca-certificates \
         curl \
         gnupg \
-        lsb-release
+        lsb-release tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -32,7 +33,7 @@ RUN apt-get -y update
 ARG DOCKER_VERSION
 
 # Installs spefic docker version informed via the ARG DOCKER_VERSION
-RUN apt-get -d -y install --no-install-recommends \
+RUN apt-get -d -y install --no-install-recommends tzdata \
       docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       -oDebug::NoLocking=1 -o=dir::cache=/packages/

--- a/bundles/docker-ubuntu1804/Dockerfile
+++ b/bundles/docker-ubuntu1804/Dockerfile
@@ -2,13 +2,14 @@
 # More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 # Update the apt package index and install packages to allow apt to use a repository over HTTPS:
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && \
+    apt-get -y install \
         ca-certificates \
         curl \
         gnupg \
-        lsb-release
+        lsb-release tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -32,7 +33,7 @@ RUN apt-get -y update
 ARG DOCKER_VERSION
 
 # Installs spefic docker version informed via the ARG DOCKER_VERSION
-RUN apt-get -d -y install --no-install-recommends \
+RUN apt-get -d -y install --no-install-recommends tzdata \
       docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       -oDebug::NoLocking=1 -o=dir::cache=/packages/

--- a/bundles/docker-ubuntu2004/Dockerfile
+++ b/bundles/docker-ubuntu2004/Dockerfile
@@ -2,13 +2,14 @@
 # More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:20.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 # Update the apt package index and install packages to allow apt to use a repository over HTTPS:
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && \
+    apt-get -y install \
         ca-certificates \
         curl \
         gnupg \
-        lsb-release
+        lsb-release tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -32,7 +33,7 @@ RUN apt-get -y update
 ARG DOCKER_VERSION
 
 # Installs spefic docker version informed via the ARG DOCKER_VERSION
-RUN apt-get -d -y install --no-install-recommends \
+RUN apt-get -d -y install --no-install-recommends tzdata \
       docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       -oDebug::NoLocking=1 -o=dir::cache=/packages/

--- a/bundles/docker-ubuntu2204/Dockerfile
+++ b/bundles/docker-ubuntu2204/Dockerfile
@@ -2,13 +2,14 @@
 # More info: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 FROM ubuntu:22.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 # Update the apt package index and install packages to allow apt to use a repository over HTTPS:
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update && \
+    apt-get -y install \
         ca-certificates \
         curl \
         gnupg \
-        lsb-release
+        lsb-release tzdata
 
 # Add Docker’s official GPG key:
 RUN mkdir -p /etc/apt/keyrings
@@ -32,7 +33,7 @@ RUN apt-get -y update
 ARG DOCKER_VERSION
 
 # Installs spefic docker version informed via the ARG DOCKER_VERSION
-RUN apt-get -d -y install --no-install-recommends \
+RUN apt-get -d -y install --no-install-recommends tzdata \
       docker-ce-cli=$(apt-cache madison docker-ce-cli | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       docker-ce=$(apt-cache madison docker-ce | grep ${DOCKER_VERSION} | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3) \
       -oDebug::NoLocking=1 -o=dir::cache=/packages/

--- a/bundles/helm/Dockerfile
+++ b/bundles/helm/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get -y install curl
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install curl tzdata
 
 RUN mkdir -p /helm
 WORKDIR /helm

--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:16.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get -y install curl apt-transport-https gnupg
+RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
@@ -10,7 +12,7 @@ RUN apt-get update
 RUN mkdir -p /packages/archives
 
 ARG KUBERNETES_VERSION
-RUN apt-get install -d -y \
+RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubernetes-cni \

--- a/bundles/k8s-ubuntu1804/Dockerfile
+++ b/bundles/k8s-ubuntu1804/Dockerfile
@@ -1,16 +1,18 @@
 FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get -y install curl apt-transport-https gnupg
+RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-
 RUN apt-get update
 RUN mkdir -p /packages/archives
 
 ARG KUBERNETES_VERSION
-RUN apt-get install -d -y \
+RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubernetes-cni \

--- a/bundles/k8s-ubuntu2004/Dockerfile
+++ b/bundles/k8s-ubuntu2004/Dockerfile
@@ -1,16 +1,17 @@
 FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get -y install curl apt-transport-https gnupg
+RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-
 RUN apt-get update
 RUN mkdir -p /packages/archives
 
 ARG KUBERNETES_VERSION
-RUN apt-get install -d -y \
+RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubernetes-cni \

--- a/bundles/k8s-ubuntu2204/Dockerfile
+++ b/bundles/k8s-ubuntu2204/Dockerfile
@@ -1,17 +1,17 @@
 FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get -y install curl apt-transport-https gnupg
+RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
 RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-
 RUN apt-get update
 RUN mkdir -p /packages/archives
 
 ARG KUBERNETES_VERSION
-RUN apt-get install -d -y \
+RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubernetes-cni \

--- a/bundles/krew/Dockerfile
+++ b/bundles/krew/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
-RUN apt-get update
-RUN apt-get -y install curl apt-transport-https gnupg git
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get -y install curl apt-transport-https gnupg git tzdata
 
 RUN mkdir -p /krew
 WORKDIR /krew


### PR DESCRIPTION
#### What this PR does / why we need it:

We build the dockerfile via script and we cannot configure via a dialog an timezone. Therefore, for the ubuntu images some installs if we run locally you will check that the dialog to set the timezone is required, i.e: 

```bash
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```

Therefore, this PR ensures for all dockerfiles using ubuntu as base image are configured with `ARG DEBIAN_FRONTEND=noninteractive` and `tzdata`  to avoid errors like:

````bash
$ make build/packages/kubernetes/1.19.3/ubuntu-18.04
...
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
```` 

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

**Note that besides the above errors the packages usually are found. However, after the new version for containerd (https://github.com/replicatedhq/kURL/pull/3750) be added I began to be unable to run its script from the codeServer and check the package container.io 1.6.10.** _PS.: Probably because my instance is setup within an Europe timezone._

To test the changes in this PR the builds were done locally by running the following commands:

```bash
make build/packages/kubernetes/1.19.3/ubuntu-18.04
make build/packages/docker/19.03.10/ubuntu-18.04
make build/krew
make build/helm
 cd addons/containerd/template/
./script.sh 
```
## Steps to reproduce
You can use the main branch to do the following steps:

```
$cd addons/containerd/template/
$docker build --pull -t ubuntu22 -f Dockerfile.ubuntu22 .
$docker run -it -t ubuntu22 /bin/bash
$apt-cache madison 'containerd.io' 
```

Then, you will check that 1.6.10-1 is missing before this changes:

```
root@7b2af9d318cc:/# apt-cache madison 'containerd.io' 
containerd.io |    1.6.9-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |    1.6.8-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |    1.6.7-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |    1.6.6-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |    1.6.4-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |   1.5.11-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
containerd.io |   1.5.10-1 | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
```

You can check that the package 1.6.10-1 is also found after this changes by looking its result within in: https://github.com/replicatedhq/kURL/pull/3766

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
