### PR TITLE
fix: path to find the manifest filesystem-singlenode.yaml to apply patch from rook version 1.6.11

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -770,7 +770,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -775,7 +775,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -538,7 +538,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -701,7 +701,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -772,7 +772,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -767,7 +767,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -775,7 +775,7 @@ function rook_cephfilesystem_patch_singlenode() {
     fi
 
     local src="$DIR/addons/rook/$ROOK_VERSION/cluster"
-    rook_cephfilesystem_patch "$src/patches/filesystem-singlenode.yaml"
+    rook_cephfilesystem_patch "$src/cephfs/patches/filesystem-singlenode.yaml"
 }
 
 function rook_cephfilesystem_patch() {


### PR DESCRIPTION
#### What this PR does / why we need it:

To sort out the following error;

<img width="1259" alt="Screenshot 2023-01-26 at 16 01 32" src="https://user-images.githubusercontent.com/7708031/214886866-0a252e27-a61f-40ae-a500-9814e6062771.png">


#### Which issue(s) this PR fixes:

Partial Fixes # [sc-67662]

#### Special notes for your reviewer:

See that the file is in the path: 

<img width="1243" alt="Screenshot 2023-01-26 at 16 02 51" src="https://user-images.githubusercontent.com/7708031/214887061-1c34ff7e-4180-4ecf-8f19-4797a1efae78.png">

## Steps to reproduce

After this PR get merged the failed testgrid : https://testgrid.kurl.sh/run/rook_upgrade_test should not have this error. 


Testing locally after the fix I can check the rook been upgraded

<img width="1433" alt="Screenshot 2023-01-27 at 12 49 03" src="https://user-images.githubusercontent.com/7708031/215091131-a8d5d74e-cb90-4fc0-a47b-5d76acd433f0.png">

#### Does this PR introduce a user-facing change?

```release-note
fix: path to find the manifest filesystem-singlenode.yaml to apply patch from rook version 1.6.11
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
