### PR TITLE
feat(ci/cd): Batch s3 copies across parallel jobs

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -143,14 +143,10 @@ jobs:
     - name: Build Package Matrix
       id: set-matrix
       run: |
-        # Get list of packages associated with a staging release from s3:
-        # Exclude common and kurl-bin-utils packages => grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*"
-        # Get raw strings NOT JSON encoded strings => jq -rc '.[]'
-        # Exclude directories => grep -vE "^${STAGING_PREFIX}/${STAGING_RELEASE}/$"
-        # Output the file name stripping the directory prefix => awk '{print $NF}' FS=/
-        # Covnert to JSON array and remove all empty string elements => jq -R -s -c 'split("\n")|map(select(length > 0))'
-        PACKAGES_JSON_ARRAY=$(aws s3api list-objects-v2 --bucket "${S3_BUCKET}" --prefix "${STAGING_PREFIX}/${STAGING_RELEASE}" --query 'Contents[].Key' | jq -rc '.[]' | grep -vE "^${STAGING_PREFIX}/${STAGING_RELEASE}/$" | grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*" | awk '{print $NF}' FS=/ | jq -R -s -c 'split("\n")|map(select(length > 0))')
-        echo "package=${PACKAGES_JSON_ARRAY}" >> $GITHUB_OUTPUT
+        export LIST_FROM_STAGE_S3="1"
+        BATCH_S3_PACKAGES=$(./bin/list-all-packages-actions-matrix.sh)
+        echo "${BATCH_S3_PACKAGES}" | jq
+        echo "package=${BATCH_S3_PACKAGES}" >> $GITHUB_OUTPUT
       env:
         S3_BUCKET: kurl-sh
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
@@ -175,8 +171,10 @@ jobs:
     - name: Copy packages to Prod
       run: |
         VERSION_TAG=$GITHUB_REF_NAME
-        package_name="${{ matrix.package }}"
-        aws s3api copy-object --copy-source "${S3_BUCKET}/${STAGING_PREFIX}/${STAGING_RELEASE}/${package_name}" --bucket "${S3_BUCKET}" --key "${PACKAGE_PREFIX}/${VERSION_TAG}/${package_name}"
+        batch="${{ matrix.batch }}"
+        for pkg in ${batch}; do
+          aws s3api copy-object --copy-source "${S3_BUCKET}/${STAGING_PREFIX}/${STAGING_RELEASE}/${pkg}" --bucket "${S3_BUCKET}" --key "${PACKAGE_PREFIX}/${VERSION_TAG}/${pkg}"
+        done
       env:
         S3_BUCKET: kurl-sh
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}

--- a/bin/list-all-packages-actions-matrix.sh
+++ b/bin/list-all-packages-actions-matrix.sh
@@ -2,9 +2,6 @@
 
 set -eo pipefail
 
-# shellcheck source=list-all-packages.sh
-source ./bin/list-all-packages.sh
-
 function require() {
     if [ -z "$2" ]; then
         echo "validation failed: $1 unset"
@@ -12,17 +9,24 @@ function require() {
     fi
 }
 
-require KURL_UTIL_IMAGE "${KURL_UTIL_IMAGE}" # required for common package
-require KURL_BIN_UTILS_FILE "${KURL_BIN_UTILS_FILE}"
-
 batch_size=3
-
 i=0
 start=0
 
-package_list=$(list_all | awk '{print $1}')
-if [ "${FILTER_GO_BINS_ONLY}" == "1" ]; then
-    package_list=$(list_go_bins| awk '{print $1}')
+package_list=
+if [ "${LIST_FROM_STAGE_S3}" == "1" ]; then
+    package_list=$(./bin/list-packages-s3.sh | awk '{print $1}')
+else
+    require KURL_UTIL_IMAGE "${KURL_UTIL_IMAGE}" # required for common package
+    require KURL_BIN_UTILS_FILE "${KURL_BIN_UTILS_FILE}"
+    # shellcheck source=list-all-packages.sh
+    source ./bin/list-all-packages.sh
+    if [ "${FILTER_GO_BINS_ONLY}" == "1" ]; then
+        package_list=$(list_go_bins| awk '{print $1}')
+    else
+        # default to listing all packages
+        package_list=$(list_all | awk '{print $1}')
+    fi
 fi
 
 printf '{"include": ['

--- a/bin/list-packages-s3.sh
+++ b/bin/list-packages-s3.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# List packages for a particular staging release from s3
+# Inovked by ./bin/list-all-packages-actions-matrix.sh
+
+set -eo pipefail
+
+function require() {
+    if [ -z "$2" ]; then
+        echo "validation failed: $1 unset"
+        exit 1
+    fi
+}
+
+require AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
+require AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
+require AWS_REGION "${AWS_REGION}"
+require S3_BUCKET "${S3_BUCKET}"
+require STAGING_RELEASE "${STAGING_RELEASE}"
+
+STAGING_PREFIX="${STAGING_PREFIX:-staging}"
+
+# Get list of packages associated with a staging release from s3:
+# Exclude common and kurl-bin-utils packages => grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*"
+# Get raw strings NOT JSON encoded strings => jq -rc '.[]'
+# Exclude directories => grep -vE "^${STAGING_PREFIX}/${STAGING_RELEASE}/$"
+# Output the file name stripping the directory prefix => awk '{print $NF}' FS=/
+list_s3_packages=$(aws s3api list-objects-v2 --bucket "${S3_BUCKET}" --prefix "${STAGING_PREFIX}/${STAGING_RELEASE}" --query 'Contents[].Key' | jq -rc '.[]' | grep -vE "^${STAGING_PREFIX}/${STAGING_RELEASE}/$" | grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*" | awk '{print $NF}' FS=/)
+
+echo "${list_s3_packages}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
GitHub Actions [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) generates a maximum of **256** jobs. Since we have over 500 packages to copy, this change enables each matrix job (running in parallel)  to copy up to **three** packages to s3.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [sc-66950](https://app.shortcut.com/replicated/story/66950/speed-up-kurl-release-process)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
