### PR TITLE
feat: flannel is incompatible with docker runtime

### DIFF
--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -13,10 +13,8 @@ function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"
     local dst="$DIR/kustomize/flannel"
 
-    if flannel_weave_conflict ; then
-        if [ -n "$DOCKER_VERSION" ]; then
-            bail "Migrations from Weave to Flannel are only supported with containerd"
-        fi
+    if [ -n "$DOCKER_VERSION" ]; then
+        bail "Flannel is not compatible with the Docker runtime, Containerd is required"
     fi
 
     if flannel_antrea_conflict ; then

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -13,10 +13,8 @@ function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"
     local dst="$DIR/kustomize/flannel"
 
-    if flannel_weave_conflict ; then
-        if [ -n "$DOCKER_VERSION" ]; then
-            bail "Migrations from Weave to Flannel are only supported with containerd"
-        fi
+    if [ -n "$DOCKER_VERSION" ]; then
+        bail "Flannel is not compatible with the Docker runtime, Containerd is required"
     fi
 
     if flannel_antrea_conflict ; then

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -82,3 +82,23 @@
       podCIDR: 172.17.0.0/16
       version: "__testver__"
       s3Override: "__testdist__"
+- name: "weave to flannel, docker to containerd, single node"
+  installerSpec:
+    kubernetes:
+      version: "1.23.x"
+    docker:
+      version: "latest"
+    weave:
+      version: "latest"
+    ekco:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.23.x"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -93,7 +93,7 @@
   installerSpec:
     kubernetes:
       version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
-    flannel:
+    weave:
       version: latest
     docker:
       version: "latest"
@@ -107,7 +107,7 @@
   upgradeSpec:
     kubernetes:
       version: "1.21.x"
-    flannel:
+    weave:
       version: latest
     docker:
       version: "latest"
@@ -138,7 +138,7 @@
       version: "1.19.x" # this is the latest version of k8s that supports rook 1.0.4
     flannel:
       version: latest
-    docker:
+    containerd:
       version: "latest"
     rook:
       version: "1.0.x"
@@ -149,7 +149,7 @@
       version: "1.21.x"
     flannel:
       version: latest
-    docker:
+    containerd:
       version: "latest"
     openebs:
       isLocalPVEnabled: true

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1046,12 +1046,12 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-- name: "Upgrade to 1.24"
+- name: "Upgrade to 1.24, weave to flannel"
   cpu: 7
   installerSpec:
     kubernetes:
       version: 1.23.x
-    flannel:
+    weave:
       version: latest
     rook:
       version: 1.9.x


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Flannel and docker appear to be incompatible in some configurations.

https://github.com/replicatedhq/kURL/pull/4014

Rather than try to support these configurations, add an incompatibility since docker is deprecated and will no longer be supported in the near future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Flannel CNI will no longer be supported with the Docker container runtime. Containerd is required.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
TODO