### PR TITLE
Add addon v0.21.2 for flannel and address a fix to its script to generate the new versions

### DIFF
--- a/addons/flannel/0.21.2/Manifest
+++ b/addons/flannel/0.21.2/Manifest
@@ -1,0 +1,2 @@
+image flannel-flannel docker.io/flannel/flannel:v0.20.2
+image flannel-flannel-cni-plugin docker.io/flannel/flannel-cni-plugin:v1.1.2

--- a/addons/flannel/0.21.2/Manifest
+++ b/addons/flannel/0.21.2/Manifest
@@ -1,2 +1,2 @@
-image flannel-flannel docker.io/flannel/flannel:v0.20.2
+image flannel-flannel docker.io/flannel/flannel:v0.21.2
 image flannel-flannel-cni-plugin docker.io/flannel/flannel-cni-plugin:v1.1.2

--- a/addons/flannel/0.21.2/host-preflight.yaml
+++ b/addons/flannel/0.21.2/host-preflight.yaml
@@ -1,0 +1,27 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: flannel
+spec:
+  collectors:
+    - udpPortStatus:
+        collectorName: Flannel UDP port 8472
+        port: 8472
+        exclude: '{{kurl .IsUpgrade }}'
+  analyzers:
+    - udpPortStatus:
+        checkName: "Flannel UDP port 8472 status"
+        collectorName: Flannel UDP port 8472
+        exclude: '{{kurl .IsUpgrade }}'
+        outcomes:
+          - warn:
+              when: "address-in-use"
+              message: Another process is already listening on port
+          - fail:
+              when: "error"
+              message: Unexpected port status
+          - pass:
+              when: "connected"
+              message: Port is open
+          - warn:
+              message: Unexpected port status

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+
+export POD_CIDR
+export POD_CIDR_RANGE
+export POD_CIDR_IPV6
+export EXISTING_POD_CIDR
+
+export FLANNEL_ENABLE_IPV4=${FLANNEL_ENABLE_IPV4:-true}
+export FLANNEL_ENABLE_IPV6=${FLANNEL_ENABLE_IPV6:-false} # TODO: support ipv6
+export FLANNEL_BACKEND=${FLANNEL_BACKEND:-vxlan} # TODO: support encryption
+export FLANNEL_IFACE=${FLANNEL_IFACE:-}
+
+function flannel_pre_init() {
+    local src="$DIR/addons/flannel/$FLANNEL_VERSION"
+    local dst="$DIR/kustomize/flannel"
+
+    if [ -n "$DOCKER_VERSION" ]; then
+        bail "Flannel is not compatible with the Docker runtime, Containerd is required"
+    fi
+
+    if flannel_antrea_conflict ; then
+        bail "Migrations from Antrea to Flannel are not supported"
+    fi
+
+    # TODO: support ipv6
+    local private_address_iface=
+    local default_gateway_iface=
+    private_address_iface=$("$BIN_KURL" netutil iface-from-ip "$PRIVATE_ADDRESS")
+    default_gateway_iface=$("$BIN_KURL" netutil default-gateway-iface)
+    # if the private address is on a different interface than the default gateway, use the private address interface
+    if [ -n "$private_address_iface" ] && [ "$private_address_iface" != "$default_gateway_iface" ]; then
+        FLANNEL_IFACE="$private_address_iface"
+    fi
+
+    flannel_init_pod_subnet
+}
+
+function flannel_join() {
+    logWarn "Flannel requires UDP port 8472 for communication between nodes."
+    logWarn "Failure to open this port will cause connection failures between containers on different nodes."
+}
+
+function flannel() {
+    local src="$DIR/addons/flannel/$FLANNEL_VERSION"
+    local dst="$DIR/kustomize/flannel"
+
+    cp "$src"/yaml/* "$dst/"
+
+    flannel_render_config
+
+    if flannel_weave_conflict; then
+        local node_count
+        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+
+        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
+        if [ "$node_count" -gt 1 ]; then
+            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
+            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
+        fi
+        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
+        if ! confirmY ; then
+            bail "Not migrating from Weave to Flannel"
+        fi
+
+        weave_to_flannel
+    else
+        kubectl -n kube-flannel apply -k "$dst/"
+    fi
+
+    flannel_ready_spinner
+
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+    fi
+
+    check_network
+}
+
+function flannel_init_pod_subnet() {
+    POD_CIDR="$FLANNEL_POD_CIDR"
+    POD_CIDR_RANGE="$FLANNEL_POD_CIDR_RANGE"
+
+    cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
+
+    if commandExists kubectl; then
+        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+    fi
+}
+
+function flannel_render_config() {
+    render_yaml_file_2 "$src/template/kube-flannel-cfg.patch.tmpl.yaml" > "$dst/kube-flannel-cfg.patch.yaml"
+
+    if [ "$FLANNEL_ENABLE_IPV6" = "true" ] && [ -n "$POD_CIDR_IPV6" ]; then
+        render_yaml_file_2 "$src/template/ipv6.patch.tmpl.yaml" > "$dst/ipv6.patch.yaml"
+        insert_patches_strategic_merge "$dst/kustomization.yaml" ipv6.patch.yaml
+    fi
+
+    if [ -n "$FLANNEL_IFACE" ]; then
+        render_yaml_file_2 "$src/template/iface.patch.tmpl.yaml" > "$dst/iface.patch.yaml"
+        insert_patches_json_6902 "$dst/kustomization.yaml" iface.patch.yaml apps v1 DaemonSet kube-flannel-ds kube-flannel
+    fi
+}
+
+function flannel_health_check() {
+    local health=
+    health="$(kubectl -n kube-flannel get pods -l app=flannel -o jsonpath="{range .items[*]}{range .status.conditions[*]}{ .type }={ .status }{'\n'}{end}{end}" 2>/dev/null)"
+    if echo "$health" | grep -q '^Ready=False' ; then
+        return 1
+    fi
+    return 0
+}
+
+function flannel_ready_spinner() {
+    echo "waiting for Flannel to become healthy"
+    if ! spinner_until 180 flannel_health_check; then
+        kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10
+        bail "The Flannel add-on failed to deploy successfully."
+    fi
+}
+
+function flannel_weave_conflict() {
+    ls /etc/cni/net.d/*weave* >/dev/null 2>&1
+}
+
+function flannel_antrea_conflict() {
+    ls /etc/cni/net.d/*antrea* >/dev/null 2>&1
+}
+
+function weave_to_flannel() {
+    local dst="$DIR/kustomize/flannel"
+
+    logStep "Removing Weave to install Flannel"
+    remove_weave
+
+    logStep "Updating kubeadm to use Flannel"
+    flannel_kubeadm
+
+    logStep "Applying Flannel"
+    kubectl -n kube-flannel apply -k "$dst/"
+
+    # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
+    local master_node_count=
+    master_node_count=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' | wc -l)
+    local hostnamevar
+    hostnamevar=$(hostname)
+    local master_node_names=
+    master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
+    if [ "$master_node_count" -gt 1 ]; then
+        local other_master_nodes=
+        other_master_nodes=$(echo "$master_node_names" | grep -v "$hostnamevar")
+        printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
+        printf "${YELLOW}Please run the following command on each of the listed primary nodes:${NC}\n\n"
+        printf "${other_master_nodes}\n"
+
+        # generate the cert key once, as the hash changes each time upload-certs is called
+        kubeadm init phase upload-certs --upload-certs 2>/dev/null > /tmp/kotsadm-cert-key
+        local cert_key=
+        cert_key=$(cat /tmp/kotsadm-cert-key | grep -v 'upload-certs' )
+        rm /tmp/kotsadm-cert-key
+
+        if [ "$AIRGAP" = "1" ]; then
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=${cert_key}${NC}\n\n"
+        else
+            local prefix=
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-primary airgap cert-key=${cert_key}${NC}\n\n"
+        fi
+
+        printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"
+        prompt
+        kubectl -n kube-flannel delete pods --all
+    fi
+
+    local worker_node_count=
+    worker_node_count=$(kubectl get nodes --no-headers --selector='!node-role.kubernetes.io/control-plane' | wc -l)
+    local worker_node_names=
+    worker_node_names=$(kubectl get nodes --no-headers --selector='!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
+    if [ "$worker_node_count" -gt 0 ]; then
+        printf "${YELLOW}Moving from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
+        printf "${YELLOW}Please run the following command on each of the listed secondary nodes:${NC}\n\n"
+        printf "${worker_node_names}\n"
+
+        if [ "$AIRGAP" = "1" ]; then
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+        else
+            local prefix=
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+        fi
+
+        printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"
+        prompt
+        kubectl -n kube-flannel delete pods --all
+    fi
+
+    echo "waiting for kube-flannel-ds to become healthy in kube-flannel"
+    spinner_until 240 daemonset_fully_updated "kube-flannel" "kube-flannel-ds"
+
+    logStep "Restarting kubelet"
+    systemctl stop kubelet
+    iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
+    echo "waiting for containerd to restart"
+    restart_systemd_and_wait containerd
+    echo "waiting for kubelet to restart"
+    restart_systemd_and_wait kubelet
+
+    logStep "Restarting pods in kube-system"
+    kubectl -n kube-system delete pods --all
+    kubectl -n kube-flannel delete pods --all
+    flannel_ready_spinner
+
+    logStep "Restarting CSI pods"
+    kubectl -n longhorn-system delete pods --all || true
+    kubectl -n rook-ceph delete pods --all || true
+    kubectl -n openebs delete pods --all || true
+
+    sleep 60
+    logStep "Restarting all other pods"
+    echo "this may take several minutes"
+    local ns=
+    for ns in $(kubectl get ns -o name | grep -Ev '(kube-system|longhorn-system|rook-ceph|openebs|kube-flannel)' | cut -f2 -d'/'); do
+        kubectl delete pods -n "$ns" --all
+    done
+
+    sleep 60
+    logSuccess "Migrated from Weave to Flannel"
+}
+
+function remove_weave() {
+    # firstnode only
+    kubectl -n kube-system delete daemonset weave-net
+    kubectl -n kube-system delete rolebinding weave-net
+    kubectl -n kube-system delete role weave-net
+    kubectl delete clusterrolebinding weave-net
+    kubectl delete clusterrole weave-net
+    kubectl -n kube-system delete serviceaccount weave-net
+    kubectl -n kube-system delete secret weave-passwd
+
+    # all nodes
+    rm -f /opt/cni/bin/weave-*
+    rm -rf /etc/cni/net.d
+    ip link delete weave
+
+}
+
+function flannel_kubeadm() {
+    # search for 'serviceSubnet', add podSubnet above it
+    local pod_cidr_range_line=
+    pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
+    if grep -q 'podSubnet:' "$KUBEADM_CONF_FILE" ; then
+        sed -i "s_  podSubnet:.*_${pod_cidr_range_line}_" "$KUBEADM_CONF_FILE"
+    else
+        sed -i "/serviceSubnet/ s/.*/${pod_cidr_range_line}\n&/" "$KUBEADM_CONF_FILE"
+    fi
+
+    kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
+    kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
+}
+
+function flannel_already_applied() {
+    # We will remove the flannel pods to let it be re-created
+    # in order to workaround the issue scenario described in
+    # https://github.com/flannel-io/flannel/issues/1721
+    if [ "$KUBERNETES_UPGRADE" == "1" ]; then
+       log "Deleting pods from kube-flannel namespace"
+       kubectl delete --all pods --namespace=kube-flannel
+       sleep 60
+    fi
+
+    flannel_ready_spinner
+    check_network
+}

