### PR TITLE
chore: address CVE for registry 2.71 and Velero 1.6.0, 1.6.1, 1.7.1, 1.8.1

### DIFF
--- a/addons/registry/2.7.1/Manifest
+++ b/addons/registry/2.7.1/Manifest
@@ -1,2 +1,2 @@
 image registry registry:2.7.1
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227

--- a/addons/registry/2.7.1/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/2.7.1/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/2.7.1/patch-deployment-velero.yaml
+++ b/addons/registry/2.7.1/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/velero/1.6.0/Manifest
+++ b/addons/velero/1.6.0/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.2.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
 image local-volume-provider replicated/local-volume-provider:v0.3.0
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.0/velero-v1.6.0-linux-amd64.tar.gz
 

--- a/addons/velero/1.6.0/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.6.0/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.6.1/Manifest
+++ b/addons/velero/1.6.1/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.2.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
 image local-volume-provider replicated/local-volume-provider:v0.3.0
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.1/velero-v1.6.1-linux-amd64.tar.gz
 

--- a/addons/velero/1.6.1/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.6.1/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.6.2/Manifest
+++ b/addons/velero/1.6.2/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.2.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.2.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.2.0
 image local-volume-provider replicated/local-volume-provider:v0.3.0
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.6.2/velero-v1.6.2-linux-amd64.tar.gz
 

--- a/addons/velero/1.6.2/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.6.2/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.7.1/Manifest
+++ b/addons/velero/1.7.1/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.3.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.3.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.3.1
 image local-volume-provider replicated/local-volume-provider:v0.3.3
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.7.1/velero-v1.7.1-linux-amd64.tar.gz
 

--- a/addons/velero/1.7.1/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.7.1/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/1.8.1/Manifest
+++ b/addons/velero/1.8.1/Manifest
@@ -4,7 +4,7 @@ image velero-aws velero/velero-plugin-for-aws:v1.4.1
 image velero-gcp velero/velero-plugin-for-gcp:v1.4.1
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.4.1
 image local-volume-provider replicated/local-volume-provider:v0.3.6
-image s3cmd kurlsh/s3cmd:7f7dc75-20210331
+image s3cmd kurlsh/s3cmd:20221219-ff60227
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.8.1/velero-v1.8.1-linux-amd64.tar.gz
 

--- a/addons/velero/1.8.1/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.8.1/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:7f7dc75-20210331
+        image: kurlsh/s3cmd:20221219-ff60227
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh


### PR DESCRIPTION
#### What this PR does / why we need it:

In the testgrid K8s 1.22x Airgap we use Velero 1.7.1 and it is failing with unmet dependecies because this version has a CVE. 
It does the same changes https://github.com/replicatedhq/kURL/pull/3871 but for those versions as well. 

#### Which issue(s) this PR fixes:

Fixes # [sc-64917]

#### Special notes for your reviewer:

## Steps to reproduce

#### Does this PR introduce a user-facing change?

Not adding since it was not added to https://github.com/replicatedhq/kURL/pull/3871 as well.

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
