### PR TITLE
feat: adding kubernetes 1.26 support

### DIFF
--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -7,6 +7,12 @@ VERSIONS=()
 function find_available_versions() {
     docker build -t k8s - < Dockerfile
 
+    local versions126=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.26\.[0-9]+' | sort -rV | uniq))
+    if [ ${#versions126[@]} -gt 0 ]; then
+        echo "Found latest version for Kubernetes 1.26: ${versions126[0]}"
+        VERSIONS+=("${versions126[0]}")
+    fi
+
     local versions125=($(docker run k8s apt list -a kubelet 2>/dev/null | grep -Eo '1\.25\.[0-9]+' | sort -rV | uniq))
     if [ ${#versions125[@]} -gt 0 ]; then
         echo "Found latest version for Kubernetes 1.25: ${versions125[0]}"
@@ -125,6 +131,13 @@ function get_latest_sonobuoy_release_version() {
 }
 
 function update_available_versions() {
+    local version126=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.26' ) )
+    if [ ${#version126[@]} -gt 0 ]; then
+        if ! sed '0,/cron-kubernetes-update-126/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version126[0]}" ; then
+            sed -i "/cron-kubernetes-update-126/a\    \"${version126[0]}\"\," ../../../web/src/installers/versions.js
+        fi
+    fi
+
     local version125=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.25' ) )
     if [ ${#version125[@]} -gt 0 ]; then
         if ! sed '0,/cron-kubernetes-update-125/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version125[0]}" ; then

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -23,6 +23,7 @@ module.exports.InstallerVersions = {
     "1.17.7",
     "1.17.3",
     "1.16.4",
+    // cron-kubernetes-update-126
     // cron-kubernetes-update-125
     "1.25.5",
     "1.25.4",


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit modifies the script that checks for new releases of Kubernetes. The updated script now also searches for 1.26.x versions that are more recent.#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
Fixes #63797

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
feat: added support for new kubernetes v1.26
```