### PR TITLE
fix: only allow users to move from Rook to OpenEBS >= 3.3.0

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -640,7 +640,9 @@ allow_remove_docker_new_install() {
      fi
 }
 
-allow_migrate_from_rook_to_openebs() {
+# bail_if_unsupported_openebs_to_rook_version will bail if the rook is being removed in favor of
+# openebs and the openebs version does not support migrations from rook.
+function bail_if_unsupported_openebs_to_rook_version() {
     if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
         if commandExists kubectl; then
             if kubectl get ns | grep -q rook-ceph; then

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -644,7 +644,9 @@ allow_migrate_from_rook_to_openebs() {
     if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
         if commandExists kubectl; then
             if kubectl get ns | grep -q rook-ceph; then
-                if [ $(echo "$OPENEBS_VERSION" | cut -d. -f1) == 2 ] || [ $(echo "$OPENEBS_VERSION" | cut -d. -f1) == 1 ] || [ "$OPENEBS_VERSION" == "3.2.0" ]; then
+                semverParse "$OPENEBS_VERSION"
+                # if $OPENEBS_VERSION is less than 3.3.0
+                if [ "$major" -lt "3" ] || { [ "$major" = "3" ] && [ "$minor" -lt "3" ] ; }; then
                    logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
                    bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
                 fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -644,7 +644,7 @@ allow_migrate_from_rook_to_openebs() {
     if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
         if commandExists kubectl; then
             if kubectl get ns | grep -q rook-ceph; then
-                if  [ "$(echo "$OPENEBS_VERSION}" | wc -l)" -le "3" ] || [ "$OPENEBS_VERSION" == "3.2.0"]; then
+                if [ $(echo "$OPENEBS_VERSION" | cut -d. -f1) == 2 ] || [ $(echo "$OPENEBS_VERSION" | cut -d. -f1) == 1 ] || [ "$OPENEBS_VERSION" == "3.2.0" ]; then
                    logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
                    bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
                 fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -13,6 +13,7 @@ function preflights() {
     kotsadm_prerelease
     host_nameservers_reachable
     allow_remove_docker_new_install
+    allow_migrate_from_rook_to_openebs
     return 0
 }
 
@@ -637,4 +638,14 @@ allow_remove_docker_new_install() {
           logWarn "\nThe installation will continue, however, if this script fails due to package"
           logWarn "conflicts, please uninstall Docker and re-run the install script."
      fi
+}
+
+allow_migrate_from_rook_to_openebs() {
+    if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
+        if kubectl get ns | grep -q rook-ceph; then
+            if  [ "$(echo "$OPENEBS_VERSION}" | wc -l)" -le "3" ] || [ "$OPENEBS_VERSION" == "3.2.0"]; then
+                  bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
+            fi
+        fi
+    fi
 }

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -647,8 +647,8 @@ allow_migrate_from_rook_to_openebs() {
                 semverParse "$OPENEBS_VERSION"
                 # if $OPENEBS_VERSION is less than 3.3.0
                 if [ "$major" -lt "3" ] || { [ "$major" = "3" ] && [ "$minor" -lt "3" ] ; }; then
-                   logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
-                   bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
+                   logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed."
+                   bail "OpenEBS versions less than 3.3.0 do not support migrations from Rook"
                 fi
             fi
         fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -13,7 +13,7 @@ function preflights() {
     kotsadm_prerelease
     host_nameservers_reachable
     allow_remove_docker_new_install
-    allow_migrate_from_rook_to_openebs
+    bail_if_unsupported_openebs_to_rook_version
     return 0
 }
 

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -644,6 +644,7 @@ allow_migrate_from_rook_to_openebs() {
     if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             if  [ "$(echo "$OPENEBS_VERSION}" | wc -l)" -le "3" ] || [ "$OPENEBS_VERSION" == "3.2.0"]; then
+                  logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
                   bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
             fi
         fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -642,11 +642,14 @@ allow_remove_docker_new_install() {
 
 allow_migrate_from_rook_to_openebs() {
     if [ -z "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
-        if kubectl get ns | grep -q rook-ceph; then
-            if  [ "$(echo "$OPENEBS_VERSION}" | wc -l)" -le "3" ] || [ "$OPENEBS_VERSION" == "3.2.0"]; then
-                  logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
-                  bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
+        if commandExists kubectl; then
+            if kubectl get ns | grep -q rook-ceph; then
+                if  [ "$(echo "$OPENEBS_VERSION}" | wc -l)" -le "3" ] || [ "$OPENEBS_VERSION" == "3.2.0"]; then
+                   logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed"
+                   bail "OpenEBS versions <= 3.2.0 does not support migration from Rook"
+                fi
             fi
         fi
     fi
 }
+


### PR DESCRIPTION
#### What this PR does / why we need it:

Only OpenEBS versions >= 3.3.0 can support the migrating path from Rook. 
Therefore, this PR adds a preflight check that will bail in case users try to move with this upgrade path

#### Which issue(s) this PR fixes:

Fixes # [sc-70256]

#### Special notes for your reviewer:

See: 


<img width="979" alt="Screenshot 2023-03-08 at 00 19 29" src="https://user-images.githubusercontent.com/7708031/223586372-d3ffce28-423a-4208-946d-cd010fccd813.png">


## Steps to reproduce


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes unsupported migration path from Rook to OpenEBS with versions < 3.3.0 by adding a preflight check to prevent the scenario. 
```

#### Does this PR require documentation?
NONE