### PR TITLE
Set correct cephfs pool replication on upgrades from 1.0.4

### DIFF
--- a/addons/rook/1.10.6/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
+++ b/addons/rook/1.10.6/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
@@ -4,7 +4,7 @@
   value: data0
 - op: replace
   path: /spec/dataPools/0/replicated/size
-  value: 1
+  value: ${CEPH_POOL_REPLICAS}
 - op: replace
   path: /spec/dataPools/0/replicated/requireSafeReplicaSize
   value: false

--- a/addons/rook/1.10.6/cluster/cephfs/patches/tmpl-filesystem.yaml
+++ b/addons/rook/1.10.6/cluster/cephfs/patches/tmpl-filesystem.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 1
+      size: ${CEPH_POOL_REPLICAS}
       requireSafeReplicaSize: false
   metadataServer:
     resources:

--- a/addons/rook/1.7.11/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
+++ b/addons/rook/1.7.11/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/dataPools/0/replicated/size
-  value: 1
+  value: ${CEPH_POOL_REPLICAS}
 - op: replace
   path: /spec/dataPools/0/replicated/requireSafeReplicaSize
   value: false

--- a/addons/rook/1.7.11/cluster/cephfs/patches/tmpl-filesystem.yaml
+++ b/addons/rook/1.7.11/cluster/cephfs/patches/tmpl-filesystem.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 1
+      size: ${CEPH_POOL_REPLICAS}
       requireSafeReplicaSize: false
   metadataServer:
     priorityClassName: system-cluster-critical

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -166,6 +166,7 @@ function rook_cluster_deploy() {
         touch "$dst/cephfs/kustomization.yaml"
         insert_resources "$dst/cephfs/kustomization.yaml" cephfs-storageclass.yaml
         insert_resources "$dst/cephfs/kustomization.yaml" filesystem.yaml
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem.yaml" > "$dst/cephfs/patches/filesystem.yaml"
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem.yaml
 
         # MDS pod anti-affinity rules prevent them from co-scheduling on single-node installations
@@ -175,6 +176,7 @@ function rook_cluster_deploy() {
             insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem-singlenode.yaml
         fi
 
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem-Json6902.yaml" > "$dst/cephfs/patches/filesystem-Json6902.yaml"
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
         insert_bases "$dst/kustomization.yaml" cephfs

--- a/addons/rook/1.8.10/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
+++ b/addons/rook/1.8.10/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
@@ -4,7 +4,7 @@
   value: data0
 - op: replace
   path: /spec/dataPools/0/replicated/size
-  value: 1
+  value: ${CEPH_POOL_REPLICAS}
 - op: replace
   path: /spec/dataPools/0/replicated/requireSafeReplicaSize
   value: false

--- a/addons/rook/1.8.10/cluster/cephfs/patches/tmpl-filesystem.yaml
+++ b/addons/rook/1.8.10/cluster/cephfs/patches/tmpl-filesystem.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 1
+      size: ${CEPH_POOL_REPLICAS}
       requireSafeReplicaSize: false
   metadataServer:
     priorityClassName: system-cluster-critical

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -190,6 +190,7 @@ function rook_cluster_deploy() {
         insert_resources "$dst/cephfs/kustomization.yaml" cephfs-storageclass.yaml
         insert_resources "$dst/cephfs/kustomization.yaml" filesystem.yaml
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/cephfs-storageclass.yaml
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem.yaml" > "$dst/cephfs/patches/filesystem.yaml"
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem.yaml
 
         # MDS pod anti-affinity rules prevent them from co-scheduling on single-node installations
@@ -199,6 +200,7 @@ function rook_cluster_deploy() {
             insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem-singlenode.yaml
         fi
 
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem-Json6902.yaml" > "$dst/cephfs/patches/filesystem-Json6902.yaml"
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
         insert_bases "$dst/kustomization.yaml" cephfs

--- a/addons/rook/1.9.12/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
+++ b/addons/rook/1.9.12/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
@@ -4,7 +4,7 @@
   value: data0
 - op: replace
   path: /spec/dataPools/0/replicated/size
-  value: 1
+  value: ${CEPH_POOL_REPLICAS}
 - op: replace
   path: /spec/dataPools/0/replicated/requireSafeReplicaSize
   value: false

--- a/addons/rook/1.9.12/cluster/cephfs/patches/tmpl-filesystem.yaml
+++ b/addons/rook/1.9.12/cluster/cephfs/patches/tmpl-filesystem.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 1
+      size: ${CEPH_POOL_REPLICAS}
       requireSafeReplicaSize: false
   metadataServer:
     resources:

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -196,6 +196,7 @@ function rook_cluster_deploy() {
         insert_resources "$dst/cephfs/kustomization.yaml" cephfs-storageclass.yaml
         insert_resources "$dst/cephfs/kustomization.yaml" filesystem.yaml
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/cephfs-storageclass.yaml
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem.yaml" > "$dst/cephfs/patches/filesystem.yaml"
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem.yaml
 
         # MDS pod anti-affinity rules prevent them from co-scheduling on single-node installations
@@ -205,6 +206,7 @@ function rook_cluster_deploy() {
             insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem-singlenode.yaml
         fi
 
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem-Json6902.yaml" > "$dst/cephfs/patches/filesystem-Json6902.yaml"
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
         insert_bases "$dst/kustomization.yaml" cephfs

--- a/addons/rook/template/base/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
+++ b/addons/rook/template/base/cluster/cephfs/patches/tmpl-filesystem-Json6902.yaml
@@ -4,7 +4,7 @@
   value: data0
 - op: replace
   path: /spec/dataPools/0/replicated/size
-  value: 1
+  value: ${CEPH_POOL_REPLICAS}
 - op: replace
   path: /spec/dataPools/0/replicated/requireSafeReplicaSize
   value: false

--- a/addons/rook/template/base/cluster/cephfs/patches/tmpl-filesystem.yaml
+++ b/addons/rook/template/base/cluster/cephfs/patches/tmpl-filesystem.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 1
+      size: ${CEPH_POOL_REPLICAS}
       requireSafeReplicaSize: false
   metadataServer:
     resources:

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -181,7 +181,7 @@ function rook_cluster_deploy() {
     cp -r "$src" "$dst"
 
     # resources
-    render_yaml_file_2 "$dst/tmpl-rbd-storageclass.yaml" > "$dst/rbd-storageclass.yaml"
+    render_yaml_file_2 "$src/tmpl-rbd-storageclass.yaml" > "$dst/rbd-storageclass.yaml"
     insert_resources "$dst/kustomization.yaml" rbd-storageclass.yaml
 
     # conditional cephfs
@@ -191,6 +191,7 @@ function rook_cluster_deploy() {
         insert_resources "$dst/cephfs/kustomization.yaml" cephfs-storageclass.yaml
         insert_resources "$dst/cephfs/kustomization.yaml" filesystem.yaml
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/cephfs-storageclass.yaml
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem.yaml" > "$dst/cephfs/patches/filesystem.yaml"
         insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem.yaml
 
         # MDS pod anti-affinity rules prevent them from co-scheduling on single-node installations
@@ -200,6 +201,7 @@ function rook_cluster_deploy() {
             insert_patches_strategic_merge "$dst/cephfs/kustomization.yaml" patches/filesystem-singlenode.yaml
         fi
 
+        render_yaml_file_2 "$src/cephfs/patches/tmpl-filesystem-Json6902.yaml" > "$dst/cephfs/patches/filesystem-Json6902.yaml"
         insert_patches_json_6902 "$dst/cephfs/kustomization.yaml" patches/filesystem-Json6902.yaml ceph.rook.io v1 CephFilesystem rook-shared-fs rook-ceph
 
         insert_bases "$dst/kustomization.yaml" cephfs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Upon upgrading Rook from 1.0.4, the CephFilesystem CRD will be created as it was not supported by our 1.0.4 add-on. It will be created with the improper replication level causing the upgrade to fail to roll out new osds.

```
✔ Upgraded to Rook 1.6.11 successfully
⚙  Upgrading to Rook 1.7.11
...
Waiting for all Rook-Ceph deployments to be using Ceph 16.2.7-0
deployments rook-ceph-crashcollector-ethanm-rook-31, rook-ceph-crashcollector-ethanm-rook-32, rook-ceph-crashcollector-ethanm-rook-33, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-mon-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 15.2.13-0
...
deployments rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5 still running 15.2.13-0
Error: failed to wait for Ceph "16.2.7-0": timed out waiting for Ceph 16.2.7-0 to roll out
Detected multiple Ceph versions
```

This has not been released so no release note is needed.

https://github.com/replicatedhq/kURL/commit/48e78b6d119707fef5ea234b59b8a9e8cde81983#diff-98cf354d0b57b3f875db34a39c6e1e3b24d8cdac61e6843bc5be713e1f7d8e9fR199-R202
