### PR TITLE
fix: create .kube/config for all installs

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -598,6 +598,7 @@ function kubeconfig_setup_outro() {
     else
         # running via sudo - automatically create ~/.kube/config if it does not exist
         ownerdir=`eval echo "~$(id -un $owner)"`
+
         if [ ! -f "$ownerdir/.kube/config" ]; then
             mkdir -p $ownerdir/.kube
             cp "$(${K8S_DISTRO}_get_kubeconfig)" $ownerdir/.kube/config
@@ -611,14 +612,10 @@ function kubeconfig_setup_outro() {
         fi
     fi
 
-    printf "To access the cluster with kubectl, the kubeconfig will be copied to your home directory with the following commands:\n"
+    printf "To access the cluster with kubectl, copy kubeconfig to your home directory:\n"
     printf "\n"
     printf "${GREEN}    cp "$(${K8S_DISTRO}_get_kubeconfig)" ~/.kube/config${NC}\n"
     printf "${GREEN}    chown -R ${owner} ~/.kube${NC}\n"
-
-    cp "$(${K8S_DISTRO}_get_kubeconfig)" $ownerdir/.kube/config
-    chown -R $owner $ownerdir/.kube
-
     printf "${GREEN}    echo unset KUBECONFIG >> ~/.bash_profile${NC}\n"
     printf "${GREEN}    bash -l${NC}\n"
     printf "\n"

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -591,13 +591,6 @@ function current_user_sudo_group() {
 
 function kubeconfig_setup_outro() {
     current_user_sudo_group
-    # If opt-in to have KUBERNETES_CIS_COMPLIANCE FOUND_SUDO_GROUP is required for kubectl access
-    if [ "$KUBERNETES_CIS_COMPLIANCE" != "1" ] && [ -n "$FOUND_SUDO_GROUP" ]; then
-        printf "To access the cluster with kubectl, reload your shell:\n"
-        printf "\n"
-        printf "${GREEN}    bash -l${NC}\n"
-        return
-    fi
     local owner="$SUDO_UID"
     if [ -z "$owner" ]; then
         # not currently running via sudo
@@ -605,7 +598,6 @@ function kubeconfig_setup_outro() {
     else
         # running via sudo - automatically create ~/.kube/config if it does not exist
         ownerdir=`eval echo "~$(id -un $owner)"`
-
         if [ ! -f "$ownerdir/.kube/config" ]; then
             mkdir -p $ownerdir/.kube
             cp "$(${K8S_DISTRO}_get_kubeconfig)" $ownerdir/.kube/config
@@ -619,10 +611,14 @@ function kubeconfig_setup_outro() {
         fi
     fi
 
-    printf "To access the cluster with kubectl, copy kubeconfig to your home directory:\n"
+    printf "To access the cluster with kubectl, the kubeconfig will be copied to your home directory with the following commands:\n"
     printf "\n"
     printf "${GREEN}    cp "$(${K8S_DISTRO}_get_kubeconfig)" ~/.kube/config${NC}\n"
     printf "${GREEN}    chown -R ${owner} ~/.kube${NC}\n"
+
+    cp "$(${K8S_DISTRO}_get_kubeconfig)" $ownerdir/.kube/config
+    chown -R $owner $ownerdir/.kube
+
     printf "${GREEN}    echo unset KUBECONFIG >> ~/.bash_profile${NC}\n"
     printf "${GREEN}    bash -l${NC}\n"
     printf "\n"


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensure .kube/config for all installs

<img width="1415" alt="Screenshot 2023-01-13 at 14 18 32" src="https://user-images.githubusercontent.com/7708031/212341206-b19ee405-c42b-4f5f-a4cc-7ef089a6f390.png">


#### Which issue(s) this PR fixes:

Fixes # [sc-63954]

#### Special notes for your reviewer:

Following the tests done with this change. 

- To do a new install with curl https://kurl.sh/95a2ab5 | sudo bash (and the changes):

<img width="1415" alt="Screenshot 2023-01-13 at 14 18 32" src="https://user-images.githubusercontent.com/7708031/212341242-b1a16e63-7051-4a5e-9038-be8196153c02.png">

- Then, upgrade k8s from 1.25.3 to 1.25.5 and ecko from 0.25.0 to 0.25.6:

<img width="1375" alt="Screenshot 2023-01-13 at 14 21 36" src="https://user-images.githubusercontent.com/7708031/212341795-6a1b4687-377d-4bfd-bd28-87ec1b27a1b7.png">

<img width="1424" alt="Screenshot 2023-01-13 at 14 33 10" src="https://user-images.githubusercontent.com/7708031/212344954-f584f831-9ec9-41f9-87b6-ea5b57eca5c1.png">

- Then, upgrade the cluster to k8s 1.26.0 using  (sudo bash -s ha) to very its scenario (without inform a Load balancer address:)

<img width="1424" alt="Screenshot 2023-01-13 at 14 34 39" src="https://user-images.githubusercontent.com/7708031/212345278-bfe67103-bfa2-4b26-9fe1-44aaa71625c3.png">

<img width="1242" alt="Screenshot 2023-01-13 at 14 35 55" src="https://user-images.githubusercontent.com/7708031/212345549-db7ca9e2-7f35-4be3-8088-55bdf6d1c9b5.png">

<img width="1414" alt="Screenshot 2023-01-13 at 14 50 09" src="https://user-images.githubusercontent.com/7708031/212348882-4ef4beff-c564-4cde-87f6-a0a1a365f451.png">

- Run bash-l and use kubectl to access the cluster to ensure that all is fine : 

<img width="1419" alt="Screenshot 2023-01-13 at 14 50 31" src="https://user-images.githubusercontent.com/7708031/212348850-7b7791e5-efa2-454a-baae-4b315260388e.png">


## Steps to reproduce

install kurl on gcp without cis compliance

```
$ ls $HOME/.kube
cache
```

#### Does this PR introduce a user-facing change?

```release-note
fix: create .kube/config for installs where that has not been created.
```

#### Does this PR require documentation?
NONE
