### PR TITLE
Use kustomize bases rather than resources for k8s <= 1.20

### DIFF
--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -87,7 +87,7 @@
       version: "latest"
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -129,7 +129,7 @@
       version: "latest"
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -47,7 +47,7 @@
       s3Override: "__testdist__"
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -161,7 +161,7 @@
       version: "latest"
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -84,7 +84,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -196,7 +196,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -81,7 +81,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         local rook_major_minor_version="${major}.${minor}"
 

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -81,7 +81,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         local rook_major_minor_version="${major}.${minor}"
 

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -63,7 +63,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -176,7 +176,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -63,7 +63,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -177,7 +177,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -201,7 +201,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -74,7 +74,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -84,7 +84,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -207,7 +207,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -84,7 +84,7 @@ function rook() {
         export CEPH_DASHBOARD_PASSWORD="$cephDashboardPassword"
     fi
 
-    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' | grep -q Running ; then
+    if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
         semverParse "$ROOK_VERSION"
         # shellcheck disable=SC2154
         local rook_major_minor_version="${major}.${minor}"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -202,7 +202,7 @@ function rook_cluster_deploy() {
 
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
-        insert_resources "$dst/kustomization.yaml" cephfs
+        insert_bases "$dst/kustomization.yaml" cephfs
     fi
 
     # patches

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -57,6 +57,7 @@
 
 # upgrade two versions
 - name: Upgrade from 1.8.10
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.23.x"
@@ -143,6 +144,7 @@
     kubectl -n default delete pvc cephfs-pvc default-pvc
 
 - name: Upgrade from 1.9.12
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.23.x"

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -19,7 +19,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info
@@ -94,7 +94,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info
@@ -108,7 +108,7 @@
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep __testver__
 
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
@@ -184,7 +184,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info
@@ -198,7 +198,7 @@
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep __testver__
 
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
@@ -258,7 +258,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -102,6 +102,9 @@
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
 
+    # the node isn't ready for long enough after the k8s upgrade for the pods with pvcs to schedule
+    wait_for_minio_ready
+
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep __testver__
 
@@ -188,6 +191,9 @@
     validate_read_write_object_store rwtest minio.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+
+    # the node isn't ready for long enough after the k8s upgrade for the pods with pvcs to schedule
+    wait_for_minio_ready
 
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep __testver__

--- a/scripts/common/yaml-test.sh
+++ b/scripts/common/yaml-test.sh
@@ -2,10 +2,15 @@
 
 set -e
 
+# shellcheck disable=SC1091
+. ./scripts/common/common.sh
+# shellcheck disable=SC1091
 . ./scripts/common/yaml.sh
 
 function test_render_yaml_file_2() {
+    # shellcheck disable=SC2034
     local PROXY_ADDRESS=a
+    # shellcheck disable=SC2034
     local NO_PROXY_ADDRESSES=b
     local expects="apiVersion: apps/v1
 kind: Deployment
@@ -27,4 +32,58 @@ spec:
     assertEquals "preserves quotes" "$expects" "$(render_yaml_file_2 "./addons/velero/template/base/tmpl-velero-deployment-proxy.yaml")"
 }
 
+function test_insert_bases_kubectl_120() {
+    local tmpdir=
+    tmpdir="$(mktemp -d)"
+
+    kubectl(){
+        echo "Client Version: v1.20.0"
+    }
+
+    echo -e "resources:\n- r1\n\nbases:\n- b1\n" > "$tmpdir/k1.yaml"
+    insert_bases "$tmpdir/k1.yaml" "b2"
+    assertEquals "inserts a second base" "$(echo -e "resources:\n- r1\n\nbases:\n- b2\n- b1\n")" "$(cat "$tmpdir/k1.yaml")"
+
+    echo -e "resources:\n- r1\n" > "$tmpdir/k2.yaml"
+    insert_bases "$tmpdir/k2.yaml" "b2"
+    assertEquals "inserts the first base" "$(echo -e "resources:\n- r1\n\nbases:\n- b2\n")" "$(cat "$tmpdir/k2.yaml")"
+}
+
+function test_insert_bases_kubectl_121() {
+    local tmpdir=
+    tmpdir="$(mktemp -d)"
+
+    kubectl(){
+        echo "Client Version: v1.21.0"
+    }
+
+    echo -e "resources:\n- r1\n\n" > "$tmpdir/k1.yaml"
+    insert_bases "$tmpdir/k1.yaml" "b2"
+    assertEquals "inserts a second base" "$(echo -e "resources:\n- b2\n- r1\n")" "$(cat "$tmpdir/k1.yaml")"
+
+    touch "$tmpdir/k2.yaml"
+    insert_bases "$tmpdir/k2.yaml" "b2"
+    assertEquals "inserts the first base" "$(echo -e "resources:\n- b2\n")" "$(cat "$tmpdir/k2.yaml")"
+}
+
+function test_insert_bases_no_kubectl() {
+    local tmpdir=
+    tmpdir="$(mktemp -d)"
+
+    commandExists(){
+        return 1
+    }
+    # shellcheck disable=SC2034
+    local KUBERNETES_VERSION="1.21.0"
+
+    echo -e "resources:\n- r1\n\n" > "$tmpdir/k1.yaml"
+    insert_bases "$tmpdir/k1.yaml" "b2"
+    assertEquals "inserts a second base" "$(echo -e "resources:\n- b2\n- r1\n")" "$(cat "$tmpdir/k1.yaml")"
+
+    touch "$tmpdir/k2.yaml"
+    insert_bases "$tmpdir/k2.yaml" "b2"
+    assertEquals "inserts the first base" "$(echo -e "resources:\n- b2\n")" "$(cat "$tmpdir/k2.yaml")"
+}
+
+# shellcheck disable=SC1091
 . shunit2

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1583,14 +1583,14 @@
       version: "latest"
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
@@ -1647,14 +1647,14 @@
     mv rook-1.5.12.tar.gz /var/lib/kurl/assets
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_read_write_object_store rwtest testfile.txt
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rook_ecph_object_store_info
+    rook_ceph_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Kubernetes <= 1.20 uses an older kustomize version that does not support bases in resources.

Error:
```
error: rawResources failed to read Resources: Load from path cephfs failed: 'cephfs' must be a file (got d='/var/lib/kurl/kustomize/rook/cluster/cephfs')
```