### PR TITLE
fix check to verify if multiple rook versions are found

### DIFF
--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -267,8 +267,16 @@ function rook_cluster_deploy_upgrade() {
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Rook version not yet rolled out"
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -193,11 +193,15 @@ function rook_cluster_deploy_upgrade() {
     echo "Awaiting rook-ceph operator"
 
     if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting Rook version to be deployed"
+        logStep "Checking Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
             logWarn "Detected multiple Rook versions"
             logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
         fi
     fi
 

--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -195,11 +195,15 @@ function rook_cluster_deploy_upgrade() {
     echo "Awaiting rook-ceph operator"
 
     if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting Rook version to be deployed"
+        logStep "Checking Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
             logWarn "Detected multiple Rook versions"
             logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
         fi
     fi
 

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -202,11 +202,15 @@ function rook_cluster_deploy_upgrade() {
     echo "Awaiting rook-ceph operator"
 
     if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting Rook version to be deployed"
+        logStep "Checking Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
             logWarn "Detected multiple Rook versions"
             logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
         fi
     fi
 

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -231,8 +231,16 @@ function rook_cluster_deploy_upgrade() {
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Detected multiple Rook versions"
-        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}name={.metadata.name}, rook-version={.metadata.labels.rook-version}{"\n"}{end}'
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -237,9 +237,17 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Rook version not yet rolled out"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -265,9 +265,17 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Rook version not yet rolled out"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # Allows Ceph Pacific to fix the following error:

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -266,9 +266,17 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Rook version not yet rolled out"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -267,8 +267,16 @@ function rook_cluster_deploy_upgrade() {
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
-        logWarn "Rook version not yet rolled out"
+        logWarn "Timeout waiting for Rook version rolled out"
+        logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
     fi
 
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -101,7 +101,7 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
         fi
 
@@ -159,7 +159,7 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
         fi
 
@@ -203,7 +203,7 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
         fi
 
@@ -240,7 +240,7 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
         fi
 

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -93,9 +93,16 @@ function rookupgrade_10to14_upgrade() {
 
         log "Waiting for Rook 1.1.9 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.1.9" --timeout=1200 ; then
-            logWarn "Detected multiple Rook versions"
+            logWarn "Timeout waiting for Rook version 1.1.9 rolled out"
+            logStep "Checking Rook versions and replicas"
             kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
-            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            local rook_versions=
+            rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+            if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+                logWarn "Detected multiple Rook versions"
+                logWarn "${rook_versions}"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            fi
         fi
 
         # todo make sure that the RGW isn't getting stuck
@@ -144,9 +151,16 @@ function rookupgrade_10to14_upgrade() {
 
         log "Waiting for Rook 1.2.7 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.2.7" --timeout=1200 ; then
-            logWarn "Detected multiple Rook versions"
+            logWarn "Timeout waiting for Rook version 1.2.7 rolled out"
+            logStep "Checking Rook versions and replicas"
             kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
-            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            local rook_versions=
+            rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+            if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+                logWarn "Detected multiple Rook versions"
+                logWarn "${rook_versions}"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            fi
         fi
 
         log "Rook 1.2.7 has been rolled out throughout the cluster"
@@ -181,9 +195,16 @@ function rookupgrade_10to14_upgrade() {
 
         log "Waiting for Rook 1.3.11 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.3.11" --timeout=1200 ; then
-            logWarn "Detected multiple Rook versions"
+            logWarn "Timeout waiting for Rook version 1.3.11 rolled out"
+            logStep "Checking Rook versions and replicas"
             kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
-            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            local rook_versions=
+            rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+            if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+                logWarn "Detected multiple Rook versions"
+                logWarn "${rook_versions}"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            fi
         fi
 
         log "Rook 1.3.11 has been rolled out throughout the cluster"
@@ -211,9 +232,16 @@ function rookupgrade_10to14_upgrade() {
 
         log "Waiting for Rook 1.4.9 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.4.9" --timeout=1200 ; then
-            logWarn "Detected multiple Rook versions"
+            logWarn "Timeout waiting for Rook version 1.4.9 rolled out"
+            logStep "Checking Rook versions and replicas"
             kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
-            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            local rook_versions=
+            rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+            if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+                logWarn "Detected multiple Rook versions"
+                logWarn "${rook_versions}"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
+            fi
         fi
 
         log "Rook 1.4.9 has been rolled out throughout the cluster"

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -101,8 +101,9 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
+            bail "Failed to verify the Rook upgrade"
         fi
 
         # todo make sure that the RGW isn't getting stuck
@@ -159,8 +160,9 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
+            bail "Failed to verify the Rook upgrade"
         fi
 
         log "Rook 1.2.7 has been rolled out throughout the cluster"
@@ -203,8 +205,9 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
+            bail "Failed to verify the Rook upgrade"
         fi
 
         log "Rook 1.3.11 has been rolled out throughout the cluster"
@@ -240,8 +243,10 @@ function rookupgrade_10to14_upgrade() {
             if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
                 logWarn "Detected multiple Rook versions"
                 logWarn "${rook_versions}"
-                bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+                logWarn "Failed to verify the Rook upgrade, multiple Rook versions detected"
             fi
+            bail "Failed to verify the Rook upgrade"
+
         fi
 
         log "Rook 1.4.9 has been rolled out throughout the cluster"


### PR DESCRIPTION
#### What this PR does / why we need it:

Note that when we are upgrading to 1.16.11 we are facing the error that multiple versions were found when they were not. We just fail in the timeout to check rook status deployments. See:

<img width="1312" alt="Screenshot 2023-01-27 at 12 51 21" src="https://user-images.githubusercontent.com/7708031/215093757-a2762ce7-efbf-464e-89e2-0c003d7dbf8f.png">

Therefore, this PR fix the check for we do not warning something that is not true.

PS.: Also, note that in this scenario we can move forward and finish the upgrade with success. (It seems that we have some know issues in rock operator which gets stuck see: https://github.com/rook/rook/issues/5090 and because of this I am assuming that we do not fail. Anyway, the scope of this PR is just sorted out the check in order to not provide an wrong info and ensure that all places are following the same wording standards)

#### Which issue(s) this PR fixes:

Fixes # [sc-67863]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
Test upgrade from 1.15.12 to 1.6.11

#### Does this PR introduce a user-facing change?
```release-note
fix: check to verify multiple rook versions in for rook upgrade 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
