### PR TITLE
Report kurl_cluster_uuid to make it possible to tie runs on different instances in a cluster together

### DIFF
--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -6,7 +6,6 @@ TESTGRID_ID=
 function report_install_start() {
     # report that the install started
     # this includes the install ID, time, kurl URL, and linux distribution name + version.
-    # TODO: HA status, server CPU count and memory size.
 
     if [ -f "/tmp/testgrid-id" ]; then
         TESTGRID_ID=$(cat /tmp/testgrid-id)
@@ -32,7 +31,20 @@ function report_install_start() {
      fi
 
      curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"started\": \"$started\", \"os\": \"$LSB_DIST $DIST_VERSION\", \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \"kurl_url\": \"$KURL_URL\", \"installer_id\": \"$INSTALLER_ID\", \"testgrid_id\": \"$TESTGRID_ID\", \"machine_id\": \"$MACHINE_ID\", \"kurl_instance_uuid\": \"$KURL_INSTANCE_UUID\", \"is_upgrade\": $is_upgrade}" \
+        -d "{\
+        \"started\": \"$started\", \
+        \"os\": \"$LSB_DIST $DIST_VERSION\", \
+        \"kernel_version\": \"$KERNEL_MAJOR.$KERNEL_MINOR\", \
+        \"kurl_url\": \"$KURL_URL\", \
+        \"installer_id\": \"$INSTALLER_ID\", \
+        \"testgrid_id\": \"$TESTGRID_ID\", \
+        \"machine_id\": \"$MACHINE_ID\", \
+        \"kurl_instance_uuid\": \"$KURL_INSTANCE_UUID\", \
+        \"is_upgrade\": $is_upgrade, \
+        \"is_ha_cluster\": \"$HA_CLUSTER\" \
+        \"num_processors\": \"$(nproc)\", \
+        \"memory_size_kb\": \"$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')\" \
+        }" \
         $REPLICATED_APP_URL/kurl_metrics/start_install/$INSTALLATION_ID || true
 }
 

--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -162,7 +162,7 @@ function addon_install_fail_nobundle() {
     local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
 
     curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
-        -d "{\"finished\": \"$completed\", \"machine_id\": \"$MACHINE_ID\", \"kurl_uuid\": \"$KURL_UUID\"}" \
+        -d "{\"finished\": \"$completed\"}" \
         $REPLICATED_APP_URL/kurl_metrics/fail_addon/$INSTALLATION_ID/$name || true
 
     return 1 # return error because the addon in question did too

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -556,6 +556,7 @@ function main() {
     report_kubernetes_install
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed
     kurl_init_config
+    maybe_set_kurl_cluster_uuid
     ${K8S_DISTRO}_addon_for_each addon_install
     maybe_cleanup_rook
     maybe_cleanup_longhorn


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This reports a new parameter, kurl_cluster_uuid, which is common to all instances in a cluster.

It also finally reports HA status, nprocs, and memtotal, because 🤦 .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
