### PR TITLE
when/if we found 2 ceph versions and one of them is 0.0.0-0 we should ignore and does not consider Rook Ceph unhealthy to migrate from it

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -301,9 +301,14 @@ function rook_is_healthy_to_upgrade() {
     local ceph_versions_found=
     ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
     if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-        logFail "Multiple Ceph versions detected"
-        logFail "${ceph_versions_found}"
-        return 1
+        if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+            log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+            echo "${ceph_versions_found}"
+        else
+            logFail "Multiple Ceph versions detected"
+            logFail "${ceph_versions_found}"
+            return 1
+        fi
     fi
     return 0
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

RookCeph has some bug where the ceph-version is not set, see for example: https://github.com/rook/rook/search?q=0.0.0-0&type=issues. Therefore,  in some scenarios/versions it seems that not all deployments have the ceph versions (i.e. when we install curl https://staging.kurl.sh/12d35d1 ). 

In this way **when/if we found 2 ceph versions and one of them is `0.0.0-0` we should ignore and does not consider Rook Ceph unhealthy to migrate from it.** 

#### Special notes for your reviewer:

You can check this scenario in the testgrid either https://testgrid.kurl.sh/run/STAGING-daily-a6c5d93-2023-03-20T01:28:42Z?kurlLogsInstanceId=catkqrrfdnvelssv&nodeId=catkqrrfdnvelssv-initialprimary

Install: curl https://staging.kurl.sh/12d35d1 
Then, run:

```sh

$ echo $(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)
ceph-version=0.0.0-0 ceph-version=15.2.4-0

$ kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
rook-ceph-crashcollector-8f259f730091e6b01d5df2702086cf12  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-mds-rook-shared-fs-a  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-mds-rook-shared-fs-b  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-mgr-a  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-mon-a  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-osd-0  	req/upd/avl: 1/1/1  	ceph-version=15.2.4-0
rook-ceph-rgw-rook-ceph-store-a  	req/upd/avl: 1/1/1  	ceph-version=0.0.0-0
``` 

#### Does this PR introduce a user-facing change?

```release-note
Fixes Rook Ceph healthy check by not considering unhealthy when a deployment does not contains the ceph-version value
```
