### PR TITLE
fix testgrid daily 

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -627,7 +627,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-- name: k8s24x_rook_upgrade_17x_latest
+- name: k8s24x_rook_upgrade_17x_110x
   flags: "yes"
   cpu: 6
   installerSpec:
@@ -651,7 +651,7 @@
       version: 2.8.1
     rook:
       bypassUpgradeWarning: true
-      version: latest
+      version: 1.10.x
     kotsadm:
       version: 1.93.x
     containerd:


### PR DESCRIPTION
#### What this PR does / why we need it:

We have an issue with kurl-api which is return 1.0.4 version for rook to latest instead of 1.10.6.
Therefore, this PR is required to fix the testgrid that is broken to run the daily tests

https://github.com/replicatedhq/kURL/actions/runs/4131138221/jobs/7154189273

