### PR TITLE
chore: verifying rook updated prior report success

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -333,18 +333,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
 # https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -355,35 +356,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -333,7 +333,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -338,7 +338,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -338,18 +338,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
 # https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -360,35 +361,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -289,16 +289,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_patch_insecure_clients
 
-    # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#3-verify-the-updated-cluster
+    verify_rook_updated_cluster
+}
 
-    echo "Awaiting Ceph healthy"
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.6/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
 
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 function rook_dashboard_ready_spinner() {

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -289,18 +289,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_patch_insecure_clients
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
-# https://rook.io/docs/rook/v1.6/ceph-upgrade.html#3-verify-the-updated-cluster
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -311,35 +312,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 function rook_dashboard_ready_spinner() {

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -307,18 +307,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
-# https://rook.io/docs/rook/v1.7/ceph-upgrade.html#3-verify-the-updated-cluster
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -329,35 +330,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -307,7 +307,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.7/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -340,7 +340,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.8/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -340,18 +340,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
-# https://rook.io/docs/rook/v1.8/ceph-upgrade.html#3-verify-the-updated-cluster
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -362,35 +363,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -338,7 +338,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -338,18 +338,19 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
+    logStep "Checking if the Rook-Ceph cluster upgrade completed successfully"
     verify_rook_updated_cluster
+    logSuccess "Rook-Ceph cluster upgraded successfully"
 }
 
 # Before to finish end report that the upgrade was done with success ensure that
 # only on rook version is found and the ceph status
 # https://rook.io/docs/rook/v1.9/ceph-upgrade.html#3-verify-the-updated-cluster
 function verify_rook_updated_cluster() {
-    logStep "Checking if Rook Upgrade is completed successfully"
-    echo "Verifying Rook Version Deployed"
-    if ! spinner_until 1200 rook_version_deployed ; then
-        logWarn "Timeout awaiting check Rook version deployed"
-        logStep "Rook versions and replicas"
+    log "Verifying Rook Version Deployed"
+    if ! "$DIR"/bin/kurl rook wait-for-rook-version "$ROOK_VERSION" --timeout=1200 ; then
+        logWarn "Timeout awaiting Rook version"
+        log "Rook versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
         local rook_versions=
         rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
@@ -360,35 +361,16 @@ function verify_rook_updated_cluster() {
         fi
     fi
 
-    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    log "Verifying Ceph version ${ceph_version} deployed"
     if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 
-    echo "Verifying Ceph Status"
+    log "Verifying Ceph status"
     if ! $DIR/bin/kurl rook wait-for-health 300 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
         bail "Failed to verify the updated cluster, Ceph is not healthy"
     fi
-
-    logSuccess "Rook-ceph cluster upgraded successfully"
-}
-
-# rook_version_deployed check that there is only one rook-version reported across the cluster
-function rook_version_deployed() {
-    # wait for our version to start reporting
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    # wait for our version to be the only one reporting
-    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
-        return 1
-    fi
-    # sanity check
-    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
-        return 1
-    fi
-    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -339,7 +339,57 @@ function rook_cluster_deploy_upgrade() {
 
     rook_cluster_deploy_upgrade_flexvolumes_to_csi
 
-    logSuccess "Rook-ceph cluster upgraded"
+    verify_rook_updated_cluster
+}
+
+# Before to finish end report that the upgrade was done with success ensure that
+# only on rook version is found and the ceph status
+# https://rook.io/docs/rook/v1.10/ceph-upgrade.html#3-verify-the-updated-cluster
+function verify_rook_updated_cluster() {
+    logStep "Checking if Rook Upgrade is completed successfully"
+    echo "Verifying Rook Version Deployed"
+    if ! spinner_until 1200 rook_version_deployed ; then
+        logWarn "Timeout awaiting check Rook version deployed"
+        logStep "Rook versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+        local rook_versions=
+        rook_versions="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${rook_versions}" ] && [ "$(echo "${rook_versions}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Rook versions"
+            logWarn "${rook_versions}"
+            bail "Failed to verify the Rook upgrade, multiple Rook versions detected"
+        fi
+    fi
+
+    echo "Verifying Ceph Version ${ceph_version} Deployed"
+    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+        bail "New Ceph version ${ceph_version} failed to deploy"
+    fi
+
+    echo "Verifying Ceph Status"
+    if ! $DIR/bin/kurl rook wait-for-health 300 ; then
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        bail "Failed to verify the updated cluster, Ceph is not healthy"
+    fi
+    
+    logSuccess "Rook-ceph cluster upgraded successfully"
+}
+
+# rook_version_deployed check that there is only one rook-version reported across the cluster
+function rook_version_deployed() {
+    # wait for our version to start reporting
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    # wait for our version to be the only one reporting
+    if [ "$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq | wc -l)" != "1" ]; then
+        return 1
+    fi
+    # sanity check
+    if ! kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | grep -q "${ROOK_VERSION}" ; then
+        return 1
+    fi
+    return 0
 }
 
 # rook_cluster_deploy_upgrade_flexvolumes_to_csi will check if the previous storageclass is using


### PR DESCRIPTION
#### What this PR does / why we need it:
Before finish the upgrade and reported that it was done with success check the status as described in the docs from version 1.6.11+. That is required in order to:

- a) Not report that the upgrade was done successfully when it might not be
- b) avoid continue the upgrading for the next versions before check that the current upgrade was performed with success and avoid issues to the next ones. 

#### Which issue(s) this PR fixes:

Fixes # [sc-68491] 
Fixes # [sc-68490]

#### Special notes for your reviewer:

- Testgrid : https://testgrid.kurl.sh/run/rook_upgrade_feb_6_check_upgrades_with_rook_check
- Testgrid After Apply the suggestions: https://testgrid.kurl.sh/run/rook_upgrade_feb_6_check_upgrades_with_rook_check_with_suggestions

Example upgrade to 1.10.6 with this changes:

```
2023-02-06 15:33:56+00:00 ⚙  Addon rook 1.10.6
....
⚙  Checking if Rook Upgrade is completed successfully
2023-02-06 15:40:15+00:00 Verifying Rook Version Deployed
2023-02-06 15:40:16+00:00 Verifying Ceph Version 17.2.5 Deployed
2023-02-06 15:40:16+00:00 Verifying Ceph Status
2023-02-06 15:40:16+00:00 Waiting for Rook-Ceph to be healthy
2023-02-06 15:40:16+00:00 Rook is healthy
2023-02-06 15:40:16+00:00 ✔ Rook-ceph cluster upgraded successfully**
...
```

## Steps to reproduce

#### Does this PR introduce a user-facing change?

```release-note
Adds check to verify the updated cluster from rook upgrade version 1.6.11 prior report success and continue the workflow with multiple upgrades
```

#### Does this PR require documentation?
NONE