### PR TITLE
Laverya/sc 62952/cleanup staging kurl versions after some

### DIFF
--- a/bin/cleanup-staging-s3.sh
+++ b/bin/cleanup-staging-s3.sh
@@ -29,6 +29,6 @@ echo "cleaning up old PR files"
 # then filter it for objects with timestamps older than 31 days
 # and then delete those objects older than 31 days
 aws s3api list-objects --bucket "$S3_BUCKET" --prefix 'pr/' --query 'Contents[].{Key: Key, LastModified: LastModified}' | \
-    jq "map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo)) | .[].Key" | grep -v '"pr/"' \
+    jq "map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo)) | .[].Key" | grep -v '"pr/"' | \
     xargs -I {} echo "{}"
 #    xargs -I {} aws s3api delete-object --bucket "$S3_BUCKET" --key "{}"

--- a/bin/cleanup-staging-s3.sh
+++ b/bin/cleanup-staging-s3.sh
@@ -21,8 +21,7 @@ echo "cleaning up old staging releases"
 # and then delete those objects older than 31 days
 aws s3api list-objects --bucket "$S3_BUCKET" --prefix 'staging/v20' --query 'Contents[].{Key: Key, LastModified: LastModified}' | \
     jq "map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo)) | .[].Key" | \
-    xargs -I {} echo "{}"
-#    xargs -I {} aws s3api delete-object --bucket "$S3_BUCKET" --key "{}"
+    xargs -I {} aws s3api delete-object --bucket "$S3_BUCKET" --key "{}"
 
 echo "cleaning up old PR files"
 # get the objects inside the PR folder


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This deletes files older than 31 days from the staging kurl s3 bucket, dramatically reducing storage usage.

https://github.com/replicatedhq/kURL/actions/runs/3621742598/jobs/6105960377 shows what files will be deleted on the first run.

It also fixes the cleanup-pr file list, so that can be enabled next.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
