### PR TITLE
feat: Tag and release specific commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DATE = `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 BUILDTAGS = netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
 BUILDFLAGS = -tags "$(BUILDTAGS)" -installsuffix netgo
 KURL_KINDS_VERSION := $(shell grep "github.com/replicatedhq/kurlkinds" go.mod | cut -d ' ' -f2)
-COMMIT_ID?=""
+COMMIT_ID?=
 
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DATE = `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 BUILDTAGS = netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
 BUILDFLAGS = -tags "$(BUILDTAGS)" -installsuffix netgo
 KURL_KINDS_VERSION := $(shell grep "github.com/replicatedhq/kurlkinds" go.mod | cut -d ' ' -f2)
+COMMIT_ID?=""
 
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
@@ -706,4 +707,8 @@ sbom: sbom/assets/kurl-sbom.tgz
 
 .PHONY: tag-and-release
 tag-and-release: ## Create tags and release
+ifneq "$(COMMIT_ID)" ""
+	@./bin/tag-and-release.sh --commit-id=$(COMMIT_ID)
+else
 	@./bin/tag-and-release.sh
+endif

--- a/README.md
+++ b/README.md
@@ -46,10 +46,23 @@ Release assets and changelog are available on the [GitHub Releases](https://gith
 Releases are created by a GitHub Workflow when a tag is pushed.
 The tag should follow the date format `vYYYY.MM.DD-#`.
 
-A new release can be tagged by running the following command:
+A new release, from HEAD, can be tagged by running the following command:
 
 ```shell
-$ make tag-and-release
+make tag-and-release
+```
+
+To tag and release a specific commit:
+
+```shell
+make COMMIT_ID=<GITHUB_SHA> tag-and-release
+```
+
+The `tag-and-release` Make task enforces the git tree to be clean and a tag to be created against
+the `main` branch. To override this behavior call the underlying script directly:
+
+```shell
+./bin/tag-and-release.sh --commit-id=<GITHUB_SHA> --no-main --outdated
 ```
 
 ## Software Bill of Materials

--- a/bin/tag-and-release.sh
+++ b/bin/tag-and-release.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# This script generates a tag in the format, <YYYY>.<MM>.<DD>-0, and pushes the tag to origin in
+# order to trigger the deploy-prod workflow.
+# Note: This script is called from the makefile target 'tag-and-release'
+#
+# Usage:
+# Tag HEAD and push tag to remote: './tag-and-release.sh'
+# Tag a particular commit and push tag to remote: './tag-and-release.sh --commit-id=<GITHUB_SHA>'
+# Ignore dirty git tree: './tag-and-release.sh --commit-id=<GITHUB_SHA> --outdated'
+# Create a tag on non main branch: './tag-and-release.sh --commit-id=<GITHUB_SHA> --no-main'
+
 set -euo pipefail
 
 function log() {

--- a/bin/tag-and-release.sh
+++ b/bin/tag-and-release.sh
@@ -22,6 +22,10 @@ function parse_flags() {
                 outdated="1"
                 shift
                 ;;
+            --commit-id=*)
+                commit_id="${1#*=}"
+                shift
+                ;;
             *)
                 bail "Unknown flag $1"
                 ;;
@@ -82,6 +86,8 @@ function find_next_tag() {
 function main() {
     local no_main=0
     local outdated=0
+    local commit_id=
+    commit_id=$(git rev-parse --short HEAD)
     parse_flags "$@"
 
     git fetch -q
@@ -101,17 +107,17 @@ function main() {
     local tag=
     tag="$(find_next_tag "$previous_tag")"
 
-    echo "Tagging and releasing version $tag ($(git rev-parse --short HEAD)) with commits:"
+    echo "Tagging and releasing version $tag (${commit_id}) with commits:"
     echo ""
 
-    git log --pretty=oneline "$previous_tag"...HEAD
+    git log --pretty=oneline "$previous_tag"..."${commit_id}"
     echo ""
 
     local confirm=
     echo -n "Are you sure? [yes/N] " && read -r confirm && [ "${confirm:-N}" = "yes" ]
     echo ""
 
-    (set -x; git tag -a -m "Release $tag" "$tag" && git push origin "$tag")
+    (set -x; git tag -a -m "Release $tag" "$tag" "${commit_id}" && git push origin "$tag")
 }
 
 main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This patch enables tagging a specific commit to trigger the release process:
```bash
# tag a specific release
make COMMIT_ID=845a8f56 tag-and-release
Tagging and releasing version v2023.01.31-0 (845a8f56) with commits:

845a8f56 (origin/emosbaugh/sc-67801/check-for-airgap-missing-images-does-not) Merge pull request #3998 from replicatedhq/emosbaugh/sc-67801/check-for-airgap-missing-images-does-not
63c2fab6 feat: list all images in node missing images output
48e0e948 fix(flannel): dynamic check for missing images on nodes
506565f3 Merge pull request #3996 from replicatedhq/St0rmz1-UpdateREADME-20230126
aeb56566 update cosign command to use double dashes on the --key and --signature flags. cosgin is deprecating the use of single dash in these flags
2d4de15c Merge pull request #3981 from replicatedhq/ricardomaraschini/sc-65977/longhorn-making-pods-to-hang-or-not-to-come
fabab526 feat(ci/cd): Use Github matrix strategy to speedup prod release (#3993)
af29d977 bug: retrying in case of conflict
1e8ee8a0 feat: adding rollback command.
992d48ef feat: adds "prepare longhorn for migration" command.
838accc4 Merge pull request #3994 from replicatedhq/laverya/sc-67475/airgap-upgrade-from-k8s-1-21-8-to-1-23-9
85040e6e also tag k8s.gcr.io images as registry.k8s.io when loading images
cf063444 Merge pull request #3986 from replicatedhq/emosbaugh/sc-61600/add-flannel-preflight-checks-2
1f970384 feat(flannel): preflight UDP port 8472 status
c4c54200 Merge pull request #3971 from replicatedhq/cbo/sc-35682/velero-server-flags
2a700408 Merge pull request #3989 from replicatedhq/emosbaugh/sc-61600/bump-troubleshoot
967e0f44 chore: bump github.com/replicatedhq/troubleshoot v0.55.0
bca02e8c Merge pull request #3988 from replicatedhq/ricardomaraschini/sc-65193/error-csidrivers-storage-k8s-io-cstor-csi
cd6610e5 chore: ignore if cstor.csi.openebs.io does not exist.
1c8c4fe1 chore: standardize minio deployment await timeout.
553ca5b8 add serverFlags field to velero add-on
3b513d78 Merge pull request #3985 from replicatedhq/emosbaugh/sc-67506/kuberentes-preflights-missing-tcp-connection
08877bfb Merge pull request #3984 from replicatedhq/emosbaugh/sc-61600/add-flannel-preflight-checks
ace1358c Add host preflights for tcp connection on ports 2379 and 6443
e6941566 feat(flannel): log warning flannel udp port 8472 must be open
f3d73bef Merge pull request #3964 from replicatedhq/automation/update-kubernetes
cf267bd6 chore: ignore warning about mon usage be higher than 70% to not block upgrades (#3982)
52cbcaf3 (chore): testgrid: add some tests to check kubectl with kube/config (#3972)
3bed4019 feat: improve the output message to clarify to users kubectl config usage (#3973)
951ed48b Create new Kubernetes version
...

# tag and release HEAD
make tag-and-release
Tagging and releasing version v2023.01.31-0 (9c75c55f) with commits:

9c75c55f (HEAD -> rafaelpolanco/sc-66950/release-commit, origin/rafaelpolanco/sc-66950/release-commit) feat: Tag and release specific commit
a96ea366 chore(deps): bump sigs.k8s.io/controller-tools from 0.11.1 to 0.11.2 (#4006)
0be41f75 Create new Sonobuoy version (#4002)
3f325e18 Merge pull request #4001 from replicatedhq/emosbaugh/sc-61608/flannel-default-testgrid
f4d03b72 chore(ci): make flannel the default in testgrid specs
1a4249df rook from 1.5.12 fix path to apply manifest (#3995)
e313c3db Create new minio version (#3987)
6e47b79b feat(ci/cd): Batch s3 copies across parallel jobs (#3997)
845a8f56 (origin/emosbaugh/sc-67801/check-for-airgap-missing-images-does-not) Merge pull request #3998 from replicatedhq/emosbaugh/sc-67801/check-for-airgap-missing-images-does-not
63c2fab6 feat: list all images in node missing images output
48e0e948 fix(flannel): dynamic check for missing images on nodes
506565f3 Merge pull request #3996 from replicatedhq/St0rmz1-UpdateREADME-20230126
aeb56566 update cosign command to use double dashes on the --key and --signature flags. cosgin is deprecating the use of single dash in these flags
2d4de15c Merge pull request #3981 from replicatedhq/ricardomaraschini/sc-65977/longhorn-making-pods-to-hang-or-not-to-come
fabab526 feat(ci/cd): Use Github matrix strategy to speedup prod release (#3993)
af29d977 bug: retrying in case of conflict
1e8ee8a0 feat: adding rollback command.
992d48ef feat: adds "prepare longhorn for migration" command.
838accc4 Merge pull request #3994 from replicatedhq/laverya/sc-67475/airgap-upgrade-from-k8s-1-21-8-to-1-23-9
85040e6e also tag k8s.gcr.io images as registry.k8s.io when loading images
cf063444 Merge pull request #3986 from replicatedhq/emosbaugh/sc-61600/add-flannel-preflight-checks-2
1f970384 feat(flannel): preflight UDP port 8472 status
c4c54200 Merge pull request #3971 from replicatedhq/cbo/sc-35682/velero-server-flags
2a700408 Merge pull request #3989 from replicatedhq/emosbaugh/sc-61600/bump-troubleshoot
967e0f44 chore: bump github.com/replicatedhq/troubleshoot v0.55.0
bca02e8c Merge pull request #3988 from replicatedhq/ricardomaraschini/sc-65193/error-csidrivers-storage-k8s-io-cstor-csi
cd6610e5 chore: ignore if cstor.csi.openebs.io does not exist.
1c8c4fe1 chore: standardize minio deployment await timeout.
553ca5b8 add serverFlags field to velero add-on
3b513d78 Merge pull request #3985 from replicatedhq/emosbaugh/sc-67506/kuberentes-preflights-missing-tcp-connection
08877bfb Merge pull request #3984 from replicatedhq/emosbaugh/sc-61600/add-flannel-preflight-checks
ace1358c Add host preflights for tcp connection on ports 2379 and 6443
e6941566 feat(flannel): log warning flannel udp port 8472 must be open
f3d73bef Merge pull request #3964 from replicatedhq/automation/update-kubernetes
cf267bd6 chore: ignore warning about mon usage be higher than 70% to not block upgrades (#3982)
52cbcaf3 (chore): testgrid: add some tests to check kubectl with kube/config (#3972)
3bed4019 feat: improve the output message to clarify to users kubectl config usage (#3973)
951ed48b Create new Kubernetes version

Are you sure? [yes/N] N
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
