### PR TITLE
Mkdir assets package path if not exists

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -279,6 +279,10 @@ function addon_fetch_airgap() {
         prompt
         if [ -n "$PROMPT_RESULT" ]; then
             local loadedPackagePath="$PROMPT_RESULT"
+            if [ ! -f "$loadedPackagePath" ]; then
+                logFail "The file $loadedPackagePath does not exist."
+                return 1
+            fi
             mkdir -p "$(dirname "$package_path")"
             cp "$loadedPackagePath" "$package_path"
         else

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -255,8 +255,10 @@ function addon_fetch_airgap() {
     local name=$1
     local version=$2
     local package="$name-$version.tar.gz"
+    local package_path=
+    package_path="$(package_filepath "$package")"
 
-    if [ -f "$(package_filepath "${package}")" ]; then
+    if [ -f "$package_path" ]; then
         # the package already exists, no need to download it
         printf "The package %s %s is already available locally.\n" "$name" "$version"
     else
@@ -267,7 +269,7 @@ function addon_fetch_airgap() {
 
         if ! prompts_can_prompt; then
             # we can't ask the user to give us the file because there are no prompts, but we can say where to put it for a future run
-            printf "Please move this file to /var/lib/kurl/%s before rerunning the installer.\n" "$(package_filepath "${package}")"
+            printf "Please move this file to /var/lib/kurl/%s before rerunning the installer.\n" "$package_path"
             return 1
         fi
 
@@ -277,11 +279,12 @@ function addon_fetch_airgap() {
         prompt
         if [ -n "$PROMPT_RESULT" ]; then
             local loadedPackagePath="$PROMPT_RESULT"
-            cp "$loadedPackagePath" "$(package_filepath "${package}")"
+            mkdir -p "$(dirname "$package_path")"
+            cp "$loadedPackagePath" "$package_path"
         else
             printf "Skipping package %s %s\n" "$name" "$version"
             printf "You can provide the path to this file the next time the installer is run,"
-            printf "or move it to %s to be detected automatically.\n" "$(package_filepath "${package}")"
+            printf "or move it to %s to be detected automatically.\n" "$package_path"
             return 1
         fi
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes add-on package fails to load if assets directory does not exist

```
You can download it from https://s3-staging.kurl.sh/staging/v2022.12.12-0-156d5965/rook-1.5.12.tar.gz with the following command:

    curl -LO https://s3-staging.kurl.sh/staging/v2022.12.12-0-156d5965/rook-1.5.12.tar.gz

If you have this file, please provide the path to the file on the server.
If you do not have the file, leave the prompt empty and this package will be skipped.
rook 1.5.12 filepath: /home/ethan/rook-1.5.12.tar.gz
cp: cannot create regular file 'assets/rook-1.5.12.tar.gz': No such file or directory
Unpacking rook 1.5.12...
tar: assets/rook-1.5.12.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
main: line 376: ./addons/rook/1.5.12/install.sh: No such file or directory
find: ‘./addons/rook/1.5.12/images’: No such file or directory
```
