### PR TITLE
chore: add check to ensure that rook-ceph namespace is removed after migration from it

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -170,6 +170,13 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+    echo "Verify if rook-ceph namespace was removed after upgrade"
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1 
+    else
+       echo "Namespace rook-ceph was removed"
+    fi
 
 - name: localpv migrate from longhorn
   flags: "yes"


### PR DESCRIPTION
#### What this PR does / why we need it:

For we start to check if the migration from ROOK will result in this namespace properly deleted and ensure the rook cleanup.

#### Which issue(s) this PR fixes:

Motivated By # [sc-69454]

#### Special notes for your reviewer:
You can check that check was verified in: https://testgrid.kurl.sh/run/verify-migration-from-rook-to-openrbs-1-wed-feb-22

