### PR TITLE
chore: replacing ceph version check in shell by golang command

### DIFF
--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -301,8 +301,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -358,8 +358,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -357,7 +357,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -306,8 +306,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -363,8 +363,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -362,7 +362,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -313,7 +313,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -270,8 +270,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -314,8 +314,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -331,7 +331,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -277,8 +277,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -332,8 +332,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -364,7 +364,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -310,8 +310,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -365,8 +365,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -362,7 +362,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -306,8 +306,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! $DIR/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -363,8 +363,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -306,8 +306,8 @@ function rook_cluster_deploy_upgrade() {
 
     # https://rook.io/docs/rook/v1.6/ceph-upgrade.html#2-wait-for-the-daemon-pod-updates-to-complete
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -362,8 +362,8 @@ function verify_rook_updated_cluster() {
 
     log "Verifying Ceph version ${ceph_version} deployed"
     if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
-        logWarn "Timeout waiting for Ceph version rolled out"
-        logStep "Checking Ceph versions and replicas"
+        logWarn "Timeout waiting for Ceph version to be rolled out"
+        log "Checking Ceph versions and replicas"
         kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -361,7 +361,21 @@ function verify_rook_updated_cluster() {
     fi
 
     log "Verifying Ceph version ${ceph_version} deployed"
-    if ! spinner_until 1200 rook_ceph_version_deployed "${ceph_version}" ; then
+    if ! "$DIR"/bin/kurl rook wait-for-ceph-version "${ceph_version}-0" --timeout=1200 ; then
+        logWarn "Timeout waiting for Ceph version rolled out"
+        logStep "Checking Ceph versions and replicas"
+        kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+        local ceph_versions_found=
+        ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
+        if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
+            logWarn "Detected multiple Ceph versions"
+            logWarn "${ceph_versions_found}"
+            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+        fi
+
+        if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
+            bail "Ceph version found ${ceph_versions_found}. New Ceph version ${ceph_version} failed to deploy"
+        fi
         bail "New Ceph version ${ceph_version} failed to deploy"
     fi
 

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -119,8 +119,8 @@ function rookupgrade_10to14_upgrade() {
             kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20201116"}}}'
             kubectl patch deployment -n rook-ceph csi-rbdplugin-provisioner -p '{"spec": {"template": {"spec":{"containers":[{"name":"csi-snapshotter","imagePullPolicy":"IfNotPresent"}]}}}}'
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "14.2.5" --timeout=1200 ; then
-                logWarn "Timeout waiting for Ceph version rolled out"
-                logStep "Checking Ceph versions and replicas"
+                logWarn "Timeout waiting for Ceph version to be rolled out"
+                log "Checking Ceph versions and replicas"
                 kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
                 local ceph_versions_found=
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
@@ -284,7 +284,7 @@ function rookupgrade_10to14_upgrade() {
 
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "15.2.8-0" --timeout=1200 ; then
                 logWarn "Timeout waiting for Ceph version 15.2.8-0 rolled out"
-                logStep "Checking Ceph versions and replicas"
+                log "Checking Ceph versions and replicas"
                 kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
                 local ceph_versions_found=
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"


### PR DESCRIPTION
#### What this PR does / why we need it:

To address the request as a follow up: https://github.com/replicatedhq/kURL/pull/4038#discussion_r1097805802

#### Which issue(s) this PR fixes:

Fixes # [sc-68491]

#### Special notes for your reviewer:

We executed the following tests after we get merged : 

https://testgrid.kurl.sh/run/rook_upgrade_feb_7_rook_upgrades_after_chages

Therefore, after we merge this changes we should run the same tests and ensure that we will get the same result. Otherwise, we might need to work on to fix the golang command used to check the ceph version. 
