### PR TITLE
also tag k8s.gcr.io images as registry.k8s.io when loading images

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -433,6 +433,8 @@ function load_images() {
     else
         find "$1" -type f | xargs -I {} bash -c "cat {} | gunzip | ctr -a $(${K8S_DISTRO}_get_containerd_sock) -n=k8s.io images import -"
     fi
+
+    retag_gcr_images
 }
 
 # try a command every 2 seconds until it succeeds, up to 30 tries max; useful for kubectl commands
@@ -996,4 +998,21 @@ function pod_count_by_selector() {
     fi
 
     echo -n "$pods" | wc -l
+}
+
+# retag_gcr_images takes every k8s.gcr.io image and adds a registry.k8s.io alias if it does not already exist
+function retag_gcr_images() {
+    if [ -n "$DOCKER_VERSION" ]; then
+        local images=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep k8s.gcr.io)
+        for image in $images; do
+            local new_image=$(echo "$image" | sed 's/k8s.gcr.io/registry.k8s.io/g')
+            docker tag "$image" "$new_image" 2>/dev/null || true
+        done
+    else
+        local images=$(ctr -n=k8s.io images list --quiet | grep k8s.gcr.io)
+        for image in $images; do
+            local new_image=$(echo "$image" | sed 's/k8s.gcr.io/registry.k8s.io/g')
+            ctr -n k8s.io images tag "$image" "$new_image" 2>/dev/null || true
+        done
+    fi
 }

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -139,6 +139,8 @@ function load_all_images() {
         fi
     fi
 
+    retag_gcr_images
+
     popd_install_directory
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When updating between certain pairs of k8s versions, the `kubeadm-config` configmap will request registry.k8s.io images when the airgap bundle only includes k8s.gcr.io. The images are the same, merely the source is different, so we can just retag things upon image load ensure the images are always available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an error updating Kubernetes from 1.21 to 1.23.{0-14} and 1.22 to 1.24.{0-8} in airgap environments.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
