### PR TITLE
fix: install docker 20.10.17 when docker or containerd is not specified in the installer

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -35,8 +35,7 @@ EOF
 function install_docker() {
     if [ "$SKIP_DOCKER_INSTALL" != "1" ]; then
         if [ -z "$DOCKER_VERSION" ]; then
-            printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version of Docker will be installed.${NC}\n"
-            logStep "Installing docker version 20.10.17"
+            printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version ($DOCKER_VERSION) of Docker will be installed.${NC}\n"
             DOCKER_VERSION="20.10.17"
         fi
         init_daemon_json

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -35,7 +35,7 @@ EOF
 function install_docker() {
     if [ "$SKIP_DOCKER_INSTALL" != "1" ]; then
         if [ -z "$DOCKER_VERSION" ]; then
-            printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but is required by all kURL installation scripts. The latest supported version of Docker will be installed.${NC}\n"
+            printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version of Docker will be installed.${NC}\n"
             logStep "Installing docker version 20.10.17"
             DOCKER_VERSION="20.10.17"
         fi

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -35,8 +35,9 @@ EOF
 function install_docker() {
     if [ "$SKIP_DOCKER_INSTALL" != "1" ]; then
         if [ -z "$DOCKER_VERSION" ]; then
-            printf "${RED}The installer did not specify a version of Docker to include, but is required by all kURL installation scripts currently. The latest supported version of Docker will be installed.${NC}\n"
-            DOCKER_VERSION="19.03.4"
+            printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but is required by all kURL installation scripts. The latest supported version of Docker will be installed.${NC}\n"
+            logStep "Installing docker version 20.10.17"
+            DOCKER_VERSION="20.10.17"
         fi
         init_daemon_json
         docker_get_host_packages_online "$DOCKER_VERSION"

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -283,7 +283,7 @@ function force_docker() {
     DOCKER_VERSION="20.10.17"
     printf "${YELLOW}NO CRI version was listed in yaml or found on host OS, defaulting to online docker install${NC}\n"
     printf "${YELLOW}THIS FEATURE IS NOT SUPPORTED AND WILL BE DEPRECATED IN FUTURE KURL VERSIONS${NC}\n"
-    printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version 20.10.17 of Docker will be installed.${NC}\n"
+    printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version ($DOCKER_VERSION) of Docker will be installed.${NC}\n"
 }
 
 function cri_preflights() {

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -280,9 +280,10 @@ must_disable_selinux() {
 }
 
 function force_docker() {
-    DOCKER_VERSION="19.03.4"
-    echo "NO CRI version was listed in yaml or found on host OS, defaulting to online docker install"
-    echo "THIS FEATURE IS NOT SUPPORTED AND WILL BE DEPRECATED IN FUTURE KURL VERSIONS"
+    DOCKER_VERSION="20.10.17"
+    printf "${YELLOW}NO CRI version was listed in yaml or found on host OS, defaulting to online docker install${NC}\n"
+    printf "${YELLOW}THIS FEATURE IS NOT SUPPORTED AND WILL BE DEPRECATED IN FUTURE KURL VERSIONS${NC}\n"
+    printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but is required by all kURL installation scripts. The latest supported version 20.10.17 of Docker will be installed.${NC}\n"
 }
 
 function cri_preflights() {

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -283,7 +283,7 @@ function force_docker() {
     DOCKER_VERSION="20.10.17"
     printf "${YELLOW}NO CRI version was listed in yaml or found on host OS, defaulting to online docker install${NC}\n"
     printf "${YELLOW}THIS FEATURE IS NOT SUPPORTED AND WILL BE DEPRECATED IN FUTURE KURL VERSIONS${NC}\n"
-    printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but is required by all kURL installation scripts. The latest supported version 20.10.17 of Docker will be installed.${NC}\n"
+    printf "${YELLOW}The installer did not specify a version of Docker or Containerd to include, but having one is required by all kURL installation scripts. The latest supported version 20.10.17 of Docker will be installed.${NC}\n"
 }
 
 function cri_preflights() {


### PR DESCRIPTION
#### What this PR does / why we need it:

The docker version 19.03.4 is no longer supported by docker and we should no install it by default.
Therefore, we ought to install 20.10.17 instead in this scenario.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

<img width="925" alt="Screenshot 2022-12-09 at 07 10 09" src="https://user-images.githubusercontent.com/7708031/206645592-76181f94-d486-4e40-81fd-b8ee6858a3fb.png">

<img width="951" alt="Screenshot 2022-12-09 at 07 11 18" src="https://user-images.githubusercontent.com/7708031/206645761-390e98ac-aeef-4573-b434-4a14df0c7966.png">

## Steps to reproduce

Try to install kURL without specify docker or containerd

```sh
INSTALLER_YAML="apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: latest
spec:
  kubernetes:
    version: 1.23.14
  weave:
    version: 2.6.5-20221025
  openebs:
    version: 3.3.0
    isLocalPVEnabled: true
    localPVStorageClassName: default
  minio:
    version: 2022-10-20T00-55-09Z
  contour:
    version: 1.23.0
  registry:
    version: 2.8.1
  prometheus:
    version: 0.60.1-41.7.3
  ekco:
    version: 0.25.0"

``` 

#### Does this PR introduce a user-facing change?

```release-note
fix: install docker 20.10.17 when docker or containerd is not specified in the installer instead of 19.03.4 which is deprecated by docker.
```

#### Does this PR require documentation?
NONE
