### PR TITLE
chore: do not wait for namespace to dissapear.

### DIFF
--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -191,7 +191,7 @@ function remove_longhorn() {
     kubectl get crd | grep 'longhorn' | awk '{ print $1 }' | xargs -I'{}' kubectl delete crd '{}'
 
     # delete longhorn ns
-    kubectl delete ns longhorn-system
+    kubectl delete ns longhorn-system --wait=false
 
     # delete longhorn storageclass(es)
     log "Removing Longhorn StorageClasses"


### PR DESCRIPTION
#### What this PR does / why we need it:

We have a testgrid case where the `longhorn-system` namespace is taking ages to disappear. This causes the testgrid to timeout after 45 minutes. I have tried this very same test case and I could not reproduce it.

I have tried it with:

- ubuntu 22.04
- oracle linux 2

Both attempts were made using machines with 4 cpus and 16gb of ram, a configuration that has the same amount of memory and less cpu power than the testgrid has, in all cases the Namespace takes a few seconds to disappear but it always go away.

If I take these two specific attempts at reproducing and add the amount of times I have manually tested the migration on top without seeing this issue it is somewhat safe to assume that this might be related to some hardware constraints in testgrid (maybe when many tests are running at the same time).

This PR adds the `--wait=false` flag to the kubectl longhorn-system delete operation, allowing the installer to move on and the cluster to delete the resources whenever it feels like it is ready to do so.

The longhorn-system namespace reports:

```json
      "status": {
        "phase": "Terminating",
        "conditions": [
          {
            "type": "NamespaceDeletionDiscoveryFailure",
            "status": "False",
            "lastTransitionTime": "2023-02-14T17:31:29Z",
            "reason": "ResourcesDiscovered",
            "message": "All resources successfully discovered"
          },
          {
            "type": "NamespaceDeletionGroupVersionParsingFailure",
            "status": "False",
            "lastTransitionTime": "2023-02-14T17:31:29Z",
            "reason": "ParsedGroupVersions",
            "message": "All legacy kube types successfully parsed"
          },
          {
            "type": "NamespaceDeletionContentFailure",
            "status": "True",
            "lastTransitionTime": "2023-02-14T17:32:05Z",
            "reason": "ContentDeletionFailed",
            "message": "Failed to delete all resource types, 1 remaining: unexpected items still remain in namespace: longhorn-system for gvr: /v1, Resource=pods"
          },
          {
            "type": "NamespaceContentRemaining",
            "status": "True",
            "lastTransitionTime": "2023-02-14T17:31:29Z",
            "reason": "SomeResourcesRemain",
            "message": "Some resources are remaining: pods. has 4 resource instances"
          },
          {
            "type": "NamespaceFinalizersRemaining",
            "status": "False",
            "lastTransitionTime": "2023-02-14T17:31:29Z",
            "reason": "ContentHasNoFinalizers",
            "message": "All content-preserving finalizers finished"
          }
        ]
      }
```

There is no clear error other than 4 pods dangling in the Namespace. These 4 pods were all running in the same Node and (funny enough) both worker nodes have the following in their statuses:

```json
        "conditions": [
          {
            "type": "NetworkUnavailable",
            "status": "False",
            "lastHeartbeatTime": "2023-02-14T17:04:17Z",
            "lastTransitionTime": "2023-02-14T17:04:17Z",
            "reason": "FlannelIsUp",
            "message": "Flannel is running on this node"
          },
          {
            "type": "MemoryPressure",
            "status": "Unknown",
            "lastHeartbeatTime": "2023-02-14T17:23:18Z",
            "lastTransitionTime": "2023-02-14T17:24:52Z",
            "reason": "NodeStatusUnknown",
            "message": "Kubelet stopped posting node status."
          },
          {
            "type": "DiskPressure",
            "status": "Unknown",
            "lastHeartbeatTime": "2023-02-14T17:23:18Z",
            "lastTransitionTime": "2023-02-14T17:24:52Z",
            "reason": "NodeStatusUnknown",
            "message": "Kubelet stopped posting node status."
          },
          {
            "type": "PIDPressure",
            "status": "Unknown",
            "lastHeartbeatTime": "2023-02-14T17:23:18Z",
            "lastTransitionTime": "2023-02-14T17:24:52Z",
            "reason": "NodeStatusUnknown",
            "message": "Kubelet stopped posting node status."
          },
          {
            "type": "Ready",
            "status": "Unknown",
            "lastHeartbeatTime": "2023-02-14T17:23:18Z",
            "lastTransitionTime": "2023-02-14T17:24:52Z",
            "reason": "NodeStatusUnknown",
            "message": "Kubelet stopped posting node status."
          }
        ],
```

The error `kubelet stopped posting node status` seems to show that the there was something wrong with the Kubelet in the worker nodes as both are failing with the same condition. In the end this does not seem to be a fault in the migration hence this PR (it is more like an improvement so users don't need to wait until the Namespace disappear). Further investigations on why nodes were on this state is still to be executed.
