### PR TITLE
Change polling interval for new rook and ceph versions from 1 second to 10 seconds

### DIFF
--- a/pkg/rook/upgrade.go
+++ b/pkg/rook/upgrade.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	waitForRookOrCephVersionLoopSleep = 10 * time.Second
+)
+
 // WaitForRookOrCephVersion waits for all deployments to report that they are using the specified rook (or ceph) version (depending on provided label key)
 func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, desiredVersion string, labelKey string, name string) error {
 	out(fmt.Sprintf("Waiting for all Rook-Ceph deployments to be using %s %s", name, desiredVersion))
@@ -52,7 +56,7 @@ func WaitForRookOrCephVersion(ctx context.Context, client kubernetes.Interface, 
 		}
 
 		select {
-		case <-time.After(loopSleep):
+		case <-time.After(waitForRookOrCephVersionLoopSleep):
 		case <-ctx.Done():
 			return fmt.Errorf("timed out waiting for %s %s to roll out", name, desiredVersion)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Upgrading rook I see the message "deployments ... still running" 166 times filling up my terminal.

```
Waiting for all Rook-Ceph deployments to be using Rook 1.10.6
...
deployments rook-ceph-crashcollector-ethanm-rook-31, rook-ceph-crashcollector-ethanm-rook-32, rook-ceph-crashcollector-ethanm-rook-33, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-mgr-b, rook-ceph-mon-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-0, rook-ceph-osd-1, rook-ceph-osd-2, rook-ceph-rgw-rook-ceph-store-a still running v1.10.6
...
```