### PR TITLE
Fixes stuck issues scenarios when is trying to delete Rook and provide better information about the steps performed.  

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -86,7 +86,8 @@ function remove_rook_ceph() {
     # remove all rook-ceph CR objects
     log "Removing rook-ceph custom resource objects - this may take some time:\n"
     if ! kubectl delete cephcluster -n rook-ceph rook-ceph --timeout=60s; then
-        logWarn "Unable to delete the rook-ceph CephCluster resource"
+        logFail "Unable to delete the rook-ceph CephCluster resource"
+        return 1
     fi
 
     log "Waiting for rook-ceph custom resources to be removed"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -69,7 +69,7 @@ function remove_rook_ceph() {
     if echo "$all_pv_drivers" | grep "rook" &>/dev/null ; then
         logFail "There are still PVs using rook-ceph."
         logFail "Remove these PV(s) before continuing:"
-        logFail "$all_pv_drivers"
+       echo $(echo "$all_pv_drivers" | grep "rook")
         return 1
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -89,7 +89,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete the rook-ceph CephCluster resource"
     fi
 
-    log "Waiting delete CRDs"
+    log "Waiting for rook-ceph custom resources to be removed"
     if ! kubectl get crd | grep 'ceph.rook.io' | awk '{ print $1 }' | xargs -I'{}' kubectl -n rook-ceph delete '{}' --all --timeout=60s; then
         logWarn "Unable to delete the rook-ceph custom resources"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -90,7 +90,7 @@ function remove_rook_ceph() {
         return 1
     fi
 
-    log "Waiting for rook-ceph custom resources to be removed"
+    log "Removing rook-ceph custom resources"
     if ! kubectl get crd | grep 'ceph.rook.io' | awk '{ print $1 }' | xargs -I'{}' kubectl -n rook-ceph delete '{}' --all --timeout=60s; then
         logWarn "Unable to delete the rook-ceph custom resources"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -235,10 +235,7 @@ function maybe_cleanup_rook() {
 
         if [ "$DID_MIGRATE_ROOK_PVCS" == "1" ] && [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
             report_addon_start "rook-ceph-removal" "v1"
-            if ! remove_rook_ceph; then
-                logFail "Unable to remove Rook."
-                return
-            fi
+            remove_rook_ceph
             report_addon_success "rook-ceph-removal" "v1"
             return
         fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -102,7 +102,7 @@ function remove_rook_ceph() {
 
     log "Removing rook-ceph OSD pods"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
-        logWarn "Unable to delete rook-ceph OSD pods"
+        logWarn "rook-ceph OSD pods were not deleted"
     fi
 
     log "Removing rook-ceph CRDs"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -125,11 +125,6 @@ function remove_rook_ceph() {
         return 1
     fi
 
-    log "Removing rook-ceph Storage Classes"
-    if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
-        logFail "Unable to delete rook-ceph StorageClasses"
-        return 1
-    fi
     
     # scale ekco back to 1 replicas if it exists
     if kubernetes_resource_exists kurl deployment ekc-operator; then

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -95,7 +95,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete the rook-ceph custom resources"
     fi
 
-    log "Waiting for rook-ceph Volume resources to be removed"
+    log "Removing rook-ceph Volume resources"
     if ! kubectl delete volumes.rook.io --all --timeout=60s; then
         logWarn "Unable to delete Rook Volume resources"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -82,7 +82,11 @@ function remove_rook_ceph() {
              return 1
         fi
     fi
-
+    log "Removing rook-ceph Storage Classes"
+    if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
+        logFail "Unable to delete rook-ceph StorageClasses"
+        return 1
+    fi
     # remove all rook-ceph CR objects
     log "Removing rook-ceph custom resource objects - this may take some time:\n"
     if ! kubectl delete cephcluster -n rook-ceph rook-ceph --timeout=300s; then

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -114,18 +114,18 @@ function remove_rook_ceph() {
         logWarn "Unable delete rook-ceph custom resources volumes"
     fi
 
-    log "Removing rook-ceph StorageClasses"
-    if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
-        logFail "Unable delete rook-ceph StorageClasses"
-        return 1
-    fi
-
     log "Removing rook-ceph namespace"
     if ! kubectl delete ns rook-ceph --timeout=60s; then
         logFail "Unable delete rook-ceph custom resources volumes"
         return 1
     fi
 
+    log "Removing rook-ceph StorageClasses"
+    if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
+        logFail "Unable delete rook-ceph StorageClasses"
+        return 1
+    fi
+    
     # scale ekco back to 1 replicas if it exists
     if kubernetes_resource_exists kurl deployment ekc-operator; then
         kubectl -n kurl get configmap ekco-config -o yaml | \

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -136,7 +136,7 @@ function remove_rook_ceph() {
 
     # print success message
     logSuccess "Removed rook-ceph successfully!"
-    logWarn  "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed."
+    logWarn "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed."
 }
 
 # scale down prometheus, move all 'rook-ceph' PVCs to provided storage class, scale up prometheus

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -102,7 +102,7 @@ function remove_rook_ceph() {
 
     log "Waiting for Rook Ceph OSD pods to be removed"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
-        logWarn "Unable to remove Rook Ceph OSD pods"
+        logWarn "Unable to remove rook-ceph OSD pods"
     fi
 
     log "Removing rook-ceph custom resources"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -123,7 +123,7 @@ function remove_rook_ceph() {
 
     log "Removing rook-ceph Storage Classes"
     if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
-        logFail "Unable delete rook-ceph StorageClasses"
+        logFail "Unable to delete rook-ceph StorageClasses"
         return 1
     fi
     

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -86,7 +86,7 @@ function remove_rook_ceph() {
     # remove all rook-ceph CR objects
     log "Removing rook-ceph custom resource objects - this may take some time:\n"
     if ! kubectl delete cephcluster -n rook-ceph rook-ceph --timeout=60s; then
-        logWarn "Unable deleting rook-ceph this first frees up resources"
+        logWarn "Unable to delete the rook-ceph CephCluster resource"
     fi
 
     log "Waiting delete CRDs"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -101,7 +101,7 @@ function remove_rook_ceph() {
 
     log "Waiting for rook-ceph OSD pods to be removed"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
-        logWarn "Unable deleting rook-ceph OSD pods"
+        logWarn "Unable to remove Rook Ceph OSD pods"
     fi
 
     log "Removing rook-ceph custom resources"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -115,7 +115,7 @@ function remove_rook_ceph() {
         logWarn "Unable delete rook-ceph custom resources volumes"
     fi
 
-    log "Removing rook-ceph namespace"
+    log "Removing the rook-ceph Namespace"
     if ! kubectl delete ns rook-ceph --timeout=60s; then
         logFail "Unable delete rook-ceph custom resources volumes"
         return 1

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -96,7 +96,7 @@ function remove_rook_ceph() {
 
     log "Waiting delete volumes"
     if ! kubectl delete volumes.rook.io --all --timeout=60s; then
-        logWarn "Unable deleting rook-ceph volumes"
+        logWarn "Unable to delete Rook Volume resources"
     fi
 
     log "Waiting for rook-ceph OSD pods to be removed"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -68,8 +68,7 @@ function remove_rook_ceph() {
     all_pv_drivers="$(kubectl get pv -o=jsonpath='{.items[*].spec.csi.driver}')"
     if echo "$all_pv_drivers" | grep "rook" &>/dev/null ; then
         logFail "There are still PVs using rook-ceph."
-        logFail "Remove these PV(s) before continuing:"
-        echo $(echo "$all_pv_drivers" | grep "rook")
+        logFail "Remove these PV(s) before continuing."
         return 1
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -97,7 +97,7 @@ function remove_rook_ceph() {
 
     log "Removing rook-ceph Volume resources"
     if ! kubectl delete volumes.rook.io --all --timeout=60s; then
-        logWarn "Unable to delete Rook Volume resources"
+        logWarn "Unable to delete rook-ceph Volume resources"
     fi
 
     log "Waiting for Rook Ceph OSD pods to be removed"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -107,7 +107,7 @@ function remove_rook_ceph() {
 
     log "Removing rook-ceph CRDs"
     if ! kubectl get crd | grep 'ceph.rook.io' | awk '{ print $1 }' | xargs -I'{}' kubectl delete crd '{}' --timeout=60s; then
-        logWarn "Unable deleting rook-ceph custom resources"
+        logWarn "Unable to delete rook-ceph CRDs"
     fi
 
     log "Removing rook-ceph custom resources volumes"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -117,7 +117,7 @@ function remove_rook_ceph() {
 
     log "Removing the rook-ceph Namespace"
     if ! kubectl delete ns rook-ceph --timeout=60s; then
-        logFail "Unable delete rook-ceph custom resources volumes"
+        logFail "Unable to delete the rook-ceph Namespace"
         return 1
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -78,8 +78,8 @@ function remove_rook_ceph() {
         kubectl -n kurl scale deploy ekc-operator --replicas=0
         log "Waiting for ekco pods to be removed"
         if ! spinner_until 300 ekco_pods_gone; then
-             logWarn "Unable to scale down ekco operator"
-             logWarn "The script will continue to try remove Rook"
+             logFail "Unable to scale down ekco operator"
+             return 1
         fi
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -77,7 +77,7 @@ function remove_rook_ceph() {
     if kubernetes_resource_exists kurl deployment ekc-operator; then
         kubectl -n kurl scale deploy ekc-operator --replicas=0
         log "Waiting for ekco pods to be removed"
-        if ! spinner_until 300 ekco_pods_gone; then
+        if ! spinner_until 120 ekco_pods_gone; then
              logFail "Unable to scale down ekco operator"
              return 1
         fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -105,7 +105,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete rook-ceph OSD pods"
     fi
 
-    log "Removing rook-ceph custom resources"
+    log "Removing rook-ceph CRDs"
     if ! kubectl get crd | grep 'ceph.rook.io' | awk '{ print $1 }' | xargs -I'{}' kubectl delete crd '{}' --timeout=60s; then
         logWarn "Unable deleting rook-ceph custom resources"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -110,9 +110,9 @@ function remove_rook_ceph() {
         logWarn "Unable to delete rook-ceph CRDs"
     fi
 
-    log "Removing rook-ceph custom resources volumes"
+    log "Removing rook-ceph volumes custom resource"
     if ! kubectl delete --ignore-not-found crd volumes.rook.io --timeout=60s; then
-        logWarn "Unable delete rook-ceph custom resources volumes"
+        logWarn "Unable delete rook-ceph volumes custom resource"
     fi
 
     log "Removing the rook-ceph Namespace"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -85,7 +85,7 @@ function remove_rook_ceph() {
 
     # remove all rook-ceph CR objects
     log "Removing rook-ceph custom resource objects - this may take some time:\n"
-    if ! kubectl delete cephcluster -n rook-ceph rook-ceph --timeout=60s; then
+    if ! kubectl delete cephcluster -n rook-ceph rook-ceph --timeout=300s; then
         logFail "Unable to delete the rook-ceph CephCluster resource"
         return 1
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -69,7 +69,7 @@ function remove_rook_ceph() {
     if echo "$all_pv_drivers" | grep "rook" &>/dev/null ; then
         logFail "There are still PVs using rook-ceph."
         logFail "Remove these PV(s) before continuing:"
-       echo $(echo "$all_pv_drivers" | grep "rook")
+        echo $(echo "$all_pv_drivers" | grep "rook")
         return 1
     fi
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -100,7 +100,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete rook-ceph Volume resources"
     fi
 
-    log "Removing rook-ceph OSD pods"
+    log "Waiting for rook-ceph OSD pods to be removed"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
         logWarn "rook-ceph OSD pods were not deleted"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -95,7 +95,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete the rook-ceph custom resources"
     fi
 
-    log "Waiting delete volumes"
+    log "Waiting for rook-ceph Volume resources to be removed"
     if ! kubectl delete volumes.rook.io --all --timeout=60s; then
         logWarn "Unable to delete Rook Volume resources"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -99,7 +99,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete Rook Volume resources"
     fi
 
-    log "Waiting for rook-ceph OSD pods to be removed"
+    log "Waiting for Rook Ceph OSD pods to be removed"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
         logWarn "Unable to remove Rook Ceph OSD pods"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -100,7 +100,7 @@ function remove_rook_ceph() {
         logWarn "Unable to delete rook-ceph Volume resources"
     fi
 
-    log "Waiting for Rook Ceph OSD pods to be removed"
+    log "Removing rook-ceph OSD pods"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
         logWarn "Unable to remove rook-ceph OSD pods"
     fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -121,7 +121,7 @@ function remove_rook_ceph() {
         return 1
     fi
 
-    log "Removing rook-ceph StorageClasses"
+    log "Removing rook-ceph Storage Classes"
     if ! kubectl get storageclass | grep rook | awk '{ print $1 }' | xargs -I'{}' kubectl delete storageclass '{}' --timeout=60s; then
         logFail "Unable delete rook-ceph StorageClasses"
         return 1

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -91,7 +91,7 @@ function remove_rook_ceph() {
 
     log "Waiting delete CRDs"
     if ! kubectl get crd | grep 'ceph.rook.io' | awk '{ print $1 }' | xargs -I'{}' kubectl -n rook-ceph delete '{}' --all --timeout=60s; then
-        logWarn "Unable deleting rook-ceph CRDs"
+        logWarn "Unable to delete the rook-ceph custom resources"
     fi
 
     log "Waiting delete volumes"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -102,7 +102,7 @@ function remove_rook_ceph() {
 
     log "Removing rook-ceph OSD pods"
     if ! spinner_until 120 rook_ceph_osd_pods_gone; then
-        logWarn "Unable to remove rook-ceph OSD pods"
+        logWarn "Unable to delete rook-ceph OSD pods"
     fi
 
     log "Removing rook-ceph custom resources"

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -121,7 +121,7 @@ function remove_rook_ceph() {
     fi
 
     log "Removing rook-ceph namespace"
-    if ! kubectl delete ns rook-ceph --timeout=120s; then
+    if ! kubectl delete ns rook-ceph --timeout=60s; then
         logFail "Unable delete rook-ceph custom resources volumes"
         return 1
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently we have the following problems that are addressed by this PR:
- The script can get stuck because it is missing timeout in the operations
- The script does not provide info/logs about what operation was or not possible to do to remove rook
- The script has not been checking and reporting the error properly when the Rook StorageClasses and Namespace is not removed


#### Which issue(s) this PR fixes:

Fixes # [sc-70239]

#### Special notes for your reviewer:

**(Test A) When is possible to remove Rook (Rook 1.0.4->To OpenEBS 3.3.0+Minio)**

- Install with:

```ymal
INSTALLER_YAML="apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: 68f22f4
spec:
  kubernetes:
    version: 1.19.16
  weave: 
    version: 2.8.1-20230222
  rook:
    version: 1.0.4
  contour:
    version: 1.24.1
  registry:
    version: 2.8.1
  prometheus:
    version: 0.63.0-45.7.1
  ekco:
    version: 0.26.4
  kurl:
    installerVersion: v2023.03.13-0
    additionalNoProxyAddresses: []
  docker: 
    version: 20.10.17  
"
```

- Then, upgrade with the following spec and the changes made in this PR:

```yaml
INSTALLER_YAML="apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: 68f22f4
spec:
  kubernetes:
    version: 1.19.16
  weave: 
    version: 2.8.1-20230222
  minio: 
    version: 2023-03-09T23-16-13Z
  openebs: 
    version: 3.3.0
    isLocalPVEnabled: true
    namespace: openebs
  contour:
    version: 1.24.1
  registry:
    version: 2.8.1
  prometheus:
    version: 0.63.0-45.7.1
  ekco:
    version: 0.26.4
  kurl:
    installerVersion: v2023.03.13-0
    additionalNoProxyAddresses: []
  docker: 
    version: 20.10.17  
"

``` 

Result: 

> See that now we have the data to be able to troubleshooting when failures occurs and this script will no longer get stuck or stop to be executed when is not possible to remove Rook so that is possible to just retry it via script OR remove Rook manually.

```sh
Waiting for ekco pods to be removed
Removing rook-ceph custom resource objects - this may take some time:\n
cephcluster.ceph.rook.io "rook-ceph" deleted
Waiting delete CRDs
cephblockpool.ceph.rook.io "replicapool" deleted
No resources found
No resources found
No resources found
cephobjectstore.ceph.rook.io "rook-ceph-store" deleted
cephobjectstoreuser.ceph.rook.io "kurl" deleted
Waiting delete volumes
No resources found
Waiting for rook-ceph OSD pods to be removed
Removing rook-ceph custom resources
customresourcedefinition.apiextensions.k8s.io "cephblockpools.ceph.rook.io" deleted
customresourcedefinition.apiextensions.k8s.io "cephclusters.ceph.rook.io" deleted
customresourcedefinition.apiextensions.k8s.io "cephfilesystems.ceph.rook.io" deleted
customresourcedefinition.apiextensions.k8s.io "cephnfses.ceph.rook.io" deleted
customresourcedefinition.apiextensions.k8s.io "cephobjectstores.ceph.rook.io" deleted
customresourcedefinition.apiextensions.k8s.io "cephobjectstoreusers.ceph.rook.io" deleted
Removing rook-ceph custom resources volumes
customresourcedefinition.apiextensions.k8s.io "volumes.rook.io" deleted
Removing rook-ceph StorageClasses
storageclass.storage.k8s.io "default" deleted
Removing rook-ceph namespace
namespace "rook-ceph" deleted
configmap/ekco-config configured
deployment.apps/ekc-operator scaled

```

**(Test B) When we know that has failures (Rook 1.10.11 ->To OpenEBS 3.3.0+Minio)**

- Install: https://staging.kurl.sh/79e1cc9
- Upgrade to: https://staging.kurl.sh/ab4aade (with the changes of this PR)
- See the result: 


<img width="1088" alt="Screenshot 2023-03-20 at 13 37 31" src="https://user-images.githubusercontent.com/7708031/226356975-71281f3e-b9a9-4e1e-9a8a-813a6f2372d8.png">


<img width="1133" alt="Screenshot 2023-03-20 at 13 37 52" src="https://user-images.githubusercontent.com/7708031/226356759-64bcfd26-4dbb-4e90-88a3-d934326fe877.png">
com/7708031/226356729-e4cfd56a-6031-4906-b294-56ddad1626d7.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?

```release-note
Fixes stuck issues scenarios when is trying to delete Rook and provide better information about the steps performed.  
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
