### PR TITLE
fix: Check for correct flannel image when migrating from Weave

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -855,9 +855,9 @@ function task_requires_root() {
     fi
 }
 
-# check if containerd on the current node has the `docker.io/rancher/mirrored-flannelcni-flannel:v<version>` image
+# check if containerd on the current node has the `docker.io/flannel/flannel` image
 function flannel_images_present() {
-    if ! ctr -n=k8s.io images ls | grep -q "docker.io/rancher/mirrored-flannelcni-flannel" ; then
+    if ! ctr -n=k8s.io images ls | grep -q "docker.io/flannel/flannel" ; then
         logFail "Flannel images not present on $(get_local_node_name), please ensure the 'load-images' task has been run successfully"
         exit 1
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The `weave-to-flannel-primary`/`weave-to-flannel-secondary` tasks are failing due to the flannel images being "missing":
```
⚙  Running tasks with the argument(s): weave-to-flannel-primary airgap cert-key=0e2bfbb240ce8436822ca27a545b635d12c979531b9c606f6380436f927f82a0
Flannel images not present on rafael-weave-to-flannel-airgap-cp-3, please ensure the 'load-images' task has been run successfully
```
However, the flannel images are present (and loaded) its just that the logic for checking whether the flannel image was present was searching for the incorrect image: `docker.io/rancher/mirrored-flannelcni-flannel`. The Flannel project changed the registry and repository for the image in this [commit](https://github.com/flannel-io/flannel/commit/3b242e9e7d72ff444c8d56566e3f2e75eb64d1e8).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

[sc-70618](https://app.shortcut.com/replicated/story/70618/weave-to-flannel-primary-task-on-airgap-node-fails-with-missing-images)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the weave-to-flannel-{primary,secondary} tasks fail with "Flannel images not present..."
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
