### PR TITLE
Add restic restore helper image from gcr.io

### DIFF
--- a/addons/velero/1.9.5/Manifest
+++ b/addons/velero/1.9.5/Manifest
@@ -1,5 +1,6 @@
 image velero velero/velero:v1.9.5
 image restic-restore velero/velero-restic-restore-helper:v1.9.5
+image restic-restore-gcr gcr.io/velero-gcp/velero-restic-restore-helper:v1.9.5
 image velero-aws velero/velero-plugin-for-aws:v1.6.0
 image velero-gcp velero/velero-plugin-for-gcp:v1.6.0
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.6.0

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -1,5 +1,6 @@
 image velero velero/velero:v__VELERO_VERSION__
 image restic-restore velero/velero-restic-restore-helper:v__VELERO_VERSION__
+image restic-restore-gcr gcr.io/velero-gcp/velero-restic-restore-helper:v__VELERO_VERSION__
 image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
 image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
 image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

It seems like the default image name for the restic restore helper image in Velero v1.9.5 changed from `velero/velero-restic-restore-helper:v1.9.5` to `gcr.io/velero-gcp/velero-restic-restore-helper:v1.9.5` either by mistake or intentionally, we're still waiting on an answer from the Velero team. In the meantime, this works around the issue by including both images for airgapped installations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

~I did not make the same change in the `template` directory since I'm not sure if the next Velero version would have the same issue or not.~

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue in [Velero add-on](https://kurl.sh/docs/add-ons/velero) version 1.9.5 where restores fail to pull the `velero-restic-restore-helper` image in air gapped environments.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE