### PR TITLE
chore: add minio and registry to longhorn to rook/openebs testgrids

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -184,6 +184,8 @@
       version: "latest"
     prometheus:
       version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
     longhorn:
       version: "1.3.1"
   upgradeSpec:
@@ -197,6 +199,8 @@
       version: "latest"
     prometheus:
       version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
     openebs:
       isLocalPVEnabled: true
       localPVStorageClassName: openebs

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -186,6 +186,8 @@
       version: "0.60.1-41.7.3"
     minio:
       version: "latest"
+    registry:
+      version: "2.8.1"
     longhorn:
       version: "1.3.1"
   upgradeSpec:
@@ -201,6 +203,8 @@
       version: "0.60.1-41.7.3"
     minio:
       version: "latest"
+    registry:
+      version: "2.8.1"
     openebs:
       isLocalPVEnabled: true
       localPVStorageClassName: openebs

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -357,6 +357,8 @@
       version: "latest"
     ekco:
       version: "latest"
+    registry:
+      version: "2.7.1"
     longhorn:
       version: "latest"
   upgradeSpec:
@@ -368,6 +370,8 @@
       version: "latest"
     ekco:
       version: "latest"
+    registry:
+      version: "2.8.1"
     rook:
       version: "__testver__"
       s3Override: "__testdist__"


### PR DESCRIPTION
#### What this PR does / why we need it:

We plan to test pushing and pulling from the Registry when migrating from Longhorn to OpenEBS and Rook. This PR adds Minio and Registry to the migrations testgrid cases.
