### PR TITLE
fix: missing error variable substitution log statement

### DIFF
--- a/pkg/rook/migrate.go
+++ b/pkg/rook/migrate.go
@@ -135,7 +135,7 @@ func patchCephcluster(ctx context.Context, cephClient *cephv1.CephV1Client) erro
 
 	_, err = cephClient.CephClusters("rook-ceph").Patch(ctx, "rook-ceph", types.JSONPatchType, []byte(disableDirectories), metav1.PatchOptions{})
 	if err != nil {
-		out("Got error %q when disabling hostpath storage, but continuing anyways")
+		out(fmt.Sprintf("Got error %q when disabling hostpath storage, but continuing anyways", err))
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Wessage is missing when disabling hostpath storage fails due to error

```
2023-02-23 07:56:57+00:00 Got error %q when disabling hostpath storage, but continuing anyways
```