### PR TITLE
fix: error to install containerd.io that conflicts with containerd because an containerd pkg installed within docker (only for new installs)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -540,6 +540,7 @@ function main() {
     else
         host_preflights "1" "0" "1"
     fi
+    uninstall_docker_new_installs_with_containerd
     install_host_dependencies
     get_common
     setup_kubeadm_kustomize


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: error to install containerd.io that conflicts with containerd because an containerd pkg installed within docker.io. (Only for new installs by checking if kubectl is or not present on the host) 

Example

``` 
⚙  Installing host packages containerd.io
Selecting previously unselected package containerd.io.
dpkg: considering removing containerd in favour of containerd.io ...
dpkg: no, cannot proceed with removal of containerd (--auto-deconfigure will help):
 docker.io depends on containerd (>= 1.2.6-0ubuntu1~)
  containerd is to be removed.

dpkg: regarding .../containerd.io_1.6.8-1_amd64.deb containing containerd.io:
 containerd.io conflicts with containerd
  containerd (version 1.5.9-0ubuntu1~20.04.4) is present and installed.

dpkg: error processing archive ./addons/containerd/1.6.8/ubuntu-20.04/containerd.io_1.6.8-1_amd64.deb (--install):
 conflicting packages - not installing containerd.io
Errors were encountered while processing:
 ./addons/containerd/1.6.8/ubuntu-20.04/containerd.io_1.6.8-1_amd64.deb
An error occurred on line 2017
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-60835]

#### Special notes for your reviewer:
Now, if the docker be installed but the k8s not (new install) so it seems safe we remove the docker before install containerd.io.

Examples:

When we uninstall docker:

<img width="1296" alt="Screenshot 2022-12-09 at 12 44 06" src="https://user-images.githubusercontent.com/7708031/206751540-bcc3cedb-460d-4c76-9ade-c3b7a1a07b9c.png">


## Steps to reproduce

```
$ sudo apt-get update
$ sudo apt-get install docker.io
$ curl https://kurl.sh/latest | sudo bash
```

#### Does this PR introduce a user-facing change?

```release-note
fix: error to install containerd.io that conflicts with containerd because an containerd pkg is installed within docker
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
