### PR TITLE
bug: now longer allow migrate the object store twice

### DIFF
--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -165,6 +165,12 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -165,6 +165,7 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-06-11T19-55-32Z/install.sh
+++ b/addons/minio/2022-06-11T19-55-32Z/install.sh
@@ -165,6 +165,12 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-06-11T19-55-32Z/install.sh
+++ b/addons/minio/2022-06-11T19-55-32Z/install.sh
@@ -165,6 +165,7 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-07-06T20-29-49Z/install.sh
+++ b/addons/minio/2022-07-06T20-29-49Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-07-06T20-29-49Z/install.sh
+++ b/addons/minio/2022-07-06T20-29-49Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-07-17T15-43-14Z/install.sh
+++ b/addons/minio/2022-07-17T15-43-14Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-07-17T15-43-14Z/install.sh
+++ b/addons/minio/2022-07-17T15-43-14Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-08-02T23-59-16Z/install.sh
+++ b/addons/minio/2022-08-02T23-59-16Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-08-02T23-59-16Z/install.sh
+++ b/addons/minio/2022-08-02T23-59-16Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-08-22T23-53-06Z/install.sh
+++ b/addons/minio/2022-08-22T23-53-06Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-08-22T23-53-06Z/install.sh
+++ b/addons/minio/2022-08-22T23-53-06Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-09-01T23-53-36Z/install.sh
+++ b/addons/minio/2022-09-01T23-53-36Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-09-01T23-53-36Z/install.sh
+++ b/addons/minio/2022-09-01T23-53-36Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-09-07T22-25-02Z/install.sh
+++ b/addons/minio/2022-09-07T22-25-02Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-09-07T22-25-02Z/install.sh
+++ b/addons/minio/2022-09-07T22-25-02Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-09-17T00-09-45Z/install.sh
+++ b/addons/minio/2022-09-17T00-09-45Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-09-17T00-09-45Z/install.sh
+++ b/addons/minio/2022-09-17T00-09-45Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -190,7 +190,6 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
-
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -190,6 +190,18 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -190,12 +190,14 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return
     fi
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -190,12 +190,6 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
-    export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
-    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
-        logWarn "Object store is set as migrated previously. Not migrating object store again."
-        return
-    fi
 
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')

