### PR TITLE
bug: migrating minio object storage (longhorn to rook migration).

### DIFF
--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -125,6 +125,7 @@ function longhorn_to_sc_migration() {
         if ! longhorn_run_pvmigrate "$longhornStorageClass" "$destStorageClass" "$didRunValidationChecks" "1"; then
             bail "Failed to migrate PVCs from $longhornStorageClass to $destStorageClass"
         fi
+        kubectl annotate storageclass "$longhornStorageClass" storageclass.kubernetes.io/is-default-class-
     done
 
     longhorn_restore_migration_replicas

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -207,8 +207,8 @@ function migrate_between_object_stores() {
             local temp_file=
             temp_file=$(mktemp)
             kubectl -n velero get secret cloud-credentials -ojsonpath='{ .data.cloud }' | base64 -d > "$temp_file"
-            sed -i "s/aws_access_key_id=.*/aws_access_key_id=${destination_access_key}/" cloud
-            sed -i "s/aws_secret_access_key=.*/aws_secret_access_key=${destination_secret_key}/" cloud
+            sed -i "s/aws_access_key_id=.*/aws_access_key_id=${destination_access_key}/" "$temp_file"
+            sed -i "s/aws_secret_access_key=.*/aws_secret_access_key=${destination_secret_key}/" "$temp_file"
             cloud=$(cat "$temp_file" | base64 -w 0)
             kubectl -n velero patch secret cloud-credentials -p "{\"data\":{\"cloud\":\"${cloud}\"}}"
             rm "$temp_file"


### PR DESCRIPTION
#### What this PR does / why we need it:
When migrating to Rook in a cluster where Minio is running we need to migrate all object storage from the latter. This commit creates the function to migrate the data. This function will called from the Rook add-on installer (coming up in a next PR).

Also with this commit:

- Removes default storage class annotation once the data has been migrated.
- Only attempts to scale down and up Prometheus if it is installed.