### PR TITLE
chore: fix longhorn generate script by skipping version 1.2.6

### DIFF
--- a/addons/longhorn/template/generate.sh
+++ b/addons/longhorn/template/generate.sh
@@ -105,6 +105,12 @@ function add_as_latest() {
 
 function main() {
     get_latest_release_version
+    # The version 1.2.6 is lower than the latest added and it does not have
+    # all manifest which causes the script fail
+    if [ "${VERSION}" == "1.2.6" ]; then
+        echo "ignore version 1.2.6"
+        return
+    fi
 
     if [ -d "../${VERSION}" ]; then
         if [ $# -ge 1 ] && [ "$1" == "force" ]; then


### PR DESCRIPTION
#### What this PR does / why we need it:

Longhorn generate is not working, see

https://github.com/replicatedhq/kURL/actions/runs/3763084697/jobs/6396325888

The reason is because the script tried to add 1.2.6 (which is lower than the latest version) and fails because this one has not all expected manifests. 

#### Which issue(s) this PR fixes:

Fixes # [sc-65099]

#### Special notes for your reviewer:

![Screenshot 2022-12-23 at 08 50 02](https://user-images.githubusercontent.com/7708031/209304232-209e8d07-6783-419a-be38-7d441396d61c.png)


## Steps to reproduce
Just try to run the script

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
