### PR TITLE
feat(ci): Speedup S3 Copy when Releasing to Prod

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -130,7 +130,7 @@ jobs:
         STAGING_RELEASE: ${{ needs.get-staging-release.outputs.staging_release }}
 
   copy-staging-release-to-prod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
      - get-staging-release
      - verify-staging-release-testgrid-result
@@ -142,10 +142,7 @@ jobs:
     - name: Copy Staging Release to Prod
       run: |
         export VERSION_TAG=$GITHUB_REF_NAME
-        export KURL_UTIL_IMAGE=replicated/kurl-util:${VERSION_TAG}
-        export KURL_BIN_UTILS_FILE=kurl-bin-utils-${VERSION_TAG}.tar.gz
-        . bin/upload-dist-versioned.sh
-        copy_staging_release_to_dist
+        bin/copy-packages-s3-parallel.sh
       env:
         S3_BUCKET: kurl-sh
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}

--- a/bin/upload-dist-versioned.sh
+++ b/bin/upload-dist-versioned.sh
@@ -97,13 +97,6 @@ function copy_package_dist() {
         --metadata-directive REPLACE --metadata md5="${md5}",gitsha="${GITSHA}"
 }
 
-function copy_staging_release_to_dist() {
-    require STAGING_RELEASE "${STAGING_RELEASE}"
-    echo "copying s3://${S3_BUCKET}/${STAGING_PREFIX}/${STAGING_RELEASE} to s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${VERSION_TAG}"
-    # do not overwrite common and kurl-bin-utils tarball packages since they will already exist
-    retry 5 aws s3 cp --exclude "common.*" --exclude "kurl-bin-utils-*" --recursive "s3://${S3_BUCKET}/${STAGING_PREFIX}/${STAGING_RELEASE}" "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${VERSION_TAG}"
-}
-
 function deploy() {
     local package="$1"
     local path="$2"

--- a/bin/upload-packages-s3-parallel.sh
+++ b/bin/upload-packages-s3-parallel.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -eo pipefail
+
+function bail() {
+    log "$1"
+    exit 1
+}
+
+function commandExists() {
+    command -v "$@" > /dev/null 2>&1
+}
+
+function log() {
+    echo "$1" 1>&2
+}
+
+function require() {
+    if [ -z "$2" ]; then
+        echo "validation failed: $1 unset"
+        exit 1
+    fi
+}
+
+function retry {
+    local retries=$1
+    shift
+
+    local count=0
+    until "$@"; do
+        exit=$?
+        wait=$((2 ** count))
+        count=$((count + 1))
+        if [ "$count" -lt "$retries" ]; then
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else
+            echo "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+    return 0
+}
+# export the retry function so that the parallel jobs can use it
+export -f retry
+
+require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
+require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
+require AWS_REGION "${AWS_REGION}"
+require S3_BUCKET "${S3_BUCKET}"
+require STAGING_RELEASE "${STAGING_RELEASE}"
+require VERSION_TAG "${VERSION_TAG}"
+
+PACKAGE_PREFIX="${PACKAGE_PREFIX:-dist}"
+STAGING_PREFIX="${STAGING_PREFIX:-staging}"
+JOBS_FILE="${JOBS_FILE:-/tmp/s3_cp_jobs.txt}"
+function main() {
+
+  # GNU parallel is required for this script to perform parallel s3 cp operations
+  if ! commandExists "parallel"; then
+    bail "GNU parallel is not installed."
+  fi
+
+  # need jq
+  if ! commandExists "jq"; then
+    bail "jq is not installed."
+  fi
+
+  # exclude common and kurl-bin-utils packages since they will be rebuilt during the prod release
+  # tail -n +2 => skip empty key in first line of output
+  local packages=
+  packages=$(aws s3api list-objects-v2 --bucket "${S3_BUCKET}" --prefix "${STAGING_PREFIX}/${STAGING_RELEASE}" --query 'Contents[].Key' | jq -rc '.[]' | tail -n +2 | grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*")
+
+  log "Objects that will be copied to s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${VERSION_TAG}:"
+  log "${packages}"
+
+  # create jobs file for parallel uploads
+  local package_name=
+  while IFS= read -r package; do
+    # remove prefix
+    package_name=$(echo "${package}" | awk '{print $NF}' FS=/)
+
+    # each copy-object command will be its own parallel job
+    echo retry 5 aws s3api copy-object --copy-source "${S3_BUCKET}/${STAGING_PREFIX}/${STAGING_RELEASE}/${package_name}" --bucket "${S3_BUCKET}" --key "${PACKAGE_PREFIX}/${VERSION_TAG}/${package_name}"
+  done <<< "${packages}" > "${JOBS_FILE}"
+
+  log "The following aws s3api commands will be executed in parallel:"
+  cat "${JOBS_FILE}"
+
+  # run s3 uploads in parallel
+  # --wil-cite => don't display citation nag
+  # --hatl now,fail=1 => running jobs will be killed immediately if any other job fails
+  # --jobs 0 => will run as many jobs in parallel as possible (depends on number of cores)
+  parallel --will-cite --halt now,fail=1 --jobs 0 < "${JOBS_FILE}"
+}
+
+main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The `copy-staging-release-to-prod` GH workflow job is optimized to now perform multiple parallel s3api `copy-object` commands. I decided to use [GNU Parallel](https://www.gnu.org/software/parallel/sphinx.html) as the job orchestrator. The goal is to explicitly leverage all the CPU cores on the Linux Github runners to run multiple s3 copy operations so that we can release faster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-66950](https://app.shortcut.com/replicated/story/66950/speed-up-kurl-release-process)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

I tested `bin/copy-packages-s3-parallel.sh` on an Amazon Linux VM via AWS CloudShell.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
