### PR TITLE
chore: decrease timeout waiting for Rook version rolled out

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -261,7 +261,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -266,7 +266,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -230,7 +230,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! $DIR/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -237,7 +237,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -265,7 +265,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -266,7 +266,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -266,7 +266,7 @@ function rook_cluster_deploy_upgrade() {
 
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
-    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=300 ; then
         logWarn "Timeout waiting for Rook version rolled out"
         logStep "Checking Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'


### PR DESCRIPTION
####  What are the problems sorted out with those changes

- **Unable to ensure the rook upgrade path with testgrid because it takes too long to be accomplished** where the impact over it is we easily introduce bugs. Note that the testgrid k8s1205_rook_upgrade (example: https://testgrid.kurl.sh/run/STAGING-daily-2023-02-01T05:03:29Z) we might able to no longer fail because is taking too longer after this PR get merged.
- **Performance issues and bad user ux**. Upgrade rook versions is taking too long without a logical reason. (we are waiting for 10 minutes in a task/check that does not bail and we are able to ensure that all finishes with success after that) The impact of this bring a bad user experience and make harder for us to do the tests and keep it maintained

**IMPORTANT: This PR can be replaced by https://github.com/replicatedhq/kURL/pull/4022 where we are looking to properly address all scenarios. It is just a split to try to mitigate the problems.**

#### Why we need it:

See that we are waiting 10 minutes to fail and finish with success afterwords. Therefore, make no sense wait 10 minutes for a check that does not bail and that we can see that make no difference at the end at all. By doing that we are introducing perform issues unnecessary and making the testgrid fail.  

We can check in the logs of the tests (example, [here](https://testgrid.kurl.sh/run/rook_upgrade_feb_1_2023?kurlLogsInstanceId=ihbjqxcfbpjmdulh&nodeId=ihbjqxcfbpjmdulh-initialprimary#L1)) that the timeout is faced but rook/ceph will have a healthy status afterwords.

The real root cause of the problems where we got stuck seems to be related rook bugs that can make the deployments and etc get stuck (similar to this example: https://github.com/rook/rook/issues/5090 ) along within the changes in logic to upgrade introduced from 1.6.11 that does not seems 100% right. See: https://github.com/replicatedhq/kURL/pull/4022 where I am trying to properly address the scenarios.

####  What this PR does 

We are only reducing the timeout for now of the specific check that we are seem taking too long without a reason from 1.6.11. You can check the following logs as an example. 

``` 
2023-02-01 11:55:50+00:00 Error: failed to wait for Rook "1.6.11": timed out waiting for Rook 1.6.11 to roll out
        2023-02-01 11:55:50+00:00 Timeout waiting for Rook version rolled out
        2023-02-01 11:55:50+00:00 ⚙  Checking Rook versions and replicas
    2023-02-01 11:55:50+00:00 rook-ceph-crashcollector-ihbjqxcfbpjmdulh-initialprimary      req/upd/avl: 1/1/1      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-mds-rook-shared-fs-a      req/upd/avl: 1/1/1      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-mds-rook-shared-fs-b      req/upd/avl: 1/1/      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-mgr-a      req/upd/avl: 1/1/1      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-mon-a      req/upd/avl: 1/1/1      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-osd-0      req/upd/avl: 1/1/1      rook-version=v1.6.11
    2023-02-01 11:55:50+00:00 rook-ceph-rgw-rook-ceph-store-a      req/upd/avl: 1/1/1      rook-version=v1.6.11
        2023-02-01 11:55:50+00:00 Awaiting Ceph healthy
        2023-02-01 11:55:50+00:00 Waiting for Rook-Ceph to be healthy
        2023-02-01 11:55:50+00:00 Rook is healthy
        2023-02-01 11:55:51+00:00 cephfilesystem.ceph.rook.io/rook-shared-fs patched
        2023-02-01 11:55:51+00:00 Awaiting Rook MDS deployments to roll out
        2023-02-01 11:56:07+00:00  [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]  Awaiting Rook MDS deployments up-to-date
        2023-02-01 12:02:50+00:00  [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]  Awaiting Rook MDS daemons ok-to-stop
        2023-02-01 12:02:51+00:00 Awaiting Ceph healthy
        2023-02-01 12:02:51+00:00 Waiting for Rook-Ceph to be healthy
        2023-02-01 12:02:52+00:00 Rook is healthy
        2023-02-01 12:02:52+00:00 ⚙  Upgrading rook-ceph cluster
        2023-02-01 12:02:52+00:00 cephcluster.ceph.rook.io/rook-ceph patched
        2023-02-01 12:02:52+00:00 Waiting for all Rook-Ceph deployments to be using Ceph 15.2.13-0
        2023-02-01 12:02:52+00:00 deployments rook-ceph-crashcollector-ihbjqxcfbpjmdulh-initialprimary, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-mon-a, rook-ceph-osd-0, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:03:23+00:00 deployments rook-ceph-crashcollector-ihbjqxcfbpjmdulh-initialprimary, rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-osd-0, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:03:33+00:00 deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-mgr-a, rook-ceph-osd-0, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:03:53+00:00 deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-osd-0, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:04:13+00:00 deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:04:23+00:00 deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0 and deployments rook-ceph-osd-0 not ready
        2023-02-01 12:04:33+00:00 deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b, rook-ceph-rgw-rook-ceph-store-a still running 15.2.11-0
        2023-02-01 12:04:43+00:00 deployments rook-ceph-mds-rook-shared-fs-b still running 15.2.11-0
        2023-02-01 12:06:03+00:00 Ceph "15.2.13-0" has been rolled out
        2023-02-01 12:06:03+00:00 Patching allowance of insecure rook clients
        2023-02-01 12:06:04+00:00 Awaiting Ceph healthy
        2023-02-01 12:06:04+00:00 Waiting for Rook-Ceph to be healthy
        2023-02-01 12:06:05+00:00 Rook is healthy
        2023-02-01 12:06:05+00:00 ✔ Rook-ceph cluster upgraded
        2023-02-01 12:06:05+00:00 Awaiting rook-ceph dashboard password
        2023-02-01 12:06:05+00:00 checking for attached secondary block device (awaiting rook-ceph RGW pod)
        2023-02-01 12:06:05+00:00     cephobjectstoreuser.ceph.rook.io/kurl unchanged
        2023-02-01 12:06:06+00:00 Awaiting rook-ceph object store health
        2023-02-01 12:06:06+00:00 configmap/kurl-current-config patched
        2023-02-01 12:06:06+00:00 ⚙  Addon ekco 0.26.3
        2023-02-01 12:06:06+00:00 label "rook-priority.kurl.sh" not found.
        2023-02-01 12:06:06+00:00 namespace/rook-ceph labeled
        2023-02-01 12:06:07+00:00 configmap/kurl-current-config patched
        2023-02-01 12:06:07+00:00 ⚙  Addon kotsadm 1.38.0
        2023-02-01 12:06:07+00:00 configmap/kurl-current-config patched
        2023-02-01 12:06:07+00:00 ⚙  Addon sonobuoy 0.56.15
        2023-02-01 12:06:08+00:00 configmap/kurl-current-config patched
        2023-02-01 12:06:08+00:00 configmap "kurl-config" deleted
        2023-02-01 12:06:08+00:00 configmap/kurl-config created
        2023-02-01 12:06:08+00:00
        2023-02-01 12:06:08+00:00 No resources found
        2023-02-01 12:06:08+00:00
        2023-02-01 12:06:08+00:00         Installation
        2023-02-01 12:06:08+00:00           Complete ✔
        2023-02-01 12:06:08+00:00
        2023-02-01 12:06:08+00:00

 Wrap
``` 

Also, see that the MDS pods will be running at the end. 

```
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-crashcollector-ihbjqxcfbpjmdulh-initialprimary-fbsqbd   1/1     Running     0          2m40s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-mds-rook-shared-fs-a-58bdf68555-7pflr                   1/1     Running     0          40s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-mds-rook-shared-fs-b-65f56675f7-79fwb                   1/1     Running     0          15s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-mgr-a-54c6466ffc-mbr8t                                  1/1     Running     0          2m10s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-mon-a-5d668466b9-vsm4x                                  1/1     Running     0          2m40s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-operator-8667f9d69c-5fbct                               1/1     Running     0          30m
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-osd-0-8475c9bb4c-6hstx                                  1/1     Running     0          110s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-osd-prepare-ihbjqxcfbpjmdulh-initialprimary-j7c28       0/1     Completed   0          2m4s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-rgw-rook-ceph-store-a-fcc56466c-qs8k6                   1/1     Running     0          90s
        2023-02-01 12:06:09+00:00 rook-ceph     rook-ceph-tools-65c94d77bb-28x8b                                  1/1     Running     0          30m
        2023-02-01 12:06:09+00:00 rook-ceph     rook-discover-r5ndm                                               1/1     Running     0          30m
        2023-02-01 12:06:09+00:00
```

#### Which issue(s) this PR fixes:

Related # [sc-67862]

#### Special notes for your reviewer:


## Steps to reproduce
Check the test made against main : https://testgrid.kurl.sh/run/rook_upgrade_feb_1_2023
