### PR TITLE
fix: ensure that binaries installed in usr/local/bin are owned by root

### DIFF
--- a/scripts/common/plugins.sh
+++ b/scripts/common/plugins.sh
@@ -2,9 +2,9 @@ export KUBECTL_PLUGINS_PATH=/usr/local/bin
 
 function install_plugins() {
     pushd "$DIR/krew"
-    tar xzf outdated.tar.gz && mv outdated /usr/local/bin/kubectl-outdated
-    tar xzf preflight.tar.gz && mv preflight /usr/local/bin/kubectl-preflight
-    tar xzf support-bundle.tar.gz && mv support-bundle /usr/local/bin/kubectl-support_bundle
+    tar xzf outdated.tar.gz && chown root:root outdated && mv outdated /usr/local/bin/kubectl-outdated
+    tar xzf preflight.tar.gz && chown root:root preflight && mv preflight /usr/local/bin/kubectl-preflight
+    tar xzf support-bundle.tar.gz && chown root:root support-bundle && mv support-bundle /usr/local/bin/kubectl-support_bundle
     popd
 
     # uninstall system-wide krew from old versions of kurl


### PR DESCRIPTION
## What this PR does / why we need it:
Binaries installed in /usr/local/bin/ by the install script (curl https://kurl.sh/latest | sudo bash) end up owned by random users i.e anyone who gets 1001 UID. These users are not necessarily the ones who launch the script.

Security risk
If the assigned user account was to be compromised.

## Which issue(s) this PR fixes:
Fixes # [59811]

## Special notes for your reviewer:
## Steps to reproduce
- Install kURL release <= v2022.11.16-1
- check the binaries installed by kurl in /use/local/bin:

```
~$ ls -la /usr/local/bin/
total 192644
drwxr-xr-x  2 root          root        4096 Nov 28 18:56 .
drwxr-xr-x 10 root          root        4096 Nov 23 02:08 ..
-rwxr-xr-x  1 root          root         481 Nov 28 18:56 ekco-purge-node
-rwxr-xr-x  1 diamonwiggins _chrony 26529792 Apr  9  2021 kubectl-outdated
-rwxr-xr-x  1 diamonwiggins _chrony 57450496 Nov 22 04:24 kubectl-preflight
-rwxr-xr-x  1 diamonwiggins _chrony 57749504 Nov 22 04:32 kubectl-support_bundle
lrwxrwxrwx  1 root          root          31 Nov 28 18:53 kustomize -> /usr/local/bin/kustomize-v3.5.4
-rwxr-xr-x  1 root          root    19723712 Nov 28 18:53 kustomize-v2.0.3
-rwxr-xr-x  1 root          root    35799040 Jan 11  2020 kustomize-v3.5.4
```
Now, you can check with the changes of this PR

<img width="770" alt="Screenshot 2022-11-29 at 01 23 29" src="https://user-images.githubusercontent.com/7708031/204487960-98790bb8-0373-4fff-8239-92a5f692a607.png">


## Does this PR introduce a user-facing change?
Binaries installed by kURL into /use/local/bin now are owned by root to ensure security concerns. 

## Does this PR require documentation?
NONE