### PR TITLE
fix(flannel): use alternate interface when private ip is specified

### DIFF
--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -5,9 +5,9 @@ export POD_CIDR_RANGE
 export POD_CIDR_IPV6
 export EXISTING_POD_CIDR
 
-export FLANNEL_ENABLE_IPV4=true
-export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
-export FLANNEL_BACKEND=vxlan # TODO: support encryption
+export FLANNEL_ENABLE_IPV4=${FLANNEL_ENABLE_IPV4:-true}
+export FLANNEL_ENABLE_IPV6=${FLANNEL_ENABLE_IPV6:-false} # TODO: support ipv6
+export FLANNEL_BACKEND=${FLANNEL_BACKEND:-vxlan} # TODO: support encryption
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -5,9 +5,9 @@ export POD_CIDR_RANGE
 export POD_CIDR_IPV6
 export EXISTING_POD_CIDR
 
-export FLANNEL_ENABLE_IPV4=true
-export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
-export FLANNEL_BACKEND=vxlan # TODO: support encryption
+export FLANNEL_ENABLE_IPV4=${FLANNEL_ENABLE_IPV4:-true}
+export FLANNEL_ENABLE_IPV6=${FLANNEL_ENABLE_IPV6:-false} # TODO: support ipv6
+export FLANNEL_BACKEND=${FLANNEL_BACKEND:-vxlan} # TODO: support encryption
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -5,10 +5,10 @@ export POD_CIDR_RANGE
 export POD_CIDR_IPV6
 export EXISTING_POD_CIDR
 
-export FLANNEL_ENABLE_IPV4=true
-export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
-export FLANNEL_BACKEND=vxlan # TODO: support encryption
-export FLANNEL_IFACE=
+export FLANNEL_ENABLE_IPV4=${FLANNEL_ENABLE_IPV4:-true}
+export FLANNEL_ENABLE_IPV6=${FLANNEL_ENABLE_IPV6:-false} # TODO: support ipv6
+export FLANNEL_BACKEND=${FLANNEL_BACKEND:-vxlan} # TODO: support encryption
+export FLANNEL_IFACE=${FLANNEL_IFACE:-}
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -8,6 +8,7 @@ export EXISTING_POD_CIDR
 export FLANNEL_ENABLE_IPV4=true
 export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
 export FLANNEL_BACKEND=vxlan # TODO: support encryption
+export FLANNEL_IFACE=
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"
@@ -19,6 +20,16 @@ function flannel_pre_init() {
 
     if flannel_antrea_conflict ; then
         bail "Migrations from Antrea to Flannel are not supported"
+    fi
+
+    # TODO: support ipv6
+    local private_address_iface=
+    local default_gateway_iface=
+    private_address_iface=$("$BIN_KURL" netutil iface-from-ip "$PRIVATE_ADDRESS")
+    default_gateway_iface=$("$BIN_KURL" netutil default-gateway-iface)
+    # if the private address is on a different interface than the default gateway, use the private address interface
+    if [ -n "$private_address_iface" ] && [ "$private_address_iface" != "$default_gateway_iface" ]; then
+        FLANNEL_IFACE="$private_address_iface"
     fi
 
     flannel_init_pod_subnet
@@ -77,6 +88,11 @@ function flannel_render_config() {
     if [ "$FLANNEL_ENABLE_IPV6" = "true" ] && [ -n "$POD_CIDR_IPV6" ]; then
         render_yaml_file_2 "$src/template/ipv6.patch.tmpl.yaml" > "$dst/ipv6.patch.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" ipv6.patch.yaml
+    fi
+
+    if [ -n "$FLANNEL_IFACE" ]; then
+        render_yaml_file_2 "$src/template/iface.patch.tmpl.yaml" > "$dst/iface.patch.yaml"
+        insert_patches_json_6902 "$dst/kustomization.yaml" iface.patch.yaml apps v1 DaemonSet kube-flannel-ds kube-flannel
     fi
 }
 

--- a/addons/flannel/0.20.2/template/iface.patch.tmpl.yaml
+++ b/addons/flannel/0.20.2/template/iface.patch.tmpl.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "--iface=$FLANNEL_IFACE"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -5,10 +5,10 @@ export POD_CIDR_RANGE
 export POD_CIDR_IPV6
 export EXISTING_POD_CIDR
 
-export FLANNEL_ENABLE_IPV4=true
-export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
-export FLANNEL_BACKEND=vxlan # TODO: support encryption
-export FLANNEL_IFACE=
+export FLANNEL_ENABLE_IPV4=${FLANNEL_ENABLE_IPV4:-true}
+export FLANNEL_ENABLE_IPV6=${FLANNEL_ENABLE_IPV6:-false} # TODO: support ipv6
+export FLANNEL_BACKEND=${FLANNEL_BACKEND:-vxlan} # TODO: support encryption
+export FLANNEL_IFACE=${FLANNEL_IFACE:-}
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -8,6 +8,7 @@ export EXISTING_POD_CIDR
 export FLANNEL_ENABLE_IPV4=true
 export FLANNEL_ENABLE_IPV6=false # TODO: support ipv6
 export FLANNEL_BACKEND=vxlan # TODO: support encryption
+export FLANNEL_IFACE=
 
 function flannel_pre_init() {
     local src="$DIR/addons/flannel/$FLANNEL_VERSION"
@@ -19,6 +20,16 @@ function flannel_pre_init() {
 
     if flannel_antrea_conflict ; then
         bail "Migrations from Antrea to Flannel are not supported"
+    fi
+
+    # TODO: support ipv6
+    local private_address_iface=
+    local default_gateway_iface=
+    private_address_iface=$("$BIN_KURL" netutil iface-from-ip "$PRIVATE_ADDRESS")
+    default_gateway_iface=$("$BIN_KURL" netutil default-gateway-iface)
+    # if the private address is on a different interface than the default gateway, use the private address interface
+    if [ -n "$private_address_iface" ] && [ "$private_address_iface" != "$default_gateway_iface" ]; then
+        FLANNEL_IFACE="$private_address_iface"
     fi
 
     flannel_init_pod_subnet
@@ -77,6 +88,11 @@ function flannel_render_config() {
     if [ "$FLANNEL_ENABLE_IPV6" = "true" ] && [ -n "$POD_CIDR_IPV6" ]; then
         render_yaml_file_2 "$src/template/ipv6.patch.tmpl.yaml" > "$dst/ipv6.patch.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" ipv6.patch.yaml
+    fi
+
+    if [ -n "$FLANNEL_IFACE" ]; then
+        render_yaml_file_2 "$src/template/iface.patch.tmpl.yaml" > "$dst/iface.patch.yaml"
+        insert_patches_json_6902 "$dst/kustomization.yaml" iface.patch.yaml apps v1 DaemonSet kube-flannel-ds kube-flannel
     fi
 }
 

--- a/addons/flannel/template/base/template/iface.patch.tmpl.yaml
+++ b/addons/flannel/template/base/template/iface.patch.tmpl.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "--iface=$FLANNEL_IFACE"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Flannel uses the default gateway interface for inter-host communication by default. If this is not the correct interface for communication between hosts then the install scripts will fail.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
If there are multiple network interfaces on a single host, rather than using the default gateway interface, the [Flannel add-on](https://kurl.sh/docs/add-ons/flannel) will prompt the user to choose an interface or use the interface of the [private-address](https://kurl.sh/docs/install-with-kurl/advanced-options#reference) flag when specified.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE