### PR TITLE
Revert "add ha flag to testgrid"

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -164,9 +164,6 @@
       version: 1.26.x
     flannel:
       version: latest
-    ekco:
-      version: latest
-  flags: "ha"
 - name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1360,7 +1360,7 @@
       version: latest
     ekco:
       version: latest
-  flags: "labels=disktype=ssd,gpu=enabled exclude-builtin-host-preflights ha" # TODO: add more flags here
+  flags: "labels=disktype=ssd,gpu=enabled exclude-builtin-host-preflights" # TODO: add more flags here
 - name: ekco-podimageoverrides
   installerSpec:
     kubernetes:


### PR DESCRIPTION
Reverts replicatedhq/kURL#4127

the cluster never became ready with this flag: https://testgrid.kurl.sh/run/laverya%20ha%20containerd