### PR TITLE
Wait longer for device_health_metrics pool to scale

### DIFF
--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -215,7 +215,7 @@ function rookupgrade_10to14_osd_pool_pg_num_lte() {
 # rookupgrade_10to14_wait_for_pool_device_health_metrics will wait for the device_health_metrics
 # pool to be created when upgrading to Ceph 15.2.8
 function rookupgrade_10to14_wait_for_pool_device_health_metrics() {
-    spinner_until 300 rookupgrade_10to14_pool_device_health_metrics_exists
+    spinner_until 1200 rookupgrade_10to14_pool_device_health_metrics_exists
 }
 
 # rookupgrade_10to14_pool_device_health_metrics_exists will return 0 if the device_health_metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

There was no actual issue in my testing but it took quite a long time to create the device_health_metrics pool which makes me nervous that this timeout is too short.