### PR TITLE
fix(kubernetes): do not explicitly install kubernetes-cni

### DIFF
--- a/bundles/k8s-rhel7-force/Dockerfile
+++ b/bundles/k8s-rhel7-force/Dockerfile
@@ -7,7 +7,6 @@ RUN yum install yum-utils -y
 RUN yumdownloader --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \
-	kubernetes-cni \
 	ncurses-compat-libs \
 	git
 

--- a/bundles/k8s-rhel7/Dockerfile
+++ b/bundles/k8s-rhel7/Dockerfile
@@ -7,7 +7,6 @@ RUN yum install -y createrepo
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \
-	kubernetes-cni \
 	git
 RUN createrepo /packages/archives
 

--- a/bundles/k8s-rhel8/Dockerfile
+++ b/bundles/k8s-rhel8/Dockerfile
@@ -11,7 +11,6 @@ RUN yum install -y modulemd-tools
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \
 	kubectl-${KUBERNETES_VERSION} \
-	kubernetes-cni \
 	git
 RUN createrepo_c /packages/archives
 RUN repo2module --module-name=kurl.local --module-stream=stable /packages/archives /tmp/modules.yaml

--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -15,7 +15,6 @@ ARG KUBERNETES_VERSION
 RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
-	kubernetes-cni \
 	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 

--- a/bundles/k8s-ubuntu1804/Dockerfile
+++ b/bundles/k8s-ubuntu1804/Dockerfile
@@ -15,7 +15,6 @@ ARG KUBERNETES_VERSION
 RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
-	kubernetes-cni \
 	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 

--- a/bundles/k8s-ubuntu2004/Dockerfile
+++ b/bundles/k8s-ubuntu2004/Dockerfile
@@ -14,7 +14,6 @@ ARG KUBERNETES_VERSION
 RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
-	kubernetes-cni \
 	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 

--- a/bundles/k8s-ubuntu2204/Dockerfile
+++ b/bundles/k8s-ubuntu2204/Dockerfile
@@ -14,7 +14,6 @@ ARG KUBERNETES_VERSION
 RUN apt-get install -d -y tzdata \
 	kubelet=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
 	kubectl=$(apt-cache madison kubeadm | grep ${KUBERNETES_VERSION}- | awk '{ print $3 }' | head -n 1) \
-	kubernetes-cni \
 	git \
 	-oDebug::NoLocking=1 -o=dir::cache=/packages/
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -158,7 +158,7 @@ EOF
         ;;
     esac
 
-    install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}" kubernetes-cni git
+    install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}" git
 
     # Update crictl: https://listman.redhat.com/archives/rhsa-announce/2019-October/msg00038.html 
     tar -C /usr/bin -xzf "$DIR/packages/kubernetes/${k8sVersion}/assets/crictl-linux-amd64.tar.gz"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

In the kubeadm installation instructions they do not explicitly say to install kubernetes-cni as it is a sub-dependency of kubelet.

https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/

This change will allow apt to resolve the correct version of the package.

There is no user facing change here.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE