### PR TITLE
chore: add test to check migration from rook without minio

### DIFF
--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -230,6 +230,47 @@
     # pulls the image we pushed before the migration.
     test_pull_image_from_registry
 
+- name: localpv migrate from rook and without MINIO
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    rook:
+      version: "1.10.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+    kotsadm:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1 
+    else
+       echo "Namespace rook-ceph was removed"
+    fi
+
 - name: localpv upgrade from latest
   flags: "yes"
   installerSpec:

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -254,8 +254,6 @@
       namespace: openebs
       version: "__testver__"
       s3Override: "__testdist__"
-    kotsadm:
-      version: "latest"
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |


### PR DESCRIPTION
#### What this PR does / why we need it:

Perform the test with upper versions to ensure that the same behaviour can properly work with them

#### Which issue(s) this PR fixes:

Motivated By # [sc-69454]

#### Special notes for your reviewer:

It is falling because rook-ceph namespace is not deleted. The test is for we start to cover this scenario. 