### PR TITLE
Fixes issue `failed to find plugin /opt/cni/bin/weave-net`

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -784,7 +784,7 @@ function kubeadm_cluster_status() {
 }
 
 function check_network() {
-	  logStep "Checking cluster networking"
+    logStep "Checking cluster networking"
 
     if [ -n "$WEAVE_VERSION" ]; then
         log "Checking if weave-net binary can be found in the path /opt/cni/bin/"

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -784,7 +784,15 @@ function kubeadm_cluster_status() {
 }
 
 function check_network() {
-	logStep "Checking cluster networking"
+	  logStep "Checking cluster networking"
+
+    if [ -n "$WEAVE_VERSION" ]; then
+        log "Checking if weave-net binary can be found in the path /opt/cni/bin/"
+        if ! ls -la /opt/cni/bin/ | grep weave-net; then
+            logWarn "Unable to find weave-net binary. Deleting weave-net pod"
+            kubectl delete pods --selector=name=weave-net -n kube-system --ignore-not-found=true
+        fi
+    fi
 
     if ! kubernetes_any_node_ready; then
         echo "Waiting for node to report Ready"

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -790,7 +790,7 @@ function check_network() {
         log "Checking if weave-net binary can be found in the path /opt/cni/bin/"
         if ! ls -la /opt/cni/bin/ | grep weave-net; then
             logWarn "Unable to find weave-net binary, deleting weave-net pod so that the binary will be recreated"
-            kubectl delete pods --selector=name=weave-net -n kube-system --ignore-not-found=true
+            kubectl delete pods --selector=name=weave-net --field-selector=spec.nodeName=$(hostname) -n kube-system --ignore-not-found=true
         fi
     fi
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -789,7 +789,7 @@ function check_network() {
     if [ -n "$WEAVE_VERSION" ]; then
         log "Checking if weave-net binary can be found in the path /opt/cni/bin/"
         if ! ls -la /opt/cni/bin/ | grep weave-net; then
-            logWarn "Unable to find weave-net binary. Deleting weave-net pod"
+            logWarn "Unable to find weave-net binary, deleting weave-net pod so that the binary will be recreated"
             kubectl delete pods --selector=name=weave-net -n kube-system --ignore-not-found=true
         fi
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Because in some scenario the weave-net cni binary is not found:
<img width="1272" alt="223588364-4751434a-4aad-4f7e-9a3c-242f55932e36" src="https://user-images.githubusercontent.com/7708031/223687844-d6fee340-64cd-48b9-a859-7a3c741c236e.png">

Therefore, we could check that by removing the pod and let be re-created we can fix it 

<img width="890" alt="Screenshot 2023-03-08 at 09 54 19" src="https://user-images.githubusercontent.com/7708031/223688022-98fd27c7-6bdf-461c-ba43-a34837ab099f.png">

#### Which issue(s) this PR fixes:

Fixes # [sc-71175]

#### Special notes for your reviewer:
I am unable to reproduce the issue but I tried to make it happens to verify this solution by
removing the removing the weave-net binary prior check if the nodes are ready. See:

<img width="893" alt="Screenshot 2023-03-08 at 10 59 57" src="https://user-images.githubusercontent.com/7708031/223695871-f6b8201b-bab5-492a-ab62-d0c5a4de1aa0.png">

Then, we can check that the installation succeed as well:

<img width="873" alt="Screenshot 2023-03-08 at 10 59 27" src="https://user-images.githubusercontent.com/7708031/223695765-33d93933-7b87-4102-b130-76079db50f2d.png">

Installer used : https://kurl.sh/9f773aa
SO: ubuntu 20.04 - GCP
## Steps to reproduce

In the script prior check the network we are removing the bin to simulate the scenario. 

#### Does this PR introduce a user-facing change?

```release-note
Fixes issue `failed to find plugin /opt/cni/bin/weave-net` when the installer is checking cluster networking by deleting the weave-net pod when the binary is not found to let it be re-created successfully  
```

#### Does this PR require documentation?
NONE