### PR TITLE
update README cosign command to use double dash flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ The following example illustrates using [cosign](https://github.com/sigstore/cos
 not been tampered with.
 
 ```shell
-$ cosign verify-blob -key key.pub -signature kurl-sbom.tgz.sig kurl-sbom.tgz
+$ cosign verify-blob --key key.pub --signature kurl-sbom.tgz.sig kurl-sbom.tgz
 Verified OK
 ```


### PR DESCRIPTION


#### What this PR does / why we need it:

cosign is deprecating the use of single dash on key and signature flags
This changes the example cosign command to use --key and --signature in the README

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Minor change to the README

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

Within the SBOM section in the README, this updates the example cosign command to use --key and --signature in the


```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