--- a/addons/minio/2022-10-02T19-29-29Z/install.sh
+++ b/addons/minio/2022-10-02T19-29-29Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-10-02T19-29-29Z/install.sh
+++ b/addons/minio/2022-10-02T19-29-29Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-10-05T14-58-27Z/install.sh
+++ b/addons/minio/2022-10-05T14-58-27Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-10-05T14-58-27Z/install.sh
+++ b/addons/minio/2022-10-05T14-58-27Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-10-08T20-11-00Z/install.sh
+++ b/addons/minio/2022-10-08T20-11-00Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-10-08T20-11-00Z/install.sh
+++ b/addons/minio/2022-10-08T20-11-00Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-10-15T19-57-03Z/install.sh
+++ b/addons/minio/2022-10-15T19-57-03Z/install.sh
@@ -190,6 +190,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-10-15T19-57-03Z/install.sh
+++ b/addons/minio/2022-10-15T19-57-03Z/install.sh
@@ -190,6 +190,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-10-20T00-55-09Z/install.sh
+++ b/addons/minio/2022-10-20T00-55-09Z/install.sh
@@ -210,6 +210,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2022-10-20T00-55-09Z/install.sh
+++ b/addons/minio/2022-10-20T00-55-09Z/install.sh
@@ -210,6 +210,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-12-12T19-27-27Z/install.sh
+++ b/addons/minio/2022-12-12T19-27-27Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2022-12-12T19-27-27Z/install.sh
+++ b/addons/minio/2022-12-12T19-27-27Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-02T09-40-09Z/install.sh
+++ b/addons/minio/2023-01-02T09-40-09Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-02T09-40-09Z/install.sh
+++ b/addons/minio/2023-01-02T09-40-09Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-06T18-11-18Z/install.sh
+++ b/addons/minio/2023-01-06T18-11-18Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-06T18-11-18Z/install.sh
+++ b/addons/minio/2023-01-06T18-11-18Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-12T02-06-16Z/install.sh
+++ b/addons/minio/2023-01-12T02-06-16Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-12T02-06-16Z/install.sh
+++ b/addons/minio/2023-01-12T02-06-16Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-18T04-36-38Z/install.sh
+++ b/addons/minio/2023-01-18T04-36-38Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-18T04-36-38Z/install.sh
+++ b/addons/minio/2023-01-18T04-36-38Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-20T02-05-44Z/install.sh
+++ b/addons/minio/2023-01-20T02-05-44Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-20T02-05-44Z/install.sh
+++ b/addons/minio/2023-01-20T02-05-44Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-25T00-19-54Z/install.sh
+++ b/addons/minio/2023-01-25T00-19-54Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-25T00-19-54Z/install.sh
+++ b/addons/minio/2023-01-25T00-19-54Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-01-31T02-24-19Z/install.sh
+++ b/addons/minio/2023-01-31T02-24-19Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-01-31T02-24-19Z/install.sh
+++ b/addons/minio/2023-01-31T02-24-19Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-02-09T05-16-53Z/install.sh
+++ b/addons/minio/2023-02-09T05-16-53Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-02-09T05-16-53Z/install.sh
+++ b/addons/minio/2023-02-09T05-16-53Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-02-10T18-48-39Z/install.sh
+++ b/addons/minio/2023-02-10T18-48-39Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-02-10T18-48-39Z/install.sh
+++ b/addons/minio/2023-02-10T18-48-39Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-02-17T17-52-43Z/install.sh
+++ b/addons/minio/2023-02-17T17-52-43Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-02-17T17-52-43Z/install.sh
+++ b/addons/minio/2023-02-17T17-52-43Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-02-22T18-23-45Z/install.sh
+++ b/addons/minio/2023-02-22T18-23-45Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-02-22T18-23-45Z/install.sh
+++ b/addons/minio/2023-02-22T18-23-45Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-02-27T18-10-45Z/install.sh
+++ b/addons/minio/2023-02-27T18-10-45Z/install.sh
@@ -234,6 +234,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-02-27T18-10-45Z/install.sh
+++ b/addons/minio/2023-02-27T18-10-45Z/install.sh
@@ -234,6 +234,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-03-09T23-16-13Z/install.sh
+++ b/addons/minio/2023-03-09T23-16-13Z/install.sh
@@ -239,6 +239,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-03-09T23-16-13Z/install.sh
+++ b/addons/minio/2023-03-09T23-16-13Z/install.sh
@@ -239,6 +239,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-03-13T19-46-17Z/install.sh
+++ b/addons/minio/2023-03-13T19-46-17Z/install.sh
@@ -239,6 +239,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-03-13T19-46-17Z/install.sh
+++ b/addons/minio/2023-03-13T19-46-17Z/install.sh
@@ -239,6 +239,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/2023-03-20T20-16-18Z/install.sh
+++ b/addons/minio/2023-03-20T20-16-18Z/install.sh
@@ -239,6 +239,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/2023-03-20T20-16-18Z/install.sh
+++ b/addons/minio/2023-03-20T20-16-18Z/install.sh
@@ -239,6 +239,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -239,6 +239,12 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
+        logWarn "Object store is set as migrated previously. Not migrating object store again."
+        return
+    fi
+    
     migrate_rgw_to_minio
     add_rook_store_object_migration_status
 }

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -239,6 +239,7 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    export DID_MIGRATE_ROOK_OBJECT_STORE=0
     DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."


### PR DESCRIPTION
#### What this PR does / why we need it:

If the object store were migrate then we would not like to migrate it twice. 

#### Which issue(s) this PR fixes:

Fixes # [sc-70239]

#### Special notes for your reviewer:
Blocked by; https://github.com/replicatedhq/kURL/pull/4239


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds check to not allow perform more than once successfully the object store migration 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
