### PR TITLE
fix testgrid becuase upgrade is missing flag yes

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1469,6 +1469,7 @@
     unset KUBECONFIG
     kubectl get namespaces
 - name: "Upgrade from Rook+OpenEBS to OpenEBS - k8s 1.19.x to 1.21.x with Docker"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: "1.19.x"


### PR DESCRIPTION
#### What this PR does / why we need it:

See that the error is faced because we ask if we can or not continue with the upgrade 

```
2023-03-20 06:18:02+00:00 [PASS] Number of CPUs: This server has at least 4 CPU cores
2023-03-20 06:18:02+00:00 [PASS] Amount of Memory: The system has at least 8G of memory
2023-03-20 06:18:02+00:00 [PASS] Ephemeral Disk Usage /var/lib/kubelet: The disk containing directory /var/lib/kubelet has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full
2023-03-20 06:18:02+00:00 [PASS] NTP Status: System clock is synchronized
2023-03-20 06:18:02+00:00 [PASS] NTP Status: Timezone is set to UTC
2023-03-20 06:18:02+00:00 [PASS] Can Access Replicated API: Connected to https://replicated.app
2023-03-20 06:18:02+00:00 ⚙  Host preflights success
2023-03-20 06:18:08+00:00 Using existing weave network: 10.32.0.0/20
2023-03-20 06:18:09+00:00 
2023-03-20 06:18:09+00:00     Detected Rook is running in the cluster. Data migration will be initiated to move data from rook-ceph to storage class openebs.
2023-03-20 06:18:09+00:00 
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'

```

See: https://testgrid.kurl.sh/run/STAGING-daily-a6c5d93-2023-03-20T01:28:42Z?kurlLogsInstanceId=xhxswdmbesppwazw&nodeId=xhxswdmbesppwazw-initialprimary

Therefore, we must to use the flag `yes` to ensure that we will be able to continue with the upgrade. 
