### PR TITLE
fix(rook): fix zapping url 404

### DIFF
--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -99,14 +99,10 @@ function rook() {
     fi
 
     if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
-        semverParse "$ROOK_VERSION"
-        # shellcheck disable=SC2154
-        local rook_major_minor_version="${major}.${minor}"
-
         printf "\n\n%bRook Ceph 1.4+ requires a secondary, unformatted block device attached to the host.%b\n" "$GREEN" "$NC"
         printf "%bIf you are stuck waiting at this step for more than two minutes, you are either missing the device or it is already formatted.%b\n" "$GREEN" "$NC"
         printf "\t%b * If it is missing, attach it now and it will be picked up; or CTRL+C, attach, and re-start the installer%b\n" "$GREEN" "$NC"
-        printf "\t%b * If the disk is attached, try wiping it using the recommended zap procedure: https://rook.io/docs/rook/v%s/ceph-teardown.html#zapping-devices%b\n\n" "$GREEN" "$rook_major_minor_version" "$NC"
+        printf "\t%b * If the disk is attached, try wiping it using the recommended zap procedure: https://rook.io/docs/rook/v1.10/Storage-Configuration/ceph-teardown/?h=zap#zapping-devices%b\n\n" "$GREEN" "$NC"
     fi
 
     printf "checking for attached secondary block device (awaiting rook-ceph RGW pod)\n"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -99,14 +99,10 @@ function rook() {
     fi
 
     if ! kubectl -n rook-ceph get pod -l app=rook-ceph-rgw -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Running ; then
-        semverParse "$ROOK_VERSION"
-        # shellcheck disable=SC2154
-        local rook_major_minor_version="${major}.${minor}"
-
         printf "\n\n%bRook Ceph 1.4+ requires a secondary, unformatted block device attached to the host.%b\n" "$GREEN" "$NC"
         printf "%bIf you are stuck waiting at this step for more than two minutes, you are either missing the device or it is already formatted.%b\n" "$GREEN" "$NC"
         printf "\t%b * If it is missing, attach it now and it will be picked up; or CTRL+C, attach, and re-start the installer%b\n" "$GREEN" "$NC"
-        printf "\t%b * If the disk is attached, try wiping it using the recommended zap procedure: https://rook.io/docs/rook/v%s/ceph-teardown.html#zapping-devices%b\n\n" "$GREEN" "$rook_major_minor_version" "$NC"
+        printf "\t%b * If the disk is attached, try wiping it using the recommended zap procedure: https://rook.io/docs/rook/v1.10/Storage-Configuration/ceph-teardown/?h=zap#zapping-devices%b\n\n" "$GREEN" "$NC"
     fi
 
     printf "checking for attached secondary block device (awaiting rook-ceph RGW pod)\n"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Current url gives a 404 https://rook.io/docs/rook/v1.10/ceph-teardown.html#zapping-devices

I have hardcoded it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a broken link to Rook zapping procedure in the script output.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE