### PR TITLE
chore: Allow containerd "ctr" command output to stdout

### DIFF
--- a/addons/ekco/0.26.3/install.sh
+++ b/addons/ekco/0.26.3/install.sh
@@ -343,8 +343,8 @@ function ekco_bootstrap_internal_lb() {
             ekco generate-haproxy-config --primary-host="$backends" \
             > /etc/haproxy/haproxy.cfg
 
-        ctr -n k8s.io task kill -s SIGKILL bootstrap-lb &>/dev/null || true
-        ctr -n k8s.io containers delete bootstrap-lb &>/dev/null || true
+        ctr -n k8s.io task kill -s SIGKILL bootstrap-lb || true
+        ctr -n k8s.io containers delete bootstrap-lb || true
         ctr -n k8s.io run --rm \
             --mount "type=bind,src=/etc/haproxy,dst=/usr/local/etc/haproxy,options=rbind:ro" \
             --net-host \

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -343,8 +343,8 @@ function ekco_bootstrap_internal_lb() {
             ekco generate-haproxy-config --primary-host="$backends" \
             > /etc/haproxy/haproxy.cfg
 
-        ctr -n k8s.io task kill -s SIGKILL bootstrap-lb &>/dev/null || true
-        ctr -n k8s.io containers delete bootstrap-lb &>/dev/null || true
+        ctr -n k8s.io task kill -s SIGKILL bootstrap-lb || true
+        ctr -n k8s.io containers delete bootstrap-lb || true
         ctr -n k8s.io run --rm \
             --mount "type=bind,src=/etc/haproxy,dst=/usr/local/etc/haproxy,options=rbind:ro" \
             --net-host \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
To aid in troubleshooting this [issue](https://community.replicated.com/t/ctr-snapshot-bootstrap-lb-already-exists/1106):
```
⚙  Addon ekco 0.26.2
Updating the Kubernetes apiserver load balancer
ctr: snapshot "bootstrap-lb": already exists
```

Allow `ctr` commands to write to `stdout`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
