### PR TITLE
fix: preflight to only recommend Docker Enterprise Edition to RHEL installs when containerd is not selected

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -300,7 +300,7 @@ function require_cri() {
     fi
 
     if [ "$LSB_DIST" = "rhel" ]; then
-        if [ -n "$NO_CE_ON_EE" ]; then
+         if [ -n "$NO_CE_ON_EE" ] && [ -z "$CONTAINERD_VERSION" ]; then
             printf "${RED}Enterprise Linux distributions require Docker Enterprise Edition. Please install Docker before running this installation script.${NC}\n" 1>&2
             return 0
         fi


### PR DESCRIPTION
#### What this PR does / why we need it:

If containerd spec was select we do not need to recommend Docker Enterprise Edition to RHEL installs

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

## Steps to reproduce

#### Does this PR introduce a user-facing change?
```release-note
fix: preflight checks only recommend Docker Enterprise Edition to RHEL installs when containerd is not selected
```

#### Does this PR require documentation?
NONE
