### PR TITLE
Remove lint and vet from kurl_util

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - run: make -C kurl_util deps test build
+      - run: make -C kurl_util test build
 
   build-bin-kurl:
     runs-on: ubuntu-20.04

--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -36,20 +36,8 @@ endef
 clean:
 	rm -rf ./bin
 
-.PHONY: deps
-deps:
-	go install golang.org/x/lint/golint
-
-.PHONY: lint
-lint:
-	golint -set_exit_status ./...
-
-.PHONY: vet
-vet:
-	go vet ./...
-
 .PHONY: test
-test: lint vet
+test:
 	go test ./cmd/...
 
 .PHONY: build


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We run lint and vet in the root Makefile. No need to duplicate here.

https://github.com/replicatedhq/kURL/blob/b7405229745676f5f924ed0c775bb6fba15671f0/Makefile#L633