### PR TITLE
feat: (for ubuntu) check status and try to fix broken dependency automatically

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -103,7 +103,7 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
     fi
 
     logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --yes"
-    sudo apt-get install --fix-broken --yes
+    apt-get install --fix-broken --yes
     if sudo apt-get check status ; then
         logSuccess "Broken packages fixed successfully"
         return

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -102,8 +102,8 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
         return
     fi
 
-    logWarn "Attempting to correct broken packages by running apt-get install -f -y"
-    sudo apt-get install -f -y
+    logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --yes"
+    sudo apt-get install --fix-broken --yes
     if sudo apt-get check status ; then
         logSuccess "Broken packages fixed successfully"
         return

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -108,7 +108,7 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
         logSuccess "Broken packages fixed successfully"
         return
     fi
-    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$sudo apt-get check status' to get further information."
+    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$ apt-get check status' to get further information."
 }
 
 function _dpkg_install_host_packages() {

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -97,7 +97,7 @@ function dpkg_install_host_packages() {
 
 function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
     logStep "Checking package manager status"
-    if  sudo apt-get check status ; then
+    if apt-get check status ; then
         logSuccess "Status checked successfully. No broken packages were found."
         return
     fi

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -95,6 +95,22 @@ function dpkg_install_host_packages() {
     _dpkg_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
 }
 
+function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
+    logStep "Checking package status"
+    if  sudo apt-get check status ; then
+        logSuccess "Status checked successfully. No broken packages were found."
+        return
+    fi
+
+    logWarn "Attempting to correct broken packages by running apt-get install -f -y"
+    sudo apt-get install -f -y
+    if sudo apt-get check status ; then
+        logSuccess "Broken packages fixed successfully"
+        return
+    fi
+    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$sudo apt-get check status' to get further information."
+}
+
 function _dpkg_install_host_packages() {
     if [ "${SKIP_SYSTEM_PACKAGE_INSTALL}" == "1" ]; then
         logStep "Skipping installation of host packages: ${packages[*]}"
@@ -114,9 +130,11 @@ function _dpkg_install_host_packages() {
         return 0
     fi
 
-    DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version --force-confold "${fullpath}"/*.deb
+    DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends-version --force-confold --auto-deconfigure "${fullpath}"/*.deb
 
     logSuccess "Host packages ${packages[*]} installed"
+
+    _dpkg_apt_get_status_and_maybe_fix_broken_pkgs
 }
 
 function yum_install_host_archives() {

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -96,7 +96,7 @@ function dpkg_install_host_packages() {
 }
 
 function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
-    logStep "Checking package status"
+    logStep "Checking package manager status"
     if  sudo apt-get check status ; then
         logSuccess "Status checked successfully. No broken packages were found."
         return

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -104,7 +104,7 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
 
     logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --yes"
     apt-get install --fix-broken --yes
-    if sudo apt-get check status ; then
+    if apt-get check status ; then
         logSuccess "Broken packages fixed successfully"
         return
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

kURL is distributing and installing the packages. Therefore, in some scenarios it might fail. 
Note that KURL uses dpkg to do the install of the packages ( [more info](https://github.com/replicatedhq/kURL/blob/main/scripts/common/host-packages.sh#L117) ) which cannot, for example sorted out unmet dependencies. From the [Package Management ubuntu docs](https://ubuntu.com/server/docs/package-management):

> “dpkg is a package manager for Debian-based systems. It can install, remove, and build packages, but unlike other package management systems, it cannot automatically download and install packages or their dependencies. Apt and Aptitude are newer, and layer additional features on top of dpkg. This section covers using dpkg to manage locally installed packages”

**Why broken packages occurs?** 

Bronken packages means that the package manager could not satisfy the criteria to properly install one or more packages. Note that each package has the info about what are the other versioned packages required to be installed within. Therefore the package manager has the purpose to ensure that the criteria for all packages installed in a server are properly respected. A lot of scenarios can result in this state. For further info: https://askubuntu.com/questions/140246/how-do-i-resolve-unmet-dependencies-after-adding-a-ppa#:~:text=One%20of%20the%20most%20common,Ubuntu%20repositories)%20or%20remove%20PPA.
 
*The goal of this PR is not sorted out all possible scenarios but instead:**
 
- a) begin to check if kURL broke or not the packages (today KURL does not do this check and finishes successfully)
- b) warning and call the recommended step to try fix the dependencies (which usually is suggested when this errors are faced) See, from https://linux.die.net/man/8/apt-get

> -f, --fix-broken
Fix. Attempt to correct a system with broken dependencies in place. This option, when used with install/remove, can omit any packages to permit APT to deduce a likely solution. Any package(s) that are specified must completely correct the problem. This option is sometimes necessary when running APT for the first time; APT itself does not allow broken package dependencies to exist on a system. It is possible that a system's dependency structure can be so corrupt as to require manual intervention. Use of this option together with -m may produce an error in some situations.
Configuration Item: APT::Get::Fix-Broken.
- c) use the --auto-deconfigure to allow remove the package when required 
- d) begin to fail if/when is not possible to sort it out to let users be aware of instead of move silent and finish successful . 

**Example Scenario that can be sorted out with:**

- Check the steps to reproduce this issue (where kURL is replacing a host dependency within a previous version causing unmet dependency)
- Then, see the error faced then run the commands to check the the apt-get status and follow the recommendation to try to fix it.

For further information check the references:
- [Difference Between APT and DPKG in Ubuntu](https://www.geeksforgeeks.org/difference-between-apt-and-dpkg-in-ubuntu/#:~:text=DPKG%20also%20supports%20local%20package%20installation.&text=APT%20doesn%27t%20terminate%20if,package%20with%20it%27s%20dependencies%20missing.)
- [What’s the Difference Between APT and dpkg in Ubuntu?](https://www.makeuseof.com/apt-vs-dpkg/)

<img width="794" alt="Screenshot 2022-12-13 at 12 06 27" src="https://user-images.githubusercontent.com/7708031/207319041-4cf8afde-1daf-445f-b999-23bf534810f0.png">

#### Which issue(s) this PR fixes:

Related # [sc-62451] 
Fix # [sc-61869]
Fix # [sc-60835]

#### Special notes for your reviewer:

See:

![Screenshot 2022-12-15 at 11 54 21](https://user-images.githubusercontent.com/7708031/207853340-0b792836-3434-412f-aa71-910de71507a4.png)

Also, see the test done with 60835:

<img width="1275" alt="Screenshot 2022-12-19 at 11 50 52" src="https://user-images.githubusercontent.com/7708031/208429651-2c4ab8c0-d5bc-4efb-944f-2820a9b05129.png">

## Steps to reproduce

- Create a VM: Ubuntu 20.04
- Run: curl https://kurl.sh/version/v2022.11.10-1/3d6adc9 | sudo bash
- Then, check that the package manager is broken sudo apt-get check status

OR

- $ curl https://kurl-sh.s3.amazonaws.com/dist/v2022.11.10-1/kubernetes-1.25.3.tar.gz > kubernetes-1.25.3.tar.gz
- $ tar zxvf kubernetes-1.25.3.tar.gz 
- $ cd packages/kubernetes/1.25.3/ubuntu-20.04/
- $ sudo dpkg --install --force-depends-version --force-confold perl-modules-5.30_5.30.0-9ubuntu0.2_all.deb
- $ sudo apt-get check status

##### To test the changes made in this PR you can:

- Ensure that you have the changes done https://github.com/replicatedhq/kURL/pull/3870 to say no to remove docker
- Use any scenario where containerd should be installed such as k8s 1.25.3 and containerd 1.6.9
- Run `sudo apt-get update` and `sudo apt-get install docker.io`
- Then, run the  install  (sub bash ./install.sh) 

Also, you can run the latest without add any conflict and check that all will work fine.

#### Does this PR introduce a user-facing change?

```release-note
feat: (for ubuntu) after install required dependencies with dpkg, check apt-get status and try to fix broken dependency automatically to sorted out unmet dependencies with `sudo apt-get install -f -y`
```

#### Does this PR require documentation?
NONE
