### PR TITLE
fix(kurl_util): allow bash flags values to contain an equals sign

### DIFF
--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -71,7 +71,7 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 	s := strings.Split(strings.TrimSpace(bashFlags), " ")
 
 	for _, flag := range s {
-		split := strings.Split(flag, "=")
+		split := strings.SplitN(flag, "=", 2)
 
 		if !checkIfFlagHasValue(len(split), split[0]) {
 			return fmt.Errorf("flag %s does not have a value", split[0])

--- a/kurl_util/cmd/bashmerge/main_test.go
+++ b/kurl_util/cmd/bashmerge/main_test.go
@@ -254,6 +254,18 @@ func Test_parseBashFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "parse flag values with equals",
+			oldInstaller: &kurlv1beta1.Installer{},
+			bashFlags:    "kubeadm-token=token=with=equals=",
+			mergedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: &kurlv1beta1.Kubernetes{
+						KubeadmToken: "token=with=equals=",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This is hypothetical but its common for base64 data to contain equals signs so this is something we will likely hit at some point.