### PR TITLE
chore: update image used to package helm

### DIFF
--- a/bundles/helm/Dockerfile
+++ b/bundles/helm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install curl tzdata


### PR DESCRIPTION
#### What this PR does / why we need it:

Update image used to package helm

**Local test:**
```
$ make build/helm
mkdir -p build/helm
docker build -t helm -f bundles/helm/Dockerfile bundles/helm
Sending build context to Docker daemon  2.048kB
Step 1/7 : FROM ubuntu:22.04
 ---> a8780b506fa4
Step 2/7 : ENV DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> 446024bf0f30
Step 3/7 : RUN apt-get update && apt-get -y install curl tzdata
 ---> Running in b72d835f515b
Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [107 kB]
Get:5 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [710 kB]
Get:6 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [5557 B]
Get:7 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [801 kB]
Get:8 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [783 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1117 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [781 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [10.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1015 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [49.0 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [22.4 kB]
Fetched 25.6 MB in 2s (12.6 MB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  ca-certificates libbrotli1 libcurl4 libldap-2.5-0 libldap-common
  libnghttp2-14 libpsl5 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libssh-4 openssl publicsuffix
Suggested packages:
  libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal
  libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql
The following NEW packages will be installed:
  ca-certificates curl libbrotli1 libcurl4 libldap-2.5-0 libldap-common
  libnghttp2-14 libpsl5 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libssh-4 openssl publicsuffix tzdata
0 upgraded, 16 newly installed, 0 to remove and 11 not upgraded.
Need to get 3297 kB of archives.
After this operation, 10.9 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openssl amd64 3.0.2-0ubuntu1.8 [1184 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 ca-certificates all 20211016ubuntu0.22.04.1 [144 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 tzdata all 2022g-0ubuntu0.22.04.1 [333 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnghttp2-14 amd64 1.43.0-1build3 [76.3 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy/main amd64 libpsl5 amd64 0.21.0-1.2build2 [58.4 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 publicsuffix all 20211207.1025-1 [129 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbrotli1 amd64 1.0.9-2build6 [315 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg2-3ubuntu1.1 [20.6 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-2 amd64 2.1.27+dfsg2-3ubuntu1.1 [53.8 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-2.5-0 amd64 2.5.13+dfsg-0ubuntu0.22.04.1 [183 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build4 [58.2 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/main amd64 libssh-4 amd64 0.9.6-2build1 [184 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.7 [289 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.7 [193 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-common all 2.5.13+dfsg-0ubuntu0.22.04.1 [15.9 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules amd64 2.1.27+dfsg2-3ubuntu1.1 [57.2 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 3297 kB in 0s (31.2 MB/s)
Selecting previously unselected package openssl.
(Reading database ... 4395 files and directories currently installed.)
Preparing to unpack .../00-openssl_3.0.2-0ubuntu1.8_amd64.deb ...
Unpacking openssl (3.0.2-0ubuntu1.8) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../01-ca-certificates_20211016ubuntu0.22.04.1_all.deb ...
Unpacking ca-certificates (20211016ubuntu0.22.04.1) ...
Selecting previously unselected package tzdata.
Preparing to unpack .../02-tzdata_2022g-0ubuntu0.22.04.1_all.deb ...
Unpacking tzdata (2022g-0ubuntu0.22.04.1) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../03-libnghttp2-14_1.43.0-1build3_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.43.0-1build3) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../04-libpsl5_0.21.0-1.2build2_amd64.deb ...
Unpacking libpsl5:amd64 (0.21.0-1.2build2) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../05-publicsuffix_20211207.1025-1_all.deb ...
Unpacking publicsuffix (20211207.1025-1) ...
Selecting previously unselected package libbrotli1:amd64.
Preparing to unpack .../06-libbrotli1_1.0.9-2build6_amd64.deb ...
Unpacking libbrotli1:amd64 (1.0.9-2build6) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../07-libsasl2-modules-db_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../08-libsasl2-2_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Selecting previously unselected package libldap-2.5-0:amd64.
Preparing to unpack .../09-libldap-2.5-0_2.5.13+dfsg-0ubuntu0.22.04.1_amd64.deb ...
Unpacking libldap-2.5-0:amd64 (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../10-librtmp1_2.4+20151223.gitfa8646d.1-2build4_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../11-libssh-4_0.9.6-2build1_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.6-2build1) ...
Selecting previously unselected package libcurl4:amd64.
Preparing to unpack .../12-libcurl4_7.81.0-1ubuntu1.7_amd64.deb ...
Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.7) ...
Selecting previously unselected package curl.
Preparing to unpack .../13-curl_7.81.0-1ubuntu1.7_amd64.deb ...
Unpacking curl (7.81.0-1ubuntu1.7) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../14-libldap-common_2.5.13+dfsg-0ubuntu0.22.04.1_all.deb ...
Unpacking libldap-common (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../15-libsasl2-modules_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libpsl5:amd64 (0.21.0-1.2build2) ...
Setting up libbrotli1:amd64 (1.0.9-2build6) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libnghttp2-14:amd64 (1.43.0-1build3) ...
Setting up libldap-common (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up tzdata (2022g-0ubuntu0.22.04.1) ...

Current default time zone: 'Etc/UTC'
Local time is now:      Mon Feb 13 15:49:07 UTC 2023.
Universal Time is now:  Mon Feb 13 15:49:07 UTC 2023.
Run 'dpkg-reconfigure tzdata' if you wish to change it.

Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libssh-4:amd64 (0.9.6-2build1) ...
Setting up openssl (3.0.2-0ubuntu1.8) ...
Setting up publicsuffix (20211207.1025-1) ...
Setting up libldap-2.5-0:amd64 (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
124 added, 0 removed; done.
Setting up libcurl4:amd64 (7.81.0-1ubuntu1.7) ...
Setting up curl (7.81.0-1ubuntu1.7) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Processing triggers for ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Removing intermediate container b72d835f515b
 ---> dde565fae8b2
Step 4/7 : RUN mkdir -p /helm
 ---> Running in 43df443634b4
Removing intermediate container 43df443634b4
 ---> 7837cb2faec5
Step 5/7 : WORKDIR /helm
 ---> Running in 4e4dfa677336
Removing intermediate container 4e4dfa677336
 ---> e43f4827f7cd
Step 6/7 : RUN curl -fsSLO "https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz" && 	tar zxvf helm-v3.5.1-linux-amd64.tar.gz && 	mv linux-amd64/helm ./helm && 	rm -rf ./linux-amd64 && 	rm helm-*
 ---> Running in b001a9ebebb5
linux-amd64/
linux-amd64/README.md
linux-amd64/helm
linux-amd64/LICENSE
Removing intermediate container b001a9ebebb5
 ---> 21a5595d5a70
Step 7/7 : RUN curl -fsSLO "https://github.com/roboll/helmfile/releases/download/v0.138.2/helmfile_linux_amd64" && 	mv helmfile_linux_amd64 helmfile && 	chmod +x helmfile
 ---> Running in bb0537d6a081
Removing intermediate container bb0537d6a081
 ---> 82b39113f278
Successfully built 82b39113f278
Successfully tagged helm:latest
docker rm -f helm 2>/dev/null
docker create --name helm helm:latest
9a52171c9ac8ccf29ccb2740d08dda5c40dbd0d6e2cab0c9ce9eb682151607c8
docker cp helm:/helm build/
docker rm helm
helm
```

