### PR TITLE
fix(rook): multi-upgrades fail if package already exists on server

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -204,9 +204,16 @@ function addon_fetch_multiple_airgap() {
         name=$(echo "$addon_version" | cut -d- -f1)
         version=$(echo "$addon_version" | cut -d- -f2)
         local package_name="$name-$version.tar.gz"
-        if [ -f "$(package_filepath "$package_name")" ]; then
+        local package_path=
+        package_path="$(package_filepath "$package_name")"
+        if [ -f "$package_path" ]; then
             # the package already exists, no need to download it
             printf "The package %s %s is already available locally.\n" "$name" "$version"
+
+            printf "Unpacking %s...\n" "$package_name"
+            if ! tar xf "$package_path" ; then
+                bail "Failed to unpack $package_name"
+            fi
         else
             # the package does not exist, add it to the list of missing packages
             missing_addon_versions+=("$addon_version")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This fixes a failure caught in testgrid that causes rook upgrades to fail with the following error when add-on packages exist on the server prior to running a multi version rook upgrade.

```
2023-02-16 08:26:51+00:00 bash: line 450: ./addons/rookupgrade/10to14/install.sh: No such file or directory
```

https://testgrid.kurl.sh/run/STAGING-daily-v2023.02.14-0-0c86508f-2023-02-16T01:28:50Z?kurlLogsInstanceId=sguonuahrknonlur&nodeId=sguonuahrknonlur-initialprimary

This failure is triggered because the pre-install script preloads the packages:

```
# download the file that the airgap upgrade requires, and place it in the correct location
curl -LO https://kurl-sh.s3.amazonaws.com/staging/rookupgrade-10to14.tar.gz
curl -LO https://kurl-sh.s3.amazonaws.com/staging/rook-1.4.9.tar.gz
curl -LO https://kurl-sh.s3.amazonaws.com/staging/rook-1.5.12.tar.gz
mkdir -p /var/lib/kurl/assets
mv rookupgrade-10to14.tar.gz /var/lib/kurl/assets
mv rook-1.4.9.tar.gz /var/lib/kurl/assets
mv rook-1.5.12.tar.gz /var/lib/kurl/assets
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes Rook multi-version upgrades to fail if add-on airgap packages exist on the server prior to upgrading.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE