### PR TITLE
bug: don't attempt to migrate from longhorn on unsupported version

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -374,6 +374,16 @@ function openebs_prompt_migrate_from_longhorn() {
     logWarn "    Detected Longhorn is running in the cluster. Data migration will be initiated to move data from Longhorn to storage class $OPENEBS_LOCALPV_STORAGE_CLASS."
     logWarn "    As part of this, all pods mounting PVCs will be stopped, taking down the application."
     logWarn "    It is recommended to take a snapshot or otherwise back up your data before proceeding."
+
+    semverParse "$KUBERNETES_VERSION"
+    if [ "$minor" -gt 24 ] ; then
+        logFail "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
+        logFail "    on your cluster. As a result, it is not possible to migrate data from Longhorn to OpenEBS. To successfully migrate data, please choose a Kubernetes"
+        logFail "    version that is compatible with the version of Longhorn running on your cluster (note: Longhorn is compatible with Kubernetes versions up to and"
+        logFail "    including 1.24)."
+        bail "Not migrating"
+    fi
+
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -374,6 +374,16 @@ function openebs_prompt_migrate_from_longhorn() {
     logWarn "    Detected Longhorn is running in the cluster. Data migration will be initiated to move data from Longhorn to storage class $OPENEBS_LOCALPV_STORAGE_CLASS."
     logWarn "    As part of this, all pods mounting PVCs will be stopped, taking down the application."
     logWarn "    It is recommended to take a snapshot or otherwise back up your data before proceeding."
+
+    semverParse "$KUBERNETES_VERSION"
+    if [ "$minor" -gt 24 ] ; then
+        logFail "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
+        logFail "    on your cluster. As a result, it is not possible to migrate data from Longhorn to OpenEBS. To successfully migrate data, please choose a Kubernetes"
+        logFail "    version that is compatible with the version of Longhorn running on your cluster (note: Longhorn is compatible with Kubernetes versions up to and"
+        logFail "    including 1.24)."
+        bail "Not migrating"
+    fi
+
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"


### PR DESCRIPTION
#### What this PR does / why we need it:

Due to compatibility issues, if the version of Kubernetes being used is v1.25 or higher, it will not be possible for Longhorn to operate properly and the migration process will fail. This commit introduces a message that will be displayed and the process will immediately terminate upon detection of a Kubernetes version of v1.25 or higher.

#### Which issue(s) this PR fixes:
Fixes #58505