--- a/addons/flannel/0.21.2/kubeadm.yaml
+++ b/addons/flannel/0.21.2/kubeadm.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+metadata:
+  name: kubeadm-cluster-configuration
+networking:
+  podSubnet: $POD_CIDR

--- a/addons/flannel/0.21.2/template/iface.patch.tmpl.yaml
+++ b/addons/flannel/0.21.2/template/iface.patch.tmpl.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "--iface=$FLANNEL_IFACE"

--- a/addons/flannel/0.21.2/template/ipv6.patch.tmpl.yaml
+++ b/addons/flannel/0.21.2/template/ipv6.patch.tmpl.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-flannel
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-flannel
+        env:
+        - name: FLANNEL_ENABLE_IPV6
+          value: "$FLANNEL_ENABLE_IPV6"
+        - name: FLANNEL_IPV6_NETWORK
+          value: "$POD_CIDR_IPV6"

--- a/addons/flannel/0.21.2/template/kube-flannel-cfg.patch.tmpl.yaml
+++ b/addons/flannel/0.21.2/template/kube-flannel-cfg.patch.tmpl.yaml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-flannel
+data:
+  net-conf.json: |
+    {
+      "Network": "$POD_CIDR",
+      "EnableIPv4": $FLANNEL_ENABLE_IPV4,
+      "Backend": {
+        "Type": "$FLANNEL_BACKEND"
+      }
+    }

