### PR TITLE
fix airgap testgrid k8s121-airgap by upgrading valero version

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -894,7 +894,7 @@
     kotsadm:
       version: latest
     velero:
-      version: 1.7.x
+      version: 1.9.x
     ekco:
       version: latest
   airgap: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the test is using valero 1.7.1 which has CVEs and will fail with unmet dependency in the airgap test.
Therefore, this PR changes the version used the latest to sort it out.  

#### Which issue(s) this PR fixes:

Fixes # [sc-64917]

#### Special notes for your reviewer:

See: https://testgrid.kurl.sh/run/airgap-cve-k8s121airgap-valero-1.9-22-12-2022-15-23

## Steps to reproduce

Check the error with the testgrid K8s 1.22x Airgap targeting Ubuntu 22.04 

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
