### PR TITLE
feat: scaling down pods before starting the Longhorn to OpenEBS/Rook migration.

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -388,4 +388,8 @@ function openebs_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -388,4 +388,8 @@ function openebs_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -942,11 +942,9 @@ function rook_prompt_migrate_from_longhorn() {
 
     local nodes=$(kubectl get nodes --no-headers | wc -l)
     if [ "$nodes" -eq 1 ]; then
-        logWarn "    WARNING: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
-        logWarn "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors. Do you wish to proceed?"
-        if ! confirmN; then
-            bail "Not migrating"
-        fi
+        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
+        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS. Do you wish to proceed?"
+        bail "Not migrating"
     fi
 
     if ! longhorn_prepare_for_migration; then

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -939,4 +939,8 @@ function rook_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -940,6 +940,15 @@ function rook_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
+    local nodes=$(kubectl get nodes --no-headers | wc -l)
+    if [ "$nodes" -eq 1 ]; then
+        logWarn "    WARNING: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
+        logWarn "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors. Do you wish to proceed?"
+        if ! confirmN; then
+            bail "Not migrating"
+        fi
+    fi
+
     if ! longhorn_prepare_for_migration; then
         bail "Not migrating"
     fi

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -942,8 +942,8 @@ function rook_prompt_migrate_from_longhorn() {
 
     local nodes=$(kubectl get nodes --no-headers | wc -l)
     if [ "$nodes" -eq 1 ]; then
-        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
-        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS. Do you wish to proceed?"
+        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. You must install OpenEBS instead."
+        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS."
         bail "Not migrating"
     fi
 

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -942,11 +942,9 @@ function rook_prompt_migrate_from_longhorn() {
 
     local nodes=$(kubectl get nodes --no-headers | wc -l)
     if [ "$nodes" -eq 1 ]; then
-        logWarn "    WARNING: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
-        logWarn "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors. Do you wish to proceed?"
-        if ! confirmN; then
-            bail "Not migrating"
-        fi
+        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
+        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS. Do you wish to proceed?"
+        bail "Not migrating"
     fi
 
     if ! longhorn_prepare_for_migration; then

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -939,4 +939,8 @@ function rook_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -940,6 +940,15 @@ function rook_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
+    local nodes=$(kubectl get nodes --no-headers | wc -l)
+    if [ "$nodes" -eq 1 ]; then
+        logWarn "    WARNING: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
+        logWarn "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors. Do you wish to proceed?"
+        if ! confirmN; then
+            bail "Not migrating"
+        fi
+    fi
+
     if ! longhorn_prepare_for_migration; then
         bail "Not migrating"
     fi

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -942,8 +942,8 @@ function rook_prompt_migrate_from_longhorn() {
 
     local nodes=$(kubectl get nodes --no-headers | wc -l)
     if [ "$nodes" -eq 1 ]; then
-        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. It is strongly recommended that you install OpenEBS instead."
-        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS. Do you wish to proceed?"
+        logFail "    ERROR: Your cluster has only one node, making Rook an unsuitable choice as a storage provisioner. You must install OpenEBS instead."
+        logFail "    Continuing with the Longhorn to Rook data migration under these conditions may result in unexpected errors potentially CAUSING DATA LOSS."
         bail "Not migrating"
     fi
 

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -345,6 +345,8 @@
 - name: Rook migrate from Longhorn
   flags: "yes"
   cpu: 6
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
   installerSpec:
     kubernetes:
       # Longhorn is not compatible with kubernetes 1.25+.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1
 	github.com/replicatedhq/kurlkinds v1.0.11
 	github.com/replicatedhq/plumber v1.16.0
 	github.com/replicatedhq/pvmigrate v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1415,6 +1415,8 @@ github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d h1:PinQItctnaL2LtkaS
 github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.44.1/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1 h1:A46xpyCEQpMFymrNJOaL5aAu3ZWgEKwJUXZrB5D3IUM=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1/go.mod h1:MNl09GdaKb/vE8QdcCWyICDV7XAbGX6gKKQAS43XW1c=
 github.com/prometheus-operator/prometheus-operator/pkg/client v0.46.0/go.mod h1:k4BrWlVQQsvBiTcDnKEMgyh/euRxyxgrHdur/ZX/sdA=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -27,12 +27,14 @@ import (
 	"github.com/replicatedhq/kurl/pkg/k8sutil"
 )
 
-var scaleDownReplicasWaitTime = time.Minute
+var scaleDownReplicasWaitTime = 5 * time.Minute
 
 const (
 	prometheusNamespace          = "monitoring"
 	prometheusName               = "k8s"
+	prometheusStatefulSetName    = "prometheus-k8s"
 	ekcoNamespace                = "kurl"
+	ekcoDeploymentName           = "ekc-operator"
 	pvmigrateScaleDownAnnotation = "kurl.sh/pvcmigrate-scale"
 	longhornNamespace            = "longhorn-system"
 	overProvisioningSetting      = "storage-over-provisioning-percentage"
@@ -263,7 +265,7 @@ func scalePrometheus(ctx context.Context, cli client.Client, replicas int32) err
 			return false, fmt.Errorf("error scaling down prometheus: %w", err)
 		}
 
-		nsn = types.NamespacedName{Namespace: prometheusNamespace, Name: "prometheus-k8s"}
+		nsn = types.NamespacedName{Namespace: prometheusNamespace, Name: prometheusStatefulSetName}
 		var st appsv1.StatefulSet
 		if err := cli.Get(ctx, nsn, &st); err != nil {
 			return false, fmt.Errorf("error getting prometheus statefulset: %w", err)
@@ -287,7 +289,7 @@ func scalePrometheus(ctx context.Context, cli client.Client, replicas int32) err
 
 // scaleEkco scales ekco operator to the number of provided replicas.
 func scaleEkco(ctx context.Context, cli client.Client, replicas int32) error {
-	nsn := types.NamespacedName{Namespace: ekcoNamespace, Name: "ekc-operator"}
+	nsn := types.NamespacedName{Namespace: ekcoNamespace, Name: ekcoDeploymentName}
 	var dep appsv1.Deployment
 	if err := cli.Get(ctx, nsn, &dep); err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -262,7 +262,7 @@ func scalePrometheus(ctx context.Context, cli client.Client, replicas int32) err
 			if errors.IsConflict(err) {
 				return false, nil
 			}
-			return false, fmt.Errorf("error scaling down prometheus: %w", err)
+			return false, fmt.Errorf("error scaling prometheus: %w", err)
 		}
 
 		nsn = types.NamespacedName{Namespace: prometheusNamespace, Name: prometheusStatefulSetName}

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -313,7 +313,7 @@ func scaleEkco(ctx context.Context, cli client.Client, replicas int32) error {
 	return nil
 }
 
-// waitForPodsToBeScaledDown waits for all pods using matching the provided selector to dissapear in the provided
+// waitForPodsToBeScaledDown waits for all pods using matching the provided selector to disappear in the provided
 // namespace.
 func waitForPodsToBeScaledDown(ctx context.Context, cli client.Client, ns string, sel labels.Selector) error {
 	// return wait.PollImmediate(3*time.Second, 5*time.Minute, func() (bool, error) {
@@ -339,16 +339,16 @@ func scaleDownObject(ctx context.Context, cli client.Client, obj client.Object) 
 	kind := strings.ToLower(fmt.Sprintf("%T", obj))
 	log.Printf("Scaling down %s %s/%s", kind, obj.GetNamespace(), obj.GetName())
 
-	selector := labels.NewSelector()
-	replicas := pointer.Int32Ptr(0)
+	var selector labels.Selector
+	replicas := pointer.Int32(0)
 	switch concrete := obj.(type) {
 	case *appsv1.Deployment:
 		replicas = concrete.Spec.Replicas
-		concrete.Spec.Replicas = pointer.Int32Ptr(0)
+		concrete.Spec.Replicas = pointer.Int32(0)
 		selector = labels.SelectorFromSet(concrete.Spec.Selector.MatchLabels)
 	case *appsv1.StatefulSet:
 		replicas = concrete.Spec.Replicas
-		concrete.Spec.Replicas = pointer.Int32Ptr(0)
+		concrete.Spec.Replicas = pointer.Int32(0)
 		selector = labels.SelectorFromSet(concrete.Spec.Selector.MatchLabels)
 	default:
 		return fmt.Errorf("unsupported object type %T", obj)

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -340,7 +340,7 @@ func scaleDownObject(ctx context.Context, cli client.Client, obj client.Object) 
 	log.Printf("Scaling down %s %s/%s", kind, obj.GetNamespace(), obj.GetName())
 
 	var selector labels.Selector
-	replicas := pointer.Int32(0)
+	var replicas *int32
 	switch concrete := obj.(type) {
 	case *appsv1.Deployment:
 		replicas = concrete.Spec.Replicas
@@ -352,6 +352,10 @@ func scaleDownObject(ctx context.Context, cli client.Client, obj client.Object) 
 		selector = labels.SelectorFromSet(concrete.Spec.Selector.MatchLabels)
 	default:
 		return fmt.Errorf("unsupported object type %T", obj)
+	}
+
+	if replicas == nil {
+		replicas = pointer.Int32(0)
 	}
 
 	annotations := obj.GetAnnotations()

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -93,7 +93,7 @@ func NewLonghornRollbackMigrationReplicas(_ CLI) *cobra.Command {
 			log.Print("Longhorn volumes have been rolled back to their original replica count.")
 
 			if err := scaleUpPodsUsingLonghorn(context.Background(), cli); err != nil {
-				return fmt.Errorf("error scaling up pods using longhorn: %s", err)
+				return fmt.Errorf("error scaling up pods using longhorn: %w", err)
 			}
 			return nil
 		},

--- a/pkg/cli/longhorn_test.go
+++ b/pkg/cli/longhorn_test.go
@@ -58,7 +58,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 
 	for _, vol := range gotVolumes.Items {
 		assert.Equal(t, int(1), vol.Spec.NumberOfReplicas)
-		assert.Equal(t, "3", vol.Annotations[volumeReplicasAnnotation])
+		assert.Equal(t, "3", vol.Annotations[pvmigrateScaleDownAnnotation])
 	}
 }
 

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -216,7 +216,7 @@ function longhorn_prepare_for_migration() {
     logFail "restore the system to its original state?"
     if confirmY; then
         log "Restoring Longhorn replicas to their original state"
-        longhorn_restore_replicas
+        longhorn_restore_migration_replicas
     fi
     return 1
 }

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -195,3 +195,19 @@ function remove_longhorn() {
 
     logSuccess "Removed Longhorn successfully"
 }
+
+# longhorn_prepare_for_migration checks if longhorn is healthy and if it is, it will scale down the all pods mounting
+# longhorn volumes. if a failure happen during the preparation fase the migration won't be executed and the user will
+# receive a message to restore the cluster to its previous state.
+function longhorn_prepare_for_migration() {
+    if "$DIR"/bin/kurl longhorn prepare-for-migration; then
+        return 0
+    fi
+    logFail "Preparation for longhorn migration failed. Please review the preceding messages for further details."
+    logFail "During the preparation for Longhorn, some replicas may have been scaled down to 0. Would you like to"
+    logFail "restore the system to its original state?"
+    if confirmY; then
+        "$DIR"/bin/kurl longhorn rollback-migration-replicas
+    fi
+    return 1
+}

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -53,6 +53,33 @@ function longhorn_install_nfs_utils_if_missing_common() {
     fi
 }
 
+# longhorn_run_pvmigrate calls pvmigrate to migrate longhorn data to a different storage class. if a failure happen
+# then rolls back the original number of volumes and replicas.
+function longhorn_run_pvmigrate() {
+    local longhorn_sc=$1
+    local destStorageClass=$2
+    local didRunValidationChecks=$3
+    local setDefaults=$4
+
+    local skipFreeSpaceCheckFlag=""
+    local skipPreflightValidationFlag=""
+    if [ "$didRunValidationChecks" == "1" ]; then
+        skipFreeSpaceCheckFlag="--skip-free-space-check"
+        skipPreflightValidationFlag="--skip-preflight-validation"
+    fi
+
+    local setDefaultsFlag=""
+    if [ "$setDefaults" == "1" ]; then
+        setDefaultsFlag="--set-defaults"
+    fi
+
+    if ! $BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE" "$skipFreeSpaceCheckFlag" "$skipPreflightValidationFlag" "$setDefaultsFlag"; then
+        longhorn_restore_migration_replicas
+        return 1
+    fi
+    return 0
+}
+
 # scale down prometheus, move all 'longhorn' PVCs to provided storage class, scale up prometheus
 # Supported storage class migrations from longhorn are: 'rook' and 'openebs'
 function longhorn_to_sc_migration() {
@@ -84,42 +111,23 @@ function longhorn_to_sc_migration() {
         fi
     fi
 
-    # get the list of StorageClasses that use Longhorn
     longhorn_scs=$(kubectl get storageclass | grep longhorn | grep -v '(default)' | awk '{ print $1}') # any non-default longhorn StorageClasses
-    longhorn_default_sc=$(kubectl get storageclass | grep longhorn | grep '(default)' | awk '{ print $1}') # any default longhorn StorageClasses
-
     for longhorn_sc in $longhorn_scs
     do
-        if [ "$didRunValidationChecks" == "1" ]; then
-            # run the migration w/o validation checks
-            $BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE" --skip-free-space-check --skip-preflight-validation
-        else
-            # run the migration (without setting defaults)
-            $BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE"
+        if ! longhorn_run_pvmigrate "$longhorn_sc" "$destStorageClass" "$didRunValidationChecks" "0"; then
+            bail "Failed to migrate PVCs from $longhorn_sc to $destStorageClass"
         fi
     done
 
+    longhorn_default_sc=$(kubectl get storageclass | grep longhorn | grep '(default)' | awk '{ print $1}') # any default longhorn StorageClasses
     for longhorn_sc in $longhorn_default_sc
     do
-        if [ "$didRunValidationChecks" == "1" ]; then
-            # run the migration w/o validation checks
-            $BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE" --skip-free-space-check --skip-preflight-validation --set-defaults
-        else
-            # run the migration (setting defaults)
-            $BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$destStorageClass" --rsync-image "$KURL_UTIL_IMAGE" --set-defaults
+        if ! longhorn_run_pvmigrate "$longhorn_sc" "$destStorageClass" "$didRunValidationChecks" "1"; then
+            bail "Failed to migrate PVCs from $longhorn_sc to $destStorageClass"
         fi
     done
 
-    # reset prometheus (and ekco) scale
-    if kubectl get namespace monitoring &>/dev/null; then
-        if kubectl get prometheus -n monitoring k8s &>/dev/null; then
-            if kubernetes_resource_exists kurl deployment ekc-operator; then
-                kubectl -n kurl scale deploy ekc-operator --replicas=1
-            fi
-
-            kubectl patch prometheus -n monitoring  k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]'
-        fi
-    fi
+    longhorn_restore_migration_replicas
 
     # print success message
     logSuccess "Migration from longhorn to $scProvisioner completed successfully!"
@@ -207,7 +215,14 @@ function longhorn_prepare_for_migration() {
     logFail "During the preparation for Longhorn, some replicas may have been scaled down to 0. Would you like to"
     logFail "restore the system to its original state?"
     if confirmY; then
-        "$DIR"/bin/kurl longhorn rollback-migration-replicas
+        log "Restoring Longhorn replicas to their original state"
+        longhorn_restore_replicas
     fi
     return 1
+}
+
+# longhorn_restore_migration_replicas scales up all longhorn volumes, deployment and statefulset replicas to their
+# original values.
+function longhorn_restore_migration_replicas() {
+    "$DIR"/bin/kurl longhorn rollback-migration-replicas
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR introduces a new command flag to the Kurl binary, allowing us to gracefully scale down pods using Longhorn volumes **prior** to migration (before running `pvmigrate`). By incorporating this flag into the Rook and OpenEBS pre-init process, we aim to scale down Pods using a more stable cluster (before start to bump things around and generate Longhorn instability). My testing has shown a noticeable improvement, as there have been no instances of Pods stuck in the "Terminating" state anymore.

However, in the event that some pods do become stuck during pre-flight, the migration will fail and may leave the cluster with some Pods down and Longhorn volumes scaled down. This is by design as it allows us to take action and manually restart Kubelet in the affected nodes. In case of failure a helpful message is also displayed with instructions on how to bring the scaled-down Pods and Volumes back up using another flag (also introduced by this PR) in the Kurl binary.

Migrations from Longhorn to Rook have been **SUSPENDED** due to failures encountered during testing on a single node cluster with 8 CPUs and 32GB of RAM. The failures were characterized by issues with etcd and the controller manager, which have been linked to a specific Kernel parameter (as previously discussed on Slack). 

#### Which issue(s) this PR fixes:
Fixes #65977