### PR TITLE
feat(flannel): preflight UDP port 8472 status

### DIFF
--- a/addons/flannel/0.20.2/host-preflight.yaml
+++ b/addons/flannel/0.20.2/host-preflight.yaml
@@ -1,0 +1,27 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: flannel
+spec:
+  collectors:
+    - udpPortStatus:
+        collectorName: Flannel UDP port 8472
+        port: 8472
+        exclude: '{{kurl .IsUpgrade }}'
+  analyzers:
+    - udpPortStatus:
+        checkName: "Flannel UDP port 8472 status"
+        collectorName: Flannel UDP port 8472
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - warn:
+              when: "address-in-use"
+              message: Another process is already listening on port
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port is open
+          - warn:
+              message: Unexpected port status

--- a/addons/flannel/template/base/host-preflight.yaml
+++ b/addons/flannel/template/base/host-preflight.yaml
@@ -1,0 +1,27 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: flannel
+spec:
+  collectors:
+    - udpPortStatus:
+        collectorName: Flannel UDP port 8472
+        port: 8472
+        exclude: '{{kurl .IsUpgrade }}'
+  analyzers:
+    - udpPortStatus:
+        checkName: "Flannel UDP port 8472 status"
+        collectorName: Flannel UDP port 8472
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - warn:
+              when: "address-in-use"
+              message: Another process is already listening on port
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port is open
+          - warn:
+              message: Unexpected port status


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Adds a preflight to check that Flannel UDP port 8472 is available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds Flannel UDP port 8472 status preflight check
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
https://github.com/replicatedhq/kurl.sh/pull/931