### PR TITLE
chore: ignore warning about mon usage be higher than 70% to not block…

### DIFF
--- a/pkg/rook/health.go
+++ b/pkg/rook/health.go
@@ -84,6 +84,11 @@ func isStatusHealthy(status cephtypes.CephStatus, ignoreChecks []string) (bool, 
 		// note that it is required to upgrade from 1.0.4-14.2.21 to 1.4.9
 		delete(status.Health.Checks, "AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED")
 
+		// By default, the following warning will be raised when more than 70% of the mon
+		// space be in usage. (df -h /var/lib/ceph/mon) This is not an error we need to stop upgrades for
+		// https://docs.ceph.com/en/quincy/rados/operations/health-checks/#mon-disk-low
+		delete(status.Health.Checks, "MON_DISK_LOW")
+
 		for _, check := range ignoreChecks {
 			delete(status.Health.Checks, check)
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:

To ignore the HEALTH_WARN `mon c is low on available space`.

#### Which issue(s) this PR fixes:

Fixes # [sc-67155]

#### Special notes for your reviewer:


## Steps to reproduce

To reproduce create a VM using ubuntu and with a disk size with 100GB 
- Then install: curl https://staging.kurl.sh/3f02c4e | sudo bash
- And  upgrade: curl https://staging.kurl.sh/b81a897 | sudo bash

You will check that the upgrade fails because: 

```
2023-01-20 07:54:00+00:00 Waiting for Rook-Ceph to be healthy
2023-01-20 07:56:00+00:00 Error: failed to check rook health: timed out waiting rook to become healthy, currently "health is HEALTH_WARN because \"mon a is low on available space\""
2023-01-20 07:56:01+00:00   cluster: 
```

After this change we can check that will be possible to move forward with the upgrade:

![Screenshot 2023-01-24 at 16 25 52](https://user-images.githubusercontent.com/7708031/214350179-80bdc958-091b-4113-a235-4cd3f206d9a8.png)

All versions were upgraded successfully. 

![Screenshot 2023-01-24 at 17 33 50](https://user-images.githubusercontent.com/7708031/214366056-d5815b31-a5d6-4595-b891-8213d0af8c21.png)

#### Does this PR introduce a user-facing change?

```release-note
fix: Ignore `mon a is low on available space` health warn to check Ceph health status to not block upgrades
```

#### Does this PR require documentation?
NONE
