### PR TITLE
chore: adding tests for kube 1.26

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -154,6 +154,16 @@
       version: 1.25.x
     flannel:
       version: latest
+- name: minimal-126
+  installerSpec:
+    containerd:
+      version: latest
+    kurl:
+      installerVersion: ""
+    kubernetes:
+      version: 1.26.x
+    flannel:
+      version: latest
 - name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
@@ -172,10 +182,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-- name: k8s125x_reserved_resources
+- name: k8s126x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
@@ -196,10 +206,10 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
-- name: k8s125-openebs
+- name: k8s126-openebs
   installerSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     kurl:
       installerVersion: ""
     containerd:
@@ -247,11 +257,11 @@
   airgap: true
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: "k8s_125x airgap"
+- name: "k8s_126x airgap"
   airgap: true
   installerSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     kurl:
       installerVersion: ""
     flannel:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -993,11 +993,11 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: "K8s 1.25x Rook, disableS3"
+- name: "K8s 1.26x Rook, disableS3"
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     containerd:
       version: latest
     weave:
@@ -1085,11 +1085,11 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: "Upgrade to 1.25 airgap"
+- name: "Upgrade to 1.26 airgap"
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.25.x
     weave:
       version: latest
     openebs:
@@ -1110,7 +1110,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     weave:
       version: latest
     openebs:
@@ -1130,10 +1130,10 @@
     ekco:
       version: latest
   airgap: true
-- name: "Upgrade to 1.25 minimal"
+- name: "Upgrade to 1.26 minimal"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.25.x
     weave:
       version: latest
     openebs:
@@ -1152,7 +1152,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     weave:
       version: latest
     openebs:
@@ -1167,10 +1167,10 @@
       version: latest
     ekco:
       version: latest
-- name: "Upgrade to 1.25 minimal airgap"
+- name: "Upgrade to 1.26 minimal airgap"
   installerSpec:
     kubernetes:
-      version: 1.24.x
+      version: 1.25.x
     weave:
       version: latest
     openebs:
@@ -1189,7 +1189,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     weave:
       version: latest
     openebs:
@@ -1276,10 +1276,10 @@
   flags: "labels=disktype=ssd,gpu=enabled"
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: k8s125-all-the-flags
+- name: k8s126-all-the-flags
   installerSpec:
     kubernetes:
-      version: 1.25.x
+      version: 1.26.x
     containerd:
       version: latest
     weave:
@@ -1300,7 +1300,7 @@
 - name: ekco-podimageoverrides
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     weave:
@@ -1366,10 +1366,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-- name: k8s125x_reserved_resources
+- name: k8s126x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
@@ -1487,7 +1487,7 @@
 - name: less_command
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
     containerd:
       version: latest
     weave:
@@ -1498,7 +1498,7 @@
 - name: "weave latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
     weave:
       version: "latest"
     containerd:
@@ -1510,7 +1510,7 @@
 - name: "flannel latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.26.x"
     flannel:
       version: "latest"
     containerd:


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit migrates tests that were using 1.25 to start using 1.26. a minimal install for 1.25 was kept.
