### PR TITLE
feat: add kurl command line for disk space check

### DIFF
--- a/pkg/cli/cluster_free_disk_space.go
+++ b/pkg/cli/cluster_free_disk_space.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	rookcli "github.com/rook/rook/pkg/client/clientset/versioned"
+
+	clusterspace "github.com/replicatedhq/kurl/pkg/cluster/space"
+)
+
+const (
+	// defaultOpenEBSPodImage is the image used during disk free check for openebs storage.
+	// this is the same image used by the pvmigrate project, it may be any image containing
+	// 'df' and 'cat' commands.
+	defaultOpenEBSPodImage          = "eeacms/rsync:2.3"
+	isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+	openEBSLocalProvisioner         = "openebs.io/local"
+	rookRBDProvisioner              = "rook-ceph.rbd.csi.ceph.com"
+	rookCephFSProvisioner           = "rook-ceph.cephfs.csi.ceph.com"
+)
+
+// NewClusterCheckFreeDiskSpaceCmd returns a command that is capable of reporting back the amount of free space in the cluster
+// for a provided storage class.
+func NewClusterCheckFreeDiskSpaceCmd(cli CLI) *cobra.Command {
+	var forStorageClass, openEBSImage, openEBSNode string
+	logbuf := bytes.NewBuffer(nil)
+	logger := log.New(logbuf, "", 0)
+	k8sConfig := config.GetConfigOrDie()
+	clientSet := kubernetes.NewForConfigOrDie(k8sConfig)
+	rookClientSet := rookcli.NewForConfigOrDie(k8sConfig)
+
+	cmd := &cobra.Command{
+		Use:          "check-free-disk-space",
+		Long:         fmt.Sprintf("Returns the amount of free disk space (in bytes) for a given storage class\nSupported storage provisioners: %s, %s, %s", openEBSLocalProvisioner, rookRBDProvisioner, rookCephFSProvisioner),
+		Example:      "kurl cluster check-free-disk-space --storageclass openebs --openebs-node-name node0 --openebs-image ubuntu:latest",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			classes, err := clientSet.StorageV1().StorageClasses().List(cmd.Context(), metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list cluster storage classes: %w", err)
+			}
+
+			var selectedClass *v1.StorageClass
+			for _, class := range classes.Items {
+				val, ok := class.Annotations[isDefaultStorageClassAnnotation]
+				if ok && val == "true" && forStorageClass == "" {
+					selectedClass = &class
+					logger.Printf("Selected default storage class %q", selectedClass.Name)
+					break
+				}
+
+				if class.Name == forStorageClass {
+					selectedClass = &class
+					logger.Printf("Selected storage class %q", selectedClass.Name)
+					break
+				}
+			}
+
+			if selectedClass == nil {
+				if forStorageClass == "" {
+					return fmt.Errorf("failed to find default storage class")
+				}
+				return fmt.Errorf("failed to find storage class %q", forStorageClass)
+			}
+
+			switch selectedClass.Provisioner {
+			case openEBSLocalProvisioner:
+				freeSpaceGetter, err := clusterspace.NewOpenEBSFreeDiskSpaceGetter(clientSet, logger, openEBSImage, selectedClass.Name)
+				if err != nil {
+					fmt.Print(logbuf.String())
+					return fmt.Errorf("failed to start openebs free space getter: %w", err)
+				}
+
+				volumes, err := freeSpaceGetter.OpenEBSVolumes(cmd.Context())
+				if err != nil {
+					fmt.Print(logbuf.String())
+					return fmt.Errorf("failed to get openebs free space: %w", err)
+				}
+
+				for node, volume := range volumes {
+					if openEBSNode == "" {
+						fmt.Printf("%d\t%s\n", volume.Free, node)
+						continue
+					}
+
+					if node != openEBSNode {
+						logger.Printf("Skipping node %q", node)
+						continue
+					}
+
+					fmt.Printf("%d\n", volume.Free)
+					return nil
+				}
+
+				if openEBSNode != "" {
+					fmt.Print(logbuf.String())
+					return fmt.Errorf("failed to collect openebs free space: node %q not found", openEBSNode)
+				}
+				return nil
+
+			case rookCephFSProvisioner, rookRBDProvisioner:
+				freeSpaceGetter, err := clusterspace.NewRookFreeDiskSpaceGetter(clientSet, rookClientSet, selectedClass.Name)
+				if err != nil {
+					return fmt.Errorf("failed to start rook free space getter: %w", err)
+				}
+
+				space, err := freeSpaceGetter.GetFreeSpace(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("failed to get rook free space: %w", err)
+				}
+
+				fmt.Println(space)
+				return nil
+
+			default:
+				return fmt.Errorf("provisioner %q is not supported", selectedClass.Provisioner)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&forStorageClass, "storageclass", "", "Inform the storage class name for which to check the free disk space. If not informed the default storage will be used.")
+	cmd.Flags().StringVar(&openEBSImage, "openebs-image", defaultOpenEBSPodImage, fmt.Sprintf("The image used by OpenEBS disk free evaluation pod. If not informed the default image used is %s", defaultOpenEBSPodImage))
+	cmd.Flags().StringVar(&openEBSNode, "openebs-node-name", "", "Show OpenEBS free disk space only for provided node.")
+	return cmd
+}

--- a/pkg/cli/cluster_free_disk_space.go
+++ b/pkg/cli/cluster_free_disk_space.go
@@ -2,24 +2,29 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"log"
+	"os/signal"
+	"syscall"
 
-	"github.com/spf13/cobra"
-	v1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"code.cloudfoundry.org/bytefmt"
 	rookcli "github.com/rook/rook/pkg/client/clientset/versioned"
+	"github.com/spf13/cobra"
 
 	clusterspace "github.com/replicatedhq/kurl/pkg/cluster/space"
 )
 
 const (
-	// defaultOpenEBSPodImage is the image used during disk free check for openebs storage.
-	// this is the same image used by the pvmigrate project, it may be any image containing
-	// 'df' and 'cat' commands.
+	// defaultOpenEBSPodImage is the image used during disk free check for openebs storage. this is the same image used by the
+	// pvmigrate project, it may be any image containing 'df' and 'cat' commands.
 	defaultOpenEBSPodImage          = "eeacms/rsync:2.3"
 	isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 	openEBSLocalProvisioner         = "openebs.io/local"
@@ -27,107 +32,192 @@ const (
 	rookCephFSProvisioner           = "rook-ceph.cephfs.csi.ceph.com"
 )
 
-// NewClusterCheckFreeDiskSpaceCmd returns a command that is capable of reporting back the amount of free space in the cluster
-// for a provided storage class.
+// getStorageClassByName returns a storage class by its name. if storageClassName is empty then this function returns the default storage
+// class for the cluster.
+func getStorageClassByName(ctx context.Context, kubeCli kubernetes.Interface, storageClassName string) (*storagev1.StorageClass, error) {
+	classes, err := kubeCli.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster storage classes: %w", err)
+	}
+
+	for _, class := range classes.Items {
+		val, ok := class.Annotations[isDefaultStorageClassAnnotation]
+		if ok && val == "true" && storageClassName == "" {
+			return &class, nil
+		}
+
+		if class.Name == storageClassName {
+			return &class, nil
+		}
+	}
+
+	if storageClassName == "" {
+		return nil, fmt.Errorf("failed to find the default storage class")
+	}
+	return nil, fmt.Errorf("failed to find storage class %q", storageClassName)
+}
+
+// hasEnoughSpace compares if free space is bigger than the requested space. returns a user friendly string representing the output
+// and a bool indicating if there is or not enough room. this function is an auxiliar function so we don't need to keep concatenating
+// the output strings in the evaluateOpenEBSFreeSpace function.
+func hasEnoughSpace(node string, free, requested int64) (string, bool) {
+	requestedString := bytefmt.ByteSize(uint64(requested))
+	freeString := bytefmt.ByteSize(uint64(free))
+	if free >= requested {
+		message := fmt.Sprintf("Node %s has %s available", node, freeString)
+		if requested > 0 {
+			message = fmt.Sprintf("%s (requested %s)", message, requestedString)
+		}
+		return message, true
+	}
+	return fmt.Sprintf("Not enough space on node %s (requested %s, available %s)", node, requestedString, freeString), false
+}
+
+// evaluateOpenEBSFreeSpace checks how much space is available in a storage class backed by openEBSLocalProvisioner. biggerThan is
+// used to check if there is enough room in one node (if onNode != "") or in all nodes (onNode == ""). onNode is the node name, image
+// is the image to be used by the openebs disk free checker pod while the biggerThan is expressed in bytes.
+func evaluateOpenEBSFreeSpace(ctx context.Context, kubeCli kubernetes.Interface, image, scname, onNode string, biggerThan int64) error {
+	logger := log.New(io.Discard, "", 0)
+	freeSpaceGetter, err := clusterspace.NewOpenEBSFreeDiskSpaceGetter(kubeCli, logger, image, scname)
+	if err != nil {
+		return fmt.Errorf("failed to start openebs free space getter: %w", err)
+	}
+
+	volumes, err := freeSpaceGetter.OpenEBSVolumes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get openebs free space: %w", err)
+	}
+
+	successOutput := bytes.NewBuffer(nil)
+	for node, volume := range volumes {
+		var msg string
+		var hasSpace bool
+		if node == onNode {
+			if msg, hasSpace = hasEnoughSpace(node, volume.Free, biggerThan); !hasSpace {
+				return fmt.Errorf(msg)
+			}
+			fmt.Println(msg)
+			return nil
+		}
+
+		if onNode == "" {
+			if msg, hasSpace = hasEnoughSpace(node, volume.Free, biggerThan); !hasSpace {
+				return fmt.Errorf(msg)
+			}
+			fmt.Fprintf(successOutput, "%s\n", msg)
+			continue
+		}
+	}
+
+	if onNode != "" {
+		return fmt.Errorf("failed to collect openebs free space: node %q not found", onNode)
+	}
+
+	fmt.Print(successOutput.String())
+	return nil
+}
+
+// evaluateOpenEBSFreeSpace checks how much space is available in a storage class backed by rookRBDProvisioner or rookCephFSProvisioner. biggerThan
+// is used to compare if there is enough room.
+func evaluateRookFreeSpace(ctx context.Context, kubeCli kubernetes.Interface, rookCli rookcli.Interface, scname string, requested int64) error {
+	freeSpaceGetter, err := clusterspace.NewRookFreeDiskSpaceGetter(kubeCli, rookCli, scname)
+	if err != nil {
+		return fmt.Errorf("failed to start rook free space getter: %w", err)
+	}
+
+	free, err := freeSpaceGetter.GetFreeSpace(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get rook free space: %w", err)
+	}
+
+	requestedString := bytefmt.ByteSize(uint64(requested))
+	freeString := bytefmt.ByteSize(uint64(free))
+	if free < requested {
+		return fmt.Errorf("not enough space on rook (requested %s, available %s)", requestedString, freeString)
+	}
+	fmt.Printf("Available disk space found in rook: %s\n", freeString)
+	return nil
+}
+
+// NewClusterCheckFreeDiskSpaceCmd returns a command that is capable of reporting back the amount of free space in the cluster for a provided storage class.
 func NewClusterCheckFreeDiskSpaceCmd(cli CLI) *cobra.Command {
-	var forStorageClass, openEBSImage, openEBSNode string
-	logbuf := bytes.NewBuffer(nil)
-	logger := log.New(logbuf, "", 0)
-	k8sConfig := config.GetConfigOrDie()
-	clientSet := kubernetes.NewForConfigOrDie(k8sConfig)
-	rookClientSet := rookcli.NewForConfigOrDie(k8sConfig)
+	var forStorageClass, openEBSImage, openEBSNode, biggerThanString string
+	var biggerThanBytes int64
+	var clientSet kubernetes.Interface
+	var rookClientSet rookcli.Interface
+	var selectedClass *storagev1.StorageClass
 
 	cmd := &cobra.Command{
 		Use:          "check-free-disk-space",
-		Long:         fmt.Sprintf("Returns the amount of free disk space (in bytes) for a given storage class\nSupported storage provisioners: %s, %s, %s", openEBSLocalProvisioner, rookRBDProvisioner, rookCephFSProvisioner),
-		Example:      "kurl cluster check-free-disk-space --storageclass openebs --openebs-node-name node0 --openebs-image ubuntu:latest",
+		Short:        "List and analyse the available disk space for a given Storage Class.",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			classes, err := clientSet.StorageV1().StorageClasses().List(cmd.Context(), metav1.ListOptions{})
+		Example: fmt.Sprintf(""+
+			"In the following examples 'openebs' is the name of a storage class backed by the %s storage provisioner while 'rook' is the name of a storage\n"+
+			"class backed by the %s or %s storage provisioners.\n\n"+
+			"# reports the available space in rook\n"+
+			"kurl cluster check-free-disk-space --storageclass rook\n\n"+
+			"# reports the available space in all nodes\n"+
+			"kurl cluster check-free-disk-space --storageclass openebs\n\n"+
+			"# checks if there is 10G available on node node0\n"+
+			"kurl cluster check-free-disk-space --storageclass openebs --openebs-node-name node0 --openebs-image ubuntu:latest --bigger-than 10G\n\n"+
+			"# checks if there is 10G available on all nodes in the cluster\n"+
+			"kurl cluster check-free-disk-space --storageclass openebs --bigger-than 10G\n"+
+			"# checks if there is 20G available in the cluster on the default storage class\n"+
+			"kurl cluster check-free-disk-space --bigger-than 20G\n",
+			openEBSLocalProvisioner, rookRBDProvisioner, rookCephFSProvisioner,
+		),
+		Long: fmt.Sprintf(""+
+			"This program returns the amount of free disk space (in bytes) for a given storage class or compares if there is enough space to hold a certain\n"+
+			"amount of data (--bigger-than). For OpenEBS, when no --bigger-than flag is provided, this program returns a list of nodes and their respective\n"+
+			"free space, while for Rook storage only the available space is returned. When --bigger-than flag is used this program sets the exit code to zero\n"+
+			"if the space available is bigger than the quantity provided. For OpenEBS, if no node has been provided through --openebs-node-name the exit code\n"+
+			"will be zero only if all nodes free space are bigger than the provided quantity (see Examples section for more details).\n\n"+
+			"Supports the following storage provisioners: %s, %s, %s",
+			openEBSLocalProvisioner, rookRBDProvisioner, rookCephFSProvisioner,
+		),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			k8sConfig := config.GetConfigOrDie()
+			clientSet = kubernetes.NewForConfigOrDie(k8sConfig)
+			rookClientSet = rookcli.NewForConfigOrDie(k8sConfig)
+
+			var err error
+			if selectedClass, err = getStorageClassByName(cmd.Context(), clientSet, forStorageClass); err != nil {
+				return err
+			}
+
+			if biggerThanString == "" {
+				return nil
+			}
+
+			parsed, err := resource.ParseQuantity(biggerThanString)
 			if err != nil {
-				return fmt.Errorf("failed to list cluster storage classes: %w", err)
+				return fmt.Errorf("failed to parse %s as a quantity: %w", biggerThanString, err)
 			}
+			biggerThanBytes = parsed.Value()
 
-			var selectedClass *v1.StorageClass
-			for _, class := range classes.Items {
-				val, ok := class.Annotations[isDefaultStorageClassAnnotation]
-				if ok && val == "true" && forStorageClass == "" {
-					selectedClass = &class
-					logger.Printf("Selected default storage class %q", selectedClass.Name)
-					break
-				}
-
-				if class.Name == forStorageClass {
-					selectedClass = &class
-					logger.Printf("Selected storage class %q", selectedClass.Name)
-					break
-				}
-			}
-
-			if selectedClass == nil {
-				if forStorageClass == "" {
-					return fmt.Errorf("failed to find default storage class")
-				}
-				return fmt.Errorf("failed to find storage class %q", forStorageClass)
-			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+			defer cancel()
 
 			switch selectedClass.Provisioner {
 			case openEBSLocalProvisioner:
-				freeSpaceGetter, err := clusterspace.NewOpenEBSFreeDiskSpaceGetter(clientSet, logger, openEBSImage, selectedClass.Name)
-				if err != nil {
-					fmt.Print(logbuf.String())
-					return fmt.Errorf("failed to start openebs free space getter: %w", err)
-				}
-
-				volumes, err := freeSpaceGetter.OpenEBSVolumes(cmd.Context())
-				if err != nil {
-					fmt.Print(logbuf.String())
-					return fmt.Errorf("failed to get openebs free space: %w", err)
-				}
-
-				for node, volume := range volumes {
-					if openEBSNode == "" {
-						fmt.Printf("%d\t%s\n", volume.Free, node)
-						continue
-					}
-
-					if node != openEBSNode {
-						logger.Printf("Skipping node %q", node)
-						continue
-					}
-
-					fmt.Printf("%d\n", volume.Free)
-					return nil
-				}
-
-				if openEBSNode != "" {
-					fmt.Print(logbuf.String())
-					return fmt.Errorf("failed to collect openebs free space: node %q not found", openEBSNode)
-				}
-				return nil
+				return evaluateOpenEBSFreeSpace(ctx, clientSet, openEBSImage, selectedClass.Name, openEBSNode, biggerThanBytes)
 
 			case rookCephFSProvisioner, rookRBDProvisioner:
-				freeSpaceGetter, err := clusterspace.NewRookFreeDiskSpaceGetter(clientSet, rookClientSet, selectedClass.Name)
-				if err != nil {
-					return fmt.Errorf("failed to start rook free space getter: %w", err)
-				}
-
-				space, err := freeSpaceGetter.GetFreeSpace(cmd.Context())
-				if err != nil {
-					return fmt.Errorf("failed to get rook free space: %w", err)
-				}
-
-				fmt.Println(space)
-				return nil
+				return evaluateRookFreeSpace(ctx, clientSet, rookClientSet, selectedClass.Name, biggerThanBytes)
 
 			default:
-				return fmt.Errorf("provisioner %q is not supported", selectedClass.Provisioner)
+				fmt.Printf("Provisioner %q is not supported, unable to determine free space.\n", selectedClass.Provisioner)
+				return nil
 			}
 		},
 	}
 
 	cmd.Flags().StringVar(&forStorageClass, "storageclass", "", "Inform the storage class name for which to check the free disk space. If not informed the default storage will be used.")
+	cmd.Flags().StringVar(&biggerThanString, "bigger-than", "", "Compares if the cluster free disk space is bigger than the provided value. Accepts the same format as used when defining storage requests in Kubernetes (e.g. 10G, 5Gi, 500M).")
 	cmd.Flags().StringVar(&openEBSImage, "openebs-image", defaultOpenEBSPodImage, fmt.Sprintf("The image used by OpenEBS disk free evaluation pod. If not informed the default image used is %s", defaultOpenEBSPodImage))
-	cmd.Flags().StringVar(&openEBSNode, "openebs-node-name", "", "Show OpenEBS free disk space only for provided node.")
+	cmd.Flags().StringVar(&openEBSNode, "openebs-node-name", "", "Evaluates OpenEBS free disk space only for the provided node name.")
 	return cmd
 }

