### PR TITLE
feat: migrate minio away from fs back store

### DIFF
--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -434,7 +434,8 @@ function minio_swap_fs_migration_hostpaths() {
 # from within the pod.
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
-    if ! spinner_until 120 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    printf "Awaiting for minio deployment to rollout\n"
+    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -433,6 +433,11 @@ function minio_swap_fs_migration_hostpaths() {
 # minio_uses_fs_format verifies if minio uses the legacy fs format. greps the file /data/.minio.sys/format.json
 # from within the pod.
 function minio_uses_fs_format() {
+    # before running this we need to ensure that the minio deployment is fully deployed.
+    if ! spinner_until 120 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+        bail "Timeout awaiting for minio deployment"
+    fi
+
     local format_string
     format_string=$(kubectl exec -n $MINIO_NAMESPACE deploy/minio -- cat /data/.minio.sys/format.json 2>/dev/null)
     if [ -z "$format_string" ]; then

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -470,8 +470,7 @@ function minio_has_enough_space_for_fs_migration() {
         minio_ask_user_hostpath_for_migration
         return 0
     fi
-    # "$DIR"/bin/kurl cluster check-free-disk-space --debug --openebs-image "$KURL_UTIL_IMAGE" --bigger-than "$MINIO_CLAIM_SIZE" 2>&1
-    /home/ubuntu/kurlbin cluster check-free-disk-space --debug --openebs-image "$KURL_UTIL_IMAGE" --bigger-than "$MINIO_CLAIM_SIZE" 2>&1
+    "$DIR"/bin/kurl cluster check-free-disk-space --debug --openebs-image "$KURL_UTIL_IMAGE" --bigger-than "$MINIO_CLAIM_SIZE" 2>&1
 }
 
 

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -486,10 +486,11 @@ function minio_pods_are_finished() {
     fi
 
     local pods_count
-    pods_count="$(echo "$pods" | wc -l)"
+    pods_count="$(echo -n "$pods" | wc -l)"
     if [ "$pods_count" -eq "0" ]; then
         return 0
     fi
+
     return 1
 }
 
@@ -595,7 +596,7 @@ function minio_migrate_fs_backend() {
 
         # get the pv in use by the fs migration deployment, we gonna need it later on when we swap the pvs.
         local migration_pv
-        migration_pv=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-pv-claim -o template="{{.spec.volumeName}}" 2>/dev/null)
+        migration_pv=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-migrate-fs-backend-pv-claim -o template="{{.spec.volumeName}}" 2>/dev/null)
         if [ -z "$migration_pv" ]; then
             minio_restore_original_deployment "$minio_replicas"
             bail "Failed to find minio pv"

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -394,6 +394,11 @@ function minio_swap_fs_migration_pvs() {
     local src="$DIR/addons/minio/__MINIO_DIR_NAME__"
     local dst="$DIR/kustomize/minio"
 
+    MINIO_ORIGINAL_CLAIM_SIZE=$(kubectl get pvc -n "$MINIO_NAMESPACE" minio-pv-claim --no-headers -o custom-columns=:.spec.resources.requests.storage)
+    if [ -z "$MINIO_ORIGINAL_CLAIM_SIZE" ]; then
+        MINIO_ORIGINAL_CLAIM_SIZE="$MINIO_CLAIM_SIZE"
+    fi
+
     kubectl patch pv "$migration_pv" --type=json -p='[{"op": "remove", "path": "/spec/claimRef"}]'
     kubectl delete pvc -n "$MINIO_NAMESPACE" minio-pv-claim
     kubectl patch pv "$minio_pv" --type=json -p='[{"op": "remove", "path": "/spec/claimRef"}]'

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -330,7 +330,7 @@ function minio_ask_user_hostpath_for_migration() {
         fi
 
         if [ "$space_needed" -gt "$free_space" ]; then
-            printf "Not enough space to migrate %s bytes from %s to %s" "$space_needed" "$MINIO_HOSTPATH" "$migration_path"
+            printf "Not enough space to migrate %s bytes from %s to %s\n" "$space_needed" "$MINIO_HOSTPATH" "$migration_path"
             continue
         fi
 

--- a/addons/minio/template/base/migrate-fs/hostpath/deployment.yaml
+++ b/addons/minio/template/base/migrate-fs/hostpath/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-migrate-fs-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-migrate-fs-backend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-migrate-fs-backend
+    spec:
+      containers:
+      - name: minio
+        volumeMounts:
+        - name: data 
+          mountPath: "/data"
+        image: minio/minio:__MINIO_VERSION__
+        args:
+        - --quiet
+        - server
+        - /data
+        env:
+        - name: MINIO_UPDATE
+          value: "off"
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_SECRET_KEY
+        ports:
+        - containerPort: 9000
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20
+      volumes:
+        - name: data
+          hostPath:
+            path: ${MINIO_MIGRATION_HOSTPATH}

--- a/addons/minio/template/base/migrate-fs/hostpath/kustomization.yaml
+++ b/addons/minio/template/base/migrate-fs/hostpath/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: ${MINIO_NAMESPACE}
+resources:
+- deployment.yaml
+- service.yaml

--- a/addons/minio/template/base/migrate-fs/hostpath/service.yaml
+++ b/addons/minio/template/base/migrate-fs/hostpath/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-migrate-fs-backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio-migrate-fs-backend

--- a/addons/minio/template/base/migrate-fs/minio-backup-pvc.yaml
+++ b/addons/minio/template/base/migrate-fs/minio-backup-pvc.yaml
@@ -9,4 +9,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: ${MINIO_CLAIM_SIZE}
+      storage: ${MINIO_ORIGINAL_CLAIM_SIZE}

--- a/addons/minio/template/base/migrate-fs/minio-backup-pvc.yaml
+++ b/addons/minio/template/base/migrate-fs/minio-backup-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pv-claim-backup
+  namespace: ${MINIO_NAMESPACE}
+spec:
+  volumeName: ${MINIO_ORIGINAL_VOLUME_NAME}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${MINIO_CLAIM_SIZE}

--- a/addons/minio/template/base/migrate-fs/minio-pvc.yaml
+++ b/addons/minio/template/base/migrate-fs/minio-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pv-claim
+  namespace: ${MINIO_NAMESPACE}
+spec:
+  volumeName: ${MINIO_NEW_VOLUME_NAME}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${MINIO_CLAIM_SIZE}

--- a/addons/minio/template/base/migrate-fs/pvc/deployment.yaml
+++ b/addons/minio/template/base/migrate-fs/pvc/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-migrate-fs-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-migrate-fs-backend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-migrate-fs-backend
+    spec:
+      containers:
+      - name: minio
+        volumeMounts:
+        - name: data 
+          mountPath: "/data"
+        image: minio/minio:__MINIO_VERSION__
+        args:
+        - --quiet
+        - server
+        - /data
+        env:
+        - name: MINIO_UPDATE
+          value: "off"
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: MINIO_SECRET_KEY
+        ports:
+        - containerPort: 9000
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 5
+          periodSeconds: 20
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-migrate-fs-backend-pv-claim

--- a/addons/minio/template/base/migrate-fs/pvc/kustomization.yaml
+++ b/addons/minio/template/base/migrate-fs/pvc/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: ${MINIO_NAMESPACE}
+resources:
+- pvc.yaml
+- deployment.yaml
+- service.yaml

--- a/addons/minio/template/base/migrate-fs/pvc/pvc.yaml
+++ b/addons/minio/template/base/migrate-fs/pvc/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-migrate-fs-backend-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${MINIO_CLAIM_SIZE}

--- a/addons/minio/template/base/migrate-fs/pvc/service.yaml
+++ b/addons/minio/template/base/migrate-fs/pvc/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-migrate-fs-backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio-migrate-fs-backend

--- a/addons/minio/template/generate.sh
+++ b/addons/minio/template/generate.sh
@@ -21,6 +21,8 @@ function generate() {
 
     sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/Manifest"
     sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/deployment.yaml"
+    sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/migrate-fs/pvc/deployment.yaml"
+    sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/migrate-fs/hostpath/deployment.yaml"
     sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/install.sh"
     sed -i "s/__MINIO_VERSION__/$VERSION/g" "$dir/tmpl-ha-statefulset.yaml"
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -104,7 +104,8 @@ EOF
 
     echo "Waiting up to 2 minutes for sync-object-store pod to start in ${namespace} namespace"
     if ! spinner_until 120 kubernetes_pod_started sync-object-store "$namespace" ; then
-        bail "sync-object-store pod failed to start within 2 minutes"
+        printf "${RED}Failed to start object store migration pod within 2 minutes${NC}\n"
+        return 1
     fi
 
     echo "Waiting up to 30 minutes for sync-object-store pod to complete"
@@ -114,7 +115,7 @@ EOF
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         printf "\n${GREEN}Object store data synced successfully${NC}\n"
         kubectl delete pod sync-object-store -n "$namespace" --force --grace-period=0 &> /dev/null
-	return 0
+        return 0
     fi
 
     return 1

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -68,7 +68,7 @@ function object_store_bucket_exists() {
 
 # migrate_object_store creates a pod that migrates data between two different object stores. receives
 # the namespace, the source and destination addresses, access keys and secret keys. returns once the
-# pos has been finished or a timeout of 5 minutes has been reached.
+# pos has been finished or a timeout of 30 minutes has been reached.
 function migrate_object_store() {
     local namespace=$1
     local source_addr=$2

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -114,9 +114,10 @@ EOF
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         printf "\n${GREEN}Object store data synced successfully${NC}\n"
         kubectl delete pod sync-object-store -n "$namespace" --force --grace-period=0 &> /dev/null
-    else
-        bail "sync-object-store pod failed"
+	return 0
     fi
+
+    return 1
 }
 
 function migrate_rgw_to_minio() {


### PR DESCRIPTION
#### What this PR does / why we need it:

fs back store has been deprecates. there is no official migration path other than copying the data over from one storage running with the fs format.

this commits enables this migration. the installer now creates a new minio deployment and copies the data from the old one. at the end the volumes backing the minio deployments are swapped.

#### Which issue(s) this PR fixes:
Fixes #61286