### PR TITLE
chore: increase prometheus scale down timeout

### DIFF
--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -80,7 +80,7 @@ function longhorn_to_sc_migration() {
 
             kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
             log "Waiting for prometheus pods to be removed"
-            spinner_until 120 prometheus_pods_gone
+            spinner_until 300 prometheus_pods_gone
         fi
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -149,7 +149,7 @@ function rook_ceph_to_sc_migration() {
 
             kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
             echo "Waiting for prometheus pods to be removed"
-            spinner_until 120 prometheus_pods_gone
+            spinner_until 300 prometheus_pods_gone
         fi
     fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR increases the timeout for prometheus pod to come down during data migration from 2 to 5 minutes.
