### PR TITLE
chore: sleep before post upgrade test.

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -211,6 +211,8 @@
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+    # sleep for a while to guarantee that the pod has been scaled up.
+    sleep 120
     # downloads the previously stored file and compares, expecting to see the same content.
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     # makes sure that the new pvc is being provisioned by openebs.

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -382,6 +382,8 @@
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+    # sleep for a while to guarantee that the pod has been scaled up.
+    sleep 120
     # downloads the previously stored file and compares, expecting to see the same content.
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     # makes sure that the new pvc is being provisioned by rook.


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR solves what seems to be a flake during Longhorn to Rook/OpenEBS migration tests (testgrid). During the upgrade Pods mounting Longhorn volumes are scaled down and they can take some time to get back up once their data has been migrated to Rook or OpenEBS.

This pr adds a sleep of 2 minutes before running the post upgrade test (this time should be more than enough for the simple Pod we are using to test to come up).