### PR TITLE
chore(dependabot): Add node dependabot with monthly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
       - "type::chore"
     schedule:
       interval: "weekly"
+      
+   - package-ecosystem: "npm"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "type::chore"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,8 @@ updates:
       - "type::chore"
     schedule:
       interval: "weekly"
-      
-   - package-ecosystem: "npm"
+
+  - package-ecosystem: "npm"
     directory: "/"
     labels:
       - "dependencies"
@@ -36,4 +36,5 @@ updates:
       - "type::chore"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 25      
+    open-pull-requests-limit: 25
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,4 @@ updates:
       - "type::chore"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5      
+    open-pull-requests-limit: 25      


### PR DESCRIPTION
#### What this PR does / why we need it:

kURL has the package json as well. So, we are just adding the dependabot to keep it updated and have the same approach across the ecosystem. 

#### Which issue(s) this PR fixes:

Fixes # [sc-57647]