--- a/pkg/cli/cluster_free_disk_space_test.go
+++ b/pkg/cli/cluster_free_disk_space_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_getStorageClassByName(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		scname string
+		objs   []runtime.Object
+		err    string
+		exp    runtime.Object
+	}{
+		{
+			name: "returns error if default storage class was not found",
+			err:  "failed to find the default storage class",
+		},
+		{
+			name:   "returns error if provided storage class was not found",
+			scname: "does-not-exist",
+			err:    "failed to find storage class",
+		},
+		{
+			name: "returns the default storage class if no name has been provided",
+			err:  "",
+			objs: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "this-is-not-the-default",
+						Annotations: map[string]string{
+							isDefaultStorageClassAnnotation: "false",
+						},
+					},
+				},
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "this-is-the-default",
+						Annotations: map[string]string{
+							isDefaultStorageClassAnnotation: "true",
+						},
+					},
+				},
+			},
+			exp: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "this-is-the-default",
+					Annotations: map[string]string{
+						isDefaultStorageClassAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name:   "returns the class by its name",
+			err:    "",
+			scname: "the-expected-class",
+			objs: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "this-is-not-the-default",
+						Annotations: map[string]string{
+							isDefaultStorageClassAnnotation: "false",
+						},
+					},
+				},
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "this-is-the-default",
+						Annotations: map[string]string{
+							isDefaultStorageClassAnnotation: "true",
+						},
+					},
+				},
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "the-expected-class",
+					},
+				},
+			},
+			exp: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-expected-class",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.objs...)
+			sc, err := getStorageClassByName(context.Background(), cli, tt.scname)
+			if err != nil {
+				if len(tt.err) == 0 {
+					t.Errorf("unexpected error: %s", err)
+				} else if !strings.Contains(err.Error(), tt.err) {
+					t.Errorf("expecting %q, %q received instead", tt.err, err)
+				}
+				return
+			}
+
+			if len(tt.err) > 0 {
+				t.Errorf("expecting error %q, nil received instead", tt.err)
+			}
+
+			if diff := cmp.Diff(tt.exp, sc); diff != "" {
+				t.Errorf("unexpected return: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_hasEnoughSpace(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		nodeName   string
+		free       int64
+		biggerThan int64
+		msg        string
+		exp        bool
+	}{
+		{
+			name:       "returns true if it has space",
+			nodeName:   "node0",
+			free:       1000,
+			biggerThan: 999,
+			msg:        "Node node0 has 1000B available",
+			exp:        true,
+		},
+		{
+			name:       "returns false if it has no space",
+			nodeName:   "node1",
+			free:       999,
+			biggerThan: 1000,
+			msg:        "Not enough space on node node1 (requested 1000B, available 999B)",
+			exp:        false,
+		},
+		{
+			name:       "returns true if it free space is equal to requested space",
+			nodeName:   "node2",
+			free:       1000,
+			biggerThan: 1000,
+			msg:        "Node node2 has 1000B available",
+			exp:        true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out, ok := hasEnoughSpace(tt.nodeName, tt.free, tt.biggerThan)
+			if ok != tt.exp {
+				t.Errorf("expected %v, received %v", tt.exp, ok)
+			}
+			fmt.Println(out)
+			if !strings.Contains(out, tt.msg) {
+				t.Errorf("expecting %s, %s received instead", tt.msg, out)
+			}
+
+		})
+	}
+}

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -21,6 +21,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 
 	clusterCmd := NewClusterCmd(cli)
 	clusterCmd.AddCommand(NewClusterNodesMissingImageCmd(cli))
+	clusterCmd.AddCommand(NewClusterCheckFreeDiskSpaceCmd(cli))
 	cmd.AddCommand(clusterCmd)
 
 	cmd.AddCommand(NewSyncObjectStoreCmd(cli))


### PR DESCRIPTION
#### What this PR does / why we need it:

this commits adds a new kurl command to check the amount of available space, by storage class, in the cluster.

usage example:
```
kurl cluster free-disk-space [--storageclass openebs] [--openebs-node node] [--openebs-image eeacms/rsync:2.3]
```

output examples:

```
$ kubectl get storageclasses
NAME                PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
default (default)   rook-ceph.rbd.csi.ceph.com      Delete          Immediate              true                   69m
openebs             openebs.io/local                Delete          WaitForFirstConsumer   false                  64m
rook-cephfs         rook-ceph.cephfs.csi.ceph.com   Delete          Immediate              true                   69m

$ /tmp/kurl cluster free-disk-space --storageclass openebs
62421426176     ip-172-31-60-177
62894407680     ip-172-31-80-103

$ # if no --storageclass flag is provided it looks for the default one.
$ /tmp/kurl cluster free-disk-space
85880889344
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE