### PR TITLE
chore: adding more test cases for minio migration

### DIFF
--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -166,3 +166,84 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+    dump_longhorn_logs
+
+# upgrade from 2020-01-25T02-50-51Z using openebs
+- name: upgrade minio from 2020-01-25T02-50-51Z (openebs)
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "default"
+    containerd:
+      version: "latest"
+    minio:
+      version: "2020-01-25T02-50-51Z"
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "default"
+    containerd:
+      version: "latest"
+    minio:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+
+- name: upgrade minio from 2020-01-25T02-50-51Z while increasing PVC claim size (openebs)
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "default"
+    containerd:
+      version: "latest"
+    minio:
+      version: "2020-01-25T02-50-51Z"
+  upgradeSpec:
+    kubernetes:
+      version: "latest"
+    weave:
+      version: "latest"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "default"
+    containerd:
+      version: "latest"
+    minio:
+      version: "__testver__"
+      claimSize: "20Gi"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt


### PR DESCRIPTION
#### What this PR does / why we need it:

this commits adds some test scenarios and introduce some small changes to make debug easier:

- migration from 2020-01-25T02-50-51Z using openebs.
- migration from 2020-01-25T02-50-51Z while increasing claim size.
- showing up longhorn pod logs for easier debug in case of failure.
