### PR TITLE
fix colour to output failures for host packages checks

### DIFF
--- a/pkg/cli/colors.go
+++ b/pkg/cli/colors.go
@@ -18,7 +18,7 @@ func OutputWarnYellow() string {
 
 // OutputFailRed return [Fail] to be outputted in red
 func OutputFailRed() string {
-	return Yellow + "[FAIL]" + Reset
+	return Red + "[FAIL]" + Reset
 }
 
 // OutputInfoBlue return [Info] to be outputted in blue


### PR DESCRIPTION
#### What this PR does / why we need it:

The failures has been outputted with yellow and not red.  This PR solves that.

<img width="1017" alt="Screenshot 2023-03-07 at 09 08 27" src="https://user-images.githubusercontent.com/7708031/223376470-aa5fd43a-691a-4f94-b327-f2510a8258d2.png">

#### Which issue(s) this PR fixes:

Fixes # [sc-70924]

