### PR TITLE
chore(Rook): Check for Rook pods in namespace to be in Running or Completed phase

### DIFF
--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -53,6 +53,10 @@ function rook_post_init() {
     if [ "$ROOK_DID_DISABLE_EKCO_OPERATOR" = "1" ]; then
         rook_enable_ekco_operator
     fi
+
+    # wait for all pods in the rook-ceph namespace to rollout
+    log "Rook Post-init: Awaiting Rook rollout in rook-ceph namespace"
+    rook_maybe_wait_for_rollout
 }
 
 ROOK_DID_DISABLE_EKCO_OPERATOR=0
@@ -987,4 +991,15 @@ function rook_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+}
+
+# wait for all pods in rook-ceph namespace to transition to Running status
+function rook_maybe_wait_for_rollout() {
+
+    # allow the Rook operator to start its reconcile loop
+    sleep 5
+
+    log "Awaiting Rook pods to transition to Running"
+    spinner_until 120 wait_for_running_pods "rook-ceph"
+
 }

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -997,7 +997,7 @@ function rook_prompt_migrate_from_longhorn() {
 function rook_maybe_wait_for_rollout() {
 
     # allow the Rook operator to start its reconcile loop
-    sleep 5
+    sleep 10
 
     log "Awaiting Rook pods to transition to Running"
     spinner_until 120 wait_for_running_pods "rook-ceph"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -57,6 +57,8 @@ function rook_post_init() {
     # wait for all pods in the rook-ceph namespace to rollout
     log "Rook Post-init: Awaiting Rook rollout in rook-ceph namespace"
     rook_maybe_wait_for_rollout
+
+    log "Rook Post-init: End"
 }
 
 ROOK_DID_DISABLE_EKCO_OPERATOR=0
@@ -993,13 +995,15 @@ function rook_prompt_migrate_from_longhorn() {
     fi
 }
 
-# wait for all pods in rook-ceph namespace to transition to Running status
+# wait for Rook deployment to be running and healthy
 function rook_maybe_wait_for_rollout() {
-
-    # allow the Rook operator to start its reconcile loop
-    sleep 10
-
     log "Awaiting Rook pods to transition to Running"
-    spinner_until 120 wait_for_running_pods "rook-ceph"
+    if ! spinner_until 120 wait_for_running_pods "rook-ceph"; then
+        logWarn "Rook-ceph rollout did not complete"
+    fi
 
+    log "Awaiting for Ceph Cluster to be Ready"
+    if ! spinner_until 120 rook_cephcluster_ready; then
+        logWarn "Ceph cluster is not ready"
+    fi
 }

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -53,12 +53,6 @@ function rook_post_init() {
     if [ "$ROOK_DID_DISABLE_EKCO_OPERATOR" = "1" ]; then
         rook_enable_ekco_operator
     fi
-
-    # wait for all pods in the rook-ceph namespace to rollout
-    log "Rook Post-init: Awaiting Rook rollout in rook-ceph namespace"
-    rook_maybe_wait_for_rollout
-
-    log "Rook Post-init: End"
 }
 
 ROOK_DID_DISABLE_EKCO_OPERATOR=0
@@ -992,18 +986,5 @@ function rook_prompt_migrate_from_longhorn() {
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"
-    fi
-}
-
-# wait for Rook deployment to be running and healthy
-function rook_maybe_wait_for_rollout() {
-    log "Awaiting Rook pods to transition to Running"
-    if ! spinner_until 120 wait_for_running_pods "rook-ceph"; then
-        logWarn "Rook-ceph rollout did not complete"
-    fi
-
-    log "Awaiting for Ceph Cluster to be Ready"
-    if ! spinner_until 120 rook_cephcluster_ready; then
-        logWarn "Ceph cluster is not ready"
     fi
 }

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1060,6 +1060,11 @@ function wait_for_running_pods() {
             is_job_controller=1
         fi
 
+        # ignore pods that have been Evicted
+        if [ "$status" == "Failed" ] && [[ $(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.status.reason}') == "Evicted" ]]; then
+            continue
+        fi
+
         if [ "$status" != "Running" ] && [ "$status" != "Succeeded" ]; then
             log "  Pod, $pod, is not ready: $status"
             return 1

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1070,7 +1070,7 @@ function wait_for_running_pods() {
             container_status=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.status.containerStatuses[?(@.name==\"$container\")].ready}")
             
             # ignore container ready status for pods managed by the Job controller
-            if [ "$container_status" != "true" ] && [ $is_job_controller -eq 0 ]; then
+            if [ "$container_status" != "true" ] && [ "$is_job_controller" = "0" ]; then
                 log "  Container, $container ($pod), is not ready: $container_status"
                 return 1
             fi

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1055,7 +1055,7 @@ function wait_for_running_pods() {
 
     for pod in $ns_pods; do
         status=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.status.phase}')
-        
+
         # determine if pod is manged by a Job
         if kubectl get pod "$pod" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[*].kind}' | grep -q "Job"; then
             is_job_controller=1
@@ -1064,7 +1064,7 @@ function wait_for_running_pods() {
         if [ "$status" != "Running" ] && [ "$status" != "Succeeded" ]; then
             pods_not_ready=1
             log "  Pod, $pod, is not ready: $status"
-            break
+            return 1
         fi
 
         containers=$(kubectl get pod "$pod" -n "$namespace" -o jsonpath="{.spec.containers[*].name}")
@@ -1080,13 +1080,9 @@ function wait_for_running_pods() {
         done
 
         if [ $pods_not_ready -ne 0 ]; then
-            break
+            return 1
         fi
     done
-
-    if [ $pods_not_ready -ne 0 ]; then
-       return 1
-    fi
 
     log "All pods and their containers in namespace $namespace are in Running phase."
     return 0

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1082,6 +1082,6 @@ function wait_for_running_pods() {
         done
     done
 
-    log "All pods and their containers in namespace $namespace are in Running phase."
+    log "All pods and their containers in namespace $namespace are running."
     return 0
 }

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -226,16 +226,14 @@ function current_ceph_version() {
         | awk -F'-' '{ print $1 }'
 }
 
-function rook_cephcluster_ready() {
-    local ceph_cluster_phase=
-    local ceph_cluster_status=
-    ceph_cluster_phase=$(kubectl -n rook-ceph get cephcluster rook-ceph --template '{{.status.phase}}')
-    if [  "$ceph_cluster_phase" = "Ready"  ]; then
-        ceph_cluster_status=$(kubectl -n rook-ceph get cephcluster rook-ceph --template '{{.status.ceph.health}}')
-        if [ "$CEPH_POOL_REPLICAS" -gt 1 ] && [ "$ceph_cluster_status" = "HEALTH_WARN" ]; then
-            return 1
-        fi
-        log "Ceph Cluster is Ready"
-        return 0
+function rook_operator_ready() {
+    local rook_status_phase=
+    local rook_status_msg=
+    rook_status_phase=$(kubectl -n rook-ceph get cephcluster rook-ceph --template '{{.status.phase}}')
+    rook_status_msg=$(kubectl -n rook-ceph get cephcluster rook-ceph --template '{{.status.message}}')
+    if [  "$rook_status_phase" != "Ready"  ]; then
+        log "Rook operator is not ready: $rook_status_msg"
+        return 1
     fi
+    return 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

After Rook is installed, ensure the Rook operator is ready and all pods in `rook-ceph` namespace are in `Running` phase before completing the install. This _could_ help with some failing tests where post-install/upgrade scripts fail due to the Rook/Ceph deployment still being rolled-out.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
