### PR TITLE
fix regression to upgrade from 1.0.4

### DIFF
--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -13,7 +13,7 @@ function rookupgrade_10to14_upgrade() {
             bail "Failed to verify the updated cluster, Ceph is not healthy"
         fi
 
-        # If the rock version installed is 1.0.4-14.2.21 then, we need to workaround
+        # If the rook version installed is 1.0.4-14.2.21 then, we need to workaround
         # the issue scenario: https://github.com/rook/rook/issues/11496
         semverCompare "$(current_ceph_version)" "14.2.21"
         if [ "$SEMVER_COMPARE_RESULT" != "-1" ]; then # greater than or equal to 14.2.21

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -13,8 +13,13 @@ function rookupgrade_10to14_upgrade() {
             bail "Failed to verify the updated cluster, Ceph is not healthy"
         fi
 
-        log "Setting mon auth_allow_insecure_global_id_reclaim true"
-        kubectl -n rook-ceph exec deploy/rook-ceph-operator -- ceph config set mon auth_allow_insecure_global_id_reclaim true
+        # If the rock version installed is 1.0.4-14.2.21 then, we need to workaround
+        # the issue scenario: https://github.com/rook/rook/issues/11496
+        semverCompare "$(current_ceph_version)" "14.2.21"
+        if [ "$SEMVER_COMPARE_RESULT" != "-1" ]; then # greater than or equal to 14.2.21
+            log "Setting mon auth_allow_insecure_global_id_reclaim true"
+            kubectl -n rook-ceph exec deploy/rook-ceph-operator -- ceph config set mon auth_allow_insecure_global_id_reclaim true
+        fi
 
         log "Updating the Ceph mon count"
         # If mon count is less than actual count, update mon count to actual count. Otherwise


### PR DESCRIPTION
#### What this PR does / why we need it:

By doing the PR: https://github.com/replicatedhq/kURL/pull/3931 we introduce an issue to upgrade from 1.0.4:

```
Started rook-ceph-toolbox deployment
Rook is healthy
Setting mon auth_allow_insecure_global_id_reclaim true
Error EINVAL: unrecognized config option 'auth_allow_insecure_global_id_reclaim'
command terminated with exit code 22
An error occurred on line 17
ethan@ethanm-rook-51:~$
```

#### Which issue(s) this PR fixes:

Fixes # [sc-63078]

#### Special notes for your reviewer:

## Steps to reproduce

#### Does this PR introduce a user-facing change?
NONE. not required unless we do a release with https://github.com/replicatedhq/kURL/pull/3931  before this one get merged. 

#### Does this PR require documentation?
NONE
