### PR TITLE
fix: add checks when minio is required

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -657,3 +657,20 @@ function bail_if_unsupported_openebs_to_rook_version() {
     fi
 }
 
+function bail_when_requires_minio_with_openebs() {
+    if [ -z "$MINIO_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
+        if [ -n "$KOTS_VERSION" ] && [[ -z "$KOTSADM_DISABLE_S3" || "$KOTSADM_DISABLE_S3" != "1" ]];then
+             logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed with kOTS version $KOTS_VERSION"
+             bail "OpenEBS and kOTS with s3 enabled requires MinIO"
+        fi
+        if [ -n "$REGISTRY_VERSION" ];then
+             logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed with kOTS version $REGISTRY_VERSION"
+             bail "OpenEBS and Registry requires MinIO. Please, ensure that your installer also provides MinIO"
+        fi
+        if [ -n "$VALERO_VERSION" ];then
+             logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed with kOTS version $VALERO_VERSION"
+             bail "OpenEBS and Registry requires Valero. Please, ensure that your installer also provides MinIO"
+        fi
+    fi
+}
+


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR ensures the mandatory selection.
We must have minio on those scenarios. 

#### Which issue(s) this PR fixes:

Fixes # [sc-70234]

#### Special notes for your reviewer:

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds check to ensure that minio will be selected when the installer is with OpenEBS.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
