### PR TITLE
fix: [testgrid] Rook Upgrade to 1.8.x cannot be tested against centos-7.4

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -687,6 +687,8 @@
       version: 20.10.17
     ekco:
       version: latest
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
 - name: k8s121
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:

For we no longer test rook Upgrade to 1.8.x cannot be tested against centos-7.4.
See that is not supported:

```
2023-02-21 03:24:46+00:00 ✔ Upgraded to Rook 1.7.11 successfully
2023-02-21 03:24:46+00:00 ⚙  Upgrading to Rook 1.8.10
2023-02-21 03:24:46+00:00 Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported.
2023-02-21 03:24:46+00:00 Rook 1.8 will not be installed due to failed preflight checks
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
2023-02-21 03:24:46+00:00 
2023-02-21 03:24:46+00:00 failed kurl upgrade with exit status 1
2023-02-21 03:24:46+00:00 kubelet status
```

#### Which issue(s) this PR fixes:

Fixes # [sc-70023]

