### PR TITLE
feat: preparing longhorn for migration.

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -388,4 +388,8 @@ function openebs_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -92,7 +92,6 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -340,14 +340,18 @@ function openebs_maybe_longhorn_migration_checks() {
     for longhorn_sc in $longhorn_scs
     do
         # run validation checks for non default Longhorn storage classes
-        if ! longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
+            longhorn_scs_pvmigrate_dryrun_output=""
+        else
             break
         fi
     done
 
     if [ -n "$longhorn_default_sc" ] ; then
-        # run validation checks for Rook default storage class
-        longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
+        # run validation checks for Longhorn default storage class
+        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
+            longhorn_default_sc_pvmigrate_dryrun_output=""
+        fi
     fi
 
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -92,7 +92,7 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-        
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -92,7 +92,7 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-        longhorn_restore_migration_replicas
+
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 
@@ -357,6 +357,7 @@ function openebs_maybe_longhorn_migration_checks() {
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$longhorn_scs_pvmigrate_dryrun_output"
         log "$longhorn_default_sc_pvmigrate_dryrun_output"
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Longhorn to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -384,6 +384,12 @@ function openebs_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
+    if [ -z "$MINIO_VERSION" ] ; then
+        logFail "    You can only migrate from Longhorn to OpenEBS if you are specifying Minio as your Object Store."
+        logFail "    Please make sure you are including Minio in your kURL Installer spec and try again."
+        bail "Not migrating"
+    fi
+
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -388,12 +388,6 @@ function openebs_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
-    if [ -z "$MINIO_VERSION" ] ; then
-        logFail "    You can only migrate from Longhorn to OpenEBS if you are specifying Minio as your Object Store."
-        logFail "    Please make sure you are including Minio in your kURL Installer spec and try again."
-        bail "Not migrating"
-    fi
-
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -388,4 +388,8 @@ function openebs_prompt_migrate_from_longhorn() {
     if ! confirmN; then
         bail "Not migrating"
     fi
+
+    if ! longhorn_prepare_for_migration; then
+        bail "Not migrating"
+    fi
 }

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -92,7 +92,6 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -340,14 +340,18 @@ function openebs_maybe_longhorn_migration_checks() {
     for longhorn_sc in $longhorn_scs
     do
         # run validation checks for non default Longhorn storage classes
-        if ! longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
+            longhorn_scs_pvmigrate_dryrun_output=""
+        else
             break
         fi
     done
 
     if [ -n "$longhorn_default_sc" ] ; then
-        # run validation checks for Rook default storage class
-        longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only || true)
+        # run validation checks for Longhorn default storage class
+        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$OPENEBS_LOCALPV_STORAGE_CLASS" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
+            longhorn_default_sc_pvmigrate_dryrun_output=""
+        fi
     fi
 
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -92,7 +92,7 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-        
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -92,7 +92,7 @@ function openebs_maybe_rook_migration_checks() {
     if [ -n "$rook_scs_pvmigrate_dryrun_output" ] || [ -n "$rook_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$rook_scs_pvmigrate_dryrun_output"
         log "$rook_default_sc_pvmigrate_dryrun_output"
-        longhorn_restore_migration_replicas
+
         bail "Cannot upgrade from Rook to OpenEBS due to previous error."
     fi
 
@@ -357,6 +357,7 @@ function openebs_maybe_longhorn_migration_checks() {
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$longhorn_scs_pvmigrate_dryrun_output"
         log "$longhorn_default_sc_pvmigrate_dryrun_output"
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Longhorn to OpenEBS due to previous error."
     fi
 

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -384,6 +384,12 @@ function openebs_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
+    if [ -z "$MINIO_VERSION" ] ; then
+        logFail "    You can only migrate from Longhorn to OpenEBS if you are specifying Minio as your Object Store."
+        logFail "    Please make sure you are including Minio in your kURL Installer spec and try again."
+        bail "Not migrating"
+    fi
+
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -388,12 +388,6 @@ function openebs_prompt_migrate_from_longhorn() {
         bail "Not migrating"
     fi
 
-    if [ -z "$MINIO_VERSION" ] ; then
-        logFail "    You can only migrate from Longhorn to OpenEBS if you are specifying Minio as your Object Store."
-        logFail "    Please make sure you are including Minio in your kURL Installer spec and try again."
-        bail "Not migrating"
-    fi
-
     log "Would you like to continue? "
     if ! confirmN; then
         bail "Not migrating"

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -966,6 +966,7 @@ function rook_maybe_longhorn_migration_checks() {
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$longhorn_scs_pvmigrate_dryrun_output"
         log "$longhorn_default_sc_pvmigrate_dryrun_output"
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Longhorn to Rook due to previous error."
     fi
 

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -949,7 +949,7 @@ function rook_maybe_longhorn_migration_checks() {
     for longhorn_sc in $longhorn_scs
     do
         # run validation checks for non default Longhorn storage classes
-        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
             longhorn_scs_pvmigrate_dryrun_output=""
         else
             break
@@ -958,7 +958,7 @@ function rook_maybe_longhorn_migration_checks() {
 
     if [ -n "$longhorn_default_sc" ] ; then
         # run validation checks for Rook default storage class
-        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
             longhorn_default_sc_pvmigrate_dryrun_output=""
         fi
     fi

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -966,6 +966,7 @@ function rook_maybe_longhorn_migration_checks() {
     if [ -n "$longhorn_scs_pvmigrate_dryrun_output" ] || [ -n "$longhorn_default_sc_pvmigrate_dryrun_output" ] ; then
         log "$longhorn_scs_pvmigrate_dryrun_output"
         log "$longhorn_default_sc_pvmigrate_dryrun_output"
+        longhorn_restore_migration_replicas
         bail "Cannot upgrade from Longhorn to Rook due to previous error."
     fi
 

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -949,7 +949,7 @@ function rook_maybe_longhorn_migration_checks() {
     for longhorn_sc in $longhorn_scs
     do
         # run validation checks for non default Longhorn storage classes
-        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_scs_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
             longhorn_scs_pvmigrate_dryrun_output=""
         else
             break
@@ -958,7 +958,7 @@ function rook_maybe_longhorn_migration_checks() {
 
     if [ -n "$longhorn_default_sc" ] ; then
         # run validation checks for Rook default storage class
-        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only) ; then
+        if longhorn_default_sc_pvmigrate_dryrun_output=$($BIN_PVMIGRATE --source-sc "$longhorn_default_sc" --dest-sc "$rook_storage_class" --rsync-image "$KURL_UTIL_IMAGE" --preflight-validation-only 2>&1) ; then
             longhorn_default_sc_pvmigrate_dryrun_output=""
         fi
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Calls `longhorn_prepare_for_migration` function in both OpenEBS and Rook add-ons code. `longhorn_prepare_for_migration` scales down pods using Longhorn volumes, as it is called earlier in the migration process we don't have pods pending on "Terminating" state anymore (I could not reproduce it anymore, at least).

This PR also migrates data from  Minio object store to Rook object store when moving away from Minio + Longhorn duo. Migrations from Longhorn to Rook has also been blocked in single node clusters.


#### Which issue(s) this PR fixes:
Fixes #65977