### PR TITLE
fix: add --allowerasing flag to allow remove conflicts

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -185,7 +185,7 @@ EOF
             if uname -r | grep -q "el8" ; then
                 yum --disablerepo=* --enablerepo=kurl.local downgrade --allowerasing -y "${packages[@]}"
             else
-                yum --disablerepo=* --enablerepo=kurl.local downgrade -y "${packages[@]}"
+                yum --disablerepo=* --enablerepo=kurl.local downgrade --allowerasing -y "${packages[@]}"
             fi
         fi
         logSuccess "Downgraded containerd"
@@ -194,7 +194,7 @@ EOF
     if [[ "${packages[*]}" == *"containerd.io"* && -n $(uname -r | grep "el8") ]]; then
         yum --disablerepo=* --enablerepo=kurl.local install --allowerasing -y "${packages[@]}"
     else
-        yum --disablerepo=* --enablerepo=kurl.local install -y "${packages[@]}"
+        yum --disablerepo=* --enablerepo=kurl.local install --allowerasing -y "${packages[@]}"
     fi
     yum clean metadata --disablerepo=* --enablerepo=kurl.local
     rm /etc/yum.repos.d/kurl.local.repo


### PR DESCRIPTION
#### What this PR does / why we need it:

kURL distributed the packages, create a repo and will install them. However, if a conflict be faced because of a previous packaged installed it fails. Note that the `--allowerasing` has been used already. It has been used with the conditions if is `containerd` and rhel-8. However, conflicts can be faced in any rhel version as when the script will still any dependency.

#### Which issue(s) this PR fixes:

Fixes # [sc-50237]

#### Special notes for your reviewer:


## Steps to reproduce

- RHEL-4
- Run `curl https://kurl.sh/37de0ce | sudo bash`

#### Does this PR introduce a user-facing change?

```release-note
fix(centos|rhel|ol): allow allowerasing previous packages installed when conflicts are faced by kURL when it is installing the packages
```

#### Does this PR require documentation?
NONE
