### PR TITLE
fix(flannel): weave to flannel additional primary task has no kubeconfig

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -729,6 +729,8 @@ function install_host_dependencies_longhorn() {
 }
 
 function weave_to_flannel_primary() {
+    export KUBECONFIG=/etc/kubernetes/admin.conf
+
     shift
     while [ "$1" != "" ]; do
         _param="$(echo "$1" | cut -d= -f1)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When running the weave-to-flannel-primary task I see an error "The connection to the server localhost:8080 was refused" due to no KUBECONFIG set in the environment. The task seems to work as expected even with the error.

```
$ cat ./tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=0bcf229885bf518880c1caee87924326bbd695a3883ddda14848df66f133857e
⚙  Running tasks with the argument(s): weave-to-flannel-primary cert-key=0bcf229885bf518880c1caee87924326bbd695a3883ddda14848df66f133857e
The connection to the server localhost:8080 was refused - did you specify the right host or port?
[preflight] Reading configuration from the cluster...
[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
W0301 17:27:50.018520  156817 utils.go:69] The recommended value for "resolvConf" in "KubeletConfiguration" is: /run/systemd/resolve/resolv.conf; the provided value is: /run/systemd/resolve/resolv.conf
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
✔ Successfully updated ethanm-upgrade-2 to use Flannel
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE