### PR TITLE
feat: scaling down pods before starting the Longhorn to OpenEBS/Rook migration

### DIFF
--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -345,6 +345,8 @@
 - name: Rook migrate from Longhorn
   flags: "yes"
   cpu: 6
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
   installerSpec:
     kubernetes:
       # Longhorn is not compatible with kubernetes 1.25+.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1
 	github.com/replicatedhq/kurlkinds v1.0.11
 	github.com/replicatedhq/plumber v1.16.0
 	github.com/replicatedhq/pvmigrate v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1415,6 +1415,8 @@ github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d h1:PinQItctnaL2LtkaS
 github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.44.1/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1 h1:A46xpyCEQpMFymrNJOaL5aAu3ZWgEKwJUXZrB5D3IUM=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.60.1/go.mod h1:MNl09GdaKb/vE8QdcCWyICDV7XAbGX6gKKQAS43XW1c=
 github.com/prometheus-operator/prometheus-operator/pkg/client v0.46.0/go.mod h1:k4BrWlVQQsvBiTcDnKEMgyh/euRxyxgrHdur/ZX/sdA=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/cli/longhorn_test.go
+++ b/pkg/cli/longhorn_test.go
@@ -58,7 +58,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 
 	for _, vol := range gotVolumes.Items {
 		assert.Equal(t, int(1), vol.Spec.NumberOfReplicas)
-		assert.Equal(t, "3", vol.Annotations[volumeReplicasAnnotation])
+		assert.Equal(t, "3", vol.Annotations[pvmigrateScaleDownAnnotation])
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR introduces a new command flag to the Kurl binary, allowing us to gracefully scale down pods using Longhorn volumes **prior** to migration (before running `pvmigrate`). By incorporating this flag into the Rook and OpenEBS pre-init process (_this is part of a different PR_), we aim to scale down Pods using a more stable cluster (before start to bump things around and generate Longhorn instability). My testing has shown a noticeable improvement, as there have been no instances of Pods stuck in the "Terminating" state anymore.

However, in the event that some pods do become stuck during pre-flight, the migration will fail and may leave the cluster with some Pods down and Longhorn volumes scaled down. This is by design as it allows us to take action and manually restart Kubelet in the affected nodes. In case of failure a helpful message is also displayed with instructions on how to bring the scaled-down Pods and Volumes back up using another flag (also introduced by this PR) in the Kurl binary.

#### Which issue(s) this PR fixes:
Fixes #65977