### PR TITLE
fix: allow kubeadm to choose node name

### DIFF
--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.10/install.sh
+++ b/addons/containerd/1.6.10/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.11/install.sh
+++ b/addons/containerd/1.6.11/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.12/install.sh
+++ b/addons/containerd/1.6.12/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.13/install.sh
+++ b/addons/containerd/1.6.13/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.14/install.sh
+++ b/addons/containerd/1.6.14/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.15/install.sh
+++ b/addons/containerd/1.6.15/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.16/install.sh
+++ b/addons/containerd/1.6.16/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.18/install.sh
+++ b/addons/containerd/1.6.18/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.8/install.sh
+++ b/addons/containerd/1.6.8/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/1.6.9/install.sh
+++ b/addons/containerd/1.6.9/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -183,7 +183,8 @@ function containerd_migrate_from_docker() {
         fi
     fi
 
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
+    local node=
+    node="$(get_local_node_name)"
     kubectl "$kubeconfigFlag" cordon "$node" 
 
     local allPodUIDs=$(kubectl "$kubeconfigFlag" get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}')

--- a/addons/ekco/0.26.3/install.sh
+++ b/addons/ekco/0.26.3/install.sh
@@ -386,7 +386,7 @@ function ekco_handle_load_balancer_address_change_kubeconfigs() {
     # in the pod to completion. Therefore the command output has to be redirected to a file in the
     # pod and then we have to poll that file to determine when the command is finished and if it was
     # successful
-    exclude=$(hostname | tr '[:upper:]' '[:lower:]')
+    exclude=$(get_local_node_name)
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         kubectl -n kurl exec deploy/ekc-operator -- /bin/bash -c "ekco change-load-balancer --exclude=${exclude} --internal --server=https://localhost:6444 &>/tmp/change-lb-log"
     else

--- a/addons/ekco/0.26.3/reboot/shutdown.sh
+++ b/addons/ekco/0.26.3/reboot/shutdown.sh
@@ -2,44 +2,81 @@
 
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
-kubectl cordon "$(hostname | tr '[:upper:]' '[:lower:]')"
+# KURL_HOSTNAME_OVERRIDE can be used to override the node name used by kURL
+KURL_HOSTNAME_OVERRIDE=${KURL_HOSTNAME_OVERRIDE:-}
 
-allPodUIDs=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' )
-
-# delete local pods with PVCs
-while read -r dev; do
-    uid=$(echo "$dev" | grep -Eo "pods\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | sed 's/pods\///')
-    pod=$(echo "${allPodUIDs[*]}" | grep "$uid")
-    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
-done < <(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")
-
-# delete local pods using the Ceph filesystem
-while read -r uid; do
-    pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
-    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
-done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
-
-# while there are still pods with PVCs mounted
-while [ -n "$(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")" ]; do
-    echo "Waiting for pods to unmount PVCs"
-    sleep 1
-done
-
-while grep -q ':6789:/' /proc/mounts; do
-    echo "Waiting for Ceph shared filesystems to unmount"
-    sleep 1
-done
-
-# remove ceph-operator and mds pods from this node so they can continue to service the cluster
-thisHost=$(hostname | tr '[:upper:]' '[:lower:]')
-while read -r row; do
-    podName=$(echo "$row" | awk '{ print $1 }')
-    ns=$(echo "$row" | awk '{ print $2 }')
-
-    if echo "$podName" | grep -q "rook-ceph-operator"; then
-        kubectl -n "$ns" delete pod "$podName"
+# kubernetes_init_hostname sets the HOSTNAME variable to equal the hostname binary output. If
+# KURL_HOSTNAME_OVERRIDE is set, it will be used instead. Otherwise, if the kubelet flags file
+# contains a --hostname-override flag, it will be used instead.
+function kubernetes_init_hostname() {
+    export HOSTNAME
+    if [ -n "$KURL_HOSTNAME_OVERRIDE" ]; then
+        HOSTNAME="$KURL_HOSTNAME_OVERRIDE"
     fi
-    if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
-        kubectl -n "$ns" delete pod "$podName"
+    local hostname_override=
+    hostname_override="$(kubernetes_get_kubelet_hostname_override)"
+    if [ -n "$hostname_override" ] ; then
+        HOSTNAME="$hostname_override"
     fi
-done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")
+    HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]')"
+}
+
+# kubernetes_get_kubelet_hostname_override returns the value of the --hostname-override flag in the
+# kubelet env flags file.
+function kubernetes_get_kubelet_hostname_override() {
+    if [ -f "$KUBELET_FLAGS_FILE" ]; then
+        grep -o '\--hostname-override=[^" ]*' "$KUBELET_FLAGS_FILE" | awk -F'=' '{ print $2 }'
+    fi
+}
+
+# get_local_node_name returns the name of the current node.
+function get_local_node_name() {
+    echo "$HOSTNAME"
+}
+
+function main() {
+    kubernetes_init_hostname
+
+    kubectl cordon "$(get_local_node_name)"
+
+    allPodUIDs=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' )
+
+    # delete local pods with PVCs
+    while read -r dev; do
+        uid=$(echo "$dev" | grep -Eo "pods\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | sed 's/pods\///')
+        pod=$(echo "${allPodUIDs[*]}" | grep "$uid")
+        kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+    done < <(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")
+
+    # delete local pods using the Ceph filesystem
+    while read -r uid; do
+        pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
+        kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+    done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
+
+    # while there are still pods with PVCs mounted
+    while [ -n "$(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")" ]; do
+        echo "Waiting for pods to unmount PVCs"
+        sleep 1
+    done
+
+    while grep -q ':6789:/' /proc/mounts; do
+        echo "Waiting for Ceph shared filesystems to unmount"
+        sleep 1
+    done
+
+    # remove ceph-operator and mds pods from this node so they can continue to service the cluster
+    while read -r row; do
+        podName=$(echo "$row" | awk '{ print $1 }')
+        ns=$(echo "$row" | awk '{ print $2 }')
+
+        if echo "$podName" | grep -q "rook-ceph-operator"; then
+            kubectl -n "$ns" delete pod "$podName"
+        fi
+        if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
+            kubectl -n "$ns" delete pod "$podName"
+        fi
+    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${HOSTNAME}$")
+}
+
+main "$@"

--- a/addons/ekco/0.26.3/reboot/shutdown.sh
+++ b/addons/ekco/0.26.3/reboot/shutdown.sh
@@ -66,6 +66,7 @@ function main() {
     done
 
     # remove ceph-operator and mds pods from this node so they can continue to service the cluster
+    thisHost=$(get_local_node_name)
     while read -r row; do
         podName=$(echo "$row" | awk '{ print $1 }')
         ns=$(echo "$row" | awk '{ print $2 }')
@@ -76,7 +77,7 @@ function main() {
         if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
             kubectl -n "$ns" delete pod "$podName"
         fi
-    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${HOSTNAME}$")
+    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")
 }
 
 main "$@"

--- a/addons/ekco/0.26.3/reboot/startup.sh
+++ b/addons/ekco/0.26.3/reboot/startup.sh
@@ -1,16 +1,54 @@
 #!/bin/bash
 
-# On first install on additional nodes the node is not yet joined to the cluster
-if [ ! -e /etc/kubernetes/kubelet.conf ]; then
-    exit 0
-fi
-
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
-# wait for Kubernetes API
-master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
-while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
-        sleep 1
-done
+# KURL_HOSTNAME_OVERRIDE can be used to override the node name used by kURL
+KURL_HOSTNAME_OVERRIDE=${KURL_HOSTNAME_OVERRIDE:-}
 
-kubectl uncordon $(hostname | tr '[:upper:]' '[:lower:]')
+# kubernetes_init_hostname sets the HOSTNAME variable to equal the hostname binary output. If
+# KURL_HOSTNAME_OVERRIDE is set, it will be used instead. Otherwise, if the kubelet flags file
+# contains a --hostname-override flag, it will be used instead.
+function kubernetes_init_hostname() {
+    export HOSTNAME
+    if [ -n "$KURL_HOSTNAME_OVERRIDE" ]; then
+        HOSTNAME="$KURL_HOSTNAME_OVERRIDE"
+    fi
+    local hostname_override=
+    hostname_override="$(kubernetes_get_kubelet_hostname_override)"
+    if [ -n "$hostname_override" ] ; then
+        HOSTNAME="$hostname_override"
+    fi
+    HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]')"
+}
+
+# kubernetes_get_kubelet_hostname_override returns the value of the --hostname-override flag in the
+# kubelet env flags file.
+function kubernetes_get_kubelet_hostname_override() {
+    if [ -f "$KUBELET_FLAGS_FILE" ]; then
+        grep -o '\--hostname-override=[^" ]*' "$KUBELET_FLAGS_FILE" | awk -F'=' '{ print $2 }'
+    fi
+}
+
+# get_local_node_name returns the name of the current node.
+function get_local_node_name() {
+    echo "$HOSTNAME"
+}
+
+function main() {
+    # On first install on additional nodes the node is not yet joined to the cluster
+    if [ ! -e /etc/kubernetes/kubelet.conf ]; then
+        exit 0
+    fi
+
+    kubernetes_init_hostname
+
+    # wait for Kubernetes API
+    master=$(grep ' server: ' /etc/kubernetes/kubelet.conf | awk '{ print $2 }')
+    while [ "$(curl --noproxy "*" -sk "$master/healthz")" != "ok" ]; do
+        sleep 1
+    done
+
+    kubectl uncordon "$(get_local_node_name)"
+}
+
+main "$@"

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -386,7 +386,7 @@ function ekco_handle_load_balancer_address_change_kubeconfigs() {
     # in the pod to completion. Therefore the command output has to be redirected to a file in the
     # pod and then we have to poll that file to determine when the command is finished and if it was
     # successful
-    exclude=$(hostname | tr '[:upper:]' '[:lower:]')
+    exclude=$(get_local_node_name)
     if [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" = "1" ]; then
         kubectl -n kurl exec deploy/ekc-operator -- /bin/bash -c "ekco change-load-balancer --exclude=${exclude} --internal --server=https://localhost:6444 &>/tmp/change-lb-log"
     else

--- a/addons/ekco/template/base/reboot/shutdown.sh
+++ b/addons/ekco/template/base/reboot/shutdown.sh
@@ -2,44 +2,81 @@
 
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
-kubectl cordon "$(hostname | tr '[:upper:]' '[:lower:]')"
+# KURL_HOSTNAME_OVERRIDE can be used to override the node name used by kURL
+KURL_HOSTNAME_OVERRIDE=${KURL_HOSTNAME_OVERRIDE:-}
 
-allPodUIDs=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' )
-
-# delete local pods with PVCs
-while read -r dev; do
-    uid=$(echo "$dev" | grep -Eo "pods\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | sed 's/pods\///')
-    pod=$(echo "${allPodUIDs[*]}" | grep "$uid")
-    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
-done < <(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")
-
-# delete local pods using the Ceph filesystem
-while read -r uid; do
-    pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
-    kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
-done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
-
-# while there are still pods with PVCs mounted
-while [ -n "$(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")" ]; do
-    echo "Waiting for pods to unmount PVCs"
-    sleep 1
-done
-
-while grep -q ':6789:/' /proc/mounts; do
-    echo "Waiting for Ceph shared filesystems to unmount"
-    sleep 1
-done
-
-# remove ceph-operator and mds pods from this node so they can continue to service the cluster
-thisHost=$(hostname | tr '[:upper:]' '[:lower:]')
-while read -r row; do
-    podName=$(echo "$row" | awk '{ print $1 }')
-    ns=$(echo "$row" | awk '{ print $2 }')
-
-    if echo "$podName" | grep -q "rook-ceph-operator"; then
-        kubectl -n "$ns" delete pod "$podName"
+# kubernetes_init_hostname sets the HOSTNAME variable to equal the hostname binary output. If
+# KURL_HOSTNAME_OVERRIDE is set, it will be used instead. Otherwise, if the kubelet flags file
+# contains a --hostname-override flag, it will be used instead.
+function kubernetes_init_hostname() {
+    export HOSTNAME
+    if [ -n "$KURL_HOSTNAME_OVERRIDE" ]; then
+        HOSTNAME="$KURL_HOSTNAME_OVERRIDE"
     fi
-    if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
-        kubectl -n "$ns" delete pod "$podName"
+    local hostname_override=
+    hostname_override="$(kubernetes_get_kubelet_hostname_override)"
+    if [ -n "$hostname_override" ] ; then
+        HOSTNAME="$hostname_override"
     fi
-done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")
+    HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]')"
+}
+
+# kubernetes_get_kubelet_hostname_override returns the value of the --hostname-override flag in the
+# kubelet env flags file.
+function kubernetes_get_kubelet_hostname_override() {
+    if [ -f "$KUBELET_FLAGS_FILE" ]; then
+        grep -o '\--hostname-override=[^" ]*' "$KUBELET_FLAGS_FILE" | awk -F'=' '{ print $2 }'
+    fi
+}
+
+# get_local_node_name returns the name of the current node.
+function get_local_node_name() {
+    echo "$HOSTNAME"
+}
+
+function main() {
+    kubernetes_init_hostname
+
+    kubectl cordon "$(get_local_node_name)"
+
+    allPodUIDs=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' )
+
+    # delete local pods with PVCs
+    while read -r dev; do
+        uid=$(echo "$dev" | grep -Eo "pods\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | sed 's/pods\///')
+        pod=$(echo "${allPodUIDs[*]}" | grep "$uid")
+        kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+    done < <(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")
+
+    # delete local pods using the Ceph filesystem
+    while read -r uid; do
+        pod=$(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.metadata.namespace}{"\n"}{end}' | grep "$uid" )
+        kubectl delete pod "$(echo "$pod" | awk '{ print $1 }')" --namespace="$(echo "$pod" | awk '{ print $3 }')" --wait=false
+    done < <(grep ':6789:/' /proc/mounts | grep -v globalmount | awk '{ print $2 }' | awk -F '/' '{ print $6 }')
+
+    # while there are still pods with PVCs mounted
+    while [ -n "$(lsblk | grep "\/var\/lib\/kubelet\/pods\/.*\/pvc-")" ]; do
+        echo "Waiting for pods to unmount PVCs"
+        sleep 1
+    done
+
+    while grep -q ':6789:/' /proc/mounts; do
+        echo "Waiting for Ceph shared filesystems to unmount"
+        sleep 1
+    done
+
+    # remove ceph-operator and mds pods from this node so they can continue to service the cluster
+    while read -r row; do
+        podName=$(echo "$row" | awk '{ print $1 }')
+        ns=$(echo "$row" | awk '{ print $2 }')
+
+        if echo "$podName" | grep -q "rook-ceph-operator"; then
+            kubectl -n "$ns" delete pod "$podName"
+        fi
+        if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
+            kubectl -n "$ns" delete pod "$podName"
+        fi
+    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${HOSTNAME}$")
+}
+
+main "$@"

--- a/addons/ekco/template/base/reboot/shutdown.sh
+++ b/addons/ekco/template/base/reboot/shutdown.sh
@@ -66,6 +66,7 @@ function main() {
     done
 
     # remove ceph-operator and mds pods from this node so they can continue to service the cluster
+    thisHost=$(get_local_node_name)
     while read -r row; do
         podName=$(echo "$row" | awk '{ print $1 }')
         ns=$(echo "$row" | awk '{ print $2 }')
@@ -76,7 +77,7 @@ function main() {
         if echo "$podName" | grep -q "rook-ceph-mds-rook-shared-fs"; then
             kubectl -n "$ns" delete pod "$podName"
         fi
-    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${HOSTNAME}$")
+    done < <(kubectl get pods --all-namespaces -ojsonpath='{ range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.nodeName}{"\n"}{end}' | grep -E "${thisHost}$")
 }
 
 main "$@"

--- a/addons/ekco/template/base/reboot/startup.sh
+++ b/addons/ekco/template/base/reboot/startup.sh
@@ -1,16 +1,54 @@
 #!/bin/bash
 
-# On first install on additional nodes the node is not yet joined to the cluster
-if [ ! -e /etc/kubernetes/kubelet.conf ]; then
-    exit 0
-fi
-
 export KUBECONFIG=/etc/kubernetes/kubelet.conf
 
-# wait for Kubernetes API
-master=$(cat /etc/kubernetes/kubelet.conf | grep ' server:' | awk '{ print $2 }')
-while [ "$(curl --noproxy "*" -sk $master/healthz)" != "ok" ]; do
-        sleep 1
-done
+# KURL_HOSTNAME_OVERRIDE can be used to override the node name used by kURL
+KURL_HOSTNAME_OVERRIDE=${KURL_HOSTNAME_OVERRIDE:-}
 
-kubectl uncordon $(hostname | tr '[:upper:]' '[:lower:]')
+# kubernetes_init_hostname sets the HOSTNAME variable to equal the hostname binary output. If
+# KURL_HOSTNAME_OVERRIDE is set, it will be used instead. Otherwise, if the kubelet flags file
+# contains a --hostname-override flag, it will be used instead.
+function kubernetes_init_hostname() {
+    export HOSTNAME
+    if [ -n "$KURL_HOSTNAME_OVERRIDE" ]; then
+        HOSTNAME="$KURL_HOSTNAME_OVERRIDE"
+    fi
+    local hostname_override=
+    hostname_override="$(kubernetes_get_kubelet_hostname_override)"
+    if [ -n "$hostname_override" ] ; then
+        HOSTNAME="$hostname_override"
+    fi
+    HOSTNAME="$(hostname | tr '[:upper:]' '[:lower:]')"
+}
+
+# kubernetes_get_kubelet_hostname_override returns the value of the --hostname-override flag in the
+# kubelet env flags file.
+function kubernetes_get_kubelet_hostname_override() {
+    if [ -f "$KUBELET_FLAGS_FILE" ]; then
+        grep -o '\--hostname-override=[^" ]*' "$KUBELET_FLAGS_FILE" | awk -F'=' '{ print $2 }'
+    fi
+}
+
+# get_local_node_name returns the name of the current node.
+function get_local_node_name() {
+    echo "$HOSTNAME"
+}
+
+function main() {
+    # On first install on additional nodes the node is not yet joined to the cluster
+    if [ ! -e /etc/kubernetes/kubelet.conf ]; then
+        exit 0
+    fi
+
+    kubernetes_init_hostname
+
+    # wait for Kubernetes API
+    master=$(grep ' server: ' /etc/kubernetes/kubelet.conf | awk '{ print $2 }')
+    while [ "$(curl --noproxy "*" -sk "$master/healthz")" != "ok" ]; do
+        sleep 1
+    done
+
+    kubectl uncordon "$(get_local_node_name)"
+}
+
+main "$@"

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -145,13 +145,11 @@ function weave_to_flannel() {
     # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
     local master_node_count=
     master_node_count=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' | wc -l)
-    local hostnamevar
-    hostnamevar=$(hostname)
     local master_node_names=
     master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$master_node_count" -gt 1 ]; then
         local other_master_nodes=
-        other_master_nodes=$(echo "$master_node_names" | grep -v "$hostnamevar")
+        other_master_nodes=$(echo "$master_node_names" | grep -v "$(get_local_node_name)")
         printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
         printf "${YELLOW}Please run the following command on each of the listed primary nodes:${NC}\n\n"
         printf "${other_master_nodes}\n"

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -145,13 +145,11 @@ function weave_to_flannel() {
     # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
     local master_node_count=
     master_node_count=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' | wc -l)
-    local hostnamevar
-    hostnamevar=$(hostname)
     local master_node_names=
     master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$master_node_count" -gt 1 ]; then
         local other_master_nodes=
-        other_master_nodes=$(echo "$master_node_names" | grep -v "$hostnamevar")
+        other_master_nodes=$(echo "$master_node_names" | grep -v "$(get_local_node_name)")
         printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
         printf "${YELLOW}Please run the following command on each of the listed primary nodes:${NC}\n\n"
         printf "${other_master_nodes}\n"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -145,13 +145,11 @@ function weave_to_flannel() {
     # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
     local master_node_count=
     master_node_count=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' | wc -l)
-    local hostnamevar
-    hostnamevar=$(hostname)
     local master_node_names=
     master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$master_node_count" -gt 1 ]; then
         local other_master_nodes=
-        other_master_nodes=$(echo "$master_node_names" | grep -v "$hostnamevar")
+        other_master_nodes=$(echo "$master_node_names" | grep -v "$(get_local_node_name)")
         printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
         printf "${YELLOW}Please run the following command on each of the listed primary nodes:${NC}\n\n"
         printf "${other_master_nodes}\n"

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -907,8 +907,9 @@ function build_installer_prefix() {
     fi
 }
 
+# get_local_node_name returns the name of the current node.
 function get_local_node_name() {
-    hostname | tr '[:upper:]' '[:lower:]'
+    echo "$HOSTNAME"
 }
 
 # this waits for a deployment to have all replicas up-to-date and available

--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -129,8 +129,7 @@ function uninstall_docker() {
 
     # With the internal loadbalancer it may take a minute or two after starting kubelet before
     # kubectl commands work
-    local node=$(hostname | tr '[:upper:]' '[:lower:]')
-    try_5m kubectl uncordon "$node" --kubeconfig=/etc/kubernetes/kubelet.conf
+    try_5m kubectl uncordon "$(get_local_node_name)" --kubeconfig=/etc/kubernetes/kubelet.conf
 
 }
 

--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -344,12 +344,9 @@ function rook_upgrade_addon_fetch_and_load_airgap() {
     local to_version="$2"
 
     if rook_upgrade_has_all_addon_version_packages "$from_version" "$to_version" ; then
-        local this_hostname=
-        this_hostname=$(hostname)
-
         local node_missing_images=
         # shellcheck disable=SC2086
-        node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "$this_hostname" "")
+        node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "$(get_local_node_name)" "")
 
         if [ -z "$node_missing_images" ]; then
             log "All images required for Rook $from_version to $to_version upgrade are present on this node"
@@ -427,12 +424,9 @@ function rook_upgrade_prompt_missing_images() {
     local from_version="$1"
     local to_version="$2"
 
-    local this_hostname=
-    this_hostname=$(hostname)
-
     local node_missing_images=
     # shellcheck disable=SC2086
-    node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "" "$this_hostname")
+    node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "" "$(get_local_node_name)")
 
     if [ -z "$node_missing_images" ]; then
         return

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-init-config-v1beta2.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-init-config-v1beta2.yml
@@ -15,8 +15,6 @@ localAPIEndpoint:
   advertiseAddress: $PRIVATE_ADDRESS
 nodeRegistration:
   taints: [] # prevent the default master taint
-  name: $HOSTNAME
   kubeletExtraArgs:
     node-labels: "kurl.sh/cluster=true,$NODE_LABELS"
-    hostname-override: $HOSTNAME
     node-ip: $PRIVATE_ADDRESS

--- a/scripts/kustomize/kubeadm/init-orig/kubeadm-init-hostname.patch.tmpl.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeadm-init-hostname.patch.tmpl.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+metadata:
+  name: kubeadm-init-configuration
+nodeRegistration:
+  name: $NODE_HOSTNAME
+  kubeletExtraArgs:
+    hostname-override: $NODE_HOSTNAME

--- a/scripts/kustomize/kubeadm/join-orig/kubeadm-join-hostname.patch.tmpl.yaml
+++ b/scripts/kustomize/kubeadm/join-orig/kubeadm-join-hostname.patch.tmpl.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+metadata:
+  name: kubeadm-join-configuration
+nodeRegistration:
+  name: $NODE_HOSTNAME
+  kubeletExtraArgs:
+    hostname-override: $NODE_HOSTNAME

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -28,6 +28,8 @@ function tasks() {
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"
 
+    kubernetes_init_hostname
+
     DOCKER_VERSION="$(get_docker_version)"
 
     K8S_DISTRO=kubeadm
@@ -758,7 +760,7 @@ function weave_to_flannel_primary() {
 
     # get current node internal IP
     local current_node_ip=
-    current_node_ip=$(kubectl get nodes -o wide | grep "$(hostname)" | awk '{print $6}' > /tmp/current_node_ip)
+    current_node_ip=$(kubectl get nodes -o wide | grep "$(get_local_node_name)" | awk '{print $6}' > /tmp/current_node_ip)
 
     # get ca cert hash, bootstrap token and master address
     local bootstrap_token=
@@ -801,7 +803,7 @@ EOM
     systemctl restart kubelet containerd
     rm /tmp/kubeadm-join.conf
 
-    logSuccess "Successfully updated $(hostname) to use Flannel"
+    logSuccess "Successfully updated $(get_local_node_name) to use Flannel"
 }
 
 function weave_to_flannel_secondary() {
@@ -831,7 +833,7 @@ function weave_to_flannel_secondary() {
     ip link delete weave
     systemctl restart kubelet containerd
 
-    logSuccess "Successfully updated $(hostname) to use Flannel"
+    logSuccess "Successfully updated $(get_local_node_name) to use Flannel"
 }
 
 function task_requires_root() {
@@ -845,7 +847,7 @@ function task_requires_root() {
 # check if containerd on the current node has the `docker.io/rancher/mirrored-flannelcni-flannel:v<version>` image
 function flannel_images_present() {
     if ! ctr -n=k8s.io images ls | grep -q "docker.io/rancher/mirrored-flannelcni-flannel" ; then
-        logFail "Flannel images not present on $(hostname), please ensure the 'load-images' task has been run successfully"
+        logFail "Flannel images not present on $(get_local_node_name), please ensure the 'load-images' task has been run successfully"
         exit 1
     fi
 }

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -110,6 +110,7 @@ function main() {
     require_root_user
     # ensure /usr/local/bin/kubectl-plugin is in the path
     path_add "/usr/local/bin"
+    kubernetes_init_hostname
     get_patch_yaml "$@"
     maybe_read_kurl_config_from_cluster
 

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1393,7 +1393,7 @@
 
     echo "Pod image override success: $pod_image"
     
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1413,7 +1413,7 @@
     kube_bench_version="$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')"
     curl -L https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz | tar -xz
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1464,7 +1464,7 @@
     sudo cat /var/lib/kubelet/config.yaml | grep "cpu: 123m"
     sudo cat /var/lib/kubelet/config.yaml | grep "ephemeral-storage: 1.23Gi"
     sudo cat /var/lib/kubelet/config.yaml | grep "memory: 123Mi"
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1575,7 +1575,7 @@
   postInstallScript: |
     echo "this is to test less command after installation" > test-less.txt
     less test-less.txt > /dev/null
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1672,7 +1672,7 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1690,8 +1690,8 @@
     echo $operatorVersion | grep 1.5.12
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
-    echo $k8sVersion | grep 1.20
-    echo "Checking kubectl with kube/config"  
+    echo $k8sVersion | grep 1.19
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1730,9 +1730,9 @@
       version: "latest"
   preInstallScript: |
     # download the file that the airgap upgrade requires, and place it in the correct location
-    curl -LO https://kurl-sh.s3.amazonaws.com/staging/rookupgrade-10to14.tar.gz
-    curl -LO https://kurl-sh.s3.amazonaws.com/staging/rook-1.4.9.tar.gz
-    curl -LO https://kurl-sh.s3.amazonaws.com/staging/rook-1.5.12.tar.gz
+    curl -LO https://s3-staging.kurl.sh/staging/rookupgrade-10to14.tar.gz
+    curl -LO https://s3-staging.kurl.sh/staging/rook-1.4.9.tar.gz
+    curl -LO https://s3-staging.kurl.sh/staging/rook-1.5.12.tar.gz
     mkdir -p /var/lib/kurl/assets
     mv rookupgrade-10to14.tar.gz /var/lib/kurl/assets
     mv rook-1.4.9.tar.gz /var/lib/kurl/assets
@@ -1744,7 +1744,7 @@
 
     minio_object_store_info
     validate_read_write_object_store rwtest minio.txt
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
@@ -1763,7 +1763,7 @@
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
     echo $k8sVersion | grep 1.19
-    echo "Checking kubectl with kube/config"  
+    echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1690,7 +1690,7 @@
     echo $operatorVersion | grep 1.5.12
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
-    echo $k8sVersion | grep 1.19
+    echo $k8sVersion | grep 1.20
     echo "Checking kubectl with kube/config"
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This attempts to standardize our use of hostname to find the node name throughout our code.
We should prefer the function get_local_node_name to using the $HOSTNAME variable directly.

This change also no longer overrides the node name and hostname-override for new installs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
(improvement) kURL will no longer choose the node name and instead defer to kubeadm to infer the node name from the hostname.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
