### PR TITLE
add kurl_machine_uuid reporting, remove redundant/unused machine_id reporting

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -860,8 +860,16 @@ function maybe() {
 }
 
 MACHINE_ID=
+KURL_INSTANCE_UUID=
 function get_machine_id() {
     MACHINE_ID="$(${DIR}/bin/kurl host protectedid || true)"
+    if [ -f /var/lib/kurl/uuid ]; then
+        KURL_INSTANCE_UUID="$(cat /var/lib/kurl/uuid)"
+    else
+        KURL_INSTANCE_UUID="$(uuidgen)"
+        mkdir -p /var/lib/kurl
+        echo "$KURL_INSTANCE_UUID" > /var/lib/kurl/uuid
+    fi
 }
 
 function kebab_to_camel() {

--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -28,11 +28,11 @@ function report_install_start() {
      # Determine if it is the first kurl install 
      if kubernetes_resource_exists kube-system configmap kurl-config; then
          curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-         -d "{\"started\": \"$started\", \"os\": \"$LSB_DIST $DIST_VERSION\", \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \"kurl_url\": \"$KURL_URL\", \"installer_id\": \"$INSTALLER_ID\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\", \"is_upgrade\": true}" \
+         -d "{\"started\": \"$started\", \"os\": \"$LSB_DIST $DIST_VERSION\", \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \"kurl_url\": \"$KURL_URL\", \"installer_id\": \"$INSTALLER_ID\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\", \"kurl_instance_uuid\": \"$KURL_INSTANCE_UUID\", \"is_upgrade\": true}" \
          $REPLICATED_APP_URL/kurl_metrics/start_install/$INSTALLATION_ID || true
      else
          curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-         -d "{\"started\": \"$started\", \"os\": \"$LSB_DIST $DIST_VERSION\", \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \"kurl_url\": \"$KURL_URL\", \"installer_id\": \"$INSTALLER_ID\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\", \"is_upgrade\": false}" \
+         -d "{\"started\": \"$started\", \"os\": \"$LSB_DIST $DIST_VERSION\", \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \"kurl_url\": \"$KURL_URL\", \"installer_id\": \"$INSTALLER_ID\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\", \"kurl_instance_uuid\": \"$KURL_INSTANCE_UUID\", \"is_upgrade\": false}" \
          $REPLICATED_APP_URL/kurl_metrics/start_install/$INSTALLATION_ID || true
      fi
 }
@@ -48,7 +48,7 @@ function report_install_success() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"finished\": \"$completed\"}" \
         $REPLICATED_APP_URL/kurl_metrics/finish_install/$INSTALLATION_ID || true
 }
 
@@ -64,7 +64,7 @@ function report_install_fail() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"cause\": \"$cause\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"finished\": \"$completed\", \"cause\": \"$cause\"}" \
         $REPLICATED_APP_URL/kurl_metrics/fail_install/$INSTALLATION_ID || true
 }
 
@@ -81,7 +81,7 @@ function report_addon_start() {
     local started=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"started\": \"$started\", \"addon_version\": \"$version\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"started\": \"$started\", \"addon_version\": \"$version\", \"testgrid_id\": \"$TESTGRID_ID\"}" \
         $REPLICATED_APP_URL/kurl_metrics/start_addon/$INSTALLATION_ID/$name || true
 }
 
@@ -98,7 +98,7 @@ function report_addon_success() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"finished\": \"$completed\"}" \
         $REPLICATED_APP_URL/kurl_metrics/finish_addon/$INSTALLATION_ID/$name || true
 }
 
@@ -139,7 +139,7 @@ function addon_install_fail() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"finished\": \"$completed\"}" \
         $REPLICATED_APP_URL/kurl_metrics/fail_addon/$INSTALLATION_ID/$name || true
 
     # provide an option for a user to provide a support bundle
@@ -163,7 +163,7 @@ function addon_install_fail_nobundle() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\"}" \
+        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\", \"kurl_uuid\": \"$KURL_UUID\"}" \
         $REPLICATED_APP_URL/kurl_metrics/fail_addon/$INSTALLATION_ID/$name || true
 
     return 1 # return error because the addon in question did too


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This creates a file `/var/lib/kurl/uuid` when not present, and stores a UUID there. That UUID is reported in addition to the existing `machine_id` that is apparently not always unique on cloned VMs.

Reporting of `machine_id` was also reduced to only be where the parameter was useful/used - at the init step. There's no point to sending it with each request, since we only store it from the "beginning of the install" reporting line anyways. (and it doesn't change)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
