### PR TITLE
bug: missing minio deployment is an ok condition

### DIFF
--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -11,7 +11,7 @@ function minio_pre_init() {
 
     # verify if we need to migrate away from the deprecated 'fs' format.
     local minio_replicas
-    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null)
+    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null || true)
     if [ -n "$minio_replicas" ] && [ "$minio_replicas" != "0" ] && minio_uses_fs_format ; then
         printf "${YELLOW}\n"
         printf "The installer has detected that the cluster is running a version of minio backed by the now legacy FS format.\n"
@@ -523,7 +523,7 @@ function minio_restore_original_deployment() {
 # unavailability of the original minio service.
 function minio_migrate_fs_backend() {
     local minio_replicas
-    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null)
+    minio_replicas=$(kubectl get deploy minio -n "$MINIO_NAMESPACE" -o template="{{.spec.replicas}}" 2>/dev/null || true)
     if [ -z "$minio_replicas" ] || [ "$minio_replicas" = "0" ] || ! minio_uses_fs_format ; then
         return
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Minio migration shouldn't fail if the minio deployment does not exist. I have been so worried with the migration from older versions that I forgot to test a fresh install that, according to testgrid, is failing.