### PR TITLE
chore(rook): update the image ceph/ceph:v14.2.5 to get the latest one built

### DIFF
--- a/addons/rookupgrade/10to14/Manifest
+++ b/addons/rookupgrade/10to14/Manifest
@@ -6,7 +6,7 @@ image rook-ceph-149 rook/ceph:v1.4.9
 image ceph-ceph-1425 ceph/ceph:v14.2.5
 image ceph-ceph-1528 ceph/ceph:v15.2.8
 
-image ceph-ceph-1425-2019 docker.io/ceph/ceph:v14.2.5-20191210
+image ceph-ceph-1425-2019 docker.io/ceph/ceph:v14.2.5-20201116
 image ceph-ceph-1528-2020 docker.io/ceph/ceph:v15.2.8-20201217
 
 image cephcsi-cephcsi-122 quay.io/cephcsi/cephcsi:v1.2.2

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -71,7 +71,7 @@ function rookupgrade_10to14_upgrade() {
         if [ "$SEMVER_COMPARE_RESULT" != "1" ]; then
             echo "Upgrading to Ceph 14.2.5"
 
-            kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20191210"}}}'
+            kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20201116"}}}'
             kubectl patch deployment -n rook-ceph csi-rbdplugin-provisioner -p '{"spec": {"template": {"spec":{"containers":[{"name":"csi-snapshotter","imagePullPolicy":"IfNotPresent"}]}}}}'
             "$DIR"/bin/kurl rook wait-for-ceph-version "14.2.5"
 

--- a/pkg/rook/testfiles/upgradedNode.json
+++ b/pkg/rook/testfiles/upgradedNode.json
@@ -374,7 +374,7 @@
           {
             "names": [
               "docker.io/ceph/ceph@sha256:8c86fc6acf47edb6c3e38777b72c3fea2bad5be18c7e88553673205b378d0121",
-              "docker.io/ceph/ceph:v14.2.5-20191210"
+              "docker.io/ceph/ceph:v14.2.5-20201116"
             ],
             "sizeBytes": 289364517
           },

--- a/pkg/rook/testfiles/upgradedNodeLess50Images.json
+++ b/pkg/rook/testfiles/upgradedNodeLess50Images.json
@@ -368,7 +368,7 @@
           {
             "names": [
               "docker.io/ceph/ceph@sha256:8c86fc6acf47edb6c3e38777b72c3fea2bad5be18c7e88553673205b378d0121",
-              "docker.io/ceph/ceph:v14.2.5-20191210"
+              "docker.io/ceph/ceph:v14.2.5-20201116"
             ],
             "sizeBytes": 289364517
           },


### PR DESCRIPTION
#### What this PR does / why we need it:

Just to ensure that we are using the latest release provided.  

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE

## Steps to reproduce
NONE

