### PR TITLE
fixes: add retry to apply original.yaml after crd is installed

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -125,7 +125,7 @@ function apply_installer_crd() {
         cat > $ORIGINAL_INSTALLER_SPEC <<EOL
 ${INSTALLER_YAML}
 EOL
-        kubectl apply -f "$ORIGINAL_INSTALLER_SPEC"
+        try_1m kubectl apply -f "$ORIGINAL_INSTALLER_SPEC"
     fi
 
     try_1m kubectl apply -f "$MERGED_YAML_SPEC"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
To accommodate slower machines when apply original installer spec, install spec sometimes fails after crd is already installed. 
  
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
Intermittently reproducible on slower machines, when using original specs to install k8s airgap using kURL package 
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE