### PR TITLE
fix: do not allow to remove packages when we use apt-get to fix broken packages

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -102,13 +102,15 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
         return
     fi
 
-    logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --yes"
-    apt-get install --fix-broken --yes
+    logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --no-remove --yes"
+    # Let's use || true here for when be required to remove the packages we properly should the error message
+    # with the steps to get it fix manually
+    apt-get install --fix-broken --no-remove --yes || true
     if apt-get check status ; then
         logSuccess "Broken packages fixed successfully"
         return
     fi
-    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$ apt-get check status' to get further information."
+    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$ apt-get check status' to get further information. You might able to fix it with '$ sudo apt-get install --fix-broken' by allowing remove the packages"
 }
 
 function _dpkg_install_host_packages() {

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -102,7 +102,7 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
         return
     fi
 
-    logWarn "Attempting to correct broken packages by running sudo apt-get install --fix-broken --no-remove --yes"
+    logWarn "Attempting to correct broken packages by running 'apt-get install --fix-broken --no-remove --yes'"
     # Let's use || true here for when be required to remove the packages we properly should the error message
     # with the steps to get it fix manually
     apt-get install --fix-broken --no-remove --yes || true

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -110,7 +110,9 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
         logSuccess "Broken packages fixed successfully"
         return
     fi
-    bail "Unable to fix broken packages. It is required manual intervention. Run the command '$ apt-get check status' to get further information. You might able to fix it with '$ sudo apt-get install --fix-broken' by allowing remove the packages"
+    logFail "Unable to fix broken packages. Manual intervention is required."
+    logFail "Run the command 'apt-get check status' to get further information."
+    bail "You may able to fix it with 'sudo apt-get install --fix-broken', allowing the removal of packages."
 }
 
 function _dpkg_install_host_packages() {


### PR DESCRIPTION
#### What this PR does / why we need it:

In the PR [#3844](https://github.com/replicatedhq/kURL/pull/3844) we introduced a feature to automatically fix the broken packages ONLY when/if we check that the KURL install broken them.
However, apt-get --fix-broken can delete packages by default More info : https://linux.die.net/man/8/apt-get

Therefore, we should not packages to fix the broken ones since, in an edge case scenario, it was possible to check that it broke the features on the host. To provide the value to fix these scenarios automatically as avoid kURL get installed with old versions, we can go safer by only installing/updating the packages but not removing them. To achieve this goal, we are:
Using the flag --no-remove
If we cannot solve the issue because the package manager needs to remove a package, then we are letting the user know and providing the commands to do that manually and with knowledge.

#### Which issue(s) this PR fixes:

Fixes # [sc-66214]

#### Special notes for your reviewer:

Following some tests done: 

**To ensure that we have cases where is possible to sorted out the broken packages without remove any**

- Create a GCP instance `gcreate ubuntu-pro-2004-focal-v20220204 myinstance`
- Do the airgap install as follows with the changes applied on this PR:

```sh
curl -LO https://kurl.sh/bundle/8f38eb0.tar.gz
tar xvzf 8f38eb0.tar.gz
cat install.sh | sudo bash -s airgap
```

Then, you will see that the kURL fix the broken packages by only updating them:

<img width="1246" alt="Screenshot 2023-01-10 at 22 28 54" src="https://user-images.githubusercontent.com/7708031/211678313-c1776589-5bd7-4e6e-a5bb-9f624d7d40d3.png">

**To ensure desired behaviour when is required to remove packages to do fix those that are broken**

- In this case you need to create a AWS instance : `ami-04505e74c0741db8d` and perform the same steps.
- Then, you will see that the install will be bail with the message:

<img width="1370" alt="Screenshot 2023-01-10 at 22 33 24" src="https://user-images.githubusercontent.com/7708031/211678582-e2f680f2-b003-4e41-85f9-d9686ef87c1c.png">

## Steps to reproduce
- create a AWS instance : `ami-04505e74c0741db8d` 
- run

```sh
curl -LO https://kurl.sh/bundle/8f38eb0.tar.gz
tar xvzf 8f38eb0.tar.gz
cat install.sh | sudo bash -s airgap
```

- check in the output that packages will be removed

```
⚙  Checking package manager status
Reading package lists... Done
Building dependency tree       
Reading state information... Done
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 openssh-server : Depends: openssh-client (= 1:8.2p1-4ubuntu0.3) but 1:8.2p1-4ubuntu0.5 is installed
 openssh-sftp-server : Depends: openssh-client (= 1:8.2p1-4ubuntu0.3) but 1:8.2p1-4ubuntu0.5 is installed
 perl : Depends: perl-base (= 5.30.0-9ubuntu0.3) but 5.30.0-9ubuntu0.2 is installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
Attempting to correct broken packages by running sudo apt-get install --fix-broken --yes
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Correcting dependencies... Done
The following packages were automatically installed and are no longer required:
  git-man libgdbm-compat4 libperl5.30
  perl-modules-5.30
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  ec2-instance-connect git liberror-perl
  openssh-server openssh-sftp-server perl
  ubuntu-server
0 upgraded, 0 newly installed, 7 to remove and 0 not upgraded.
After this operation, 39.2 MB disk space will be freed.
(Reading database ... 64000 files and directories currently installed.)
Removing ec2-instance-connect (1.1.12+dfsg1-0ubuntu3.20.04.1) ...
Deleted system user ec2-instance-connect
Removing ubuntu-server (1.450.2) ...
Removing git (1:2.25.1-1ubuntu3.6) ...
Removing liberror-perl (0.17029-1) ...
Removing openssh-server (1:8.2p1-4ubuntu0.3) ...
Removing openssh-sftp-server (1:8.2p1-4ubuntu0.3) ...
Removing perl (5.30.0-9ubuntu0.3) ...
Processing triggers for man-db (2.9.1-1) ...
Reading package lists... Done
Building dependency tree       
Reading state information... Done
✔ Broken packages fixed successfully
```

#### Does this PR introduce a user-facing change?
```release-note
fix: (for ubuntu) does not allow remove packages when broken packages are sorted out automatically. Therefore, if be required to do removals ask for manual intervention instead. 
```

#### Does this PR require documentation?
NONE