### PR TITLE
fix testgrid k8s119_ctrd_longhorn-airgap targeting 20.04

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -456,7 +456,7 @@
     certManager:
       version: 1.0.3
     longhorn:
-      version: 1.1.2
+      version: 1.3.1
       uiBindPort: 30080
   airgap: true
   unsupportedOSIDs:


### PR DESCRIPTION
#### What this PR does / why we need it:

The onghorn version used in this test is old and has a CVE which is making it fails.
This PR should sorted out the error faced targeting 20.04

#### Which issue(s) this PR fixes:

Fixes # [sc-65056]

#### Special notes for your reviewer:
See: https://testgrid.kurl.sh/run/k8s119_ctrd_longhorn-airgap-with-version-1-3-1

NOTE: 22.04 is not supported on this (you can check the daily tests) 

## Steps to reproduce

See the daily tests and its error

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
