### PR TITLE
chore: Add further log information about ceph state for rook upgrades 

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -301,8 +301,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -306,8 +306,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -270,8 +270,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Detected multiple Ceph versions"
-        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}name={.metadata.name}, ceph-version={.metadata.labels.ceph-version}{"\n"}{end}'
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -277,8 +277,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -310,8 +310,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -306,8 +306,20 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -306,8 +306,21 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Ceph version not yet rolled out"
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        # Fail when more than one version is found
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version failed to deploy"
     fi
 

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -119,8 +119,21 @@ function rookupgrade_10to14_upgrade() {
             kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20201116"}}}'
             kubectl patch deployment -n rook-ceph csi-rbdplugin-provisioner -p '{"spec": {"template": {"spec":{"containers":[{"name":"csi-snapshotter","imagePullPolicy":"IfNotPresent"}]}}}}'
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "14.2.5" --timeout=1200 ; then
-                logWarn "Ceph version not yet rolled out"
+                logWarn "Timeout waiting for Ceph version rolled out"
+                logStep "Checking Ceph versions and replicas"
                 kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+                local ceph_versions_found=
+                ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+                # Fail when more than one version is found
+                if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+                    logWarn "Detected multiple Ceph versions"
+                    logWarn "${ceph_versions_found}"
+                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                fi
+
+                if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+                    logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+                fi
                 bail "New Ceph version failed to deploy"
             fi
 
@@ -270,9 +283,20 @@ function rookupgrade_10to14_upgrade() {
             rookupgrade_10to14_maybe_scale_pool_device_health_metrics
 
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "15.2.8-0" --timeout=1200 ; then
-                logWarn "Ceph version not yet rolled out"
-                kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
-                bail "New Ceph version failed to deploy"
+                  logWarn "Timeout waiting for Ceph version 15.2.8-0 rolled out"
+                  logStep "Checking Ceph versions and replicas"
+                  kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+                  local ceph_versions_found=
+                  ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+                  if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+                      logWarn "Detected multiple Ceph versions"
+                      logWarn "${ceph_versions_found}"
+                      bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                  fi
+
+                  if [[ "$(echo "${ceph_versions_found}")" == *"15.2.8"* ]]; then
+                      bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+                  fi
             fi
 
             log "Enabling pg pool autoscaling"

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -283,20 +283,21 @@ function rookupgrade_10to14_upgrade() {
             rookupgrade_10to14_maybe_scale_pool_device_health_metrics
 
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "15.2.8-0" --timeout=1200 ; then
-                  logWarn "Timeout waiting for Ceph version 15.2.8-0 rolled out"
-                  logStep "Checking Ceph versions and replicas"
-                  kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
-                  local ceph_versions_found=
-                  ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
-                  if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-                      logWarn "Detected multiple Ceph versions"
-                      logWarn "${ceph_versions_found}"
-                      bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
-                  fi
+                logWarn "Timeout waiting for Ceph version 15.2.8-0 rolled out"
+                logStep "Checking Ceph versions and replicas"
+                kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+                local ceph_versions_found=
+                ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+                if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+                    logWarn "Detected multiple Ceph versions"
+                    logWarn "${ceph_versions_found}"
+                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                fi
 
-                  if [[ "$(echo "${ceph_versions_found}")" == *"15.2.8"* ]]; then
-                      bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
-                  fi
+                if [[ "$(echo "${ceph_versions_found}")" == *"15.2.8"* ]]; then
+                    logWarn "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+                fi
+                bail "New Ceph version failed to deploy"
             fi
 
             log "Enabling pg pool autoscaling"


### PR DESCRIPTION
#### What this PR does / why we need it:

Just to let us know have further information about when we face issues with Ceph versions as we have for Rook version to help us out troubleshooting. 


```release-note
Adds further log information about Ceph replicas and versions for Rook upgrades from the Rook version 1.6.11
```