### PR TITLE
adds new command to get hostname as it is done by k8s api to use it crosswise

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -11,6 +11,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	hostCmd := newHostCmd(cli)
 	hostCmd.AddCommand(newHostProtectedidCmd(cli))
 	hostCmd.AddCommand(newHostPreflightCmd(cli))
+	hostCmd.AddCommand(newHostnameCmd(cli))
 	cmd.AddCommand(hostCmd)
 
 	rookCmd := NewRookCmd(cli)

--- a/pkg/cli/hostname.go
+++ b/pkg/cli/hostname.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/kurl/pkg/host"
+	"github.com/spf13/cobra"
+)
+
+func newHostnameCmd(_ CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hostname",
+		Short: "Prints the kURL hostname",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := host.GetHostname()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), id)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/pkg/host/hostname.go
+++ b/pkg/host/hostname.go
@@ -7,6 +7,8 @@ import (
 )
 
 // GetHostname returns the node hostname using kubernetes as lib to ensure that will obtain the same value
+// This code is the same used kubernetes project: (We copied to avoid to add a dependency only because of this snipt)
+//https://github.com/kubernetes/kubernetes/blob/6b34fafdaf5998039c7e01fa33920a641b216d3e/staging/src/k8s.io/component-helpers/node/util/hostname.go#L25-L46
 func GetHostname() (string, error) {
 	nodeName, err := os.Hostname()
 	if err != nil {

--- a/pkg/host/hostname.go
+++ b/pkg/host/hostname.go
@@ -8,7 +8,7 @@ import (
 
 // GetHostname returns the node hostname using kubernetes as lib to ensure that will obtain the same value
 // This code is the same used kubernetes project: (We copied to avoid to add a dependency only because of this snipt)
-//https://github.com/kubernetes/kubernetes/blob/6b34fafdaf5998039c7e01fa33920a641b216d3e/staging/src/k8s.io/component-helpers/node/util/hostname.go#L25-L46
+// https://github.com/kubernetes/kubernetes/blob/6b34fafdaf5998039c7e01fa33920a641b216d3e/staging/src/k8s.io/component-helpers/node/util/hostname.go#L25-L46
 func GetHostname() (string, error) {
 	nodeName, err := os.Hostname()
 	if err != nil {

--- a/pkg/host/hostname.go
+++ b/pkg/host/hostname.go
@@ -1,0 +1,25 @@
+package host
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GetHostname returns the node hostname using kubernetes as lib to ensure that will obtain the same value
+func GetHostname() (string, error) {
+	nodeName, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("couldn't determine hostname: %w", err)
+	}
+	hostName := nodeName
+
+	// Trim whitespaces first to avoid getting an empty hostname
+	// For linux, the hostname is read from file /proc/sys/kernel/hostname directly
+	hostName = strings.TrimSpace(hostName)
+	if len(hostName) == 0 {
+		return "", fmt.Errorf("empty hostname is invalid")
+	}
+
+	return strings.ToLower(hostName), nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, kurl scripts and ekco use the func `$(hostname | tr '[:upper:]' '[:lower:]')` to get the node name. However, in some edge cases scenarios it seems that we have a mismatch. 

Therefore, by looking at kubernetes implementation we can check that they are using [os.Hostname()](https://github.com/kubernetes/kubernetes/blob/f58f70bd5730658505042cd9baa80f72d3b6e31e/staging/src/k8s.io/component-helpers/node/util/hostname.go#L28-L46) which its implementation will look for `cat /proc/sys/kernel/hostname.` This PR ensure that we are getting the information at the same way that kubernetes does for Linux environments to avoid problematic edge cases scenarios. 

As agreed in the review this PR creates a new command to do the same k8s implementation

<img width="1205" alt="Screenshot 2023-02-13 at 10 52 46" src="https://user-images.githubusercontent.com/7708031/218439351-b0d9bfc9-7e39-4197-9000-5775bba33169.png">

In a follow up we will start to use it. 

#### Which issue(s) this PR fixes:

Partial Fixes # [sc-68468]

#### Special notes for your reviewer:

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds new command to kurl binary to get hostname `kurl host hostname`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
