### PR TITLE
EKCO disable rook-priority.kurl.sh mutating webhook on Rook upgrade

### DIFF
--- a/addons/ekco/0.26.2/install.sh
+++ b/addons/ekco/0.26.2/install.sh
@@ -2,6 +2,7 @@
 
 EKCO_HAPROXY_IMAGE=haproxy:2.7.0-alpine3.17
 
+EKCO_ROOK_PRIORITY_CLASS=
 function ekco_pre_init() {
     if [ -z "$EKCO_NODE_UNREACHABLE_TOLERATION_DURATION" ]; then
         EKCO_NODE_UNREACHABLE_TOLERATION_DURATION=5m
@@ -87,6 +88,8 @@ function ekco() {
             bail "EKCO failed to deploy the pod-image-overrides.kurl.sh mutating webhook configuration"
         fi
     fi
+
+    ekco_maybe_remove_rook_priority_class_label
 }
 
 function ekco_join() {
@@ -122,16 +125,29 @@ function ekco_already_applied() {
     fi
 
     # check if EKCO deployment needs to be scaled up after a Rook upgrade
-    maybe_scaleup_ekco_operator
+    ekco_maybe_scaleup_operator
+
+    ekco_maybe_remove_rook_priority_class_label
 }
 
-function maybe_scaleup_ekco_operator() {
+function ekco_maybe_scaleup_operator() {
     local ekcoReplicas=
     ekcoReplicas=$(kubectl -n kurl get deployment ekc-operator -o jsonpath='{.spec.replicas}')
 
     if [ -z "$ekcoReplicas" ] || [ "$ekcoReplicas" -eq 0 ]; then
         echo "Scaling up EKCO operator deployment"
         kubectl -n kurl scale deploy ekc-operator --replicas=1
+    fi
+}
+
+# ekco_maybe_remove_rook_priority_class_label will remove the rook-priority.kurl.sh label
+# indicating that the EKCO rook-priority.kurl.sh mutating webhook should no longer be applied
+# to the rook-ceph namespace.
+function ekco_maybe_remove_rook_priority_class_label() {
+    if kubectl get namespace rook-ceph >/dev/null 2>&1 ; then
+        if [ -z "$EKCO_ROOK_PRIORITY_CLASS" ]; then
+            kubectl label namespace rook-ceph rook-priority.kurl.sh-
+        fi
     fi
 }
 

--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -137,6 +137,12 @@ function rook_upgrade() {
 
     rook_upgrade_prompt_missing_images "$from_version" "$to_version"
 
+    # delete the mutatingwebhookconfiguration and remove the rook-priority.kurl.sh label
+    # as the EKCO rook-priority.kurl.sh mutating webhook is no longer necessary passed Rook
+    # 1.0.4.
+    kubectl label namespace rook-ceph rook-priority.kurl.sh-
+    kubectl delete mutatingwebhookconfigurations rook-priority.kurl.sh --ignore-not-found
+
     if rook_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
         addon_source "rookupgrade" "10to14"
         rookupgrade_10to14_upgrade "$from_version"

--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -73,7 +73,8 @@ function rook_upgrade_should_upgrade_rook() {
     fi
 
     # for now upgrades not supported to minor versions greater than 7
-    if [ "$next_rook_version_minor" -gt "7" ]; then
+    # unless ALLOW_ROOK_UPGRADE_FULL exported env var is set to 1 for testing
+    if [ "$ALLOW_ROOK_UPGRADE_FULL" != "1" ] && [ "$next_rook_version_minor" -gt "7" ]; then
         return 1
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

when updating to 1.8.12 i am seeing a timeout rolling out ceph

```
deployments rook-ceph-osd-5 still running 16.2.7-0
Error: failed to wait for Ceph "16.2.9-0": timed out waiting for Ceph 16.2.9-0 to roll out
Detected multiple Ceph versions
name=rook-ceph-crashcollector-ethanm-rook-11, ceph-version=16.2.9-0
name=rook-ceph-crashcollector-ethanm-rook-12, ceph-version=16.2.9-0
name=rook-ceph-crashcollector-ethanm-rook-13, ceph-version=16.2.9-0
name=rook-ceph-mds-rook-shared-fs-a, ceph-version=16.2.9-0
name=rook-ceph-mds-rook-shared-fs-b, ceph-version=16.2.9-0
name=rook-ceph-mgr-a, ceph-version=16.2.9-0
name=rook-ceph-mon-a, ceph-version=16.2.9-0
name=rook-ceph-mon-b, ceph-version=16.2.9-0
name=rook-ceph-mon-c, ceph-version=16.2.9-0
name=rook-ceph-osd-3, ceph-version=16.2.9-0
name=rook-ceph-osd-4, ceph-version=16.2.9-0
name=rook-ceph-osd-5, ceph-version=16.2.7-0
name=rook-ceph-rgw-rook-ceph-store-a, ceph-version=16.2.9-0
New Ceph version failed to deploy
```

it looks like rook cannot update the osd deployment

```
2022-12-20 00:35:27.191263 E | util: error occurred waiting for deployments to be updated. retrying after 2s. failed to list deployments: context canceled
2022-12-20 00:35:29.191594 E | util: error occurred waiting for deployments to be updated. retrying after 2s. failed to list deployments: context canceled
2022-12-20 00:35:31.192744 E | util: error occurred waiting for deployments to be updated. retrying after 2s. failed to list deployments: context canceled
```

upon further investigation of the api server logs it looks like ekco mutating webhook may be causing the issue since during the upgrade ekco is scaled down

```
W1220 00:35:05.746827       1 dispatcher.go:170] Failed calling webhook, failing open rook-priority.kurl.sh: failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
E1220 00:35:05.746866       1 dispatcher.go:171] failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
W1220 00:35:09.795266       1 dispatcher.go:170] Failed calling webhook, failing open rook-priority.kurl.sh: failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
E1220 00:35:09.795331       1 dispatcher.go:171] failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
W1220 00:35:09.821787       1 dispatcher.go:170] Failed calling webhook, failing open rook-priority.kurl.sh: failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
E1220 00:35:09.821834       1 dispatcher.go:171] failed calling webhook "rook-priority.kurl.sh": Post "https://ekco.kurl.svc:443/rook-priority?timeout=10s": dial tcp 10.96.2.194:443: connect: connection refused
```

```
ethan@ethanm-rook-11:~$ kubectl get mutatingwebhookconfigurations
NAME                    WEBHOOKS   AGE
rook-priority.kurl.sh   1          46h
```

this pr will disable the mutating webhook for the rook-ceph namespace when upgrading rook as it is not applicable passed rook 1.0.4

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause Rook upgrades to fail if EKCO is scaled down due to failures to recreate the Rook OSD deployments since the rook-priority.kurl.sh MutatingAdmissionWebhook is unreachable.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
