### PR TITLE
chore: increase timeout to check mds from 300 to 1200 in rook upgrades from version 1.7.11

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -810,13 +810,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -825,14 +825,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! "$DIR"/bin/kurl rook wait-for-health 120 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -815,13 +815,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -830,14 +830,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! "$DIR"/bin/kurl rook wait-for-health 120 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -741,13 +741,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -756,14 +756,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! $DIR/bin/kurl rook wait-for-health 120 ; then
+    if ! $DIR/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -812,13 +812,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -827,14 +827,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! $DIR/bin/kurl rook wait-for-health 120 ; then
+    if ! $DIR/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -807,13 +807,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -822,14 +822,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! $DIR/bin/kurl rook wait-for-health 120 ; then
+    if ! $DIR/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -816,13 +816,13 @@ function rook_cephfilesystem_patch() {
     fi
 
     echo "Awaiting Rook MDS deployments to roll out"
-    if ! spinner_until 300 rook_mds_deployments_updated "$mds_observedgeneration" ; then
+    if ! spinner_until 1200 rook_mds_deployments_updated "$mds_observedgeneration" ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments did not roll out"
     fi
 
     echo "Awaiting Rook MDS deployments up-to-date"
-    if ! spinner_until 300 rook_mds_deployments_uptodate ; then
+    if ! spinner_until 1200 rook_mds_deployments_uptodate ; then
         kubectl -n rook-ceph get deploy -l app=rook-ceph-mds
         bail "Refusing to update cluster rook-ceph, MDS deployments not up-to-date"
     fi
@@ -831,14 +831,14 @@ function rook_cephfilesystem_patch() {
     sleep 60
 
     echo "Awaiting Rook MDS daemons ok-to-stop"
-    if ! spinner_until 300 rook_mds_daemons_oktostop ; then
+    if ! spinner_until 1200 rook_mds_daemons_oktostop ; then
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop a
         kubectl -n rook-ceph exec deployment/rook-ceph-tools -- ceph mds ok-to-stop b
         bail "Refusing to update cluster rook-ceph, MDS daemons not ok-to-stop"
     fi
 
     echo "Awaiting Ceph healthy"
-    if ! "$DIR"/bin/kurl rook wait-for-health 120 ; then
+    if ! "$DIR"/bin/kurl rook wait-for-health 1200 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

If we take long to check the mds in the upgrade then the process will fail when it could successfully work out. Example:

<img width="1222" alt="Screenshot 2023-02-02 at 12 12 11" src="https://user-images.githubusercontent.com/7708031/216746250-44e634ff-3f16-44aa-a81d-43811ff1df2a.png">

Note that we change it for rook upgrade version 1.6.11 (https://github.com/replicatedhq/kURL/pull/4022/files) and now we are apply the same change to all upper versions and template. 

#### Which issue(s) this PR fixes:

Follow-up # [sc-67862]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
chore: increase timeout to check mds Pods from 300 to 1200 in rook upgrades from Rook version 1.7.11 in order to avoid unnecessary failures. 
```

#### Does this PR require documentation?
NONE