### PR TITLE
chore: Revert changes made that broken the main branch (PR #4100 and  #4093)

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -874,7 +874,7 @@ function get_machine_id() {
     if [ -f /var/lib/kurl/uuid ]; then
         KURL_INSTANCE_UUID="$(cat /var/lib/kurl/uuid)"
     else
-        KURL_INSTANCE_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
+        KURL_INSTANCE_UUID="$(uuidgen)"
         mkdir -p /var/lib/kurl
         echo "$KURL_INSTANCE_UUID" > /var/lib/kurl/uuid
     fi

--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -269,7 +269,7 @@ function stacktrace {
 # if it does not exist, make a new UUID for KURL_CLUSTER_UUID.
 function attempt_get_cluster_id() {
     if ! kubernetes_resource_exists kurl configmap kurl_cluster_uuid; then
-        KURL_CLUSTER_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
+        KURL_CLUSTER_UUID="$(uuidgen)"
         return 0
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -560,7 +560,6 @@ function main() {
     report_kubernetes_install
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed
     kurl_init_config
-    maybe_set_kurl_cluster_uuid
     ${K8S_DISTRO}_addon_for_each addon_install
     maybe_cleanup_rook
     maybe_cleanup_longhorn


### PR DESCRIPTION
#### What this PR does / why we need it:

We broke the main branch, see that testgrid is failing for all tests; https://testgrid.kurl.sh/run/STAGING-daily--2023-02-15T01:28:51Z.

```sh
2023-02-15 03:23:01+00:00 error: failed to create configmap: ConfigMap "kurl_cluster_uuid" is invalid: metadata.name: Invalid value: "kurl_cluster_uuid": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
2023-02-15 03:23:01+00:00 An error occurred on line 5234
2023-02-15 03:23:01+00:00 Would you like to provide a support bundle to aid us in avoiding similar errors in the future?
2023-02-15 03:23:01+00:00 (y/N) main: line 4421: /dev/tty: No such device or address
+ KURL_EXIT_STATUS=1
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl install with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
```

See: https://testgrid.kurl.sh/run/STAGING-release-v2023.02.14-0-db8532ca-20230214201141

It seems to be related to the following commits which are reverting here:

```
commit a33c262e1baec492e313a4dadc6bcd54e416707e (HEAD -> main, origin/main, origin/HEAD)
Merge: db8532ca 55102b87
Author: Andrew Lavery <laverya@umich.edu>
Date:   Tue Feb 14 14:53:20 2023 -0600

    Merge pull request #4100 from replicatedhq/laverya/sc-63060/make-machineid-available-to-kots
    
    remove the use of uuidgen, as it is not always present

commit 55102b872ec70da45c82f6889048301e4781ef3a
Author: Andrew Lavery <laverya@umich.edu>
Date:   Tue Feb 14 14:39:49 2023 -0600

    remove the use of uuidgen, as it is not always present

commit db8532ca882f431bece94af30a25d45941e19ecc
Merge: 62bd7699 87c5fc6c
Author: Andrew Lavery <laverya@umich.edu>
Date:   Tue Feb 14 13:46:50 2023 -0600

    Merge pull request #4093 from replicatedhq/laverya/sc-63060/make-machineid-available-to-kots
    
    Report kurl_cluster_uuid to make it possible to tie runs on different instances in a cluster together
:
```

