### PR TITLE
fix: revert change to remove from aws, centos and so targets the dock…

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -112,7 +112,7 @@ function uninstall_docker() {
             ;;
 
         centos|rhel|amzn|ol)
-            local dockerPackages=("docker.io", "docker-ce" "docker-ce-cli")
+            local dockerPackages=("docker-ce" "docker-ce-cli")
             if rpm -qa | grep -q 'docker-ce-rootless-extras'; then
                 dockerPackages+=("docker-ce-rootless-extras")
             fi


### PR DESCRIPTION
#### What this PR does / why we need it:

In the PR: https://github.com/replicatedhq/kURL/pull/3798/files#diff-ebc0ba4096159b3bef1e162827acf41c10207ff4dcdcb5c88c5edd5641f14188R115 we added docker.io to be removed which is  broken the upgrade from docker to containerd in the target OS. 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
We have been testing it out with ubuntu and we should not changed it for the other target OS.

## Steps to reproduce

See the logs: https://testgrid.kurl.sh/run/STAGING-release-v2022.11.29-0-52b6b483-20221205150335

#### Does this PR introduce a user-facing change?
NONE
#### Does this PR require documentation?
NONE
