### PR TITLE
chore: add test to verify rook migration OpenEBS in the daily checks

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1782,7 +1782,7 @@
       version: latest
     containerd:
       version: latest
-- name: Migrate from Rook to OpenEBS with localpv migrate
+- name: Migrate from Rook 1.10.x to OpenEBS 3.4.0 with localpv migrate
   flags: "yes"
   installerSpec:
     kubernetes:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1782,3 +1782,50 @@
       version: latest
     containerd:
       version: latest
+- name: Migrate from Rook to OpenEBS with localpv migrate
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    rook:
+      version: "1.10.x"
+    kotsadm:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      "version": "3.4.0"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt    
+    echo "Verify if rook-ceph namespace was removed after upgrade"
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1 
+    else
+       echo "Namespace rook-ceph was removed"
+    fi


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that we do not break this migration with the changes.
Add test for the daily checks. 

#### Which issue(s) this PR fixes:

Motivated By # [sc-69454]


See that is failing today: https://testgrid.kurl.sh/run/verify-migration-from-rook-to-openrbs-latest-versions-0-wed-feb-22?kurlLogsInstanceId=swnymrwcmglnldgj&nodeId=swnymrwcmglnldgj-initialprimary