### PR TITLE
chore: add better info to no block devices found in Rook preflights

### DIFF
--- a/addons/rook/1.10.11/host-preflight.yaml
+++ b/addons/rook/1.10.11/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.10.11/host-preflight.yaml
+++ b/addons/rook/1.10.11/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.10.6/host-preflight.yaml
+++ b/addons/rook/1.10.6/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.10.6/host-preflight.yaml
+++ b/addons/rook/1.10.6/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.10.8/host-preflight.yaml
+++ b/addons/rook/1.10.8/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.10.8/host-preflight.yaml
+++ b/addons/rook/1.10.8/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.4.3/host-preflight.yaml
+++ b/addons/rook/1.4.3/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.4.3/host-preflight.yaml
+++ b/addons/rook/1.4.3/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.4.9/host-preflight.yaml
+++ b/addons/rook/1.4.9/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.4.9/host-preflight.yaml
+++ b/addons/rook/1.4.9/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.10/host-preflight.yaml
+++ b/addons/rook/1.5.10/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.10/host-preflight.yaml
+++ b/addons/rook/1.5.10/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.11/host-preflight.yaml
+++ b/addons/rook/1.5.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.11/host-preflight.yaml
+++ b/addons/rook/1.5.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.12/host-preflight.yaml
+++ b/addons/rook/1.5.12/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.12/host-preflight.yaml
+++ b/addons/rook/1.5.12/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.9/host-preflight.yaml
+++ b/addons/rook/1.5.9/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.5.9/host-preflight.yaml
+++ b/addons/rook/1.5.9/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.6.11/host-preflight.yaml
+++ b/addons/rook/1.6.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.6.11/host-preflight.yaml
+++ b/addons/rook/1.6.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.7.11/host-preflight.yaml
+++ b/addons/rook/1.7.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.7.11/host-preflight.yaml
+++ b/addons/rook/1.7.11/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.8.10/host-preflight.yaml
+++ b/addons/rook/1.8.10/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.8.10/host-preflight.yaml
+++ b/addons/rook/1.8.10/host-preflight.yaml
@@ -20,4 +20,4 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"

--- a/addons/rook/1.9.12/host-preflight.yaml
+++ b/addons/rook/1.9.12/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/1.9.12/host-preflight.yaml
+++ b/addons/rook/1.9.12/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/template/base/host-preflight.yaml
+++ b/addons/rook/template/base/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: No available block devices
+          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"

--- a/addons/rook/template/base/host-preflight.yaml
+++ b/addons/rook/template/base/host-preflight.yaml
@@ -24,7 +24,7 @@ spec:
           when: "{{kurl if (and .Installer.Spec.Rook.Version .Installer.Spec.Rook.BlockDeviceFilter) }}{{kurl .Installer.Spec.Rook.BlockDeviceFilter }}{{kurl else }}.*{{kurl end }} > 1"
           message: Multiple available block devices
       - fail:
-          message: "No available block devices unformatted and dedicated to be use by Rook only were found attached to each node in the cluster. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
+          message: "No available unformatted block devices were found, and Rook requires one. For further information see: https://kurl.sh/docs/add-ons/rook#block-storage"
   - tcpPortStatus:
       checkName: "Pod csi-rbdplugin Host Port Status"
       collectorName: "Pod csi-rbdplugin Host Port"


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently when no block devices are found we only show: `[FAIL] Block Devices: No available block device`
Therefore, this PR improves the info provided and add the link to help the users have further information. 


```release-note
Adds better information to block devices check for Rook versions >= 1.4.3
```

#### Does this PR require documentation?
NONE