### PR TITLE
fix: start to delete flannel pods to workaround issue scenario

### DIFF
--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -85,9 +85,11 @@ function flannel_already_applied() {
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
-    log "Deleting pods from kube-flannel namespace"
-    kubectl delete --all pods --namespace=kube-flannel
-    sleep 60
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
 
     flannel_ready_spinner
     check_network

--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -82,6 +82,13 @@ function flannel_antrea_conflict() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    log "Deleting pods from kube-flannel namespace"
+    kubectl delete --all pods --namespace=kube-flannel
+    sleep 60
+
     flannel_ready_spinner
     check_network
 }

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -85,9 +85,11 @@ function flannel_already_applied() {
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
-    log "Deleting pods from kube-flannel namespace"
-    kubectl delete --all pods --namespace=kube-flannel
-    sleep 60
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
 
     flannel_ready_spinner
     check_network

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -82,6 +82,13 @@ function flannel_antrea_conflict() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    log "Deleting pods from kube-flannel namespace"
+    kubectl delete --all pods --namespace=kube-flannel
+    sleep 60
+
     flannel_ready_spinner
     check_network
 }

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -256,9 +256,11 @@ function flannel_already_applied() {
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
-    log "Deleting pods from kube-flannel namespace"
-    kubectl delete --all pods --namespace=kube-flannel
-    sleep 60
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
 
     flannel_ready_spinner
     check_network

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -253,6 +253,13 @@ function flannel_kubeadm() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    log "Deleting pods from kube-flannel namespace"
+    kubectl delete --all pods --namespace=kube-flannel
+    sleep 60
+
     flannel_ready_spinner
     check_network
 }

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -256,9 +256,11 @@ function flannel_already_applied() {
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
-    log "Deleting pods from kube-flannel namespace"
-    kubectl delete --all pods --namespace=kube-flannel
-    sleep 60
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
 
     flannel_ready_spinner
     check_network

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -253,6 +253,13 @@ function flannel_kubeadm() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    log "Deleting pods from kube-flannel namespace"
+    kubectl delete --all pods --namespace=kube-flannel
+    sleep 60
+
     flannel_ready_spinner
     check_network
 }

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -253,6 +253,15 @@ function flannel_kubeadm() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
+
     flannel_ready_spinner
     check_network
 }

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -256,9 +256,11 @@ function flannel_already_applied() {
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
-    log "Deleting pods from kube-flannel namespace"
-    kubectl delete --all pods --namespace=kube-flannel
-    sleep 60
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
 
     flannel_ready_spinner
     check_network

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -253,6 +253,13 @@ function flannel_kubeadm() {
 }
 
 function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    log "Deleting pods from kube-flannel namespace"
+    kubectl delete --all pods --namespace=kube-flannel
+    sleep 60
+
     flannel_ready_spinner
     check_network
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

To workaround the issue scenario: https://github.com/flannel-io/flannel/issues/1721 where the pods will get stuck to create the containers. It is sorted out by re-creating the flannel pods. 

#### Which issue(s) this PR fixes:

Fixes # [sc-68370]

#### Special notes for your reviewer:

Testgrid: https://testgrid.kurl.sh/run/flannel_k8s_upgrade_feb_8_workaround
Tests with the latest changes (1c7db82) : https://testgrid.kurl.sh/run/rook_upgrade_flannel_feb_9_1c7db82


## Steps to reproduce

https://staging.kurl.sh/47129cf -> https://staging.kurl.sh/1a98e97

#### Does this PR introduce a user-facing change?

```release-note
Fixes issue scenario faced where the containers are not created after k8s upgrades because flannel issues. 
```

#### Does this PR require documentation?
NONE
