### PR TITLE
bug: missing kubectl during add-on pre init

### DIFF
--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -11,7 +11,7 @@ function minio_pre_init() {
 
     # verify if we need to migrate away from the deprecated 'fs' format.
     local minio_replicas
-    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null)
+    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null || true)
     if [ -n "$minio_replicas" ] && [ "$minio_replicas" != "0" ] && minio_uses_fs_format ; then
         printf "${YELLOW}\n"
         printf "The installer has detected that the cluster is running a version of minio backed by the now legacy FS format.\n"


### PR DESCRIPTION
#### What this PR does / why we need it:

When fresh installing the kubectl binary is not yet available during the add-on pre init execution. Avoid to fail there otherwise the install process can not move forward.