### PR TITLE
feat: accept environment vars as well as flags

### DIFF
--- a/pkg/cli/sync_object_store.go
+++ b/pkg/cli/sync_object_store.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/minio/minio-go"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 func NewSyncObjectStoreCmd(cli CLI) *cobra.Command {
@@ -21,6 +23,21 @@ func NewSyncObjectStoreCmd(cli CLI) *cobra.Command {
 	syncObjectStoreCmd := &cobra.Command{
 		Use:   "sync-object-store",
 		Short: "Copies buckets and objects from one object store to another",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.New()
+			v.SetEnvPrefix("KURL")
+			v.AutomaticEnv()
+			cmd.Flags().VisitAll(
+				func(f *pflag.Flag) {
+					if f.Changed || !v.IsSet(f.Name) {
+						return
+					}
+					value := fmt.Sprintf("%v", v.Get(f.Name))
+					_ = cmd.Flags().Set(f.Name, value)
+				},
+			)
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			src, err := minio.New(
 				srcHost,


### PR DESCRIPTION
#### What this PR does / why we need it:

in order to make execution in a pod cleaner this commits adds support for setting flags through environment variables. this is the relation among flags and environment variables:

| flag                       | environment variable          |
|----------------------------|-------------------------------|
| --source_host              | KURL_SOURCE_HOST              |
| --source_access_key_id     | KURL_SOURCE_ACCESS_KEY_ID     |
| --source_access_key_secret | KURL_SOURCE_ACCESS_KEY_SECRET |
| --dest_host                | KURL_DEST_HOST                |
| --dest_access_key_id       | KURL_DEST_ACCESS_KEY_ID       |
| --dest_access_key_secret   | KURL_DEST_ACCESS_KEY_SECRET   |

flags being set in the command line take precedence over environment variables.