### PR TITLE
doc: add addon content from the website into the CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,61 +251,7 @@ see the source repository at [replicatedhq/kurl.sh](https://github.com/replicate
 
 ## Contributing an Add-On
 
-### Structure
-
-New add-ons should be added to a source directory following the format `/addons/<name>/<version>`.
-That directory must have at least two files: `install.sh` and `Manifest`.
-
-The Manifest file specifies a list of images required for the add-on.
-These will be pulled during CI and saved to the directory `/addons/<name>/<version>/images/`.
-
-The `install.sh` script must define a function named `<add-on>` that will perform the install.
-For example, `/addons/weave/2.5.2/install.sh` defines the function named `weave`.
-
-Most add-ons include yaml files that will be applied to the cluster.
-These should be copied to the directory `kustomize/<name>` and applied with `kubectl apply -k` rather than applied directly with `kubectl apply -f`.
-This will allow users to easily review all applied yaml, add their own patches and re-apply after the script completes.
-
-All files and directories in the add-on's source directory will be included in the package built for the add-on.
-The package will be built and uploaded to `s3://kurl-sh/dist/<name>-<version>.tar.gz` during CI.
-It can be downloaded directly from S3 or by redirect from `https://kurl.sh/dist/<name>-<version>.tar.gz`.
-The built package will include the images from the Manifest saved as tar archives.
-
-The `install.sh` script may also define the functions `<name>_pre_init` and `<name>_join`.
-The pre_init function will be called prior to initializing the Kubernetes cluster.
-This may be used to modify the configuration that will be passed to `kubeadm init`.
-The join function will be called on remote nodes before they join the cluster and is useful for host configuration tasks such as loading a kernel module.
-
-### Runtime
-
-For online installs, the add-on package will be downloaded and extracted at runtime.
-For airgap installs, the add-on package will already be included in the installer bundle.
-
-The [add-on](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh) function in kURL will first load all images from the add-on's `images/` directory and create the directory `<KURL_ROOT>/kustomize/<add-on>`.
-It will then dynamically source the `install.sh` script and execute the function named `<add-on>`.
-
-### Developing Add-ons
-
-The `DIR` env var will be defined to the install root.
-Any yaml that is ready to be applied unmodified should be copied from the add-on directory to the kustomize directory.
-```
-cp "$DIR/addons/weave/2.5.2/kustomization.yaml" "$DIR/kustomize/weave/kustomization.yaml"
-```
-
-The [`insert_resources`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L29) function can be used to add an item to the resources object of a kustomization.yaml:
-```
-insert_resources "$DIR/kustomize/weave/kustomization.yaml" secret.yaml
-```
-
-The [`insert_patches_strategic_merge`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L18) function can be used to add an item to the `patchesStrategicMerge` object of a kustomization.yaml:
-```
-insert_patches_strategic_merge "$DIR/kustomize/weave/kustomization.yaml" ip-alloc-range.yaml
-```
-
-The [`render_yaml_file`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L14) function can be used to substitute env vars in a yaml file at runtime:
-```
-render_yaml_file "$DIR/addons/weave/2.5.2/tmpl-secret.yaml" > "$DIR/kustomize/weave/secret.yaml"
-```
+See the [addons README](./addons/README.md) for further information. 
 
 ## FAQ
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,9 +246,66 @@ You might want try to use [UTM](https://mac.getutm.app/).
 
 ## Documentation
 
-
 For contributions to the kURL documentation published at https://kurl.sh/docs/introduction/,
 see the source repository at [replicatedhq/kurl.sh](https://github.com/replicatedhq/kurl.sh).
+
+## Contributing an Add-On
+
+### Structure
+
+New add-ons should be added to a source directory following the format `/addons/<name>/<version>`.
+That directory must have at least two files: `install.sh` and `Manifest`.
+
+The Manifest file specifies a list of images required for the add-on.
+These will be pulled during CI and saved to the directory `/addons/<name>/<version>/images/`.
+
+The `install.sh` script must define a function named `<add-on>` that will perform the install.
+For example, `/addons/weave/2.5.2/install.sh` defines the function named `weave`.
+
+Most add-ons include yaml files that will be applied to the cluster.
+These should be copied to the directory `kustomize/<name>` and applied with `kubectl apply -k` rather than applied directly with `kubectl apply -f`.
+This will allow users to easily review all applied yaml, add their own patches and re-apply after the script completes.
+
+All files and directories in the add-on's source directory will be included in the package built for the add-on.
+The package will be built and uploaded to `s3://kurl-sh/dist/<name>-<version>.tar.gz` during CI.
+It can be downloaded directly from S3 or by redirect from `https://kurl.sh/dist/<name>-<version>.tar.gz`.
+The built package will include the images from the Manifest saved as tar archives.
+
+The `install.sh` script may also define the functions `<name>_pre_init` and `<name>_join`.
+The pre_init function will be called prior to initializing the Kubernetes cluster.
+This may be used to modify the configuration that will be passed to `kubeadm init`.
+The join function will be called on remote nodes before they join the cluster and is useful for host configuration tasks such as loading a kernel module.
+
+### Runtime
+
+For online installs, the add-on package will be downloaded and extracted at runtime.
+For airgap installs, the add-on package will already be included in the installer bundle.
+
+The [add-on](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh) function in kURL will first load all images from the add-on's `images/` directory and create the directory `<KURL_ROOT>/kustomize/<add-on>`.
+It will then dynamically source the `install.sh` script and execute the function named `<add-on>`.
+
+### Developing Add-ons
+
+The `DIR` env var will be defined to the install root.
+Any yaml that is ready to be applied unmodified should be copied from the add-on directory to the kustomize directory.
+```
+cp "$DIR/addons/weave/2.5.2/kustomization.yaml" "$DIR/kustomize/weave/kustomization.yaml"
+```
+
+The [`insert_resources`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L29) function can be used to add an item to the resources object of a kustomization.yaml:
+```
+insert_resources "$DIR/kustomize/weave/kustomization.yaml" secret.yaml
+```
+
+The [`insert_patches_strategic_merge`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L18) function can be used to add an item to the `patchesStrategicMerge` object of a kustomization.yaml:
+```
+insert_patches_strategic_merge "$DIR/kustomize/weave/kustomization.yaml" ip-alloc-range.yaml
+```
+
+The [`render_yaml_file`](https://github.com/replicatedhq/kurl/blob/5e6c9549ad6410df1f385444b83eabaf42a7e244/scripts/common/yaml.sh#L14) function can be used to substitute env vars in a yaml file at runtime:
+```
+render_yaml_file "$DIR/addons/weave/2.5.2/tmpl-secret.yaml" > "$DIR/kustomize/weave/secret.yaml"
+```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Use of MinIO is governed by the GNU AGPLv3 license that can be found in their [L
 One optional add-on available for Metrics & Monitoring is Prometheus via the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), which includes Grafana.
 Use of Grafana is currently governed by the GNU AGPL v3 license that can be found in their [License](https://github.com/grafana/grafana/blob/main/LICENSE) file.
 
+## Contributing
+
+Contributions are greatly appreciated. See [CONTRIBUTING.md](CONTRIBUTING.md) or more details. 
+Before starting any work, please either comment on an existing issue, or file a new one.
+
 ## Releases
 
 For details on each release, see the [changelog](https://github.com/replicatedhq/kURL/releases).

--- a/addons/README.md
+++ b/addons/README.md
@@ -2,21 +2,44 @@
 
 ## Structure
 
-Each available add-on has a directory with subdirectories (<addon>/<version>) for each available version of the add-on.
-Each add-on is require to define at a minimum two files, `install.sh` and `Manifest`.
+Each available add-on has a directory with subdirectories for each available version of the add-on following the format `/addons/<name>/<version>`.
+Each add-on is required to define at a minimum two files, `install.sh` and `Manifest`.
 
 The Manifest file specifies a list of assets required by the add-on.
 These will be downloaded during CI and saved to the add-on [directory](/ARCHITECTURE.md#directory-structure).
+The built add-on package will include the assets, including images, from the Manifest, saved as tar archives.
 
 The install.sh script can implement a set of [Lifecycle Hooks](#lifecycle-hooks).
+The `install.sh` script must define a function named `<add-on>` that will perform the install.
+For example, `/addons/weave/2.5.2/install.sh` defines the function named `weave`.
 
-Any [other files](/ARCHITECTURE.md#directory-structure) in the <addon>/<version> subdirectory will be included in the package built for the add-on.
-The package will be built and uploaded to s3://[bucket]/[(dist\|staging)]/[kURL version]/<addon>-<version>.tar.gz during CI.
+Any [other files](/ARCHITECTURE.md#directory-structure) in the `<addon>/<version>` subdirectory will be included in the package built for the add-on.
+The package will be built and uploaded to `s3://[bucket]/[(dist\|staging)]/[kURL version]/<addon>-<version>.tar.gz` during CI.
+It can be downloaded directly from S3 or by redirect from `https://kurl.sh/dist/<name>-<version>.tar.gz`.
+The built package will include the images from the Manifest saved as tar archives.
+
+Most add-ons include yaml files that will be applied to the cluster.
+These should be copied to the directory `kustomize/<name>` and applied with `kubectl apply -k` rather than applied directly with `kubectl apply -f`.
+This will allow users to easily review all applied yaml, add their own patches and re-apply after the script completes.
+
+The `install.sh` script may also define the functions `<name>_pre_init` and `<name>_join`.
+The pre_init function will be called prior to initializing the Kubernetes cluster.
+This may be used to modify the configuration that will be passed to `kubeadm init`.
+The join function will be called on remote nodes before they join the cluster and is useful for host configuration tasks such as loading a kernel module.
 
 ## Runtime
 
-During installation, upgrades and joining additional nodes, the installer will invoke a set of add-on lifecycle hooks.
+During installation, upgrades and joining additional nodes, the installer will first load all assets and container images from the add-on's directory and create the directory `$DIR/kustomize/<add-on>` for rendered add-on scripts.
+It will then source the `<add-on>/install.sh` script and execute a set of add-on [lifecycle hooks](#lifecycle-hooks).
+
+Functions relating to the add-on runtime can be found [here](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh).
 See the [flow charts](/ARCHITECTURE.md#flow-chart) in ARCHITECTURE.md for more details.
+
+For online installs, the add-on package will be downloaded and extracted at runtime.
+For airgap installs, the add-on package will already be included in the installer bundle.
+
+The [add-on](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh) function in kURL will first load all images from the add-on's `images/` directory and create the directory `<KURL_ROOT>/kustomize/<add-on>`.
+It will then dynamically source the `install.sh` script and execute the function named `<add-on>`.
 
 ### Lifecycle Hooks
 

--- a/addons/README.md
+++ b/addons/README.md
@@ -9,23 +9,14 @@ The Manifest file specifies a list of assets required by the add-on.
 These will be downloaded during CI and saved to the add-on [directory](/ARCHITECTURE.md#directory-structure).
 The built add-on package will include the assets, including images, from the Manifest, saved as tar archives.
 
-The install.sh script can implement a set of [Lifecycle Hooks](#lifecycle-hooks).
-The `install.sh` script must define a function named `<add-on>` that will perform the install.
-For example, `/addons/weave/2.5.2/install.sh` defines the function named `weave`.
-
 Any [other files](/ARCHITECTURE.md#directory-structure) in the `<addon>/<version>` subdirectory will be included in the package built for the add-on.
 The package will be built and uploaded to `s3://[bucket]/[(dist\|staging)]/[kURL version]/<addon>-<version>.tar.gz` during CI.
 It can be downloaded directly from S3 or by redirect from `https://kurl.sh/dist/<name>-<version>.tar.gz`.
 The built package will include the images from the Manifest saved as tar archives.
 
-Most add-ons include yaml files that will be applied to the cluster.
-These should be copied to the directory `kustomize/<name>` and applied with `kubectl apply -k` rather than applied directly with `kubectl apply -f`.
-This will allow users to easily review all applied yaml, add their own patches and re-apply after the script completes.
-
-The `install.sh` script may also define the functions `<name>_pre_init` and `<name>_join`.
-The pre_init function will be called prior to initializing the Kubernetes cluster.
-This may be used to modify the configuration that will be passed to `kubeadm init`.
-The join function will be called on remote nodes before they join the cluster and is useful for host configuration tasks such as loading a kernel module.
+The install.sh script can implement a set of [Lifecycle Hooks](#lifecycle-hooks).
+The `install.sh` script must define a function named `<add-on>` that will perform the install.
+For example, `/addons/weave/2.5.2/install.sh` defines the function named `weave`.
 
 ## Runtime
 
@@ -35,11 +26,11 @@ It will then source the `<add-on>/install.sh` script and execute a set of add-on
 Functions relating to the add-on runtime can be found [here](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh).
 See the [flow charts](/ARCHITECTURE.md#flow-chart) in ARCHITECTURE.md for more details.
 
-For online installs, the add-on package will be downloaded and extracted at runtime.
-For airgap installs, the add-on package will already be included in the installer bundle.
-
 The [add-on](https://github.com/replicatedhq/kurl/blob/master/scripts/common/addon.sh) function in kURL will first load all images from the add-on's `images/` directory and create the directory `<KURL_ROOT>/kustomize/<add-on>`.
 It will then dynamically source the `install.sh` script and execute the function named `<add-on>`.
+
+- For online installs, the add-on package will be downloaded and extracted at runtime.
+- For airgap installs, the add-on package will already be included in the installer bundle.
 
 ### Lifecycle Hooks
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Track the info from https://kurl.sh/docs/add-on-author/ into the repo so that we can remove the page in the website since in the long run kURL is unlike be looking to receive new external addons contributions.

Allow us get merged: https://github.com/replicatedhq/kurl.sh/pull/887

#### Which issue(s) this PR fixes:
[60599]

#### Special notes for your reviewer:
NONE

## Steps to reproduce
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
