### PR TITLE
chore:update image used to package krew

### DIFF
--- a/bundles/krew/Dockerfile
+++ b/bundles/krew/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \


### PR DESCRIPTION
## Description 

chore:update image used to package krew

**Local Test**

```sh

$ make build/krew
mkdir -p build/krew
docker build -t krew -f bundles/krew/Dockerfile bundles/krew
Sending build context to Docker daemon   2.56kB
Step 1/13 : FROM ubuntu:22.04
 ---> a8780b506fa4
Step 2/13 : ENV DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> 446024bf0f30
Step 3/13 : RUN apt-get update &&     apt-get -y install curl apt-transport-https gnupg git tzdata
 ---> Running in a5937f9a6d50
Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:4 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [783 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [107 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:7 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [801 kB]
Get:8 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [5557 B]
Get:9 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [710 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1015 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [781 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [10.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1117 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [22.4 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [49.0 kB]
Fetched 25.6 MB in 3s (9310 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  ca-certificates dirmngr git-man gnupg-l10n gnupg-utils gpg gpg-agent
  gpg-wks-client gpg-wks-server gpgconf gpgsm less libassuan0 libbrotli1
  libbsd0 libcbor0.8 libcurl3-gnutls libcurl4 libedit2 liberror-perl libexpat1
  libfido2-1 libgdbm-compat4 libgdbm6 libksba8 libldap-2.5-0 libldap-common
  libmd0 libnghttp2-14 libnpth0 libperl5.34 libpsl5 libreadline8 librtmp1
  libsasl2-2 libsasl2-modules libsasl2-modules-db libsqlite3-0 libssh-4
  libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1 netbase
  openssh-client openssl patch perl perl-modules-5.34 pinentry-curses
  publicsuffix readline-common xauth
Suggested packages:
  dbus-user-session libpam-systemd pinentry-gnome3 tor gettext-base
  git-daemon-run | git-daemon-sysvinit git-doc git-email git-gui gitk gitweb
  git-cvs git-mediawiki git-svn parcimonie xloadimage scdaemon gdbm-l10n
  libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal
  libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql keychain
  libpam-ssh monkeysphere ssh-askpass ed diffutils-doc perl-doc
  libterm-readline-gnu-perl | libterm-readline-perl-perl make
  libtap-harness-archive-perl pinentry-doc readline-doc
The following NEW packages will be installed:
  apt-transport-https ca-certificates curl dirmngr git git-man gnupg
  gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf
  gpgsm less libassuan0 libbrotli1 libbsd0 libcbor0.8 libcurl3-gnutls libcurl4
  libedit2 liberror-perl libexpat1 libfido2-1 libgdbm-compat4 libgdbm6
  libksba8 libldap-2.5-0 libldap-common libmd0 libnghttp2-14 libnpth0
  libperl5.34 libpsl5 libreadline8 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libsqlite3-0 libssh-4 libx11-6 libx11-data libxau6
  libxcb1 libxdmcp6 libxext6 libxmuu1 netbase openssh-client openssl patch
  perl perl-modules-5.34 pinentry-curses publicsuffix readline-common tzdata
  xauth
0 upgraded, 61 newly installed, 0 to remove and 11 not upgraded.
Need to get 21.4 MB of archives.
After this operation, 97.3 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 perl-modules-5.34 all 5.34.0-3ubuntu1.1 [2976 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy/main amd64 libgdbm6 amd64 1.23-1 [33.9 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy/main amd64 libgdbm-compat4 amd64 1.23-1 [6606 B]
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libperl5.34 amd64 5.34.0-3ubuntu1.1 [4819 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 perl amd64 5.34.0-3ubuntu1.1 [232 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openssl amd64 3.0.2-0ubuntu1.8 [1184 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 ca-certificates all 20211016ubuntu0.22.04.1 [144 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 less amd64 590-1ubuntu0.22.04.1 [143 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 libmd0 amd64 1.0.4-1build1 [23.0 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbsd0 amd64 0.11.5-1 [44.8 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libexpat1 amd64 2.4.7-1ubuntu0.2 [91.0 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/main amd64 readline-common all 8.1.2-1 [53.5 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy/main amd64 libreadline8 amd64 8.1.2-1 [153 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsqlite3-0 amd64 3.37.2-2ubuntu0.1 [641 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy/main amd64 netbase all 6.3 [12.9 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 tzdata all 2022g-0ubuntu0.22.04.1 [333 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy/main amd64 libcbor0.8 amd64 0.8.0-2ubuntu1 [24.6 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy/main amd64 libedit2 amd64 3.1-20210910-1build1 [96.8 kB]
Get:19 http://archive.ubuntu.com/ubuntu jammy/main amd64 libfido2-1 amd64 1.10.0-1 [82.8 kB]
Get:20 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnghttp2-14 amd64 1.43.0-1build3 [76.3 kB]
Get:21 http://archive.ubuntu.com/ubuntu jammy/main amd64 libpsl5 amd64 0.21.0-1.2build2 [58.4 kB]
Get:22 http://archive.ubuntu.com/ubuntu jammy/main amd64 libxau6 amd64 1:1.0.9-1build5 [7634 B]
Get:23 http://archive.ubuntu.com/ubuntu jammy/main amd64 libxdmcp6 amd64 1:1.1.3-0ubuntu5 [10.9 kB]
Get:24 http://archive.ubuntu.com/ubuntu jammy/main amd64 libxcb1 amd64 1.14-3ubuntu3 [49.0 kB]
Get:25 http://archive.ubuntu.com/ubuntu jammy/main amd64 libx11-data all 2:1.7.5-1 [119 kB]
Get:26 http://archive.ubuntu.com/ubuntu jammy/main amd64 libx11-6 amd64 2:1.7.5-1 [666 kB]
Get:27 http://archive.ubuntu.com/ubuntu jammy/main amd64 libxext6 amd64 2:1.3.4-1build1 [31.8 kB]
Get:28 http://archive.ubuntu.com/ubuntu jammy/main amd64 libxmuu1 amd64 2:1.1.3-3 [10.2 kB]
Get:29 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openssh-client amd64 1:8.9p1-3ubuntu0.1 [908 kB]
Get:30 http://archive.ubuntu.com/ubuntu jammy/main amd64 publicsuffix all 20211207.1025-1 [129 kB]
Get:31 http://archive.ubuntu.com/ubuntu jammy/main amd64 xauth amd64 1:1.1-1build2 [27.5 kB]
Get:32 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 apt-transport-https all 2.4.8 [1506 B]
Get:33 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbrotli1 amd64 1.0.9-2build6 [315 kB]
Get:34 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg2-3ubuntu1.1 [20.6 kB]
Get:35 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-2 amd64 2.1.27+dfsg2-3ubuntu1.1 [53.8 kB]
Get:36 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-2.5-0 amd64 2.5.13+dfsg-0ubuntu0.22.04.1 [183 kB]
Get:37 http://archive.ubuntu.com/ubuntu jammy/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build4 [58.2 kB]
Get:38 http://archive.ubuntu.com/ubuntu jammy/main amd64 libssh-4 amd64 0.9.6-2build1 [184 kB]
Get:39 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.7 [289 kB]
Get:40 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.7 [193 kB]
Get:41 http://archive.ubuntu.com/ubuntu jammy/main amd64 libassuan0 amd64 2.5.5-1build1 [38.2 kB]
Get:42 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpgconf amd64 2.2.27-3ubuntu2.1 [94.2 kB]
Get:43 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libksba8 amd64 1.6.0-2ubuntu0.2 [119 kB]
Get:44 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnpth0 amd64 1.6-3build2 [8664 B]
Get:45 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 dirmngr amd64 2.2.27-3ubuntu2.1 [293 kB]
Get:46 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl3-gnutls amd64 7.81.0-1ubuntu1.7 [283 kB]
Get:47 http://archive.ubuntu.com/ubuntu jammy/main amd64 liberror-perl all 0.17029-1 [26.5 kB]
Get:48 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 git-man all 1:2.34.1-1ubuntu1.6 [953 kB]
Get:49 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 git amd64 1:2.34.1-1ubuntu1.6 [3142 kB]
Get:50 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg-l10n all 2.2.27-3ubuntu2.1 [54.4 kB]
Get:51 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg-utils amd64 2.2.27-3ubuntu2.1 [308 kB]
Get:52 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg amd64 2.2.27-3ubuntu2.1 [519 kB]
Get:53 http://archive.ubuntu.com/ubuntu jammy/main amd64 pinentry-curses amd64 1.1.1-1build2 [34.4 kB]
Get:54 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-agent amd64 2.2.27-3ubuntu2.1 [209 kB]
Get:55 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-wks-client amd64 2.2.27-3ubuntu2.1 [62.7 kB]
Get:56 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-wks-server amd64 2.2.27-3ubuntu2.1 [57.5 kB]
Get:57 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpgsm amd64 2.2.27-3ubuntu2.1 [197 kB]
Get:58 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg all 2.2.27-3ubuntu2.1 [315 kB]
Get:59 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-common all 2.5.13+dfsg-0ubuntu0.22.04.1 [15.9 kB]
Get:60 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules amd64 2.1.27+dfsg2-3ubuntu1.1 [57.2 kB]
Get:61 http://archive.ubuntu.com/ubuntu jammy/main amd64 patch amd64 2.7.6-7build2 [109 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 21.4 MB in 3s (7974 kB/s)
Selecting previously unselected package perl-modules-5.34.
(Reading database ... 4395 files and directories currently installed.)
Preparing to unpack .../00-perl-modules-5.34_5.34.0-3ubuntu1.1_all.deb ...
Unpacking perl-modules-5.34 (5.34.0-3ubuntu1.1) ...
Selecting previously unselected package libgdbm6:amd64.
Preparing to unpack .../01-libgdbm6_1.23-1_amd64.deb ...
Unpacking libgdbm6:amd64 (1.23-1) ...
Selecting previously unselected package libgdbm-compat4:amd64.
Preparing to unpack .../02-libgdbm-compat4_1.23-1_amd64.deb ...
Unpacking libgdbm-compat4:amd64 (1.23-1) ...
Selecting previously unselected package libperl5.34:amd64.
Preparing to unpack .../03-libperl5.34_5.34.0-3ubuntu1.1_amd64.deb ...
Unpacking libperl5.34:amd64 (5.34.0-3ubuntu1.1) ...
Selecting previously unselected package perl.
Preparing to unpack .../04-perl_5.34.0-3ubuntu1.1_amd64.deb ...
Unpacking perl (5.34.0-3ubuntu1.1) ...
Selecting previously unselected package openssl.
Preparing to unpack .../05-openssl_3.0.2-0ubuntu1.8_amd64.deb ...
Unpacking openssl (3.0.2-0ubuntu1.8) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../06-ca-certificates_20211016ubuntu0.22.04.1_all.deb ...
Unpacking ca-certificates (20211016ubuntu0.22.04.1) ...
Selecting previously unselected package less.
Preparing to unpack .../07-less_590-1ubuntu0.22.04.1_amd64.deb ...
Unpacking less (590-1ubuntu0.22.04.1) ...
Selecting previously unselected package libmd0:amd64.
Preparing to unpack .../08-libmd0_1.0.4-1build1_amd64.deb ...
Unpacking libmd0:amd64 (1.0.4-1build1) ...
Selecting previously unselected package libbsd0:amd64.
Preparing to unpack .../09-libbsd0_0.11.5-1_amd64.deb ...
Unpacking libbsd0:amd64 (0.11.5-1) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../10-libexpat1_2.4.7-1ubuntu0.2_amd64.deb ...
Unpacking libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Selecting previously unselected package readline-common.
Preparing to unpack .../11-readline-common_8.1.2-1_all.deb ...
Unpacking readline-common (8.1.2-1) ...
Selecting previously unselected package libreadline8:amd64.
Preparing to unpack .../12-libreadline8_8.1.2-1_amd64.deb ...
Unpacking libreadline8:amd64 (8.1.2-1) ...
Selecting previously unselected package libsqlite3-0:amd64.
Preparing to unpack .../13-libsqlite3-0_3.37.2-2ubuntu0.1_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.37.2-2ubuntu0.1) ...
Selecting previously unselected package netbase.
Preparing to unpack .../14-netbase_6.3_all.deb ...
Unpacking netbase (6.3) ...
Selecting previously unselected package tzdata.
Preparing to unpack .../15-tzdata_2022g-0ubuntu0.22.04.1_all.deb ...
Unpacking tzdata (2022g-0ubuntu0.22.04.1) ...
Selecting previously unselected package libcbor0.8:amd64.
Preparing to unpack .../16-libcbor0.8_0.8.0-2ubuntu1_amd64.deb ...
Unpacking libcbor0.8:amd64 (0.8.0-2ubuntu1) ...
Selecting previously unselected package libedit2:amd64.
Preparing to unpack .../17-libedit2_3.1-20210910-1build1_amd64.deb ...
Unpacking libedit2:amd64 (3.1-20210910-1build1) ...
Selecting previously unselected package libfido2-1:amd64.
Preparing to unpack .../18-libfido2-1_1.10.0-1_amd64.deb ...
Unpacking libfido2-1:amd64 (1.10.0-1) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../19-libnghttp2-14_1.43.0-1build3_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.43.0-1build3) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../20-libpsl5_0.21.0-1.2build2_amd64.deb ...
Unpacking libpsl5:amd64 (0.21.0-1.2build2) ...
Selecting previously unselected package libxau6:amd64.
Preparing to unpack .../21-libxau6_1%3a1.0.9-1build5_amd64.deb ...
Unpacking libxau6:amd64 (1:1.0.9-1build5) ...
Selecting previously unselected package libxdmcp6:amd64.
Preparing to unpack .../22-libxdmcp6_1%3a1.1.3-0ubuntu5_amd64.deb ...
Unpacking libxdmcp6:amd64 (1:1.1.3-0ubuntu5) ...
Selecting previously unselected package libxcb1:amd64.
Preparing to unpack .../23-libxcb1_1.14-3ubuntu3_amd64.deb ...
Unpacking libxcb1:amd64 (1.14-3ubuntu3) ...
Selecting previously unselected package libx11-data.
Preparing to unpack .../24-libx11-data_2%3a1.7.5-1_all.deb ...
Unpacking libx11-data (2:1.7.5-1) ...
Selecting previously unselected package libx11-6:amd64.
Preparing to unpack .../25-libx11-6_2%3a1.7.5-1_amd64.deb ...
Unpacking libx11-6:amd64 (2:1.7.5-1) ...
Selecting previously unselected package libxext6:amd64.
Preparing to unpack .../26-libxext6_2%3a1.3.4-1build1_amd64.deb ...
Unpacking libxext6:amd64 (2:1.3.4-1build1) ...
Selecting previously unselected package libxmuu1:amd64.
Preparing to unpack .../27-libxmuu1_2%3a1.1.3-3_amd64.deb ...
Unpacking libxmuu1:amd64 (2:1.1.3-3) ...
Selecting previously unselected package openssh-client.
Preparing to unpack .../28-openssh-client_1%3a8.9p1-3ubuntu0.1_amd64.deb ...
Unpacking openssh-client (1:8.9p1-3ubuntu0.1) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../29-publicsuffix_20211207.1025-1_all.deb ...
Unpacking publicsuffix (20211207.1025-1) ...
Selecting previously unselected package xauth.
Preparing to unpack .../30-xauth_1%3a1.1-1build2_amd64.deb ...
Unpacking xauth (1:1.1-1build2) ...
Selecting previously unselected package apt-transport-https.
Preparing to unpack .../31-apt-transport-https_2.4.8_all.deb ...
Unpacking apt-transport-https (2.4.8) ...
Selecting previously unselected package libbrotli1:amd64.
Preparing to unpack .../32-libbrotli1_1.0.9-2build6_amd64.deb ...
Unpacking libbrotli1:amd64 (1.0.9-2build6) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../33-libsasl2-modules-db_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../34-libsasl2-2_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Selecting previously unselected package libldap-2.5-0:amd64.
Preparing to unpack .../35-libldap-2.5-0_2.5.13+dfsg-0ubuntu0.22.04.1_amd64.deb ...
Unpacking libldap-2.5-0:amd64 (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../36-librtmp1_2.4+20151223.gitfa8646d.1-2build4_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../37-libssh-4_0.9.6-2build1_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.6-2build1) ...
Selecting previously unselected package libcurl4:amd64.
Preparing to unpack .../38-libcurl4_7.81.0-1ubuntu1.7_amd64.deb ...
Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.7) ...
Selecting previously unselected package curl.
Preparing to unpack .../39-curl_7.81.0-1ubuntu1.7_amd64.deb ...
Unpacking curl (7.81.0-1ubuntu1.7) ...
Selecting previously unselected package libassuan0:amd64.
Preparing to unpack .../40-libassuan0_2.5.5-1build1_amd64.deb ...
Unpacking libassuan0:amd64 (2.5.5-1build1) ...
Selecting previously unselected package gpgconf.
Preparing to unpack .../41-gpgconf_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpgconf (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package libksba8:amd64.
Preparing to unpack .../42-libksba8_1.6.0-2ubuntu0.2_amd64.deb ...
Unpacking libksba8:amd64 (1.6.0-2ubuntu0.2) ...
Selecting previously unselected package libnpth0:amd64.
Preparing to unpack .../43-libnpth0_1.6-3build2_amd64.deb ...
Unpacking libnpth0:amd64 (1.6-3build2) ...
Selecting previously unselected package dirmngr.
Preparing to unpack .../44-dirmngr_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking dirmngr (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../45-libcurl3-gnutls_7.81.0-1ubuntu1.7_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.81.0-1ubuntu1.7) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../46-liberror-perl_0.17029-1_all.deb ...
Unpacking liberror-perl (0.17029-1) ...
Selecting previously unselected package git-man.
Preparing to unpack .../47-git-man_1%3a2.34.1-1ubuntu1.6_all.deb ...
Unpacking git-man (1:2.34.1-1ubuntu1.6) ...
Selecting previously unselected package git.
Preparing to unpack .../48-git_1%3a2.34.1-1ubuntu1.6_amd64.deb ...
Unpacking git (1:2.34.1-1ubuntu1.6) ...
Selecting previously unselected package gnupg-l10n.
Preparing to unpack .../49-gnupg-l10n_2.2.27-3ubuntu2.1_all.deb ...
Unpacking gnupg-l10n (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gnupg-utils.
Preparing to unpack .../50-gnupg-utils_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gnupg-utils (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg.
Preparing to unpack .../51-gpg_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package pinentry-curses.
Preparing to unpack .../52-pinentry-curses_1.1.1-1build2_amd64.deb ...
Unpacking pinentry-curses (1.1.1-1build2) ...
Selecting previously unselected package gpg-agent.
Preparing to unpack .../53-gpg-agent_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-agent (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg-wks-client.
Preparing to unpack .../54-gpg-wks-client_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-wks-client (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg-wks-server.
Preparing to unpack .../55-gpg-wks-server_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-wks-server (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpgsm.
Preparing to unpack .../56-gpgsm_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpgsm (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gnupg.
Preparing to unpack .../57-gnupg_2.2.27-3ubuntu2.1_all.deb ...
Unpacking gnupg (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../58-libldap-common_2.5.13+dfsg-0ubuntu0.22.04.1_all.deb ...
Unpacking libldap-common (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../59-libsasl2-modules_2.1.27+dfsg2-3ubuntu1.1_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Selecting previously unselected package patch.
Preparing to unpack .../60-patch_2.7.6-7build2_amd64.deb ...
Unpacking patch (2.7.6-7build2) ...
Setting up libksba8:amd64 (1.6.0-2ubuntu0.2) ...
Setting up libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Setting up libxau6:amd64 (1:1.0.9-1build5) ...
Setting up libpsl5:amd64 (0.21.0-1.2build2) ...
Setting up apt-transport-https (2.4.8) ...
Setting up libcbor0.8:amd64 (0.8.0-2ubuntu1) ...
Setting up libbrotli1:amd64 (1.0.9-2build6) ...
Setting up libsqlite3-0:amd64 (3.37.2-2ubuntu0.1) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libnghttp2-14:amd64 (1.43.0-1build3) ...
Setting up less (590-1ubuntu0.22.04.1) ...
Setting up libnpth0:amd64 (1.6-3build2) ...
Setting up libassuan0:amd64 (2.5.5-1build1) ...
Setting up perl-modules-5.34 (5.34.0-3ubuntu1.1) ...
Setting up libldap-common (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up tzdata (2022g-0ubuntu0.22.04.1) ...

Current default time zone: 'Etc/UTC'
Local time is now:      Mon Feb 13 15:52:31 UTC 2023.
Universal Time is now:  Mon Feb 13 15:52:31 UTC 2023.
Run 'dpkg-reconfigure tzdata' if you wish to change it.

Setting up libx11-data (2:1.7.5-1) ...
Setting up gnupg-l10n (2.2.27-3ubuntu2.1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Setting up patch (2.7.6-7build2) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.1) ...
Setting up libssh-4:amd64 (0.9.6-2build1) ...
Setting up libmd0:amd64 (1.0.4-1build1) ...
Setting up git-man (1:2.34.1-1ubuntu1.6) ...
Setting up netbase (6.3) ...
Setting up libfido2-1:amd64 (1.10.0-1) ...
Setting up openssl (3.0.2-0ubuntu1.8) ...
Setting up libbsd0:amd64 (0.11.5-1) ...
Setting up readline-common (8.1.2-1) ...
Setting up publicsuffix (20211207.1025-1) ...
Setting up libgdbm6:amd64 (1.23-1) ...
Setting up pinentry-curses (1.1.1-1build2) ...
Setting up libxdmcp6:amd64 (1:1.1.3-0ubuntu5) ...
Setting up libxcb1:amd64 (1.14-3ubuntu3) ...
Setting up libedit2:amd64 (3.1-20210910-1build1) ...
Setting up libreadline8:amd64 (8.1.2-1) ...
Setting up libldap-2.5-0:amd64 (2.5.13+dfsg-0ubuntu0.22.04.1) ...
Setting up ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
124 added, 0 removed; done.
Setting up libgdbm-compat4:amd64 (1.23-1) ...
Setting up gpgconf (2.2.27-3ubuntu2.1) ...
Setting up libcurl4:amd64 (7.81.0-1ubuntu1.7) ...
Setting up libx11-6:amd64 (2:1.7.5-1) ...
Setting up curl (7.81.0-1ubuntu1.7) ...
Setting up libxmuu1:amd64 (2:1.1.3-3) ...
Setting up gpg (2.2.27-3ubuntu2.1) ...
Setting up gnupg-utils (2.2.27-3ubuntu2.1) ...
Setting up libperl5.34:amd64 (5.34.0-3ubuntu1.1) ...
Setting up gpg-agent (2.2.27-3ubuntu2.1) ...
Setting up openssh-client (1:8.9p1-3ubuntu0.1) ...
update-alternatives: using /usr/bin/ssh to provide /usr/bin/rsh (rsh) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/rsh.1.gz because associated file /usr/share/man/man1/ssh.1.gz (of link group rsh) doesn't exist
update-alternatives: using /usr/bin/slogin to provide /usr/bin/rlogin (rlogin) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/rlogin.1.gz because associated file /usr/share/man/man1/slogin.1.gz (of link group rlogin) doesn't exist
update-alternatives: using /usr/bin/scp to provide /usr/bin/rcp (rcp) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/rcp.1.gz because associated file /usr/share/man/man1/scp.1.gz (of link group rcp) doesn't exist
Setting up gpgsm (2.2.27-3ubuntu2.1) ...
Setting up libxext6:amd64 (2:1.3.4-1build1) ...
Setting up libcurl3-gnutls:amd64 (7.81.0-1ubuntu1.7) ...
Setting up dirmngr (2.2.27-3ubuntu2.1) ...
Setting up perl (5.34.0-3ubuntu1.1) ...
Setting up gpg-wks-server (2.2.27-3ubuntu2.1) ...
Setting up xauth (1:1.1-1build2) ...
Setting up gpg-wks-client (2.2.27-3ubuntu2.1) ...
Setting up liberror-perl (0.17029-1) ...
Setting up git (1:2.34.1-1ubuntu1.6) ...
Setting up gnupg (2.2.27-3ubuntu2.1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Processing triggers for ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Removing intermediate container a5937f9a6d50
 ---> 987fb72ae1dd
Step 4/13 : RUN mkdir -p /krew
 ---> Running in 2e0ddea7fa24
Removing intermediate container 2e0ddea7fa24
 ---> 13737a070993
Step 5/13 : WORKDIR /krew
 ---> Running in 3f361bd1af68
Removing intermediate container 3f361bd1af68
 ---> ef3ef1c812e2
Step 6/13 : RUN curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/v0.3.2/krew.{tar.gz,yaml}" && 	tar zxvf krew.tar.gz && 	./krew-linux_amd64 install --manifest=krew.yaml --archive=krew.tar.gz && 	./krew-linux_amd64 update && 	rm krew-*
 ---> Running in 91c3ba20f469
./krew-darwin_amd64
./krew-linux_amd64
./krew-linux_arm
./krew-windows_amd64.exe
WARNING: Detected stdin, but discarding it because of --manifest or args
Installing plugin: krew
CAVEATS:
\
 |  krew is now installed! To start using kubectl plugins, you need to add
 |  krew's installation directory to your PATH:
 |  
 |    * macOS/Linux:
 |      - Add the following to your ~/.bashrc or ~/.zshrc:
 |          export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 |      - Restart your shell.
 |  
 |    * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable
 |  
 |  To list krew commands and to get help, run:
 |    $ kubectl krew
 |  For a full list of available plugins, run:
 |    $ kubectl krew search
 |  
 |  You can find documentation at https://sigs.k8s.io/krew.
/
Installed plugin: krew
WARNING: You installed a plugin from the krew-index plugin repository.
   These plugins are not audited for security by the Krew maintainers.
   Run them at your own risk.
Updated the local copy of plugin index.
Removing intermediate container 91c3ba20f469
 ---> c51d1a088b4e
Step 7/13 : RUN cp /root/.krew/index/plugins/outdated.yaml /krew
 ---> Running in 7a2f49510220
Removing intermediate container 7a2f49510220
 ---> 65e44b2bf1c7
Step 8/13 : RUN cp /root/.krew/index/plugins/preflight.yaml /krew
 ---> Running in d7c557eb21fe
Removing intermediate container d7c557eb21fe
 ---> d9ff3c810ecb
Step 9/13 : RUN cp /root/.krew/index/plugins/support-bundle.yaml /krew
 ---> Running in a7f9b94b1d7f
Removing intermediate container a7f9b94b1d7f
 ---> 087d101cc2d9
Step 10/13 : RUN tar cf index.tar -C /root/.krew index
 ---> Running in 5744b1cb25a5
Removing intermediate container 5744b1cb25a5
 ---> fd751413e617
Step 11/13 : RUN curl -L $(cat /root/.krew/index/plugins/outdated.yaml | grep linux_amd64 | awk '{ print $2 }') > outdated.tar.gz
 ---> Running in a2ccf381d93c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 8171k  100 8171k    0     0  3661k      0  0:00:02  0:00:02 --:--:-- 4613k
Removing intermediate container a2ccf381d93c
 ---> bb292b457e8d
Step 12/13 : RUN curl -L $(cat /root/.krew/index/plugins/preflight.yaml | grep linux_amd64 | awk '{ print $2 }') > preflight.tar.gz
 ---> Running in 6e0322538c35
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 19.0M  100 19.0M    0     0  14.1M      0  0:00:01  0:00:01 --:--:-- 20.0M
Removing intermediate container 6e0322538c35
 ---> 6a214da1c4b1
Step 13/13 : RUN curl -L $(cat /root/.krew/index/plugins/support-bundle.yaml | grep linux_amd64 | awk '{ print $2 }') > support-bundle.tar.gz
 ---> Running in 79864298be5a
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 19.1M  100 19.1M    0     0  8880k      0  0:00:02  0:00:02 --:--:-- 18.0M
Removing intermediate container 79864298be5a
 ---> ff2c7f25c6d1
Successfully built ff2c7f25c6d1
Successfully tagged krew:latest
docker rm -f krew 2>/dev/null
docker create --name krew krew:latest
c9ff777c295443240d08bbfbbac2d17676068b541c09c84c8536259f5deb190d
docker cp krew:/krew build/
docker rm krew
krew
```