### PR TITLE
fix: debug print all arguments

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -501,7 +501,7 @@ function report_kubernetes_install() {
 K8S_DISTRO=kubeadm
 
 function main() {
-    logStep "Running install with the argument(s): $@"
+    logStep "Running install with the argument(s): $*"
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -125,7 +125,7 @@ outro() {
 K8S_DISTRO=kubeadm
 
 function main() {
-    logStep "Running join with the argument(s): $@"
+    logStep "Running join with the argument(s): $*"
     export KUBECONFIG=/etc/kubernetes/admin.conf
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -24,7 +24,7 @@ DIR=.
 
 K8S_DISTRO=
 function tasks() {
-    logStep "Running tasks with the argument(s): $@"
+    logStep "Running tasks with the argument(s): $*"
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -106,7 +106,7 @@ function outro() {
 K8S_DISTRO=kubeadm
 
 function main() {
-    logStep "Running upgrade with the argument(s): $@"
+    logStep "Running upgrade with the argument(s): $*"
     export KUBECONFIG=/etc/kubernetes/admin.conf
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The debug output at the beginning of the script only prints the first argument.

```
$ curl -s https://k8s.kurl.sh/fced04a/tasks.sh | sudo bash -s rook-upgrade-load-images from-version=1.0 to-version=1.10
⚙  Running tasks with the argument(s): rook-upgrade-load-images
```
