### PR TITLE
fix: kubelet pause image gets garbage collected, does not match containerd sandbox image

### DIFF
--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -242,14 +242,14 @@ function flannel_kubeadm() {
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
-    if grep 'podSubnet:' /opt/replicated/kubeadm.conf; then
-        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" /opt/replicated/kubeadm.conf
+    if grep -q 'podSubnet:' "$KUBEADM_CONF_FILE" ; then
+        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" "$KUBEADM_CONF_FILE"
     else
-        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" /opt/replicated/kubeadm.conf
+        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" "$KUBEADM_CONF_FILE"
     fi
 
-    kubeadm init phase upload-config kubeadm --config=/opt/replicated/kubeadm.conf
-    kubeadm init phase control-plane controller-manager --config=/opt/replicated/kubeadm.conf
+    kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
+    kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
 }
 
 function flannel_already_applied() {

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -242,14 +242,14 @@ function flannel_kubeadm() {
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
-    if grep 'podSubnet:' /opt/replicated/kubeadm.conf; then
-        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" /opt/replicated/kubeadm.conf
+    if grep -q 'podSubnet:' "$KUBEADM_CONF_FILE" ; then
+        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" "$KUBEADM_CONF_FILE"
     else
-        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" /opt/replicated/kubeadm.conf
+        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" "$KUBEADM_CONF_FILE"
     fi
 
-    kubeadm init phase upload-config kubeadm --config=/opt/replicated/kubeadm.conf
-    kubeadm init phase control-plane controller-manager --config=/opt/replicated/kubeadm.conf
+    kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
+    kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
 }
 
 function flannel_already_applied() {

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -242,14 +242,14 @@ function flannel_kubeadm() {
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
-    if grep 'podSubnet:' /opt/replicated/kubeadm.conf; then
-        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" /opt/replicated/kubeadm.conf
+    if grep -q 'podSubnet:' "$KUBEADM_CONF_FILE" ; then
+        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" "$KUBEADM_CONF_FILE"
     else
-        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" /opt/replicated/kubeadm.conf
+        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" "$KUBEADM_CONF_FILE"
     fi
 
-    kubeadm init phase upload-config kubeadm --config=/opt/replicated/kubeadm.conf
-    kubeadm init phase control-plane controller-manager --config=/opt/replicated/kubeadm.conf
+    kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
+    kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
 }
 
 function flannel_already_applied() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -242,14 +242,14 @@ function flannel_kubeadm() {
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
-    if grep 'podSubnet:' /opt/replicated/kubeadm.conf; then
-        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" /opt/replicated/kubeadm.conf
+    if grep -q 'podSubnet:' "$KUBEADM_CONF_FILE" ; then
+        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" "$KUBEADM_CONF_FILE"
     else
-        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" /opt/replicated/kubeadm.conf
+        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" "$KUBEADM_CONF_FILE"
     fi
 
-    kubeadm init phase upload-config kubeadm --config=/opt/replicated/kubeadm.conf
-    kubeadm init phase control-plane controller-manager --config=/opt/replicated/kubeadm.conf
+    kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
+    kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
 }
 
 function flannel_already_applied() {

--- a/scripts/common/kubernetes-test.sh
+++ b/scripts/common/kubernetes-test.sh
@@ -48,4 +48,32 @@ function test_kubernetes_version_minor() {
     assertEquals "v1.20.0" "20" "$(kubernetes_version_minor "1.20.0")"
 }
 
+function test_kubernetes_configure_pause_image_upgrade() {
+    systemctl() {
+        #shellcheck disable=SC2317
+        true # noop
+    }
+    kubernetes_containerd_pause_image() {
+        #shellcheck disable=SC2317
+        echo "registry.k8s.io/pause:3.6"
+    }
+
+    KUBELET_FLAGS_FILE=$(mktemp)
+    echo 'KUBELET_KUBEADM_ARGS="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --node-ip=10.128.0.79 --node-labels=kurl.sh/cluster=true, --pod-infra-container-image=k8s.gcr.io/pause:3.5"' > "$KUBELET_FLAGS_FILE"
+
+    kubernetes_configure_pause_image_upgrade
+
+    local expected='KUBELET_KUBEADM_ARGS="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --node-ip=10.128.0.79 --node-labels=kurl.sh/cluster=true, --pod-infra-container-image=registry.k8s.io/pause:3.6"'
+    assertEquals "should replace correctly with flag at end" "$expected" "$(cat "$KUBELET_FLAGS_FILE")"
+
+    echo 'KUBELET_KUBEADM_ARGS="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --node-ip=10.128.0.79 --pod-infra-container-image=k8s.gcr.io/pause:3.5 --node-labels=kurl.sh/cluster=true,"' > "$KUBELET_FLAGS_FILE"
+
+    kubernetes_configure_pause_image_upgrade
+
+    local expected='KUBELET_KUBEADM_ARGS="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --node-ip=10.128.0.79 --pod-infra-container-image=registry.k8s.io/pause:3.6 --node-labels=kurl.sh/cluster=true,"'
+    assertEquals "should replace correctly with flag in middle" "$expected" "$(cat "$KUBELET_FLAGS_FILE")"
+
+    rm "$KUBELET_FLAGS_FILE"
+}
+
 . shunit2

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -746,17 +746,17 @@ function kubernetes_pod_succeeded() {
 
 function kubernetes_is_current_cluster() {
     local api_service_address="$1"
-    if cat /etc/kubernetes/kubelet.conf 2>/dev/null | grep -q "${api_service_address}"; then
+    if grep -sq "${api_service_address}" /etc/kubernetes/kubelet.conf ; then
         return 0
     fi
-    if cat /opt/replicated/kubeadm.conf 2>/dev/null | grep -q "${api_service_address}"; then
+    if grep -sq "${api_service_address}" "$KUBEADM_CONF_FILE" ; then
         return 0
     fi
     return 1
 }
 
 function kubernetes_is_join_node() {
-    if cat /opt/replicated/kubeadm.conf 2>/dev/null | grep -q 'kind: JoinConfiguration'; then
+    if grep -sq 'kind: JoinConfiguration' "$KUBEADM_CONF_FILE" ; then
         return 0
     fi
     return 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,7 +70,8 @@ function init() {
         ekco_bootstrap_internal_lb
     fi
 
-    kustomize_kubeadm_init=./kustomize/kubeadm/init
+    local kustomize_kubeadm_init="$DIR/kustomize/kubeadm/init"
+
     CERT_KEY=
     CERT_KEY_EXPIRY=
     if [ "$HA_CLUSTER" = "1" ]; then
@@ -166,6 +167,8 @@ function init() {
 
         render_yaml_file $kustomize_kubeadm_init/patch-kubelet-container-log-max-files.tpl > $kustomize_kubeadm_init/patch-kubelet-container-log-max-files.yaml
     fi
+
+    kubernetes_configure_pause_image "$kustomize_kubeadm_init"
 
     # Add kubeadm init patches from addons.
     for patch in $(ls -1 ${kustomize_kubeadm_init}-patches/* 2>/dev/null || echo); do
@@ -551,6 +554,7 @@ function main() {
     discover_service_subnet
     configure_no_proxy
     install_cri
+    kubernetes_configure_pause_image_upgrade
     get_shared
     report_upgrade_kubernetes
     report_kubernetes_install

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -83,7 +83,7 @@ function join() {
     mkdir -p /var/log/apiserver
 
     set +e
-    (set -x; kubeadm join --config /opt/replicated/kubeadm.conf --ignore-preflight-errors=all)
+    (set -x; kubeadm join --config "$KUBEADM_CONF_FILE" --ignore-preflight-errors=all)
     _status=$?
     set -e
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -52,12 +52,16 @@ function join() {
         logStep "Join Kubernetes node"
     fi
 
-    kustomize_kubeadm_join=./kustomize/kubeadm/join
+    local kustomize_kubeadm_join="$DIR/kustomize/kubeadm/join"
+
     if [ "$MASTER" = "1" ]; then
         insert_patches_strategic_merge \
             $kustomize_kubeadm_join/kustomization.yaml \
             patch-control-plane.yaml
     fi
+
+    kubernetes_configure_pause_image "$kustomize_kubeadm_join"
+
     # Add kubeadm join patches from addons.
     for patch in $(ls -1 ${kustomize_kubeadm_join}-patches/* 2>/dev/null || echo); do
         patch_basename="$(basename $patch)"

--- a/scripts/kustomize/kubeadm/init-orig/kubelet-args-pause-image.patch.tmpl.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/kubelet-args-pause-image.patch.tmpl.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    pod-infra-container-image: $CONTAINERD_PAUSE_IMAGE

--- a/scripts/kustomize/kubeadm/join-orig/kubelet-args-pause-image.patch.tmpl.yaml
+++ b/scripts/kustomize/kubeadm/join-orig/kubelet-args-pause-image.patch.tmpl.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  kubeletExtraArgs:
+    pod-infra-container-image: $CONTAINERD_PAUSE_IMAGE

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -139,6 +139,7 @@ function main() {
     get_shared
     ${K8S_DISTRO}_addon_for_each addon_join
     maybe_upgrade
+    kubernetes_configure_pause_image_upgrade
     install_helm
     uninstall_docker
     outro


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We have had reports of kubernetes garbage collecting the pause image causing containers to get stuck in container creating state.

I believe this is because the pod-infra-container-image does not match the sandbox image set in containerd config.toml

```bash
$ cat /var/lib/kubelet/kubeadm-flags.env
KUBELET_KUBEADM_ARGS="--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --hostname-override=ethanm-flannel-5 --node-ip=10.128.0.105 --node-labels=kurl.sh/cluster=true, --pod-infra-container-image=k8s.gcr.io/pause:3.4.1"
ethan@ethanm-flannel-5:~$ sudo ctr -n k8s.io container ls | grep pause
fbd4ff11167253c60adf8d12a908488838ed5eaa2b959ff63464345e7a52ba2f    registry.k8s.io/pause:3.6                                       io.containerd.runc.v2
$ cat /etc/containerd/config.toml | grep pause:
    sandbox_image = "registry.k8s.io/pause:3.6"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a misconfigured in the kubelet that causes Kubernetes to garbage collect the pause image causing new containers to fail to start and get stuck in ContainerCreating state.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE