### PR TITLE
feat: add check to not allow use the installer with previously versions

### DIFF
--- a/scripts/common/kurl.sh
+++ b/scripts/common/kurl.sh
@@ -25,3 +25,8 @@ function kurl_set_current_version() {
 function kurl_get_current_version() {
     kubectl get configmap -n kurl kurl-current-config -o jsonpath="{.data.kurl-version}"
 }
+
+function kurl_get_last_version() {
+    kubectl get configmap -n kurl kurl-last-config -o jsonpath="{.data.kurl-version}"
+}
+

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -664,7 +664,7 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
        local previous_kurl_version
        previous_kurl_version="$(kurl_get_current_version)"
        if [ -z "$previous_kurl_version" ]; then
-               previous_kurl_version="$(kurl_get_current_version)"
+               previous_kurl_version="$(kurl_get_last_version)"
        fi
 
        semverCompare $(echo "$KURL_VERSION" | sed 's/v//g') "$(echo "$previous_kurl_version" | sed 's/v//g')"

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -669,8 +669,7 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
 
        semverCompare $(echo "$KURL_VERSION" | sed 's/v//g') "$(echo "$previous_kurl_version" | sed 's/v//g')"
        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 14.2.21
-           logFail "This host was previously installed using the kURL release version $previous_kurl_version"
-           logFail "which is greater than the current version $KURL_VERSION."
+           logFail "The current kURL release version $KURL_VERSION is less than the previously installed version $previous_kurl_version."
            bail "Please use a kURL release version which is equal to or greater than the version used previously."
        fi
        log "Previous kURL version used to install or update the cluster is $previous_kurl_version"

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -14,6 +14,7 @@ function preflights() {
     host_nameservers_reachable
     allow_remove_docker_new_install
     bail_if_unsupported_openebs_to_rook_version
+    bail_if_kurl_version_is_lower_than_previous_config
     return 0
 }
 
@@ -657,3 +658,22 @@ function bail_if_unsupported_openebs_to_rook_version() {
     fi
 }
 
+# not allow run the installer/upgrade when kurl version is lower than the previous applied before
+function bail_if_kurl_version_is_lower_than_previous_config() {
+    if commandExists kubectl; then
+       local previous_kurl_version
+       previous_kurl_version="$(kurl_get_current_version)"
+       if [ -z "$previous_kurl_version" ]; then
+               previous_kurl_version="$(kurl_get_current_version)"
+       fi
+
+       semverCompare $(echo "$KURL_VERSION" | sed 's/v//g') "$(echo "$previous_kurl_version" | sed 's/v//g')"
+       if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 14.2.21
+           logFail "This host was previously installed using the kURL release version $previous_kurl_version"
+           logFail "which is greater than the current version $KURL_VERSION."
+           bail "Please use a kURL release version which is equal to or greater than the version used previously."
+       fi
+       log "Previous kURL version used to install or update the cluster is $previous_kurl_version"
+       log "and the current kURL version used is $KURL_VERSION"
+    fi
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

It seems not possible ensure that the workflows can work well within backwards. 
The preflight ensure that the script will not possible try to install/update within an script that is a lower release than the version used to install/update previously. 

#### Which issue(s) this PR fixes:

Fixes # [sc-72065]

#### Special notes for your reviewer:

Test made trying to do the update within an old release:
<img width="1097" alt="Screenshot 2023-03-18 at 08 17 30" src="https://user-images.githubusercontent.com/7708031/226094059-cedb3abb-038a-4bd9-8ac4-8cc2eab3d5e4.png">


Test made trying to do the update within an upper release:
<img width="987" alt="Screenshot 2023-03-18 at 08 14 38" src="https://user-images.githubusercontent.com/7708031/226094064-c3864b37-56fc-4014-8647-8a6365c941fa.png">

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight check to ensure that a host will not be updated with previously kURL releases
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
