### PR TITLE
Rook: race condition when scaling down prometheuses statefulset

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -327,6 +327,9 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     local src_sc="${STORAGE_CLASS:-default}"
     local tmp_sc=rook-ceph-tmp
 
+    local rook_did_scale_down_ekco=0
+    local rook_did_scale_down_prometheus=0
+
     # if the "default" storage class exists and it is still using the flex volume provisioner
     if [ "$(kubectl get sc "$src_sc" --ignore-not-found -o jsonpath='{.provisioner}')" = "ceph.rook.io/block" ]; then
         # patch the existing storage class to not be the default
@@ -334,6 +337,13 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
 
         # deploy a new storage class with the CSI provisioner
         rook_cluster_deploy_upgrade_create_storageclass "$tmp_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
 
         # run the actual flex volumes to csi volumes migration
         rook_cluster_deploy_upgrade_pvmigrator "$src_sc" "$tmp_sc"
@@ -345,10 +355,25 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     if kubectl get sc "$tmp_sc" >/dev/null 2>&1 ; then
         # migrate a second time effectively renaming the temp storageclass back to "default"
         rook_cluster_deploy_upgrade_create_storageclass "$src_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
+
         rook_cluster_deploy_upgrade_pvmigrator "$tmp_sc" "$src_sc"
 
         # delete the temp storageclass
         kubectl delete sc "$tmp_sc"
+    fi
+
+    if [ "$rook_did_scale_down_ekco" = "1" ]; then
+        rook_scale_up_ekco
+    fi
+    if [ "$rook_did_scale_down_prometheus" = "1" ]; then
+        rook_scale_up_prometheus
     fi
 }
 
@@ -380,14 +405,69 @@ function rook_cluster_deploy_upgrade_pvmigrator() {
     local dst_sc="$2"
 
     logStep "Migrating Rook Flex volumes to CSI volumes"
+    local node_name=
+    node_name="$(get_local_node_name)"
+    local bin_path=
+    bin_path="$(realpath "$BIN_ROOK_PVMIGRATOR")"
+
     ( set -x;
     "$BIN_KURL" rook flexvolume-to-csi \
         --source-sc "$src_sc" \
         --destination-sc "$dst_sc" \
-        --node "$(get_local_node_name)" \
-        --pv-migrator-bin-path "$(realpath "$BIN_ROOK_PVMIGRATOR")" \
+        --node "$node_name" \
+        --pv-migrator-bin-path "$bin_path" \
         --ceph-migrator-image "rook/ceph:v$ROOK_VERSION" )
     logSuccess "Rook Flex volumes to CSI volumes migrated successfully"
+}
+
+# rook_scale_down_ekco will scale down ekco to 0 replicas
+function rook_scale_down_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    if [ "$(kubectl -n kurl get deployments ekc-operator -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=0
+    rook_did_scale_down_ekco=1 # local to caller
+    log "Waiting for ekco pods to be removed"
+    spinner_until 120 ekco_pods_gone
+}
+
+# rook_scale_up_ekco will scale up ekco to 1 replica
+function rook_scale_up_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=1
+}
+
+# rook_scale_down_prometheus will scale down prometheus to 0 replicas
+function rook_scale_down_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    if [ "$(kubectl -n monitoring get prometheus k8s -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+    rook_did_scale_down_prometheus=1 # local to caller
+    log "Waiting for prometheus pods to be removed"
+    spinner_until 300 prometheus_pods_gone
+}
+
+# rook_scale_up_prometheus will scale up prometheus replicas to 2
+function rook_scale_up_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]'
 }
 
 function rook_dashboard_ready_spinner() {

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -301,6 +301,9 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     local src_sc="${STORAGE_CLASS:-default}"
     local tmp_sc=rook-ceph-tmp
 
+    local rook_did_scale_down_ekco=0
+    local rook_did_scale_down_prometheus=0
+
     # if the "default" storage class exists and it is still using the flex volume provisioner
     if [ "$(kubectl get sc "$src_sc" --ignore-not-found -o jsonpath='{.provisioner}')" = "ceph.rook.io/block" ]; then
         # patch the existing storage class to not be the default
@@ -308,6 +311,13 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
 
         # deploy a new storage class with the CSI provisioner
         rook_cluster_deploy_upgrade_create_storageclass "$tmp_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
 
         # run the actual flex volumes to csi volumes migration
         rook_cluster_deploy_upgrade_pvmigrator "$src_sc" "$tmp_sc"
@@ -319,10 +329,25 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     if kubectl get sc "$tmp_sc" >/dev/null 2>&1 ; then
         # migrate a second time effectively renaming the temp storageclass back to "default"
         rook_cluster_deploy_upgrade_create_storageclass "$src_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
+
         rook_cluster_deploy_upgrade_pvmigrator "$tmp_sc" "$src_sc"
 
         # delete the temp storageclass
         kubectl delete sc "$tmp_sc"
+    fi
+
+    if [ "$rook_did_scale_down_ekco" = "1" ]; then
+        rook_scale_up_ekco
+    fi
+    if [ "$rook_did_scale_down_prometheus" = "1" ]; then
+        rook_scale_up_prometheus
     fi
 }
 
