### PR TITLE
Wait for pgs to scale down before proceeding with upgrade

### DIFF
--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -42,9 +42,9 @@ function rookupgrade_10to14_upgrade() {
         non_osd_pools="$(kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd pool ls | grep -v rook-ceph-store)"
         rookupgrade_10to14_scale_down_osd_pool_pg_num "$osd_pools" 16
         rookupgrade_10to14_scale_down_osd_pool_pg_num "$non_osd_pools" 32
-        # log "Waiting for pool pgs to scale down"
-        # rookupgrade_10to14_osd_pool_wait_for_pg_num "$osd_pools" 16
-        # rookupgrade_10to14_osd_pool_wait_for_pg_num "$non_osd_pools" 32
+        log "Waiting for pool pgs to scale down"
+        rookupgrade_10to14_osd_pool_wait_for_pg_num "$osd_pools" 16
+        rookupgrade_10to14_osd_pool_wait_for_pg_num "$non_osd_pools" 32
 
         logStep "Upgrading to Rook 1.1.9"
         "$DIR"/bin/kurl rook wait-for-health


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

I am often facing a timeout when upgrading ceph to 14.2.5.

```
2022-12-20 19:44:37.674425 E | op-osd: failed to update osd deployment 5. failed to check if deployment rook-ceph-osd-5 can be updated: max retries exceeded, last err: failed to check if we can stop the deployment rook-ceph-osd-5: failed to check if rook-ceph-osd-5 was ok to stop. deployment rook-ceph-osd-5 cannot be stopped. exit status 16
```

I noticed that with newer versions of ceph we often wait for the autoscaler when checking for health

```

Waiting for Rook-Ceph to be healthy
1 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (60s)      [==========..................] (remaining: 100s)" is 37.5001 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (60s)      [==========..................] (remaining: 100s)" is 37.5001 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (60s)      [==========..................] (remaining: 100s)" is 37.5001 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (60s)      [==========..................] (remaining: 100s)" is 37.5001 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (60s)      [==========..................] (remaining: 100s)" is 37.500 ... 1 tasks in progress, first task "PG autoscaler decreasing pool 6 PGs from 32 to 8 (2m)      [==================..........] (remaining: 60s)" is 66.666660.775194% of PGs are inactive, 0.000000% are degraded, and 0.000000% are misplaced; recovering at 0 B/secRook is healthy
Upgraded to Ceph 15.2.8 successfully
```

I wonder if there is too much osd activity as the pgs scale.

This adds quite a bit of time to the upgrade procedure.