### PR TITLE
Fixes issue when migrate from Longhorn and it is not uninstalled by adding a check and better log information to allow users be aware of and the reasons for Longhorn not be able to be uninstalled programmatically.

### DIFF
--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -155,7 +155,7 @@ function maybe_cleanup_longhorn() {
 
         logWarn ""
         logWarn "ATTENTION: Unable to remove Longhorn."
-        if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
+        if [ "$DID_MIGRATE_LONGHORN_PVCS" != "1" ]; then
             logFail "Storage class migration did not succeed"
         fi
     fi

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -154,7 +154,7 @@ function maybe_cleanup_longhorn() {
         fi
 
         logWarn ""
-        logWarn "ATTENTION: Unable to remove Longhorn."
+        logFail "Unable to remove Longhorn."
         if [ "$DID_MIGRATE_LONGHORN_PVCS" != "1" ]; then
             logFail "Storage class migration did not succeed"
         fi

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -145,7 +145,7 @@ function maybe_cleanup_longhorn() {
         if ! kubectl get ns | grep -q longhorn-system; then
             return
         fi 
-            logStep "Removing Longhorn"
+        logStep "Removing Longhorn"
         if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
             report_addon_start "longhorn-removal" "v1"
             remove_longhorn

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -141,9 +141,10 @@ function longhorn_to_sc_migration() {
 # if PVCs and object store data have both been migrated from longhorn and longhorn is no longer specified in the kURL spec, remove longhorn
 function maybe_cleanup_longhorn() {
     if [ -z "$LONGHORN_VERSION" ]; then
-        if kubectl get ns | grep -q longhorn-system; then
-            logStep "Removing Longhorn ..."
-        fi
+        # Just continue if longhorn is installed. 
+        if ! kubectl get ns | grep -q longhorn-system; then
+            return
+        fi 
 
         if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
             report_addon_start "longhorn-removal" "v1"

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -141,10 +141,21 @@ function longhorn_to_sc_migration() {
 # if PVCs and object store data have both been migrated from longhorn and longhorn is no longer specified in the kURL spec, remove longhorn
 function maybe_cleanup_longhorn() {
     if [ -z "$LONGHORN_VERSION" ]; then
+        if kubectl get ns | grep -q longhorn-system; then
+            logStep "Removing Longhorn ..."
+        fi
+
         if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
             report_addon_start "longhorn-removal" "v1"
             remove_longhorn
             report_addon_success "longhorn-removal" "v1"
+            return
+        fi
+
+        logWarn ""
+        logWarn "ATTENTION: Unable to remove Rook."
+        if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
+            logFail "Storage class migration did not succeed"
         fi
     fi
 }

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -145,7 +145,7 @@ function maybe_cleanup_longhorn() {
         if ! kubectl get ns | grep -q longhorn-system; then
             return
         fi 
-
+            logStep "Removing Longhorn"
         if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
             report_addon_start "longhorn-removal" "v1"
             remove_longhorn

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -153,7 +153,6 @@ function maybe_cleanup_longhorn() {
             return
         fi
 
-        logWarn ""
         logFail "Unable to remove Longhorn."
         if [ "$DID_MIGRATE_LONGHORN_PVCS" != "1" ]; then
             logFail "Storage class migration did not succeed"

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -154,7 +154,7 @@ function maybe_cleanup_longhorn() {
         fi
 
         logWarn ""
-        logWarn "ATTENTION: Unable to remove Rook."
+        logWarn "ATTENTION: Unable to remove Longhorn."
         if [ "$DID_MIGRATE_LONGHORN_PVCS" == "1" ]; then
             logFail "Storage class migration did not succeed"
         fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, by installing a new install where we are migrating from Longhorn users are unable to check that Longhorn was or not delete. Also, no information about why it was not possible to delete it is provided to them when failures occurs. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-71884]

#### Special notes for your reviewer:

Just adding the namespace to check out the error;

<img width="655" alt="Screenshot 2023-03-17 at 13 05 45" src="https://user-images.githubusercontent.com/7708031/225913033-f8b2c46a-86de-4208-9a4d-b5417f7201bf.png">

Just forcing DID_MIGRATE_LONGHORN_PVCS=1 to check out its results:

<img width="889" alt="Screenshot 2023-03-17 at 13 08 54" src="https://user-images.githubusercontent.com/7708031/225913971-a12f7c45-97a9-46e2-b622-70be3ab488f0.png">

(script fails because it is a mock longhorn does not exist)

PS: Tested without the namespace to check that would not print the step

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes issue when migrate from Longhorn and it is not uninstalled by adding a check and better log information to allow users be aware of and the reasons for Longhorn not be able to be uninstalled programmatically.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
