### PR TITLE
fix: just ensure that we have the step so we can have clear logs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,7 +365,7 @@ function kubernetes_maybe_generate_bootstrap_token() {
 }
 
 function kurl_config() {
-    logStep "Configuring the installer ..."
+    logStep "Persisting the kurl installer spec"
     if kubernetes_resource_exists kube-system configmap kurl-config; then
         kubectl -n kube-system delete configmap kurl-config
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,6 +365,7 @@ function kubernetes_maybe_generate_bootstrap_token() {
 }
 
 function kurl_config() {
+    logStep "Configuring the installer ..."
     if kubernetes_resource_exists kube-system configmap kurl-config; then
         kubectl -n kube-system delete configmap kurl-config
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

By looking the logs we will see something like:

<img width="1297" alt="Screenshot 2023-03-16 at 08 57 14" src="https://user-images.githubusercontent.com/7708031/225565496-6646754e-7b43-4132-b656-56a19409c750.png">


See that is not clear from where the config pacthes came from or in what step it is made.
That is confusing (mainly to troubleshot) since we use the stepLog to make clear about each part of the workflows.

So, this PR fix that by adding a logStep prior config kurl. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes missguided logs by adding clear output to the step to configure the installer.  
```

#### Does this PR require documentation?
NONE