--- a/addons/flannel/0.21.2/yaml/kube-flannel.yml
+++ b/addons/flannel/0.21.2/yaml/kube-flannel.yml
@@ -1,0 +1,209 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-flannel
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - clustercidrs
+  verbs:
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-flannel
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-flannel
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni-plugin
+        image: docker.io/flannel/flannel-cni-plugin:v1.1.2
+       #image: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.2
+        command:
+        - cp
+        args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        volumeMounts:
+        - name: cni-plugin
+          mountPath: /opt/cni/bin
+      - name: install-cni
+        image: docker.io/flannel/flannel:v0.20.2
+       #image: docker.io/rancher/mirrored-flannelcni-flannel:v0.20.2
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+        image: docker.io/flannel/flannel:v0.20.2
+       #image: docker.io/rancher/mirrored-flannelcni-flannel:v0.20.2
+        command:
+        - /opt/bin/flanneld
+        args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        volumeMounts:
+        - name: run
+          mountPath: /run/flannel
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+      volumes:
+      - name: run
+        hostPath:
+          path: /run/flannel
+      - name: cni-plugin
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: flannel-cfg
+        configMap:
+          name: kube-flannel-cfg
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate

--- a/addons/flannel/0.21.2/yaml/kube-flannel.yml
+++ b/addons/flannel/0.21.2/yaml/kube-flannel.yml
@@ -142,7 +142,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.20.2
+        image: docker.io/flannel/flannel:v0.21.2
        #image: docker.io/rancher/mirrored-flannelcni-flannel:v0.20.2
         command:
         - cp
