### PR TITLE
chore: Update daily cronjob to create test with commit ref

### DIFF
--- a/.github/workflows/cron-testgrid-daily.yaml
+++ b/.github/workflows/cron-testgrid-daily.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         docker run --rm -e TESTGRID_API_TOKEN -v `pwd`:/wrk -w /wrk \
           replicated/tgrun:latest queue --staging \
-            --ref "STAGING-daily-$(date --utc +%FT%TZ)" \
+            --ref "STAGING-daily-$(git rev-list "${GITHUB_REF_NAME}" -n 1 | xargs git rev-parse --short)-$(date --utc +%FT%TZ)" \
             --spec ./testgrid/specs/full.yaml \
             --os-spec ./testgrid/specs/os-firstlast.yaml \
             --priority -1


### PR DESCRIPTION
The daily tests names does not have the commit id.
This PR adds the commit id for we are able to easily check what was the commit tested with

