### PR TITLE
Fix nodes-missing-images loop closure may report incorrect nodes

### DIFF
--- a/pkg/cluster/nodes.go
+++ b/pkg/cluster/nodes.go
@@ -60,7 +60,8 @@ func NodeImages(ctx context.Context, client kubernetes.Interface, logger *log.Lo
 		opts.nodeImagesJobRunner = runNodeImagesJob
 	}
 
-	for _, node := range nodes.Items {
+	for _, n := range nodes.Items {
+		node := n
 		thisNodeImages := map[string]struct{}{}
 		for _, image := range node.Status.Images {
 			for _, name := range image.Names {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes an issue where the nodes-missing-images command may report the wrong images missing nodes due to improper loop closure.