### PR TITLE
chore: using rebuilt s3cmd image

### DIFF
--- a/addons/registry/2.8.1/Manifest
+++ b/addons/registry/2.8.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.8.1
-image s3cmd kurlsh/s3cmd:20221029-37473ee
+image s3cmd kurlsh/s3cmd:20221219-ff60227

--- a/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.8.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.8.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.8.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/velero/1.9.2/Manifest
+++ b/addons/velero/1.9.2/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.5.1
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.1
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.1
 image local-volume-provider replicated/local-volume-provider:v0.4.0
-image s3cmd kurlsh/s3cmd:20221029-37473ee
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.2/velero-v1.9.2-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.2/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.2/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.9.3/Manifest
+++ b/addons/velero/1.9.3/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.5.2
 image velero-gcp velero/velero-plugin-for-gcp:v1.5.2
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.5.2
 image local-volume-provider replicated/local-volume-provider:v0.4.1
-image s3cmd kurlsh/s3cmd:20221029-37473ee
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.3/velero-v1.9.3-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.3/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.3/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.9.4/Manifest
+++ b/addons/velero/1.9.4/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.6.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.6.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.6.0
 image local-volume-provider replicated/local-volume-provider:v0.4.1
-image s3cmd kurlsh/s3cmd:20221029-37473ee
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.9.4/velero-v1.9.4-linux-amd64.tar.gz
 

--- a/addons/velero/1.9.4/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.9.4/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20221029-37473ee
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR makes the Registry and the Velero add-ons default to a new `s3cmd` image. The new `s3cmd` image uses, as its base, the Alpine version 3.16.3 instead of 3.16.2 as the old image.

#### Which issue(s) this PR fixes:
Fixes #63702

#### Special notes for your reviewer:

I have manually dispatched the `build-image` GitHub action to rebuild the s3cmd image and verified that I can pull it and that it does not report the same issues as the old image:

```
$ docker pull kurlsh/s3cmd:20221219-ff60227
20221219-ff60227: Pulling from kurlsh/s3cmd
ca7dd9ec2225: Pull complete
eab94e9f41af: Pull complete
f60cb74099f7: Pull complete
Digest: sha256:08384f85979e48a52a6f8291c7b9fb1cf7def15afaeaf525d99495976f147a27
Status: Downloaded newer image for kurlsh/s3cmd:20221219-ff60227
docker.io/kurlsh/s3cmd:20221219-ff60227
$ trivy image kurlsh/s3cmd:20221219-ff60227
2022-12-19T16:42:14.035+0100    INFO    Vulnerability scanning is enabled
2022-12-19T16:42:14.036+0100    INFO    Secret scanning is enabled
2022-12-19T16:42:14.036+0100    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-12-19T16:42:14.036+0100    INFO    Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2022-12-19T16:42:14.039+0100    INFO    Detected OS: alpine
2022-12-19T16:42:14.039+0100    INFO    Detecting Alpine vulnerabilities...
2022-12-19T16:42:14.041+0100    INFO    Number of language-specific files: 0

kurlsh/s3cmd:20221219-ff60227 (alpine 3.16.3)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

$
``` 