### PR TITLE
fix: issue faced to upgrade docker to containerd (follow up 3798)

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -108,7 +108,7 @@ function uninstall_docker() {
     case "$LSB_DIST" in
         ubuntu)
             export DEBIAN_FRONTEND=noninteractive
-            dpkg --purge docker-ce docker-ce-cli
+            dpkg --purge docker.io docker-ce docker-ce-cli
             ;;
 
         centos|rhel|amzn|ol)
@@ -128,6 +128,10 @@ function uninstall_docker() {
     rm -f /var/run/docker.sock || true
 
     log "Docker successfully uninstalled."
+
+    if ! commandExists kubectl; then
+        return
+    fi
 
     # With the internal loadbalancer it may take a minute or two after starting kubelet before
     # kubectl commands work

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -115,15 +115,15 @@ function _dpkg_install_host_packages() {
     fi
 
     # Remove docker packages, if installed to install containerd
-    # It is required because of an bug where the package manager is unable to sort it out and 
-    # the installation/upgrade will fails with `dpkg: no, cannot proceed with removal of containerd ... docker.io     
-    # depends on containerd (>= 1.2.6-0ubuntu1~)  containerd is to be removed.` 
+    # It is required because of an bug where the package manager is unable to sort it out and
+    # the installation/upgrade will fails with `dpkg: no, cannot proceed with removal of containerd ... docker.io
+    # depends on containerd (>= 1.2.6-0ubuntu1~)  containerd is to be removed.`
     # More info: https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1940920
-    # https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1939140       
-    if  commandExists docker && [[ "${packages[*]}" == *"containerd.io"* ]]; then
+    # https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1939140
+    if commandExists docker && [[ "${packages[*]}" == *"containerd.io"* ]]; then
+        # Uninstall docker before install containerd
         logStep "Removing docker packages to install ${packages[*]}..."
-        export DEBIAN_FRONTEND=noninteractive
-        dpkg --purge docker.io docker-ce docker-ce-cli
+        uninstall_docker
     fi
 
     DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version --force-confold "${fullpath}"/*.deb

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -148,3 +148,4 @@ function main() {
 }
 
 main "$@"
+


### PR DESCRIPTION
#### What this PR does / why we need it: 

After we merge the PR: https://github.com/replicatedhq/kURL/pull/3798 we checked that the changes break the upgrade path from docker to container id (see: https://testgrid.kurl.sh/run/STAGING-release-v2022.11.29-0-52b6b483-20221205150335 ) with the error when the scripts will try `systemctl disable docker.service --now`:

``` 
Removed symlink /etc/systemd/system/multi-user.target.wants/docker.service.
Warning: Stopping docker.service, but it can still be activated by:
  docker.socket
error: package docker.io, is not installed
2022-12-05 17:57:24+00:00 An error occurred on line 
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
```

#### Which issue(s) this PR fixes:

Fixes # [60835]

#### Special notes for your reviewer:

Instead of purge only the packages note that we are calling the current the current implementation in order to uninstall docker to ensure that the same workable steps will be performed. Therefore, we just mark the nodes as schedulable at the end of install/upgrade and after the kubectl and all packages be installed.

## Steps to reproduce

#### Does this PR introduce a user-facing change?
NONE (we created a release notes in #3798 already)

#### Does this PR require documentation?
NONE