### PR TITLE
Rook add-on ceph image version mismatch - should be v16.2.7

### DIFF
--- a/addons/rook/1.7.11/Manifest
+++ b/addons/rook/1.7.11/Manifest
@@ -3,7 +3,7 @@ yumol lvm2
 apt lvm2
 
 image rook-ceph rook/ceph:v1.7.11
-image ceph-ceph quay.io/ceph/ceph:v16.2.6
+image ceph-ceph quay.io/ceph/ceph:v16.2.7
 image cephcsi-cephcsi quay.io/cephcsi/cephcsi:v3.4.0
 image sig-storage-csi-node-driver-registrar k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
 image sig-storage-csi-resizer k8s.gcr.io/sig-storage/csi-resizer:v1.3.0

--- a/addons/rook/1.7.11/cluster/cluster.yaml
+++ b/addons/rook/1.7.11/cluster/cluster.yaml
@@ -21,7 +21,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such quay.io/ceph/ceph:v16.2.6-20210918
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: quay.io/ceph/ceph:v16.2.6
+    image: quay.io/ceph/ceph:v16.2.7
     # Whether to allow unsupported versions of Ceph. Currently `nautilus`, `octopus`, and `pacific` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -1,3 +1,61 @@
+- name: Rook minimal airgap
+  installerSpec:
+    kubernetes:
+      version: "1.24.x"
+    weave:
+      version: "latest"
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    ekco:
+      version: "latest"
+    rook:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+    minio_object_store_info
+    validate_read_write_object_store rwtest minio.txt
+
+    # validate data pools
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: cephfs-pvc
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: rook-cephfs
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: default-pvc
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+    EOF
+    sleep 10
+    kubectl -n default get pvc default-pvc | grep Bound
+    kubectl -n default get pvc cephfs-pvc | grep Bound
+    kubectl -n default delete pvc cephfs-pvc default-pvc
+
 - name: Rook minimal
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Rook upgrade fails with the following script output due to an ImagePullBackoff. Seems that the add-on is using two different versions.

https://github.com/replicatedhq/kURL/blob/f0466124142b53e27a4df379cdc0920cd8cebcb9/addons/rook/1.7.11/install.sh#L222

Preferring v16.2.7 based on the rook documentation https://www.rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades

> WARNING: There is a notice from Ceph for users upgrading to Ceph Pacific v16.2.6 or lower from an earlier major version of Ceph. If you are upgrading to Ceph Pacific (v16), please upgrade to v16.2.7 or higher if possible.

```
⚙  Upgrading rook-ceph cluster
cephcluster.ceph.rook.io/rook-ceph patched
Waiting for all Rook-Ceph deployments to be using Ceph 16.2.7-0
deployments rook-ceph-crashcollector-ethanm-rook-31, rook-ceph-crashcollector-ethanm-rook-32, rook-ceph-crashcollector-ethanm-rook-33, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-mon-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 15.2.13-0
Error: failed to wait for Ceph "16.2.7-0": timed out waiting for Ceph 16.2.7-0 to roll out
Detected multiple Ceph versions
name=rook-ceph-crashcollector-ethanm-rook-31, ceph-version=15.2.13-0
name=rook-ceph-crashcollector-ethanm-rook-32, ceph-version=15.2.13-0
name=rook-ceph-crashcollector-ethanm-rook-33, ceph-version=15.2.13-0
name=rook-ceph-mds-rook-shared-fs-a, ceph-version=15.2.13-0
name=rook-ceph-mds-rook-shared-fs-b, ceph-version=15.2.13-0
name=rook-ceph-mgr-a, ceph-version=15.2.13-0
name=rook-ceph-mon-a, ceph-version=15.2.13-0
name=rook-ceph-mon-b, ceph-version=15.2.13-0
name=rook-ceph-mon-c, ceph-version=15.2.13-0
name=rook-ceph-osd-3, ceph-version=15.2.13-0
name=rook-ceph-osd-4, ceph-version=15.2.13-0
name=rook-ceph-osd-5, ceph-version=15.2.13-0
name=rook-ceph-rgw-rook-ceph-store-a, ceph-version=15.2.13-0
New Ceph version failed to deploy
ethan@ethanm-rook-31:~/upgrade$
```

```
rook-ceph-detect-version-qlz5q                             0/1     ImagePullBackOff   0          2m57s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes airgapped upgrades to Rook add-on version 1.7.11 to fail with ImagePullBackoff errors.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE