### PR TITLE
feat: add logs for kurl scripts

### DIFF
--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -5,7 +5,7 @@
 function prompts_can_prompt() {
     # Need the TTY to accept input and stdout to display
     # Prompts when running the script through the terminal but not as a subshell
-    if [ -t 1 ] && [ -c /dev/tty ]; then
+    if [ -c /dev/tty ]; then
         return 0
     fi
     return 1
@@ -266,7 +266,7 @@ function prompt_airgap_preload_images() {
     fi
 
     local unattended_nodes_missing_images=0
- 
+
     while read -r node; do
         local nodeName=$(echo "$node" | awk '{ print $1 }')
         if [ "$nodeName" = "$(get_local_node_name)" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -501,6 +501,7 @@ function report_kubernetes_install() {
 K8S_DISTRO=kubeadm
 
 function main() {
+    logStep "Running install with the argument(s): $@"
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"
@@ -569,4 +570,11 @@ function main() {
     report_install_success
 }
 
-main "$@"
+# tee logs into /var/log/kurl/install-<date>.log and stdout
+mkdir -p /var/log/kurl
+LOGFILE="/var/log/kurl/install-$(date +"%Y-%m-%dT%H-%M-%S").log"
+main "$@" 2>&1 | tee $LOGFILE
+# it is required to return the exit status of the script
+FINAL_RESULT="${PIPESTATUS[0]}"
+sed -i "/\b\(password\)\b/d" $LOGFILE > /dev/null 2>&1
+exit "$FINAL_RESULT"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -125,6 +125,7 @@ outro() {
 K8S_DISTRO=kubeadm
 
 function main() {
+    logStep "Running join with the argument(s): $@"
     export KUBECONFIG=/etc/kubernetes/admin.conf
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path
@@ -171,4 +172,11 @@ function main() {
     popd_install_directory
 }
 
-main "$@"
+# tee logs into /var/log/kurl/install-<date>.log and stdout
+mkdir -p /var/log/kurl
+LOGFILE="/var/log/kurl/join-$(date +"%Y-%m-%dT%H-%M-%S").log"
+main "$@" 2>&1 | tee $LOGFILE
+# it is required to return the exit status of the script
+FINAL_RESULT="${PIPESTATUS[0]}"
+sed -i "/\b\(password\)\b/d" $LOGFILE > /dev/null 2>&1
+exit "$FINAL_RESULT"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -24,6 +24,7 @@ DIR=.
 
 K8S_DISTRO=
 function tasks() {
+    logStep "Running tasks with the argument(s): $@"
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"
 
@@ -717,4 +718,10 @@ function install_host_dependencies_longhorn() {
     longhorn_host_init_common "${DIR}/packages/host/longhorn"
 }
 
-tasks "$@"
+mkdir -p /var/log/kurl
+LOGFILE="/var/log/kurl/tasks-$(date +"%Y-%m-%dT%H-%M-%S").log"
+tasks "$@" 2>&1 | tee $LOGFILE
+# it is required to return the exit status of the script
+FINAL_RESULT="${PIPESTATUS[0]}"
+sed -i "/\b\(password\)\b/d" $LOGFILE > /dev/null 2>&1
+exit "$FINAL_RESULT"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -e
@@ -107,6 +106,7 @@ function outro() {
 K8S_DISTRO=kubeadm
 
 function main() {
+    logStep "Running upgrade with the argument(s): $@"
     export KUBECONFIG=/etc/kubernetes/admin.conf
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path
@@ -148,4 +148,11 @@ function main() {
     popd_install_directory
 }
 
-main "$@"
+# tee logs into /var/log/kurl/upgrade-<date>.log and stdout
+mkdir -p /var/log/kurl
+LOGFILE="/var/log/kurl/upgrade-$(date +"%Y-%m-%dT%H-%M-%S").log"
+main "$@" 2>&1 | tee $LOGFILE
+# it is required to return the exit status of the script
+FINAL_RESULT="${PIPESTATUS[0]}"
+sed -i "/\b\(password\)\b/d" $LOGFILE > /dev/null 2>&1
+exit "$FINAL_RESULT"


### PR DESCRIPTION
#### What this PR does / why we need it:

Have the logs from what was executed with kurl is very helpful in the support.
After we get this PR merged we will be able to check all logs under /var/log/kurl

Examples:

<img width="911" alt="Screenshot 2022-12-23 at 07 53 40" src="https://user-images.githubusercontent.com/7708031/209295787-721057bb-091b-44ea-ac91-74b89c5f6dc5.png">

#### Which issue(s) this PR fixes:

Fixes # [sc-35094]

#### Special notes for your reviewer:

**See that the output in the console still:** 

<img width="901" alt="Screenshot 2022-12-23 at 07 51 42" src="https://user-images.githubusercontent.com/7708031/209295572-1a7a005c-373a-4560-9a92-4cf6e93336a6.png">

**Also, if fails the error still showing in the output and log files:**

<img width="830" alt="Screenshot 2022-12-23 at 07 54 46" src="https://user-images.githubusercontent.com/7708031/209295932-3d09d5df-be07-46f4-b5be-698e56d22a27.png">

**We are also hidden any line which might has a password:**

Following the test done by changing the script: 

- a) Change the script with the same done in: https://github.com/replicatedhq/kURL/pull/3891/files

<img width="818" alt="Screenshot 2022-12-28 at 12 52 28" src="https://user-images.githubusercontent.com/7708031/209815264-9abd5c3c-d489-4af0-b27c-d6f7e6d64072.png">

- b) Add in the main func the same print that will be done by kots example:

<img width="826" alt="Screenshot 2022-12-28 at 12 19 38" src="https://user-images.githubusercontent.com/7708031/209811272-4bed8ba6-b5d4-454c-a38d-05102a08845f.png">

- c) Run the sudo bash ./install
- d) Check that the line `"Login with password (will not be shown again): senha"`  cannot be found in the logs:

<img width="981" alt="Screenshot 2022-12-28 at 12 58 46" src="https://user-images.githubusercontent.com/7708031/209816000-cca9aa78-044b-4472-81e4-030da0e3d61f.png">

**Also, to ensure that the script would fail after these changes:**

- a) Now, let's run without sudo
- b) See that it finished with the error code:

<img width="911" alt="Screenshot 2022-12-28 at 12 55 23" src="https://user-images.githubusercontent.com/7708031/209815630-9fd10033-0e54-4a16-be3c-98a57be0f7c4.png">

**By last see that we need to change the funcs to read the data, so that we can have an interactive shell and the logs:**

<img width="1311" alt="Screenshot 2022-12-29 at 12 36 52" src="https://user-images.githubusercontent.com/7708031/209952217-772f4695-afcf-4b6f-bbc4-3b497bf3ae23.png">

## Steps to reproduce

#### Does this PR introduce a user-facing change?
```release-note
feat: kURL execution logs can be found now under /var/log/kurl/
```

#### Does this PR require documentation?
NONE
