### PR TITLE
chore(prometheus): testgrid test unsupported on centos-74

### DIFF
--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -15,6 +15,8 @@
       s3Override: "__testdist__"
 - name: "prometheus upgrade from 0.33.0"
   cpu: 5
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   installerSpec:
     kubernetes:
       version: "1.21.x"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Marks testgrid run as unsupported

```
2023-02-16 14:45:28+00:00 Rook 1.10.8 will not be installed due to failed preflight checks.
```

https://testgrid.kurl.sh/run/pr-4054-46caa7a-prometheus-0.63.0-45.1.0-k8s-docker-2023-02-16T14:19:28Z?kurlLogsInstanceId=almcjgsnmxvtkpmz&nodeId=almcjgsnmxvtkpmz-initialprimary