### PR TITLE
Normalize rook version for comparison

### DIFF
--- a/pkg/rook/upgrade.go
+++ b/pkg/rook/upgrade.go
@@ -12,6 +12,7 @@ import (
 
 // WaitForRookOrCephVersion waits for all deployments to report that they are using the specified rook (or ceph) version (depending on provided label key)
 func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, desiredVersion string, labelKey string, name string) error {
+	desiredVersion = normalizeRookVersion(desiredVersion)
 	out(fmt.Sprintf("Waiting for all Rook-Ceph deployments to be using %s %s", name, desiredVersion))
 	errCount := 0
 	for {
@@ -27,7 +28,7 @@ func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, 
 			oldVersions := map[string][]string{}
 			// compare labels with desired version
 			for _, dep := range deployments.Items {
-				rookVer := dep.Labels[labelKey]
+				rookVer := normalizeRookVersion(dep.Labels[labelKey])
 				if rookVer != desiredVersion {
 					_, ok := oldVersions[rookVer]
 					if !ok {
@@ -57,4 +58,9 @@ func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, 
 			return fmt.Errorf("timed out waiting for %s %s to roll out", name, desiredVersion)
 		}
 	}
+}
+
+// normalizeRookVersion trims the "v" prefix from a rook version.
+func normalizeRookVersion(v string) string {
+	return strings.TrimPrefix(v, "v")
 }

--- a/pkg/rook/upgrade_test.go
+++ b/pkg/rook/upgrade_test.go
@@ -1,0 +1,38 @@
+package rook
+
+import (
+	"testing"
+)
+
+func Test_normalizeRookVersion(t *testing.T) {
+	type args struct {
+		v string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "v1.4.6",
+			args: args{
+				v: "v1.4.6",
+			},
+			want: "1.4.6",
+		},
+		{
+			name: "1.4.6",
+			args: args{
+				v: "1.4.6",
+			},
+			want: "1.4.6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeRookVersion(tt.args.v); got != tt.want {
+				t.Errorf("normalizeRookVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Upgrading rook times out waiting for rook. The version is missing the "v" in the argument but relies on it in the conditional.

```
Waiting for all Rook-Ceph deployments to be using Rook 1.10.6
...
deployments rook-ceph-crashcollector-ethanm-rook-31, rook-ceph-crashcollector-ethanm-rook-32, rook-ceph-crashcollector-ethanm-rook-33, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-mgr-b, rook-ceph-mon-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-0, rook-ceph-osd-1, rook-ceph-osd-2, rook-ceph-rgw-rook-ceph-store-a still running v1.10.6
...
Error: failed to wait for Rook "1.10.6": timed out waiting for Rook 1.10.6 to roll out
Detected multiple Rook versions
name=rook-ceph-crashcollector-ethanm-rook-31, rook-version=v1.10.6
name=rook-ceph-crashcollector-ethanm-rook-32, rook-version=v1.10.6
name=rook-ceph-crashcollector-ethanm-rook-33, rook-version=v1.10.6
name=rook-ceph-mds-rook-shared-fs-a, rook-version=v1.10.6
name=rook-ceph-mds-rook-shared-fs-b, rook-version=v1.10.6
name=rook-ceph-mgr-a, rook-version=v1.10.6
name=rook-ceph-mgr-b, rook-version=v1.10.6
name=rook-ceph-mon-a, rook-version=v1.10.6
name=rook-ceph-mon-b, rook-version=v1.10.6
name=rook-ceph-mon-c, rook-version=v1.10.6
name=rook-ceph-osd-0, rook-version=v1.10.6
name=rook-ceph-osd-1, rook-version=v1.10.6
name=rook-ceph-osd-2, rook-version=v1.10.6
name=rook-ceph-rgw-rook-ceph-store-a, rook-version=v1.10.6
Awaiting Ceph healthy
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes rook upgrades to unnecessarily pause with the message "failed to wait for Rook" for an extended period of time before proceeding with the upgrade.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE