### PR TITLE
chore: standardize minio deployment await timeout.

### DIFF
--- a/addons/minio/2022-07-06T20-29-49Z/install.sh
+++ b/addons/minio/2022-07-06T20-29-49Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-07-17T15-43-14Z/install.sh
+++ b/addons/minio/2022-07-17T15-43-14Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-08-02T23-59-16Z/install.sh
+++ b/addons/minio/2022-08-02T23-59-16Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-08-22T23-53-06Z/install.sh
+++ b/addons/minio/2022-08-22T23-53-06Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-09-01T23-53-36Z/install.sh
+++ b/addons/minio/2022-09-01T23-53-36Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-09-07T22-25-02Z/install.sh
+++ b/addons/minio/2022-09-07T22-25-02Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-09-17T00-09-45Z/install.sh
+++ b/addons/minio/2022-09-17T00-09-45Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-10-02T19-29-29Z/install.sh
+++ b/addons/minio/2022-10-02T19-29-29Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-10-05T14-58-27Z/install.sh
+++ b/addons/minio/2022-10-05T14-58-27Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-10-08T20-11-00Z/install.sh
+++ b/addons/minio/2022-10-08T20-11-00Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-10-15T19-57-03Z/install.sh
+++ b/addons/minio/2022-10-15T19-57-03Z/install.sh
@@ -153,7 +153,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-10-20T00-55-09Z/install.sh
+++ b/addons/minio/2022-10-20T00-55-09Z/install.sh
@@ -173,7 +173,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"

--- a/addons/minio/2022-12-12T19-27-27Z/install.sh
+++ b/addons/minio/2022-12-12T19-27-27Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/2023-01-02T09-40-09Z/install.sh
+++ b/addons/minio/2023-01-02T09-40-09Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/2023-01-06T18-11-18Z/install.sh
+++ b/addons/minio/2023-01-06T18-11-18Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/2023-01-12T02-06-16Z/install.sh
+++ b/addons/minio/2023-01-12T02-06-16Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/2023-01-18T04-36-38Z/install.sh
+++ b/addons/minio/2023-01-18T04-36-38Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/2023-01-20T02-05-44Z/install.sh
+++ b/addons/minio/2023-01-20T02-05-44Z/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -196,7 +196,7 @@ function minio_object_store_output() {
 
 function minio_wait_for_health() {
     printf "awaiting minio deployment\n"
-    spinner_until 120 deployment_fully_updated minio minio
+    spinner_until 300 deployment_fully_updated minio minio
 
     MINIO_CLUSTER_IP=$(kubectl -n ${MINIO_NAMESPACE} get service minio | tail -n1 | awk '{ print $3}')
     printf "awaiting minio readiness\n"
@@ -447,7 +447,7 @@ function minio_swap_fs_migration_hostpaths() {
 function minio_uses_fs_format() {
     # before running this we need to ensure that the minio deployment is fully deployed.
     printf "Awaiting for minio deployment to rollout\n"
-    if ! spinner_until 600 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
+    if ! spinner_until 300 deployment_fully_updated minio "$MINIO_NAMESPACE"; then
         bail "Timeout awaiting for minio deployment"
     fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

In some cases testgrid is failing to bring minio up, the failure reported is:

```
2022-12-28 07:26:30+00:00 awaiting minio deployment
2022-12-28 07:29:00+00:00 [/] An error occurred on line 199
```

By inspecting the testgrid log the pod seems to be running but not in a healthy state yet:

```
NAMESPACE     NAME                    STATUS    RESTARTS   AGE
minio         minio-5b8df4f997-vhhws  Running   0          2m31s
```

Worthy to mention that in the test in case the host preflight had a warning regarding disk performance (that may be related). As this problem does not happen consistently (the same test passed in the next daily run) this commit changes the timeout applied when waiting for Minio to come up.

#### Which issue(s) this PR fixes:
Fixes #sc-65193