### PR TITLE
fix(ci/cd): KURL_UTIL_IMAGE envar required for copy-staging-to-release-prod Job

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -140,6 +140,7 @@ jobs:
     - name: Copy Staging Release to Prod
       run: |
         export VERSION_TAG=$GITHUB_REF_NAME
+        export KURL_UTIL_IMAGE=replicated/kurl-util:${VERSION_TAG}
         . bin/upload-dist-versioned.sh
         copy_staging_release_to_dist
       env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Fix the following `deploy-prod` Job error:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/6497491/212129890-3d0955a1-fc9e-4c61-82c3-e52151266df3.png">

Ref: #3867 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
