### PR TITLE
Rook add-on scales down ekco operator without scaling it back up

### DIFF
--- a/addons/ekco/0.25.0/deployment.yaml
+++ b/addons/ekco/0.25.0/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: ekc-operator
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: ekc-operator

--- a/addons/ekco/template/base/deployment.yaml
+++ b/addons/ekco/template/base/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: ekc-operator
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: ekc-operator

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -55,6 +55,7 @@ function rook() {
     # Disable EKCO updates
     # Disallow the EKCO operator from updating Rook custom resources during a Rook upgrade
     rook_disable_ekco_operator
+    ROOK_DID_DISABLE_EKCO_OPERATOR=1
 
     rook_operator_crds_deploy
     rook_operator_deploy
@@ -90,8 +91,12 @@ function rook() {
     if ! spinner_until 120 rook_rgw_is_healthy ; then
         bail "Failed to detect healthy rook-ceph object store"
     fi
+}
 
-    rook_enable_ekco_operator
+function rook_post_init() {
+    if [ "$ROOK_DID_DISABLE_EKCO_OPERATOR" = "1" ]; then
+        rook_enable_ekco_operator
+    fi
 }
 
 function rook_join() {

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -54,8 +54,7 @@ function rook() {
 
     # Disable EKCO updates
     # Disallow the EKCO operator from updating Rook custom resources during a Rook upgrade
-    # EKCO will be enabled (i.e. deployment scaled up) again when the EKCO add-on is applied
-    disable_ekco_operator
+    rook_disable_ekco_operator
 
     rook_operator_crds_deploy
     rook_operator_deploy
@@ -91,6 +90,8 @@ function rook() {
     if ! spinner_until 120 rook_rgw_is_healthy ; then
         bail "Failed to detect healthy rook-ceph object store"
     fi
+
+    rook_enable_ekco_operator
 }
 
 function rook_join() {
@@ -473,12 +474,19 @@ function rook_should_skip_rook_install() {
     return 1
 }
 
-function disable_ekco_operator() {
-    echo "Rook-preinit: Scaling down EKCO deployment to 0 replicas"
-    if kubernetes_resource_exists kurl deployment ekc-operator; then
-        kubernetes_scale_down "kurl" "deployment" "ekc-operator"
+function rook_disable_ekco_operator() {
+    if kubernetes_resource_exists kurl deployment ekc-operator ; then
+        echo "Scaling down EKCO deployment to 0 replicas"
+        kubernetes_scale_down kurl deployment ekc-operator
         echo "Waiting for ekco pods to be removed"
         spinner_until 120 ekco_pods_gone
+    fi
+}
+
+function rook_enable_ekco_operator() {
+    if kubernetes_resource_exists kurl deployment ekc-operator ; then
+        echo "Scaling up EKCO deployment to 1 replica"
+        kubernetes_scale kurl deployment ekc-operator 1
     fi
 }
 

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -65,6 +65,7 @@ function rook() {
     # Disable EKCO updates
     # Disallow the EKCO operator from updating Rook custom resources during a Rook upgrade
     rook_disable_ekco_operator
+    ROOK_DID_DISABLE_EKCO_OPERATOR=1
 
     rook_operator_crds_deploy
     rook_operator_deploy
@@ -100,8 +101,12 @@ function rook() {
     if ! spinner_until 120 rook_rgw_is_healthy ; then
         bail "Failed to detect healthy rook-ceph object store"
     fi
+}
 
-    rook_enable_ekco_operator
+function rook_post_init() {
+    if [ "$ROOK_DID_DISABLE_EKCO_OPERATOR" = "1" ]; then
+        rook_enable_ekco_operator
+    fi
 }
 
 function rook_join() {

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -64,8 +64,7 @@ function rook() {
 
     # Disable EKCO updates
     # Disallow the EKCO operator from updating Rook custom resources during a Rook upgrade
-    # EKCO will be enabled (i.e. deployment scaled up) again when the EKCO add-on is applied
-    disable_ekco_operator
+    rook_disable_ekco_operator
 
     rook_operator_crds_deploy
     rook_operator_deploy
@@ -101,6 +100,8 @@ function rook() {
     if ! spinner_until 120 rook_rgw_is_healthy ; then
         bail "Failed to detect healthy rook-ceph object store"
     fi
+
+    rook_enable_ekco_operator
 }
 
 function rook_join() {
@@ -478,12 +479,19 @@ function rook_should_skip_rook_install() {
     return 1
 }
 
-function disable_ekco_operator() {
-    echo "Rook-preinit: Scaling down EKCO deployment to 0 replicas"
-    if kubernetes_resource_exists kurl deployment ekc-operator; then
-        kubernetes_scale_down "kurl" "deployment" "ekc-operator"
+function rook_disable_ekco_operator() {
+    if kubernetes_resource_exists kurl deployment ekc-operator ; then
+        echo "Scaling down EKCO deployment to 0 replicas"
+        kubernetes_scale_down kurl deployment ekc-operator
         echo "Waiting for ekco pods to be removed"
         spinner_until 120 ekco_pods_gone
+    fi
+}
+
+function rook_enable_ekco_operator() {
+    if kubernetes_resource_exists kurl deployment ekc-operator ; then
+        echo "Scaling up EKCO deployment to 1 replica"
+        kubernetes_scale kurl deployment ekc-operator 1
     fi
 }
 

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -65,6 +65,7 @@ function rook() {
     # Disable EKCO updates
     # Disallow the EKCO operator from updating Rook custom resources during a Rook upgrade
     rook_disable_ekco_operator
+    ROOK_DID_DISABLE_EKCO_OPERATOR=1
 
     rook_operator_crds_deploy
     rook_operator_deploy
@@ -100,8 +101,12 @@ function rook() {
     if ! spinner_until 120 rook_rgw_is_healthy ; then
         bail "Failed to detect healthy rook-ceph object store"
     fi
+}
 
-    rook_enable_ekco_operator
+function rook_post_init() {
+    if [ "$ROOK_DID_DISABLE_EKCO_OPERATOR" = "1" ]; then
+        rook_enable_ekco_operator
+    fi
 }
 
 function rook_join() {

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -414,11 +414,20 @@ function kubernetes_scale_down() {
     local kind="$2"
     local name="$3"
 
+    kubernetes_scale "$ns" "$kind" "$name" "0"
+}
+
+function kubernetes_scale() {
+    local ns="$1"
+    local kind="$2"
+    local name="$3"
+    local replicas="$4"
+
     if ! kubernetes_resource_exists "$ns" "$kind" "$name"; then
         return 0
     fi
 
-    kubectl -n "$ns" scale "$kind" "$name" --replicas=0
+    kubectl -n "$ns" scale "$kind" "$name" --replicas="$replicas"
 }
 
 function kubernetes_secret_value() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Rook versions 1.8.10 and 1.9.12 scale ekc-operator deployment to 0 replicas without scaling it back up.

```
⚙  Addon rook 1.10.6
Rook-preinit: Scaling down EKCO deployment to 0 replicas
deployment.apps/ekc-operator scaled
...
To add MASTER nodes to this installation, run the following script on your other nodes:
    curl -fsSL https://staging.kurl.sh/version/v2022.11.16-1-dirty/f0c40c2/join.sh | sudo bash -s kubernetes-master-address=localhost:6444 kubeadm-token=30lvwy.x1rl8x9eid2w5274 kubeadm-token-ca-hash=sha256:0a973c82e084b4c9300aaa6350f0e61689e09bb6087c36d58da0013201d83c9f kubernetes-version=1.25.4 cert-key=1c769cd21d62a444ebc9c591184fd11900b6d53453fb0f91ad25fa1267ccc3ee control-plane docker-registry-ip=10.96.1.197 primary-host=10.128.15.199 primary-host=10.128.15.202 primary-host=10.128.15.200

$ kubectl -n kurl get deploy
NAME           READY   UP-TO-DATE   AVAILABLE   AGE
ekc-operator   0/0     0            0           6d3h
registry       2/2     2            2           6d3h
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that leaves the EKCO operator scaled down to 0 replicas when upgrading a cluster with Rook add-on versions 1.8.10 and 1.9.12.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE