### PR TITLE
chore: increase timeout to check sync-object-store and improve the logs for failures scenarios

### DIFF
--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -116,7 +116,8 @@ EOF
     if ! spinner_until 600 kubernetes_pod_completed sync-object-store "$namespace" ; then
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
     fi
-    kubectl logs -n "$namespace" sync-object-store || true
+    # this command intentionally tails the logs until the pod completes to get the full logs
+    kubectl logs -n "$namespace" -f sync-object-store || true
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         logSuccess "Object store data synced successfully"
         kubectl delete pod sync-object-store -n "$namespace" --force --grace-period=0 &> /dev/null

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -115,9 +115,8 @@ EOF
     log "Waiting up to 10 minutes for sync-object-store pod to complete"
     if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
-        kubectl logs -n "$namespace" sync-object-store || true
     fi
-
+    kubectl logs -n "$namespace" sync-object-store || true
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         logSuccess "Object store data synced successfully"
         kubectl delete pod sync-object-store -n "$namespace" --force --grace-period=0 &> /dev/null

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -103,21 +103,23 @@ spec:
     - --dest_access_key_secret=$destination_secret_key
 EOF
 
-    echo "Waiting up to 5 minutes for sync-object-store pod to start in ${namespace} namespace"
-    if ! spinner_until 300 kubernetes_pod_started sync-object-store "$namespace" ; then
-        printf "${RED}Failed to start object store migration pod within 5 minutes${NC}\n"
+    log "Waiting up to 10 minutes for sync-object-store pod to start in ${namespace} namespace"
+    if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
+        logFail "Failed to start object store migration pod within 10 minutes"
         return 1
     fi
 
-    # The 5 minute spinner allows the pod to crash a few times waiting for the object store to be ready
+    # The 10 minute spinner allows the pod to crash a few times waiting for the object store to be ready
     # and then following the logs allows for an indefinite amount of time for the migration to
     # complete in case there is a lot of data
-    echo "Waiting up to 5 minutes for sync-object-store pod to complete"
-    spinner_until 300 kubernetes_pod_completed sync-object-store "$namespace" || true
+    log "Waiting up to 10 minutes for sync-object-store pod to complete"
+    if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
+        logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
+    fi
     kubectl logs -n "$namespace" -f sync-object-store || true
 
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
-        printf "\n${GREEN}Object store data synced successfully${NC}\n"
+        logSuccess "Object store data synced successfully"
         kubectl delete pod sync-object-store -n "$namespace" --force --grace-period=0 &> /dev/null
         return 0
     fi
@@ -150,6 +152,7 @@ function migrate_between_object_stores() {
         if kubernetes_resource_exists kurl deployment ekc-operator; then
             kubectl -n kurl scale deploy ekc-operator --replicas=1
         fi
+        kubectl logs -n "default" -f sync-object-store || true
         bail "sync-object-store pod failed"
     fi
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -116,7 +116,7 @@ EOF
     if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
     fi
-    kubectl logs -n "$namespace" -f sync-object-store || true
+    kubectl logs -n "$namespace" sync-object-store || true
 
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         logSuccess "Object store data synced successfully"
@@ -152,7 +152,7 @@ function migrate_between_object_stores() {
         if kubernetes_resource_exists kurl deployment ekc-operator; then
             kubectl -n kurl scale deploy ekc-operator --replicas=1
         fi
-        kubectl logs -n "default" -f sync-object-store || true
+        kubectl logs -n "default" sync-object-store || true
         bail "sync-object-store pod failed"
     fi
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -113,7 +113,7 @@ EOF
     # and then following the logs allows for an indefinite amount of time for the migration to
     # complete in case there is a lot of data
     log "Waiting up to 10 minutes for sync-object-store pod to complete"
-    if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
+    if ! spinner_until 600 kubernetes_pod_completed sync-object-store "$namespace" ; then
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
     fi
     kubectl logs -n "$namespace" sync-object-store || true

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -115,6 +115,7 @@ EOF
     log "Waiting up to 10 minutes for sync-object-store pod to complete"
     if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
+        kubectl logs -n "$namespace" sync-object-store || true
     fi
     kubectl logs -n "$namespace" sync-object-store || true
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -103,9 +103,9 @@ spec:
     - --dest_access_key_secret=$destination_secret_key
 EOF
 
-    log "Waiting up to 10 minutes for sync-object-store pod to start in ${namespace} namespace"
-    if ! spinner_until 600 kubernetes_pod_started sync-object-store "$namespace" ; then
-        logFail "Failed to start object store migration pod within 10 minutes"
+    log "Waiting up to 5 minutes for sync-object-store pod to start in ${namespace} namespace"
+    if ! spinner_until 300 kubernetes_pod_started sync-object-store "$namespace" ; then
+        logFail "Failed to start object store migration pod within 5 minutes"
         return 1
     fi
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -151,7 +151,6 @@ function migrate_between_object_stores() {
         if kubernetes_resource_exists kurl deployment ekc-operator; then
             kubectl -n kurl scale deploy ekc-operator --replicas=1
         fi
-        kubectl logs -n "default" sync-object-store || true
         bail "sync-object-store pod failed"
     fi
 

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -117,7 +117,6 @@ EOF
         logWarn "Timeout faced waiting for start object store migration pod within 10 minutes"
         kubectl logs -n "$namespace" sync-object-store || true
     fi
-    kubectl logs -n "$namespace" sync-object-store || true
 
     if kubernetes_pod_succeeded sync-object-store "$namespace" ; then
         logSuccess "Object store data synced successfully"


### PR DESCRIPTION
#### What this PR does / why we need it:

By using the option to force selinuxConfig we can see that it faces an timeout and not enough information is provided in this case for we better troubleshooting. Therefore, this PR improves the log and increase the timeout from 5 to 10 minutes. 

#### Which issue(s) this PR fixes:

Related to # [sc-70880]

#### Special notes for your reviewer:


## Steps to reproduce
See: https://testgrid.kurl.sh/run/check-rook-upgrades-mon-27?kurlLogsInstanceId=viuwqcdcnyyfbwqa&nodeId=viuwqcdcnyyfbwqa-initialprimary

#### Does this PR introduce a user-facing change?

```release-note
Adds capture of sync-object-store pod logs when the store migration fails and increase the timeout to check the pod running
```

#### Does this PR require documentation?
NONE