### PR TITLE
feat: add prompt when preflights warnings are raised

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -583,6 +583,13 @@ function host_preflights() {
                 ;;  
             2)
                 logWarn "Host preflights have warnings"
+                logWarn "It is highly recommended to sort out the warning conditions before proceeding."
+                logWarn "Be aware that continuing with preflight warnings can result in failures."
+                log ""
+                logWarn "Would you like to continue?"
+                if ! confirmY ; then
+                    bail "The installation will not continue"
+                fi
                 return 0
                 ;;
             1)


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, users are not requested for confirmation before moving on with the installation if the host pre-flight has warnings. As we don't ask for confirmation we don't give the user the option of aborting the install and fix the warning' root cause before resuming.

Therefore, this PR will let them be aware of and give this oppritunity.

#### Which issue(s) this PR fixes:

Fixes # [sc-66713]

#### Special notes for your reviewer:

See:

<img width="884" alt="Screenshot 2023-02-03 at 16 17 59" src="https://user-images.githubusercontent.com/7708031/216653162-260d251f-dac5-4b20-9cc4-a03cd763db7f.png">

## Steps to reproduce
Create a VM  which will raise:

[WARN] Number of CPUs: At least 4 CPU cores are recommended
[WARN] Amount of Memory: At least 8G of memory is recommended

#### Does this PR introduce a user-facing change?

```release-note
- Adds a prompt when preflight warnings are faced to ensure that user is aware and given the opportunity to cancel the install to and fix the root cause before resuming.
```

#### Does this PR require documentation?
NONE
