### PR TITLE
chore: remove the bail line when the packages are broken

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -112,7 +112,6 @@ function _dpkg_apt_get_status_and_maybe_fix_broken_pkgs() {
     fi
     logFail "Unable to fix broken packages. Manual intervention is required."
     logFail "Run the command 'apt-get check status' to get further information."
-    bail "You may able to fix it with 'sudo apt-get install --fix-broken', allowing the removal of packages."
 }
 
 function _dpkg_install_host_packages() {


### PR DESCRIPTION
#### What this PR does / why we need it:

We decide that we should not stop the install in this case just log.

#### Which issue(s) this PR fixes:

Fixes # [sc-66214]