@@ -157,7 +157,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.20.2
+        image: docker.io/flannel/flannel:v0.21.2
        #image: docker.io/rancher/mirrored-flannelcni-flannel:v0.20.2
         command:
         - /opt/bin/flanneld

--- a/addons/flannel/0.21.2/yaml/kustomization.yaml
+++ b/addons/flannel/0.21.2/yaml/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - kube-flannel.yml
+  - troubleshoot.yaml
+
+patches:
+  - kube-flannel-cfg.patch.yaml

--- a/addons/flannel/0.21.2/yaml/troubleshoot.yaml
+++ b/addons/flannel/0.21.2/yaml/troubleshoot.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flannel-troubleshoot-spec
+  labels:
+    troubleshoot.io/kind: support-bundle
+stringData:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: flannel
+    spec:
+
+      collectors:
+        - logs:
+            collectorName: kube-flannel
+            selector:
+              - app=flannel
+            namespace: kube-flannel
+            name: kots/kurl/flannel
+
+      analyzers:
+        - textAnalyze:
+            checkName: "Flannel: can read net-conf.json"
+            ignoreIfNoFiles: true
+            fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+            outcomes:
+              - fail:
+                  when: "true"
+                  message: "failed to read net-conf.json"
+              - pass:
+                  when: "false"
+                  message: "can read net-conf.json"
+            regex: 'failed to read net conf'
+        - textAnalyze:
+            checkName: "Flannel: net-conf.json properly formatted"
+            ignoreIfNoFiles: true
+            fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+            outcomes:
+              - fail:
+                  when: "true"
+                  message: "malformed net-conf.json"
+              - pass:
+                  when: "false"
+                  message: "properly formatted net-conf.json"
+            regex: 'error parsing subnet config'
+        - textAnalyze:
+            checkName: "Flannel: has access"
+            ignoreIfNoFiles: true
+            fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+            outcomes:
+              - fail:
+                  when: "true"
+                  message: "RBAC error"
+              - pass:
+                  when: "false"
+                  message: "has access"
+            regex: 'the server does not allow access to the requested resource'

--- a/addons/flannel/template/generate.sh
+++ b/addons/flannel/template/generate.sh
@@ -10,8 +10,12 @@ function generate() {
     cp -r ./base/* "$dir"
 
     download_yaml
-
+    replace_flannel_image_with_version
     find_images_in_yaml
+}
+
+function replace_flannel_image_with_version() {
+    sed -E -i "s/docker\.io\/flannel\/flannel:.*/docker\.io\/flannel\/flannel:v$version/g" "$dir/yaml/kube-flannel.yml"
 }
 
 function download_yaml() {

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -139,6 +139,7 @@ module.exports.InstallerVersions = {
   ],
   flannel: [
     // cron-flannel-update
+    "0.21.2",
     "0.21.1",
     "0.21.0",
     "0.20.2",


### PR DESCRIPTION
#### What this PR does / why we need it:

To fix the automated generation of the flannel addon to ensure that the flannel image used will be the same version of its release. And to add the new version v0.21.2.


#### Which issue(s) this PR fixes:

Fixes # [sc-51232]

Closes: https://github.com/replicatedhq/kURL/pull/4102/files
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?

```release-note
Adds [Flannel add-on](https://kurl.sh/docs/add-ons/flannel) version 0.21.2.
```

#### Does this PR require documentation?
NONE
