### PR TITLE
chore: fix testgrid by updating it to the latest versions to cover rook upgrade workflow

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -627,40 +627,66 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: k8s1205_rook_upgrade
+- name: k8s24x_rook_upgrade_17x_latest
   flags: "yes"
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.18.4
+      version: 1.24.x
+    weave:
+      version: 2.8.1
+    rook:
+      isBlockStorageEnabled: true
+      version: 1.7.x
+    kotsadm:
+      version: 1.93.x
+    containerd:
+      version: 1.6.x
+    ekco:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.26.x
+    weave:
+      version: 2.8.1
+    rook:
+      bypassUpgradeWarning: true
+      version: latest
+    kotsadm:
+      version: 1.93.x
+    containerd:
+      version: 1.6.x
+    ekco:
+      version: latest
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+- name: k8s19x_rook_upgrade_143_18x_docker
+  flags: "yes"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: 1.19.x
     weave:
       version: 2.8.1
     rook:
       isBlockStorageEnabled: true
       version: 1.4.3
-    kotsadm:
-      version: 1.38.0
-    containerd:
-      version: 1.4.6
+    docker:
+      version: 20.10.17
     ekco:
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.20.2
+      version: 1.21.x
     weave:
       version: 2.8.1
     rook:
       bypassUpgradeWarning: true
-      version: 1.9.x
-    kotsadm:
-      version: 1.38.0
-    containerd:
-      version: 1.4.12
+      version: 1.8.x
+    docker:
+      version: 20.10.17
     ekco:
       version: latest
-  unsupportedOSIDs:
-  - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
 - name: k8s121
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently this test using old versions is getting stuck.
However, we should no longer be testing with so older versions and by updating it to use the latest after the fix we can check that test can be performed with success which allows us to cover the workflow. 

This PR proposes 
- Update the current test to check rook upgrade with the latest versions. From rook 1.7.x to latest and k8s 1.24
- Add a new test to check rook upgrade from 1.4.x to 1.8.x using docker and old k8s release since this one we can check that pass in the tests. 

#### Which issue(s) this PR fixes:

Fixes # [sc-68484]

#### Special notes for your reviewer:
See the testgrid: https://testgrid.kurl.sh/run/rook_upgrade_fix_test_feb_7_3?kurlLogsInstanceId=vcrtefrlgmsfftyy&nodeId=vcrtefrlgmsfftyy-initialprimary