### PR TITLE
fix(centos|rhel|ol): allow allowerasing previous packages installed when conflicts are faced with yum install

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -182,19 +182,13 @@ EOF
         previous_version="$(ctr -v | grep -o '[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*')"
         logStep "Downgrading containerd, $previous_version -> $next_version"
         if semverCompare "$next_version" "$previous_version" && [ "$SEMVER_COMPARE_RESULT" -lt "0" ]; then
-            if uname -r | grep -q "el8" ; then
-                yum --disablerepo=* --enablerepo=kurl.local downgrade --allowerasing -y "${packages[@]}"
-            else
-                yum --disablerepo=* --enablerepo=kurl.local downgrade -y "${packages[@]}"
-            fi
+            yum --disablerepo=* --enablerepo=kurl.local downgrade --allowerasing -y "${packages[@]}"
         fi
         logSuccess "Downgraded containerd"
     fi
     # shellcheck disable=SC2086
-    if [[ "${packages[*]}" == *"containerd.io"* && -n $(uname -r | grep "el8") ]]; then
+    if [[ "${packages[*]}" == *"containerd.io"* ]]; then
         yum --disablerepo=* --enablerepo=kurl.local install --allowerasing -y "${packages[@]}"
-    else
-        yum --disablerepo=* --enablerepo=kurl.local install -y "${packages[@]}"
     fi
     yum clean metadata --disablerepo=* --enablerepo=kurl.local
     rm /etc/yum.repos.d/kurl.local.repo


### PR DESCRIPTION
#### What this PR does / why we need it:

kURL distributed the packages, create a repo and will install them. However, if a conflict be faced because of a previous packaged installed it fails. Note that the `--allowerasing` has been used already. It has been used with the conditions if is `containerd` and rhel-8. However, conflicts can be faced in any rhel version as when the script will still any dependency.

#### Which issue(s) this PR fixes:

Fixes # [sc-50237]
Also similar case: https://github.com/replicated-collab/cylance-kots/issues/16

#### Special notes for your reviewer:


## Steps to reproduce

- RHEL-4
- Run `curl https://kurl.sh/37de0ce | sudo bash`

#### Does this PR introduce a user-facing change?

```release-note
fix(centos|rhel|ol): allow allowerasing previous packages installed when conflicts are faced by kURL when it is installing the packages
```

#### Does this PR require documentation?
NONE
