### PR TITLE
chore: enable push and pull tests for longhorn migration.

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -217,6 +217,8 @@
     create_deployment_with_mounted_volume "migration-test" "default" "/data"
     # generate a random file and copies it to the pod deployed by the previously created deployment.
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    # pushes an image to the internal registry.
+    test_push_image_to_registry
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     # sleep for a while to guarantee that the pod has been scaled up.
@@ -225,6 +227,8 @@
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     # makes sure that the new pvc is being provisioned by openebs.
     pvc_uses_provisioner "migration-test" "default" "openebs"
+    # pulls the image we pushed before the migration.
+    test_pull_image_from_registry
 
 - name: localpv upgrade from latest
   flags: "yes"

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -384,6 +384,8 @@
     create_deployment_with_mounted_volume "migration-test" "default" "/data"
     # generate a random file and copies it to the pod deployed by the previously created deployment.
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    # pushes an image to the internal registry.
+    test_push_image_to_registry
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     # sleep for a while to guarantee that the pod has been scaled up.
@@ -392,3 +394,5 @@
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     # makes sure that the new pvc is being provisioned by rook.
     pvc_uses_provisioner "migration-test" "default" "rook"
+    # pulls the image we pushed before the migration.
+    test_pull_image_from_registry


### PR DESCRIPTION
#### What this PR does / why we need it:

Pushes an image to the internal registry after installing the cluster and attempts to pull it once the migration from Longhorn has been finished.