### PR TITLE
fix: use get_local_node_name instead of hostname

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -790,7 +790,7 @@ function check_network() {
         log "Checking if weave-net binary can be found in the path /opt/cni/bin/"
         if ! ls -la /opt/cni/bin/ | grep weave-net; then
             logWarn "Unable to find weave-net binary, deleting weave-net pod so that the binary will be recreated"
-            kubectl delete pods --selector=name=weave-net --field-selector=spec.nodeName=$(hostname) -n kube-system --ignore-not-found=true
+            kubectl delete pods --selector=name=weave-net --field-selector="spec.nodeName=$(get_local_node_name)" -n kube-system --ignore-not-found=true
         fi
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We should standardize on get_local_node_name function to get the local node name.