### PR TITLE
fix(ekco): haproxy processes still running after reset script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,11 +620,11 @@ golangci-lint:
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint and vet linter
-	$(GOLANGCI_LINT) --build-tags "${BUILDTAGS}" run --timeout 5m ./cmd/... ./pkg/... ./kurl_util/...
+	$(GOLANGCI_LINT) --build-tags "${BUILDTAGS}" run --timeout 10m ./cmd/... ./pkg/... ./kurl_util/...
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform small fixes
-	$(GOLANGCI_LINT) --build-tags "${BUILDTAGS}" run --fix --timeout 5m ./cmd/... ./pkg/... ./kurl_util/...
+	$(GOLANGCI_LINT) --build-tags "${BUILDTAGS}" run --fix --timeout 10m ./cmd/... ./pkg/... ./kurl_util/...
 
 .PHONY: vet
 vet: ## Go vet the code

--- a/addons/ekco/0.26.4/install.sh
+++ b/addons/ekco/0.26.4/install.sh
@@ -264,7 +264,7 @@ function ekco_bootstrap_internal_lb() {
     # which will cause the load balancer to restart.
     local already_bootstrapped=0
     local last_modified=
-    if curl -skf https://localhost:6444/healthz >/dev/null ; then
+    if curl -skf https://localhost:6444/healthz >/dev/null && [ -f /etc/kubernetes/manifests/haproxy.yaml ] ; then
         already_bootstrapped=1
         last_modified="$(stat -c %Y /etc/kubernetes/manifests/haproxy.yaml)"
     fi

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -264,7 +264,7 @@ function ekco_bootstrap_internal_lb() {
     # which will cause the load balancer to restart.
     local already_bootstrapped=0
     local last_modified=
-    if curl -skf https://localhost:6444/healthz >/dev/null ; then
+    if curl -skf https://localhost:6444/healthz >/dev/null && [ -f /etc/kubernetes/manifests/haproxy.yaml ] ; then
         already_bootstrapped=1
         last_modified="$(stat -c %Y /etc/kubernetes/manifests/haproxy.yaml)"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

After a reset, kurl install script fails with the following error:

```
⚙  Addon ekco 0.26.4
stat: cannot stat '/etc/kubernetes/manifests/haproxy.yaml': No such file or directory
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes an HA install to fail after a node has been reset with error "stat: cannot stat '/etc/kubernetes/manifests/haproxy.yaml': No such file or directory"
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE