### PR TITLE
(chore): testgrid: add some tests to check kubectl with kube/config

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -182,6 +182,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: k8s126x_reserved_resources
   installerSpec:
     kubernetes:
@@ -206,6 +210,10 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: k8s126-openebs
   installerSpec:
     kubernetes:
@@ -318,6 +326,10 @@
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -183,8 +183,8 @@
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: k8s126x_reserved_resources
   installerSpec:
@@ -211,8 +211,8 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: k8s126-openebs
   installerSpec:
@@ -327,8 +327,8 @@
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1327,8 +1327,8 @@
     echo "Pod image override success: $pod_image"
     
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: k8s124x_cis_benchmarks_checks
   installerSpec:
@@ -1347,8 +1347,8 @@
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: k8s123x_124x_upgrade_cis_benchmarks_checks
   installerSpec:
@@ -1398,8 +1398,8 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: "Cust1 Upgrade - no HA"
   installerSpec:
@@ -1509,8 +1509,8 @@
     echo "this is to test less command after installation" > test-less.txt
     less test-less.txt > /dev/null
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: "weave latest multinode"
   installerSpec:
@@ -1606,8 +1606,8 @@
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -1625,8 +1625,8 @@
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: rook-upgrade-to-1.5-airgap
   flags: "yes"
@@ -1678,8 +1678,8 @@
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -1697,8 +1697,8 @@
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.19
     echo "Checking kubectl with kube/config"  
-    echo unset KUBECONFIG >> ~/.bash_profile
-    bash -l
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
     kubectl get namespaces
 - name: "k8s_125x containerd 1.5.x upgrade to latest"
   installerSpec:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1325,6 +1325,11 @@
     fi
 
     echo "Pod image override success: $pod_image"
+    
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
@@ -1341,6 +1346,10 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: k8s123x_124x_upgrade_cis_benchmarks_checks
   installerSpec:
     kubernetes:
@@ -1388,6 +1397,10 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: "Cust1 Upgrade - no HA"
   installerSpec:
     kubernetes:
@@ -1495,6 +1508,10 @@
   postInstallScript: |
     echo "this is to test less command after installation" > test-less.txt
     less test-less.txt > /dev/null
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: "weave latest multinode"
   installerSpec:
     kubernetes:
@@ -1588,6 +1605,10 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info
@@ -1603,6 +1624,10 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.20
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: rook-upgrade-to-1.5-airgap
   flags: "yes"
   airgap: true
@@ -1652,6 +1677,10 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info
@@ -1667,6 +1696,10 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.19
+    echo "Checking kubectl with kube/config"  
+    echo unset KUBECONFIG >> ~/.bash_profile
+    bash -l
+    kubectl get namespaces
 - name: "k8s_125x containerd 1.5.x upgrade to latest"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding some tests to check kubectl with kube/config

#### Which issue(s) this PR fixes:

Fixes # [sc-63954]

#### Special notes for your reviewer:

Add the for all tests that we have postinstal scripts today just to ensure that we do not break the kubectl behaviour if we unset KUBECONFIG 

