### PR TITLE
Rook - Increase time to check if PVC is bound for addon testgrid only

### DIFF
--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -51,7 +51,7 @@
         requests:
           storage: 1Gi
     EOF
-    sleep 10
+    sleep 300
     kubectl -n default get pvc default-pvc | grep Bound
     kubectl -n default get pvc cephfs-pvc | grep Bound
     kubectl -n default delete pvc cephfs-pvc default-pvc
@@ -199,7 +199,7 @@
         requests:
           storage: 1Gi
     EOF
-    sleep 10
+    sleep 300
     kubectl -n default get pvc default-pvc | grep Bound
     kubectl -n default get pvc cephfs-pvc | grep Bound
     kubectl -n default delete pvc cephfs-pvc default-pvc


### PR DESCRIPTION
#### What this PR does / why we need it:

We are checking in the testgrid that 10 seconds is not enough for all tests:

https://testgrid.kurl.sh/run/pr-3953-e529bce-rook-1.10.10-k8s-docker-2023-02-10T04:16:36Z

This testgrid ONLY runs when we add a new addon so it is totally fine we wait a little more to get the answer. It is better then get a false negative result.  


#### Which issue(s) this PR fixes:


It will allow we check the new rook version 1.10.10 and ensure that it is OK prior get merged.
