### PR TITLE
fix: host preflight checks results output colored

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/chzyer/readline v1.5.1
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/distribution v2.8.1+incompatible
-	github.com/fatih/color v1.14.1
 	github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
@@ -99,6 +98,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
+	github.com/fatih/color v1.14.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
@@ -319,6 +319,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.1
 	k8s.io/cri-api => k8s.io/cri-api v0.26.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.1
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.1
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.1
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.1
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.1

--- a/pkg/cli/colors.go
+++ b/pkg/cli/colors.go
@@ -1,11 +1,27 @@
 package cli
 
-import (
-	"github.com/fatih/color"
-)
+var Reset = "\033[0m"
+var Red = "\033[31m"
+var Green = "\033[32m"
+var Yellow = "\033[33m"
+var Blue = "\033[34m"
 
-var (
-	green  = color.New(color.FgGreen).SprintFunc()
-	yellow = color.New(color.FgYellow).SprintFunc()
-	red    = color.New(color.FgRed).SprintFunc()
-)
+// OutputPassGreen return [PASS] to be outputted in green
+func OutputPassGreen() string {
+	return Green + "[PASS]" + Reset
+}
+
+// OutputWarnYellow return [Warn] to be outputted in yellow
+func OutputWarnYellow() string {
+	return Yellow + "[WARN]" + Reset
+}
+
+// OutputFailRed return [Fail] to be outputted in red
+func OutputFailRed() string {
+	return Yellow + "[FAIL]" + Reset
+}
+
+// OutputInfoBlue return [Info] to be outputted in blue
+func OutputInfoBlue() string {
+	return Blue + "[INFO]" + Reset
+}

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -137,7 +137,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 				return errors.Wrap(err, "run host preflight")
 			}
 
-			printPreflightResults(cmd.OutOrStdout(), results)
+			printPreflightResults(results)
 
 			if v.GetBool("use-exit-codes") {
 				switch {
@@ -291,20 +291,20 @@ func retrieveInstallerSpecDataFromArg(fs afero.Fs, stdin io.Reader, arg string) 
 	return data, errors.Wrapf(err, "read from file %s", arg)
 }
 
-func printPreflightResults(w io.Writer, results []*analyze.AnalyzeResult) {
+func printPreflightResults(results []*analyze.AnalyzeResult) {
 	for _, result := range results {
-		printPreflightResult(w, result)
+		printPreflightResult(result)
 	}
 }
 
-func printPreflightResult(w io.Writer, result *analyze.AnalyzeResult) {
+func printPreflightResult(result *analyze.AnalyzeResult) {
 	switch {
 	case result.IsPass:
-		fmt.Fprintln(w, green("[PASS]"), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Println(OutputPassGreen(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	case result.IsWarn:
-		fmt.Fprintln(w, yellow("[WARN]"), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Println(OutputWarnYellow(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	case result.IsFail:
-		fmt.Fprintln(w, red("[FAIL]"), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Println(OutputFailRed(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	}
 }
 

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -137,7 +137,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 				return errors.Wrap(err, "run host preflight")
 			}
 
-			printPreflightResults(results)
+			printPreflightResults(cmd.OutOrStdout(), results)
 
 			if v.GetBool("use-exit-codes") {
 				switch {
@@ -291,20 +291,20 @@ func retrieveInstallerSpecDataFromArg(fs afero.Fs, stdin io.Reader, arg string) 
 	return data, errors.Wrapf(err, "read from file %s", arg)
 }
 
-func printPreflightResults(results []*analyze.AnalyzeResult) {
+func printPreflightResults(w io.Writer, results []*analyze.AnalyzeResult) {
 	for _, result := range results {
-		printPreflightResult(result)
+		printPreflightResult(w, result)
 	}
 }
 
-func printPreflightResult(result *analyze.AnalyzeResult) {
+func printPreflightResult(w io.Writer, result *analyze.AnalyzeResult) {
 	switch {
 	case result.IsPass:
-		fmt.Println(OutputPassGreen(), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Fprintln(w, OutputPassGreen(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	case result.IsWarn:
-		fmt.Println(OutputWarnYellow(), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Fprintln(w, OutputWarnYellow(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	case result.IsFail:
-		fmt.Println(OutputFailRed(), fmt.Sprintf("%s: %s", result.Title, result.Message))
+		fmt.Fprintln(w, OutputFailRed(), fmt.Sprintf("%s: %s", result.Title, result.Message))
 	}
 }
 

--- a/pkg/cli/host_preflight_test.go
+++ b/pkg/cli/host_preflight_test.go
@@ -45,7 +45,7 @@ func TestNewHostPreflightCmd(t *testing.T) {
 					IsPass:  true,
 				},
 			},
-			stdout: green("[PASS]") + " Number of CPUs: At least 4 CPU cores are required\n",
+			stdout: OutputPassGreen() + " Number of CPUs: At least 4 CPU cores are required\n",
 			stderr: "",
 		},
 		{
@@ -59,7 +59,7 @@ func TestNewHostPreflightCmd(t *testing.T) {
 				},
 			},
 			isWarn:  true,
-			stdout:  yellow("[WARN]") + " Number of CPUs: At least 4 CPU cores are required\n",
+			stdout:  OutputWarnYellow() + " Number of CPUs: At least 4 CPU cores are required\n",
 			stderr:  "Error: host preflights have warnings\n",
 			wantErr: true,
 		},
@@ -75,8 +75,8 @@ func TestNewHostPreflightCmd(t *testing.T) {
 			},
 			isWarn:         true,
 			ignoreWarnings: true,
-			stdout:         yellow("[WARN]") + " Number of CPUs: At least 4 CPU cores are required\n",
-			stderr:         "",
+			stdout:         OutputWarnYellow() + " Number of CPUs: At least 4 CPU cores are required\n",
+			stderr:         "Warnings ignored by CLI flag \"ignore-warnings\"\n",
 		},
 		{
 			name:          "fail",
@@ -89,7 +89,7 @@ func TestNewHostPreflightCmd(t *testing.T) {
 				},
 			},
 			isFail: true,
-			stdout: red("[FAIL]") + " Number of CPUs: At least 4 CPU cores are required\n",
+			stdout: OutputFailRed() + " Number of CPUs: At least 4 CPU cores are required\n",
 			stderr: "Error: host preflights have failures\n",
 		},
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, because of the usage of the tee to generate the logs we are unable to check the host preflights results with colours which makes harder to identify what is an error, warning and etc. 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

See:

<img width="892" alt="Screenshot 2023-03-06 at 12 30 12" src="https://user-images.githubusercontent.com/7708031/223111896-b2958305-8395-4a7f-8ba1-1f36a42746bb.png">


## Steps to reproduce
Just run the install command and check the host preflights checks result. 

#### Does this PR introduce a user-facing change?

```release-note
fix: host preflight checks result by outputting them with colours in order to improve the user experience
```

#### Does this PR require documentation?
NONE
