### PR TITLE
chore: temporarily removing longhorn logs

### DIFF
--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -166,7 +166,6 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
-    dump_longhorn_logs
 
 # upgrade from 2020-01-25T02-50-51Z using openebs
 - name: upgrade minio from 2020-01-25T02-50-51Z (openebs)


### PR DESCRIPTION
#### What this PR does / why we need it:

testgrid started to fail after this funcion call was added. it is still not clear why it is failing but i am removing it so i can have a fresh run and analyse if it makes a difference.
