### PR TITLE
chore: clean up cli api

### DIFF
--- a/pkg/cli/cluster_images.go
+++ b/pkg/cli/cluster_images.go
@@ -17,7 +17,7 @@ func NewClusterNodesMissingImageCmd(_ CLI) *cobra.Command {
 	var excludeHostDeprecated string
 
 	cmd := &cobra.Command{
-		Use:   "nodes-missing-images IMAGE...",
+		Use:   "nodes-missing-images IMAGE [IMAGE...]",
 		Short: "Lists nodes missing the provided image(s). If a node is missing multiple images, it is only returned once.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -36,9 +36,13 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	netutilCmd := newNetutilCommand(cli)
 	netutilCmd.AddCommand(newNetutilIfaceFromIPCommand(cli))
 	netutilCmd.AddCommand(newNetutilDefaultIfaceCommand(cli))
+	netutilCmd.AddCommand(newNetutilFormatIPAddressCmd(cli))
 	cmd.AddCommand(netutilCmd)
 
-	cmd.AddCommand(newSyncObjectStoreCmd(cli))
+	objectStoreCmd := newObjectStoreCmd(cli)
+	objectStoreCmd.AddCommand(newSyncObjectStoreCmd(cli))
+	cmd.AddCommand(objectStoreCmd)
 
-	cmd.AddCommand(newFormatAddressCmd(cli))
+	cmd.AddCommand(newSyncObjectStoreCmdDeprecated(cli))
+	cmd.AddCommand(newNetutilFormatIPAddressCmdDeprecated(cli))
 }

--- a/pkg/cli/format_address.go
+++ b/pkg/cli/format_address.go
@@ -7,9 +7,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFormatAddressCmd(_ CLI) *cobra.Command {
+func newNetutilFormatIPAddressCmdDeprecated(cli CLI) *cobra.Command {
+	cmd := newNetutilFormatIPAddressCmd(cli)
+	cmd.Use = "format-address"
+	cmd.Deprecated = "use 'kurl netutil format-ip-address' instead"
+	return cmd
+}
+
+func newNetutilFormatIPAddressCmd(_ CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "format-address",
+		Use:   "format-ip-address",
 		Short: "Adds brackets around ipv6 addresses",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -36,7 +36,7 @@ const (
 
 func newHostPreflightCmd(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "preflight [installer spec file|-]",
+		Use:          "preflight [INSTALLER SPEC FILE|-]",
 		Short:        "Runs kURL host preflight checks",
 		Example:      hostPreflightCmdExample,
 		SilenceUsage: true,

--- a/pkg/cli/object_store.go
+++ b/pkg/cli/object_store.go
@@ -11,6 +11,28 @@ import (
 	"github.com/spf13/viper"
 )
 
+func newObjectStoreCmd(cli CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "object-store",
+		Short: "Perform operations related to the object store within a kURL cluster",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.PersistentFlags())
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.Flags())
+		},
+	}
+	return cmd
+}
+
+func newSyncObjectStoreCmdDeprecated(cli CLI) *cobra.Command {
+	cmd := newSyncObjectStoreCmd(cli)
+	cmd.Use = "sync-object-store"
+	cmd.Deprecated = "use 'kurl object-store sync' instead"
+	cmd.Hidden = true
+	return cmd
+}
+
 func newSyncObjectStoreCmd(_ CLI) *cobra.Command {
 	var srcHost string
 	var srcAccessKeyID string
@@ -21,7 +43,7 @@ func newSyncObjectStoreCmd(_ CLI) *cobra.Command {
 	var dstAccessKeySecret string
 
 	syncObjectStoreCmd := &cobra.Command{
-		Use:   "sync-object-store",
+		Use:   "sync",
 		Short: "Copies buckets and objects from one object store to another",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.New()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Clean up CLI root command.

```
$ build/bin/kurl
A CLI for the kURL custom Kubernetes distro creator

Usage:
  kurl [command]

Available Commands:
  cluster           Perform operations on the kURL cluster
  completion        Generate the autocompletion script for the specified shell
  help              Help about any command
  host              Perform operations on the kURL host
  longhorn          Perform operations on a longhorn installation within a kURL cluster
  netutil           Networking utility commands
  object-store      Perform operations related to the object store within a kURL cluster
  rook              Perform operations on a rook-ceph installation within a kURL cluster
  version           Prints the kURL version

Flags:
      --debug   enable debug logging
  -h, --help    help for kurl

Use "kurl [command] --help" for more information about a command.
$ build/bin/kurl netutil
Networking utility commands

Usage:
  kurl netutil [command]

Available Commands:
  default-gateway-iface Gets the default gateway interface name
  format-ip-address     Adds brackets around ipv6 addresses
  iface-from-ip         Gets the interface name for a given IP address

Flags:
  -h, --help   help for netutil

Global Flags:
      --debug   enable debug logging

Use "kurl netutil [command] --help" for more information about a command.
$ build/bin/kurl object-store
Perform operations related to the object store within a kURL cluster

Usage:
  kurl object-store [command]

Available Commands:
  sync-object-store Copies buckets and objects from one object store to another

Flags:
  -h, --help   help for object-store

Global Flags:
      --debug   enable debug logging

Use "kurl object-store [command] --help" for more information about a command.
```

This change is backwards compatible.

```
$ build/bin/kurl format-address --help
Command "format-address" is deprecated, use 'kurl netutil format-ip-address' instead
Adds brackets around ipv6 addresses

Usage:
  kurl format-address [flags]

Flags:
  -h, --help   help for format-address

Global Flags:
      --debug   enable debug logging
$ build/bin/kurl sync-object-store --help
Command "sync-object-store" is deprecated, use 'kurl object-store sync' instead
Copies buckets and objects from one object store to another

Usage:
  kurl sync-object-store [flags]

Flags:
      --dest_access_key_id string         Access key ID for the destination object store
      --dest_access_key_secret string     Access key secret for the destination object store
      --dest_host string                  Hostname of the destination object store
  -h, --help                              help for sync-object-store
      --source_access_key_id string       Access key ID for the source object store
      --source_access_key_secret string   Access key secret for the source object store
      --source_host string                Hostname of the source object store

Global Flags:
      --debug   enable debug logging
```