### PR TITLE
chore: add new tests for addons to ensure that is possible to migrate  from rook 1.10x

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -171,7 +171,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
-- name: localpv migrate from rook latest versions
+- name: localpv migrate from rook 1.10.x and from k8s 1.24.x
   flags: "yes"
   installerSpec:
     kubernetes:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -131,7 +131,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
-- name: localpv migrate from rook
+- name: localpv migrate from rook old versions
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -170,6 +170,55 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+
+- name: localpv migrate from rook latest versions
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.x" # this is the latest version of k8s that supports rook 1.0.4
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    rook:
+      version: "1.10.x"
+    kotsadm:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt    
+    echo "Verify if rook-ceph namespace was removed after upgrade"
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1 
+    else
+       echo "Namespace rook-ceph was removed"
+    fi
 
 - name: localpv migrate from longhorn
   flags: "yes"

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -131,7 +131,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
 
-- name: localpv migrate from rook old versions
+- name: localpv migrate from Rook 1.0.4 with old versions
   flags: "yes"
   installerSpec:
     kubernetes:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -175,7 +175,7 @@
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "1.24.x" # this is the latest version of k8s that supports rook 1.0.4
+      version: "1.24.x" 
     flannel:
       version: latest
     containerd:


### PR DESCRIPTION
#### What this PR does / why we need it:

Perform the test with upper versions to ensure that the same behaviour can properly work with them

#### Which issue(s) this PR fixes:

Motivated By # [sc-69454]

#### Special notes for your reviewer:

Rook has changes according to their versions and we need to ensure that the migration from the latest versions still working fine which is not today, see: https://testgrid.kurl.sh/run/verify-migration-from-rook-to-openrbs-latest-versions-0-wed-feb-22?kurlLogsInstanceId=swnymrwcmglnldgj&nodeId=swnymrwcmglnldgj-initialprimary 
