### PR TITLE
fix: preflight check which verifies if docker is or not supported

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -80,14 +80,11 @@ function docker_install() {
 function is_docker_version_supported() {
     case "$LSB_DIST" in
     centos|rhel|ol)
-        if [ "${DIST_VERSION_MAJOR}" = "8" ]; then
-            if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
-                return 1
-            fi
+        if [ "${DIST_VERSION_MAJOR}" = "8" ] && [ -n "$DOCKER_VERSION" ]; then
+            return 1
         fi
         ;;
     esac
-
     return 0
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The code implementation to verify if docker is or not support was looking for specific docker versions. Therefore, when a new docker version was added it was unable to let the users know that docker is not supported with RHEL 8. 

#### Which issue(s) this PR fixes:

Fixes # [sc-50237]

#### Special notes for your reviewer:
See the test made:

<img width="865" alt="Screenshot 2022-12-21 at 11 23 49" src="https://user-images.githubusercontent.com/7708031/208894851-60e02e93-c814-4367-8b11-5f7aa1b4c65d.png">

## Steps to reproduce

- ENV: VM rhel 8.4
- Install: curl https://kurl.sh/version/v2022.05.19-0/37de0ce | sudo bash

Also, using latest with:

- curl https://kurl.sh/37de0ce | sudo bash

#### Does this PR introduce a user-facing change?

```release-note
fix: preflight check informing that docker is not support on RHEL 8. 
```

#### Does this PR require documentation?
NONE
