### PR TITLE
chore: validate rook upgrade after change MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations from Rook version 1.7.11 

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -259,6 +259,15 @@ function rook_cluster_deploy_upgrade() {
         return 0
     fi
 
+    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
+        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
+        local ready_node_count
+        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
+        if [ "$ready_node_count" -le "1" ]; then
+            rook_cephfilesystem_patch_singlenode
+        fi
+    fi
+
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
@@ -281,15 +290,6 @@ function rook_cluster_deploy_upgrade() {
     if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
-    fi
-
-    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
-        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
-        local ready_node_count
-        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
-        if [ "$ready_node_count" -le "1" ]; then
-            rook_cephfilesystem_patch_singlenode
-        fi
     fi
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -264,6 +264,15 @@ function rook_cluster_deploy_upgrade() {
         return 0
     fi
 
+    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
+        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
+        local ready_node_count
+        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
+        if [ "$ready_node_count" -le "1" ]; then
+            rook_cephfilesystem_patch_singlenode
+        fi
+    fi
+
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
@@ -286,15 +295,6 @@ function rook_cluster_deploy_upgrade() {
     if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
-    fi
-
-    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
-        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
-        local ready_node_count
-        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
-        if [ "$ready_node_count" -le "1" ]; then
-            rook_cephfilesystem_patch_singlenode
-        fi
     fi
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -263,6 +263,15 @@ function rook_cluster_deploy_upgrade() {
         return 0
     fi
 
+    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
+        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
+        local ready_node_count
+        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
+        if [ "$ready_node_count" -le "1" ]; then
+            rook_cephfilesystem_patch_singlenode
+        fi
+    fi
+
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
@@ -290,15 +299,6 @@ function rook_cluster_deploy_upgrade() {
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
-    fi
-
-    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
-        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
-        local ready_node_count
-        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
-        if [ "$ready_node_count" -le "1" ]; then
-            rook_cephfilesystem_patch_singlenode
-        fi
     fi
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -264,6 +264,15 @@ function rook_cluster_deploy_upgrade() {
         return 0
     fi
 
+    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
+        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
+        local ready_node_count
+        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
+        if [ "$ready_node_count" -le "1" ]; then
+            rook_cephfilesystem_patch_singlenode
+        fi
+    fi
+
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
@@ -286,15 +295,6 @@ function rook_cluster_deploy_upgrade() {
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
-    fi
-
-    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
-        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
-        local ready_node_count
-        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
-        if [ "$ready_node_count" -le "1" ]; then
-            rook_cephfilesystem_patch_singlenode
-        fi
     fi
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -264,6 +264,15 @@ function rook_cluster_deploy_upgrade() {
         return 0
     fi
 
+    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
+        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
+        local ready_node_count
+        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
+        if [ "$ready_node_count" -le "1" ]; then
+            rook_cephfilesystem_patch_singlenode
+        fi
+    fi
+
     # 4. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#4-wait-for-the-upgrade-to-complete
     echo "Awaiting rook-ceph operator"
     if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
@@ -286,15 +295,6 @@ function rook_cluster_deploy_upgrade() {
     if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Refusing to update cluster rook-ceph, Ceph is not healthy"
-    fi
-
-    if kubernetes_resource_exists rook-ceph cephfilesystem rook-shared-fs ; then
-        # When upgrading we need both MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations
-        local ready_node_count
-        ready_node_count="$(kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready')"
-        if [ "$ready_node_count" -le "1" ]; then
-            rook_cephfilesystem_patch_singlenode
-        fi
     fi
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#ceph-version-upgrades


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that we are checking the rook upgrade after change MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations so that we can avoid scenarios where Rook faces a timeout because those changes was not applied beforehand.

NOTE: We are looking to ensure that all versions has the same changes applied to 1.6.12 :  (https://github.com/replicatedhq/kURL/pull/4022/files)

#### Which issue(s) this PR fixes:

Follow up # [sc-67862]

#### Special notes for your reviewer:

We need to first merge the increase for the timeouts https://github.com/replicatedhq/kURL/pull/4035 otherwise the installs can fail. 

We checked the status of the rook upgrade prior this commit with the testgrid: https://testgrid.kurl.sh/run/rook_upgrade_feb_4_2023-commit-3e393ebacc5548d036eccb6bd8537ff92bd78f2c

And the same test must be executed after we get this merged to ensure that no breaking changes will be faced. 

## Steps to reproduce

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
chore: validate rook upgrades after change MDS pods and anti-affinity rules prevent them from co-scheduling on single-node installations from Rook version 1.7.11 
```

#### Does this PR require documentation?
NONE
