### PR TITLE
fix(testgrid): use weave with docker on rhel based distros

### DIFF
--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -96,11 +96,11 @@
   postUpgradeScript: |
     containerd --version | grep "__testver__"
 
-- name: "Migrate from Docker to Containerd"
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
   installerSpec:
     kubernetes:
       version: 1.23.x
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -118,8 +118,8 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.24.x
-    flannel:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -136,11 +136,24 @@
     containerd:
       version: "__testver__"
       s3Override: "__testdist__"
-- name: "Migrate from Docker to Containerd airgap"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   installerSpec:
     kubernetes:
       version: 1.23.x
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -158,8 +171,8 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.24.x
-    flannel:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -177,3 +190,16 @@
       version: "__testver__"
       s3Override: "__testdist__"
   airgap: true
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -286,13 +286,11 @@
       version: latest
     kotsadm:
       version: latest
-- name: "Airgap upgrade from k8s 1.23 to 1.25, and from Docker to Containerd"
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   installerSpec:
     kubernetes:
       version: 1.23.x
-    kurl:
-      installerVersion: ""
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -301,15 +299,17 @@
     minio:
       version: latest
     ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
       version: latest
     docker:
       version: latest
   upgradeSpec:
     kubernetes:
       version: 1.25.x
-    kurl:
-      installerVersion: ""
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
     openebs:
       version: latest
@@ -318,6 +318,10 @@
     minio:
       version: latest
     ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
       version: latest
     containerd:
       version: latest

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -900,73 +900,111 @@
   airgap: true
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: "Migrate from Docker to Containerd"
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
   installerSpec:
     kubernetes:
       version: 1.23.x
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
-    longhorn:
+    openebs:
       version: latest
-    registry:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
       version: latest
     ekco:
       version: latest
+    registry:
+      version: latest
     kotsadm:
       version: latest
-      disableS3: true
     docker:
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
-    flannel:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
       version: latest
-    longhorn:
+    openebs:
       version: latest
-    registry:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
       version: latest
     ekco:
       version: latest
+    registry:
+      version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
-- name: "Migrate from Docker to Containerd airgap"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   installerSpec:
     kubernetes:
       version: 1.23.x
-    flannel:
+    weave: # flannel has errors with dns and docker
       version: latest
-    longhorn:
+    openebs:
       version: latest
-    registry:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
       version: latest
     ekco:
       version: latest
+    registry:
+      version: latest
     kotsadm:
       version: latest
-      disableS3: true
     docker:
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.23.x
-    flannel:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
       version: latest
-    longhorn:
+    openebs:
       version: latest
-    registry:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
       version: latest
     ekco:
       version: latest
+    registry:
+      version: latest
     kotsadm:
       version: latest
-      disableS3: true
     containerd:
       version: latest
   airgap: true
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
 - name: "K8s 1.24x Rook"
   cpu: 6
   installerSpec:
@@ -1712,45 +1750,6 @@
     kubernetes:
       version: 1.25.x
     flannel:
-      version: latest
-    containerd:
-      version: latest
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    flannel:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    registry:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-    docker:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: 1.25.x
-    flannel:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    registry:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
       version: latest
     containerd:
       version: latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We recently changed our default CNI in our E2E tests from Weave to Flannel. It seems that RHEL 8 based distros are timing out when Docker is included in the spec with error "dial tcp: lookup kurlnet.default.svc.cluster.local: Temporary failure in name resolution".

https://testgrid.kurl.sh/run/STAGING-release-v2023.01.23-0-0be41f75-20230130102645?kurlLogsInstanceId=iczzwxxbjuihopco&nodeId=iczzwxxbjuihopco-initialprimary

```
2023-01-30 12:26:23+00:00  [|]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]  There appears to be a problem with cluster networking
2023-01-30 12:26:23+00:00 2023/01/30 12:25:39 Post "http://kurlnet.default.svc.cluster.local:8080": dial tcp: lookup kurlnet.default.svc.cluster.local: Temporary failure in name resolution
2023-01-30 12:26:23+00:00 2023/01/30 12:26:00 Post "http://kurlnet.default.svc.cluster.local:8080": dial tcp: lookup kurlnet.default.svc.cluster.local: Temporary failure in name resolution
2023-01-30 12:26:23+00:00 2023/01/30 12:26:21 Post "http://kurlnet.default.svc.cluster.local:8080": dial tcp: lookup kurlnet.default.svc.cluster.local: Temporary failure in name resolution
```

Looking at the coredns pod logs I see

```
[ERROR] plugin/errors: 2 4923495531643749656.2179855082739856985. HINFO: read udp 10.32.0.5:55907->172.19.0.10:53: i/o timeout
```

Upon further investigation the issue seems to be that Kubernetes and Flannel are using iptables-nft and Docker is using iptables-legacy in this configuration. This is causing packets to be dropped that should not.

```
$ sudo iptables -L -nv
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
11067 4116K KUBE-NODE-PORT  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes health check rules */
29562   11M KUBE-FIREWALL  all  --  *      *       0.0.0.0/0            0.0.0.0/0

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 FLANNEL-FWD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* flanneld forward */
    0     0 KUBE-FORWARD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes forwarding rules */
...
Chain FLANNEL-FWD (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     all  --  *      *       10.32.0.0/20         0.0.0.0/0            /* flanneld forward */
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            10.32.0.0/20         /* flanneld forward */
# Warning: iptables-legacy tables present, use iptables-legacy to see them
```

```
$ sudo iptables-legacy -L -nv
Chain INPUT (policy ACCEPT 32903 packets, 12M bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain FORWARD (policy DROP 124 packets, 9996 bytes)
 pkts bytes target     prot opt in     out     source               destination
  124  9996 DOCKER-USER  all  --  *      *       0.0.0.0/0            0.0.0.0/0
  124  9996 DOCKER-ISOLATION-STAGE-1  all  --  *      *       0.0.0.0/0            0.0.0.0/0
    0     0 ACCEPT     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 DOCKER     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0
    0     0 ACCEPT     all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0
    0     0 ACCEPT     all  --  docker0 docker0  0.0.0.0/0            0.0.0.0/0

Chain OUTPUT (policy ACCEPT 32907 packets, 12M bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain DOCKER (1 references)
 pkts bytes target     prot opt in     out     source               destination

Chain DOCKER-ISOLATION-STAGE-1 (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DOCKER-ISOLATION-STAGE-2  all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0
  124  9996 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0

Chain DOCKER-ISOLATION-STAGE-2 (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DROP       all  --  *      docker0  0.0.0.0/0            0.0.0.0/0
    0     0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0

Chain DOCKER-USER (1 references)
 pkts bytes target     prot opt in     out     source               destination
  124  9996 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0
```

For some reason the affects Flannel VLAN but not Weave's Layer 2 network.

Given that Docker is technically unsupported on these distros I propose we roll back the spec to use Weave rather than Flannel. This pull request also unifies the multiple tests that are essentially testing the same scenario.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE