### PR TITLE
fix(ci/cd): match any length git SHA short ID when looking for staging release folder

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -101,7 +101,7 @@ jobs:
         version_commit="$(git rev-list "${GITHUB_REF_NAME}" -n 1 | xargs git rev-parse --short)"
         # Grab the release asset directory name in s3. Should look like this:
         # PRE v2023.01.03-0-1cee33ec/
-        staging_release_dir="$(aws s3 ls s3://"${S3_BUCKET}/${STAGING_PREFIX}/" | grep "${version_commit}/" | awk '{print $2}')"
+        staging_release_dir="$(aws s3 ls s3://"${S3_BUCKET}/${STAGING_PREFIX}/" | grep "${version_commit}[0-9a-f]*/" | awk '{print $2}')"
         if [ -z "${staging_release_dir}" ]; then
             echo "Could not find staging release for commit ${GITHUB_REF_NAME} (${version_commit})"
             exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Could not find staging release directory because I was matching on a 7 character short GIT sha. Fixed `grep` regex so SHA ID length is not an issue.

Ref: https://github.com/replicatedhq/kURL/pull/3867



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
