### PR TITLE
fix: net utility commands output to stdout

### DIFF
--- a/pkg/cli/netutil.go
+++ b/pkg/cli/netutil.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
 			}
 			iface, err := netutils.GetInterfaceByIPv6(ip)
 			if err == nil {
-				cmd.Println(iface.Name)
+				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
 				return nil
 			}
 			if ip.To4() != nil {
@@ -42,7 +43,7 @@ func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				cmd.Println(iface.Name)
+				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
 				return nil
 			}
 			return err
@@ -62,14 +63,14 @@ func newNetutilDefaultIfaceCommand(_ CLI) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				cmd.Println(iface.Name)
+				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
 				return nil
 			}
 			iface, err := netutils.GetDefaultGatewayInterface()
 			if err != nil {
 				return err
 			}
-			cmd.Println(iface.Name)
+			fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
 			return nil
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Command will output to stdout rather than stderr for utility usage.