### PR TITLE
feat: adds "prepare longhorn for migration" command.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/itchyny/gojq v0.12.11
+	github.com/longhorn/longhorn-manager v1.4.0
 	github.com/mattn/go-isatty v0.0.17
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/pelletier/go-toml v1.9.5
@@ -155,6 +156,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgx/v5 v5.2.0 // indirect
+	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -164,7 +166,7 @@ require (
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221103224036-07dde5c41fdd // indirect
 	github.com/libopenstorage/secrets v0.0.0-20220823020833-2ecadaf59d8a // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e // indirect
+	github.com/longhorn/go-iscsi-helper v0.0.0-20221219041640-6c94fb0d483a // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/c9s/goprocinfo v0.0.0-20170724085704-0010a05ce49f // indirect
+	github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,9 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/c9s/goprocinfo v0.0.0-20170724085704-0010a05ce49f h1:tRk+aBit+q3oqnj/1mF5HHhP2yxJM2lSa0afOJxQ3nE=
 github.com/c9s/goprocinfo v0.0.0-20170724085704-0010a05ce49f/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
+github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b h1:4yfM1Zm+7U+m0inJ0g6JvdqGePXD8eG4nXUTbcLT6gk=
+github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
@@ -1062,6 +1063,8 @@ github.com/jefferai/jsonx v1.0.0/go.mod h1:OGmqmi2tTeI/PS+qQfBDToLHHJIy/RMp24fPo
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1139,8 +1142,10 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/linode/linodego v0.7.1 h1:4WZmMpSA2NRwlPZcc0+4Gyn7rr99Evk9bnr0B3gXRKE=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
-github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20221219041640-6c94fb0d483a h1:wyL5quo6Z6PiM2XJJ2ZRmd5Yq1dXoyEZQgL5GGMzcoY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20221219041640-6c94fb0d483a/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
+github.com/longhorn/longhorn-manager v1.4.0 h1:zlwWA6IfFW3VNipRcvggT2xazR7dCsY058CyCeDQrTc=
+github.com/longhorn/longhorn-manager v1.4.0/go.mod h1:mK/Kk5aXYILJd2NKqnrZ3v0tOe0dj6Ueels5sBoqxuk=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -23,6 +23,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 
 	longhornCmd := NewLonghornCmd(cli)
 	longhornCmd.AddCommand(NewLonghornPrepareForMigration(cli))
+	longhornCmd.AddCommand(NewLonghornRollbackMigrationReplicas(cli))
 	cmd.AddCommand(longhornCmd)
 
 	clusterCmd := NewClusterCmd(cli)

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -21,6 +21,10 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	rookCmd.AddCommand(NewRookFlexvolumeToCSI(cli))
 	cmd.AddCommand(rookCmd)
 
+	longhornCmd := NewLonghornCmd(cli)
+	longhornCmd.AddCommand(NewLonghornPrepareForMigration(cli))
+	cmd.AddCommand(longhornCmd)
+
 	clusterCmd := NewClusterCmd(cli)
 	clusterCmd.AddCommand(NewClusterNodesMissingImageCmd(cli))
 	clusterCmd.AddCommand(NewClusterCheckFreeDiskSpaceCmd(cli))

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	lhv1b1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+)
+
+var (
+	scaleDownReplicasWaitTime = time.Minute
+)
+
+const (
+	longhornNamespace       = "longhorn-system"
+	overProvisioningSetting = "storage-over-provisioning-percentage"
+)
+
+func NewLonghornCmd(cli CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "longhorn",
+		Short: "Perform operations on a longhorn installation within a kURL cluster",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.PersistentFlags())
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.Flags())
+		},
+	}
+}
+
+func NewLonghornPrepareForMigration(_ CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:          "prepare-for-migration",
+		Short:        "Prepares Longhorn for migration to a different storage provisioner.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Print("Preparing Longhorn deployment for migration.")
+			cli, err := client.New(config.GetConfigOrDie(), client.Options{})
+			if err != nil {
+				return fmt.Errorf("error creating client: %s", err)
+			}
+			lhv1b1.AddToScheme(cli.Scheme())
+
+			var nodes corev1.NodeList
+			if err := cli.List(cmd.Context(), &nodes); err != nil {
+				return fmt.Errorf("error listing kubernetes nodes: %s", err)
+			} else if len(nodes.Items) == 1 {
+				log.Print("Only one node found, scaling down the number of volume replicas to 1.")
+				if err := scaleDownReplicas(cmd.Context(), cli); err != nil {
+					return fmt.Errorf("error scaling down longhorn replicas: %s", err)
+				}
+			}
+
+			unhealthy, err := unhealthyVolumes(cmd.Context(), cli)
+			if err != nil {
+				return fmt.Errorf("error assessing unhealthy volumes: %s", err)
+			}
+
+			if len(unhealthy) > 0 {
+				log.Printf("The following Longhorn volumes are unhealthy:")
+				for _, vol := range unhealthy {
+					log.Printf(" - %s/%s", longhornNamespace, vol)
+				}
+				return fmt.Errorf("error preparing longhorn for migration: unhealthy volumes")
+			}
+
+			unhealthy, err = unhealthyNodes(cmd.Context(), cli)
+			if err != nil {
+				return fmt.Errorf("error assessing unhealthy Longhorn nodes: %s", err)
+			}
+
+			if len(unhealthy) > 0 {
+				log.Printf("The following Longhorn nodes are unhealthy:")
+				for _, node := range unhealthy {
+					log.Printf(" - %s", node)
+				}
+				return fmt.Errorf("error preparing longhorn for migration: unhealthy nodes")
+			}
+
+			log.Print("All Longhorn volumes and nodes are healthy, ready for migration.")
+			return nil
+		},
+	}
+}
+
+// scaleDownReplicas scales down the number of replicas for all volumes to 1.
+func scaleDownReplicas(ctx context.Context, cli client.Client) error {
+	var l1b1Volumes lhv1b1.VolumeList
+	if err := cli.List(ctx, &l1b1Volumes, client.InNamespace(longhornNamespace)); err != nil {
+		return fmt.Errorf("error listing longhorn volumes: %w", err)
+	}
+
+	var volumesToScale []lhv1b1.Volume
+	for _, volume := range l1b1Volumes.Items {
+		if volume.Spec.NumberOfReplicas == 1 {
+			log.Printf("Volume %s already has 1 replica, skipping.", volume.Name)
+			continue
+		}
+		volumesToScale = append(volumesToScale, volume)
+	}
+
+	if len(volumesToScale) == 0 {
+		return nil
+	}
+
+	for _, volume := range volumesToScale {
+		volume.Spec.NumberOfReplicas = 1
+		log.Printf("Scaling down replicas for volume %s.", volume.Name)
+		if err := cli.Update(ctx, &volume); err != nil {
+			return fmt.Errorf("error updating replicas for volume %s: %w", volume.Name, err)
+		}
+	}
+
+	log.Printf("Awaiting %v for replicas to scale down.", scaleDownReplicasWaitTime)
+	time.Sleep(scaleDownReplicasWaitTime)
+	return nil
+}
+
+// unreadyDisks returns a list of attached volumes that are not in a healthy state.
+func unhealthyVolumes(ctx context.Context, cli client.Client) ([]string, error) {
+	var volumes lhv1b1.VolumeList
+	if err := cli.List(ctx, &volumes, client.InNamespace(longhornNamespace)); err != nil {
+		return nil, fmt.Errorf("error listing volumes: %w", err)
+	}
+	var result []string
+	for _, volume := range volumes.Items {
+		log.Printf("Checking health of volume %s.", volume.Name)
+		if volume.Status.State != lhv1b1.VolumeStateAttached || isVolumeHealthy(volume) {
+			continue
+		}
+		result = append(result, volume.Name)
+	}
+	return result, nil
+}
+
+// isVolumeHealthy returns true if the volume is in a healthy state.
+func isVolumeHealthy(vol lhv1b1.Volume) bool {
+	for _, cond := range vol.Status.Conditions {
+		if cond.Type != lhv1b1.VolumeConditionTypeScheduled {
+			continue
+		}
+		if cond.Status == lhv1b1.ConditionStatusTrue {
+			break
+		}
+		return false
+	}
+	return vol.Status.Robustness == lhv1b1.VolumeRobustnessHealthy
+}
+
+// unhealthyNodes returns a list of nodes that are not in a healthy state.
+func unhealthyNodes(ctx context.Context, cli client.Client) ([]string, error) {
+	var longhornNodes lhv1b1.NodeList
+	if err := cli.List(ctx, &longhornNodes); err != nil {
+		return nil, fmt.Errorf("error listing longhorn nodes: %w", err)
+	}
+	var result []string
+	for _, node := range longhornNodes.Items {
+		log.Printf("Checking health of node %s.", node.Name)
+		if healthy, err := isNodeHealthy(ctx, cli, node); err != nil {
+			return nil, fmt.Errorf("error checking node health: %w", err)
+		} else if !healthy {
+			result = append(result, node.Name)
+		}
+	}
+	return result, nil
+}
+
+// isNodeHealthy returns true if the node is in a healthy state.
+func isNodeHealthy(ctx context.Context, cli client.Client, node lhv1b1.Node) (bool, error) {
+	if !nodeIs(lhv1b1.NodeConditionTypeReady, node) {
+		return false, nil
+	}
+	if !nodeIs(lhv1b1.NodeConditionTypeSchedulable, node) {
+		return false, nil
+	}
+	if !disksAre(lhv1b1.DiskConditionTypeReady, node.Status.DiskStatus) {
+		return false, nil
+	}
+	if !disksAre(lhv1b1.DiskConditionTypeSchedulable, node.Status.DiskStatus) {
+		return false, nil
+	}
+	if over, err := disksAreOvercommited(ctx, cli, node.Status.DiskStatus); err != nil {
+		return false, fmt.Errorf("error checking disk overcommit: %w", err)
+	} else if over {
+		return false, nil
+	}
+	return true, nil
+}
+
+// disksAreOvercommited returns true if any disk in the node is overcommited.
+func disksAreOvercommited(ctx context.Context, cli client.Client, disks map[string]*lhv1b1.DiskStatus) (bool, error) {
+	var config lhv1b1.Setting
+	nsn := client.ObjectKey{Name: overProvisioningSetting, Namespace: longhornNamespace}
+	if err := cli.Get(ctx, nsn, &config); err != nil {
+		return false, fmt.Errorf("error getting over provisioning setting: %w", err)
+	}
+
+	value, err := strconv.Atoi(config.Value)
+	if err != nil {
+		return false, fmt.Errorf("error parsing overcommit setting: %w", err)
+	}
+	pct := float64(value) / 100
+	for _, disk := range disks {
+		max := float64(disk.StorageAvailable) * pct
+		if disk.StorageScheduled >= int64(max) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// disksAre returns true if all disks are in the given condition.
+func disksAre(condition string, disks map[string]*lhv1b1.DiskStatus) bool {
+	for _, disk := range disks {
+		for _, cond := range disk.Conditions {
+			if cond.Type != condition {
+				continue
+			}
+			return cond.Status == lhv1b1.ConditionStatusTrue
+		}
+	}
+	return false
+}
+
+// nodeIs returns true if the node is in the given condition.
+func nodeIs(condition string, node lhv1b1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type != condition {
+			continue
+		}
+		return cond.Status == lhv1b1.ConditionStatusTrue
+	}
+	return false
+}

--- a/pkg/cli/longhorn_test.go
+++ b/pkg/cli/longhorn_test.go
@@ -31,7 +31,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 				Namespace: longhornNamespace,
 			},
 			Spec: lhv1b1.VolumeSpec{
-				NumberOfReplicas: 4,
+				NumberOfReplicas: 3,
 			},
 		},
 		&lhv1b1.Volume{
@@ -40,7 +40,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 				Namespace: longhornNamespace,
 			},
 			Spec: lhv1b1.VolumeSpec{
-				NumberOfReplicas: 5,
+				NumberOfReplicas: 3,
 			},
 		},
 	}
@@ -48,7 +48,8 @@ func Test_scaleDownReplicas(t *testing.T) {
 	scheme := runtime.NewScheme()
 	lhv1b1.AddToScheme(scheme)
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(volumes...).Build()
-	err := scaleDownReplicas(context.Background(), cli)
+	scaled, err := scaleDownReplicas(context.Background(), cli)
+	assert.True(t, scaled)
 	assert.NoError(t, err)
 
 	var gotVolumes lhv1b1.VolumeList
@@ -57,6 +58,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 
 	for _, vol := range gotVolumes.Items {
 		assert.Equal(t, int(1), vol.Spec.NumberOfReplicas)
+		assert.Equal(t, "3", vol.Annotations[volumeReplicasAnnotation])
 	}
 }
 

--- a/pkg/cli/longhorn_test.go
+++ b/pkg/cli/longhorn_test.go
@@ -1,0 +1,555 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	lhv1b1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_scaleDownReplicas(t *testing.T) {
+	scaleDownReplicasWaitTime = 0
+	volumes := []client.Object{
+		&lhv1b1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-0",
+				Namespace: longhornNamespace,
+			},
+			Spec: lhv1b1.VolumeSpec{
+				NumberOfReplicas: 3,
+			},
+		},
+		&lhv1b1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-1",
+				Namespace: longhornNamespace,
+			},
+			Spec: lhv1b1.VolumeSpec{
+				NumberOfReplicas: 4,
+			},
+		},
+		&lhv1b1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-2",
+				Namespace: longhornNamespace,
+			},
+			Spec: lhv1b1.VolumeSpec{
+				NumberOfReplicas: 5,
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	lhv1b1.AddToScheme(scheme)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(volumes...).Build()
+	err := scaleDownReplicas(context.Background(), cli)
+	assert.NoError(t, err)
+
+	var gotVolumes lhv1b1.VolumeList
+	err = cli.List(context.Background(), &gotVolumes, &client.ListOptions{})
+	assert.NoError(t, err)
+
+	for _, vol := range gotVolumes.Items {
+		assert.Equal(t, int(1), vol.Spec.NumberOfReplicas)
+	}
+}
+
+func Test_unhealthyVolumes(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		expected []string
+		objects  []client.Object
+	}{
+		{
+			name:    "if no volumes then returns as healthy",
+			objects: []client.Object{},
+		},
+		{
+			name: "if the volume is not attached then it is should be considered healthy",
+			objects: []client.Object{
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-0",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State: lhv1b1.VolumeStateDetached,
+					},
+				},
+			},
+		},
+		{
+			name:     "if the volume is not scheduled then it is should be considered unhealthy",
+			expected: []string{"volume-0"},
+			objects: []client.Object{
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-0",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State: lhv1b1.VolumeStateAttached,
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.VolumeConditionTypeScheduled,
+								Status: lhv1b1.ConditionStatusFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if the volume robustness is not healthy then the volume is not healthy",
+			expected: []string{"volume-0"},
+			objects: []client.Object{
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-0",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State:      lhv1b1.VolumeStateAttached,
+						Robustness: lhv1b1.VolumeRobustnessUnknown,
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.VolumeConditionTypeScheduled,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "healthy volume should not be included in the result",
+			objects: []client.Object{
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-0",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State:      lhv1b1.VolumeStateAttached,
+						Robustness: lhv1b1.VolumeRobustnessHealthy,
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.VolumeConditionTypeScheduled,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "detached unhealthy volumes should be ignored",
+			objects: []client.Object{
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-0",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State:      lhv1b1.VolumeStateDetached,
+						Robustness: lhv1b1.VolumeRobustnessDegraded,
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.VolumeConditionTypeScheduled,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+				&lhv1b1.Volume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "volume-1",
+						Namespace: longhornNamespace,
+					},
+					Status: lhv1b1.VolumeStatus{
+						State:      lhv1b1.VolumeStateAttached,
+						Robustness: lhv1b1.VolumeRobustnessHealthy,
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.VolumeConditionTypeScheduled,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			lhv1b1.AddToScheme(scheme)
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
+			result, err := unhealthyVolumes(context.Background(), cli)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_unhealthyNodes(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		expected []string
+		objects  []client.Object
+	}{
+		{
+			name:    "if no nodes then returns as healthy",
+			objects: []client.Object{},
+		},
+		{
+			name:     "if the node is not ready then it is should be considered unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						Conditions: map[string]lhv1b1.Condition{
+							"": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if the node is not schedulable then it is should be considered unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusFalse,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if the node contain a disk that is not ready then it is should be considered unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						DiskStatus: map[string]*lhv1b1.DiskStatus{
+							"disk-0": {
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusFalse,
+									},
+								},
+							},
+						},
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if the node contain a disk that is not scheduleable then it is should be considered unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						DiskStatus: map[string]*lhv1b1.DiskStatus{
+							"disk-0": {
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+									"1": {
+										Type:   lhv1b1.DiskConditionTypeSchedulable,
+										Status: lhv1b1.ConditionStatusFalse,
+									},
+								},
+							},
+						},
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if the node has not enough space in a disk then it is should be considered unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      overProvisioningSetting,
+						Namespace: longhornNamespace,
+					},
+					Value: "100",
+				},
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						DiskStatus: map[string]*lhv1b1.DiskStatus{
+							"disk-0": {
+								StorageScheduled: 100,
+								StorageAvailable: 100,
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+									"1": {
+										Type:   lhv1b1.DiskConditionTypeSchedulable,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+								},
+							},
+						},
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "if disk usage is still under the threshold then it is should be considered healthy",
+			objects: []client.Object{
+				&lhv1b1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      overProvisioningSetting,
+						Namespace: longhornNamespace,
+					},
+					Value: "200",
+				},
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						DiskStatus: map[string]*lhv1b1.DiskStatus{
+							"disk-0": {
+								StorageScheduled: 199,
+								StorageAvailable: 100,
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+									"1": {
+										Type:   lhv1b1.DiskConditionTypeSchedulable,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+								},
+							},
+						},
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "if only one of disk usage is over limit then the node is unhealthy",
+			expected: []string{"node-0"},
+			objects: []client.Object{
+				&lhv1b1.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      overProvisioningSetting,
+						Namespace: longhornNamespace,
+					},
+					Value: "200",
+				},
+				&lhv1b1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: lhv1b1.NodeStatus{
+						DiskStatus: map[string]*lhv1b1.DiskStatus{
+							"disk-0": {
+								StorageScheduled: 199,
+								StorageAvailable: 100,
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+									"1": {
+										Type:   lhv1b1.DiskConditionTypeSchedulable,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+								},
+							},
+							"disk-1": {
+								StorageScheduled: 101,
+								StorageAvailable: 50,
+								Conditions: map[string]lhv1b1.Condition{
+									"0": {
+										Type:   lhv1b1.DiskConditionTypeReady,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+									"1": {
+										Type:   lhv1b1.DiskConditionTypeSchedulable,
+										Status: lhv1b1.ConditionStatusTrue,
+									},
+								},
+							},
+						},
+						Conditions: map[string]lhv1b1.Condition{
+							"0": {
+								Type:   lhv1b1.NodeConditionTypeReady,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+							"1": {
+								Type:   lhv1b1.NodeConditionTypeSchedulable,
+								Status: lhv1b1.ConditionStatusTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			lhv1b1.AddToScheme(scheme)
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
+			result, err := unhealthyNodes(context.Background(), cli)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_nodeIs(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		expected  bool
+		condition string
+		node      lhv1b1.Node
+	}{
+		{
+			name:      "if condition is not found then returns false",
+			expected:  false,
+			condition: "DiskConditionReasonDiskNotReady",
+			node: lhv1b1.Node{
+				Status: lhv1b1.NodeStatus{
+					Conditions: map[string]lhv1b1.Condition{
+						"foo": {
+							Type:   "foo",
+							Status: "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "if multiple conditions are present it should filter by the right one",
+			expected:  true,
+			condition: lhv1b1.NodeConditionTypeReady,
+			node: lhv1b1.Node{
+				Status: lhv1b1.NodeStatus{
+					Conditions: map[string]lhv1b1.Condition{
+						"0": {
+							Type:   "foo",
+							Status: lhv1b1.ConditionStatusFalse,
+						},
+						"1": {
+							Type:   "bar",
+							Status: lhv1b1.ConditionStatusFalse,
+						},
+						"2": {
+							Type:   lhv1b1.NodeConditionTypeReady,
+							Status: lhv1b1.ConditionStatusTrue,
+						},
+						"3": {
+							Type:   "baz",
+							Status: lhv1b1.ConditionStatusFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "condition is found and status is true then returns true",
+			expected:  true,
+			condition: lhv1b1.NodeConditionTypeReady,
+			node: lhv1b1.Node{
+				Status: lhv1b1.NodeStatus{
+					Conditions: map[string]lhv1b1.Condition{
+						"": {
+							Type:   lhv1b1.NodeConditionTypeReady,
+							Status: lhv1b1.ConditionStatusTrue,
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeIs(tt.condition, tt.node)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a command that will be used during Longhorn to Rook or OpenEBS migration path. 

This new command executes the following steps:

1. if running in a single node cluster all "number of replicas" are 1.
2. ensures that all attached longhorn volumes are in a healthy state.
3. ensures that all longhorn nodes are healthy.
4. makes sure that no nodes are out of space.

#### Special notes for your reviewer:

This PR only partially fixes sc-65977, the rest of the code is part of the shell script installation and will be raised shortly.

#### Running

```sh
$ kurl longhorn prepare-for-migration
2023-01-24 11:54:41.354726 I | Preparing Longhorn deployment for migration.
2023-01-24 11:54:42.297047 I | Only one node found, scaling down the number of volume replicas to 1.
2023-01-24 11:54:42.431263 I | Volume pvc-b5d4fa76-7ebe-4c15-b0a4-a56b4cbbcc94 already has 1 replica, skipping.
2023-01-24 11:54:42.431282 I | Volume pvc-b8e24c2f-0524-4539-bd1c-f401376e10b4 already has 1 replica, skipping.
2023-01-24 11:54:42.431285 I | Scaling down replicas for volume pvc-36079fe9-1f90-459d-9ea9-9669a9358c1e.
2023-01-24 11:54:42.562931 I | Scaling down replicas for volume pvc-496055ea-0c27-47d3-a781-248bf1f6566a.
2023-01-24 11:54:42.694783 I | Scaling down replicas for volume pvc-520651ca-643e-4c9a-8fc6-f15c785f18d6.
2023-01-24 11:54:42.822267 I | Scaling down replicas for volume pvc-5ffb69e3-c94d-4e2a-9074-d680743f5692.
2023-01-24 11:54:42.951044 I | Scaling down replicas for volume pvc-693405d6-0011-45ea-b2c6-c81c462a2f2c.
2023-01-24 11:54:43.079192 I | Scaling down replicas for volume pvc-88261d30-533a-4b14-a319-a827738e1202.
2023-01-24 11:54:43.207866 I | Scaling down replicas for volume pvc-a5024ac2-d806-4cb3-8d73-8eab4d7d66f9.
2023-01-24 11:54:43.337206 I | Awaiting 1m0s for replicas to scale down.
2023-01-24 11:55:43.577758 I | Checking health of volume pvc-36079fe9-1f90-459d-9ea9-9669a9358c1e.
2023-01-24 11:55:43.577785 I | Checking health of volume pvc-496055ea-0c27-47d3-a781-248bf1f6566a.
2023-01-24 11:55:43.577788 I | Checking health of volume pvc-520651ca-643e-4c9a-8fc6-f15c785f18d6.
2023-01-24 11:55:43.577790 I | Checking health of volume pvc-5ffb69e3-c94d-4e2a-9074-d680743f5692.
2023-01-24 11:55:43.577792 I | Checking health of volume pvc-693405d6-0011-45ea-b2c6-c81c462a2f2c.
2023-01-24 11:55:43.577795 I | Checking health of volume pvc-88261d30-533a-4b14-a319-a827738e1202.
2023-01-24 11:55:43.577800 I | Checking health of volume pvc-a5024ac2-d806-4cb3-8d73-8eab4d7d66f9.
2023-01-24 11:55:43.577802 I | Checking health of volume pvc-b5d4fa76-7ebe-4c15-b0a4-a56b4cbbcc94.
2023-01-24 11:55:43.577805 I | Checking health of volume pvc-b8e24c2f-0524-4539-bd1c-f401376e10b4.
2023-01-24 11:55:43.686490 I | Checking health of node ip-172-31-4-158.
2023-01-24 11:55:43.792462 I | All Longhorn volumes and nodes are healthy, ready for migration.
$
```