### PR TITLE
feat: improve the output message to clarify to users kubectl config

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -604,15 +604,21 @@ function kubeconfig_setup_outro() {
             cp "$(${K8S_DISTRO}_get_kubeconfig)" $ownerdir/.kube/config
             chown -R $owner $ownerdir/.kube
 
-            printf "To access the cluster with kubectl, ensure the KUBECONFIG environment variable is unset:\n"
+            printf "To access the cluster with kubectl:\n"
+            printf "\n"
+            printf "${GREEN}    bash -l${NC}\n"
+            printf "Kurl uses "$(${K8S_DISTRO}_get_kubeconfig)", you might want to unset KUBECONFIG to use .kube/config:\n"
             printf "\n"
             printf "${GREEN}    echo unset KUBECONFIG >> ~/.bash_profile${NC}\n"
-            printf "${GREEN}    bash -l${NC}\n"
             return
         fi
     fi
 
-    printf "To access the cluster with kubectl, copy kubeconfig to your home directory:\n"
+    printf "To access the cluster with kubectl:\n"
+    printf "\n"
+    printf "${GREEN}    bash -l${NC}\n"
+    printf "\n"
+    printf "Kurl uses "$(${K8S_DISTRO}_get_kubeconfig)", you might want to copy kubeconfig to your home directory:\n"
     printf "\n"
     printf "${GREEN}    cp "$(${K8S_DISTRO}_get_kubeconfig)" ~/.kube/config${NC}\n"
     printf "${GREEN}    chown -R ${owner} ~/.kube${NC}\n"


### PR DESCRIPTION
#### What this PR does / why we need it:

Kurl uses and export KUBECONFIG with kubernetes/admin.conf.
However, it also created the .kube/config by copying kubernetes/admin.conf to kube/config

Therefore, the output does not clarifies why unset KUBECONFIG and what is used by kurl.
Also, it is not required unset KUBECONFIG to use kubectl as described in the output. 

So, the goal of this PR is try to clarifies it to the users and sorted out the current misleading message 

#### Which issue(s) this PR fixes:

Fixes # [sc-63954]

#### Special notes for your reviewer:
Before this PR: 

<img width="902" alt="Screenshot 2023-01-22 at 09 55 40" src="https://user-images.githubusercontent.com/7708031/213910806-ebb4716d-272f-4543-aa61-debe91f82e18.png">

After this PR:

<img width="901" alt="Screenshot 2023-01-22 at 10 14 08" src="https://user-images.githubusercontent.com/7708031/213910812-ffb4ab4b-5dc3-483f-8869-6537e0822cf1.png">


Also:

<img width="889" alt="Screenshot 2023-01-22 at 10 19 51" src="https://user-images.githubusercontent.com/7708031/213910832-ad75d445-93c7-4cef-8daf-f28f6e565ea1.png">


## Steps to reproduce
Just install and re-install

#### Does this PR introduce a user-facing change?

```release-note
Improve output message to clarifies the kubectl config used by kurl
```

#### Does this PR require documentation?
NONE