@@ -354,14 +379,69 @@ function rook_cluster_deploy_upgrade_pvmigrator() {
     local dst_sc="$2"
 
     logStep "Migrating Rook Flex volumes to CSI volumes"
+    local node_name=
+    node_name="$(get_local_node_name)"
+    local bin_path=
+    bin_path="$(realpath "$BIN_ROOK_PVMIGRATOR")"
+
     ( set -x;
     "$BIN_KURL" rook flexvolume-to-csi \
         --source-sc "$src_sc" \
         --destination-sc "$dst_sc" \
-        --node "$(get_local_node_name)" \
-        --pv-migrator-bin-path "$(realpath "$BIN_ROOK_PVMIGRATOR")" \
+        --node "$node_name" \
+        --pv-migrator-bin-path "$bin_path" \
         --ceph-migrator-image "rook/ceph:v$ROOK_VERSION" )
     logSuccess "Rook Flex volumes to CSI volumes migrated successfully"
+}
+
+# rook_scale_down_ekco will scale down ekco to 0 replicas
+function rook_scale_down_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    if [ "$(kubectl -n kurl get deployments ekc-operator -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=0
+    rook_did_scale_down_ekco=1 # local to caller
+    log "Waiting for ekco pods to be removed"
+    spinner_until 120 ekco_pods_gone
+}
+
+# rook_scale_up_ekco will scale up ekco to 1 replica
+function rook_scale_up_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=1
+}
+
+# rook_scale_down_prometheus will scale down prometheus to 0 replicas
+function rook_scale_down_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    if [ "$(kubectl -n monitoring get prometheus k8s -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+    rook_did_scale_down_prometheus=1 # local to caller
+    log "Waiting for prometheus pods to be removed"
+    spinner_until 300 prometheus_pods_gone
+}
+
+# rook_scale_up_prometheus will scale up prometheus replicas to 2
+function rook_scale_up_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]'
 }
 
 function rook_dashboard_ready_spinner() {

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -334,6 +334,9 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     local src_sc="${STORAGE_CLASS:-default}"
     local tmp_sc=rook-ceph-tmp
 
+    local rook_did_scale_down_ekco=0
+    local rook_did_scale_down_prometheus=0
+
     # if the "default" storage class exists and it is still using the flex volume provisioner
     if [ "$(kubectl get sc "$src_sc" --ignore-not-found -o jsonpath='{.provisioner}')" = "ceph.rook.io/block" ]; then
         # patch the existing storage class to not be the default
@@ -341,6 +344,13 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
 
         # deploy a new storage class with the CSI provisioner
         rook_cluster_deploy_upgrade_create_storageclass "$tmp_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
 
         # run the actual flex volumes to csi volumes migration
         rook_cluster_deploy_upgrade_pvmigrator "$src_sc" "$tmp_sc"
@@ -352,10 +362,25 @@ function rook_cluster_deploy_upgrade_flexvolumes_to_csi() {
     if kubectl get sc "$tmp_sc" >/dev/null 2>&1 ; then
         # migrate a second time effectively renaming the temp storageclass back to "default"
         rook_cluster_deploy_upgrade_create_storageclass "$src_sc"
+
+        if [ "$rook_did_scale_down_ekco" != "1" ]; then
+            rook_scale_down_ekco
+        fi
+        if [ "$rook_did_scale_down_prometheus" != "1" ]; then
+            rook_scale_down_prometheus
+        fi
+
         rook_cluster_deploy_upgrade_pvmigrator "$tmp_sc" "$src_sc"
 
         # delete the temp storageclass
         kubectl delete sc "$tmp_sc"
+    fi
+
+    if [ "$rook_did_scale_down_ekco" = "1" ]; then
+        rook_scale_up_ekco
+    fi
+    if [ "$rook_did_scale_down_prometheus" = "1" ]; then
+        rook_scale_up_prometheus
     fi
 }
 
@@ -387,14 +412,69 @@ function rook_cluster_deploy_upgrade_pvmigrator() {
     local dst_sc="$2"
 
     logStep "Migrating Rook Flex volumes to CSI volumes"
+    local node_name=
+    node_name="$(get_local_node_name)"
+    local bin_path=
+    bin_path="$(realpath "$BIN_ROOK_PVMIGRATOR")"
+
     ( set -x;
     "$BIN_KURL" rook flexvolume-to-csi \
         --source-sc "$src_sc" \
         --destination-sc "$dst_sc" \
-        --node "$(get_local_node_name)" \
-        --pv-migrator-bin-path "$(realpath "$BIN_ROOK_PVMIGRATOR")" \
+        --node "$node_name" \
+        --pv-migrator-bin-path "$bin_path" \
         --ceph-migrator-image "rook/ceph:v$ROOK_VERSION" )
     logSuccess "Rook Flex volumes to CSI volumes migrated successfully"
+}
+
+# rook_scale_down_ekco will scale down ekco to 0 replicas
+function rook_scale_down_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    if [ "$(kubectl -n kurl get deployments ekc-operator -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=0
+    rook_did_scale_down_ekco=1 # local to caller
+    log "Waiting for ekco pods to be removed"
+    spinner_until 120 ekco_pods_gone
+}
+
+# rook_scale_up_ekco will scale up ekco to 1 replica
+function rook_scale_up_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    kubectl -n kurl scale deployment ekc-operator --replicas=1
+}
+
+# rook_scale_down_prometheus will scale down prometheus to 0 replicas
+function rook_scale_down_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    if [ "$(kubectl -n monitoring get prometheus k8s -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+    rook_did_scale_down_prometheus=1 # local to caller
+    log "Waiting for prometheus pods to be removed"
+    spinner_until 300 prometheus_pods_gone
+}
+
+# rook_scale_up_prometheus will scale up prometheus replicas to 2
+function rook_scale_up_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]'
 }
 
 function rook_dashboard_ready_spinner() {

--- a/pkg/rook/flexvolume_test.go
+++ b/pkg/rook/flexvolume_test.go
@@ -3,8 +3,6 @@ package rook
 import (
 	"context"
 	"fmt"
-	"io"
-	"log"
 	"sort"
 	"testing"
 
@@ -177,9 +175,8 @@ func Test_runFlexMigrator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cli := fakeclient.NewClientBuilder().Build()
-			logger := log.New(io.Discard, "", 0)
 
-			err := runFlexMigrator(context.Background(), logger, cli, tt.opts)
+			err := runFlexMigrator(context.Background(), cli, tt.opts)
 			require.NoError(t, err)
 
 			obj := &appsv1.Deployment{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes error due to prometheuses operator scaling back up the stateful set.

```
Error: failed to migrate PVC prometheus-k8s-db-prometheus-k8s-0 : failed to Delete PVC object prometheus-k8s-db-prometheus-k8s-0: timed out waiting for the condition
```

Special cases prometheuses and scales the replicas in the CR.

Deploys the pod prior to scaling the resource to avoid the race condition if possible.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE