### PR TITLE
 chore: split rook upgrade tests

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -627,7 +627,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: k8s1205_rook_upgrade
+- name: k8s184_rook_upgrade_from_143_to_18x
   flags: "yes"
   cpu: 6
   installerSpec:
@@ -651,7 +651,41 @@
       version: 2.8.1
     rook:
       bypassUpgradeWarning: true
-      version: 1.9.x
+      version: 1.8.x
+    kotsadm:
+      version: 1.38.0
+    containerd:
+      version: 1.4.12
+    ekco:
+      version: latest
+  unsupportedOSIDs:
+    - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+- name: k8s184_rook_upgrade_from_17x_to_latest
+  flags: "yes"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: 1.18.4
+    weave:
+      version: 2.8.1
+    rook:
+      isBlockStorageEnabled: true
+      version: 1.7.x
+    kotsadm:
+      version: 1.38.0
+    containerd:
+      version: 1.4.6
+    ekco:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.20.2
+    weave:
+      version: 2.8.1
+    rook:
+      bypassUpgradeWarning: true
+      version: latest
     kotsadm:
       version: 1.38.0
     containerd:


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently the test will upgrade from 1.4.3 to 1.9.x. This PR split the tests into:
- from 1.4.3 to 1.8.x 
- from 1.7.x to latest 

So e can better cover the upgrade and avoid flakes. Also, by doing it we are increasing the coverage because we are testing 1.7.x to latest instead up 1.9.x only.


#### Which issue(s) this PR fixes:

Related # [sc-67862]

#### Special notes for your reviewer: