### PR TITLE
fix healthy check to upgrade rook by ignoring Rook Ceph issue scenario where the version is not set in the deployment

### DIFF
--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -314,9 +314,15 @@ function rook_cluster_deploy_upgrade() {
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         # Fail when more than one version is found
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -369,9 +375,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -312,9 +312,15 @@ function rook_cluster_deploy_upgrade() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -369,9 +375,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -314,9 +314,15 @@ function rook_cluster_deploy_upgrade() {
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         # Fail when more than one version is found
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -371,9 +377,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -288,9 +288,15 @@ function rook_cluster_deploy_upgrade() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -343,9 +349,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -321,9 +321,15 @@ function rook_cluster_deploy_upgrade() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -376,9 +382,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -317,9 +317,15 @@ function rook_cluster_deploy_upgrade() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -374,9 +380,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -314,9 +314,15 @@ function rook_cluster_deploy_upgrade() {
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         # Fail when more than one version is found
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -369,9 +375,15 @@ function verify_rook_updated_cluster() {
         local ceph_versions_found=
         ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
         if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-            logWarn "Detected multiple Ceph versions"
-            logWarn "${ceph_versions_found}"
-            bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            # Ignore the RookCeph issue scenario when the version is not set
+            if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                echo "${ceph_versions_found}"
+            else
+                logWarn "Detected multiple Ceph versions"
+                logWarn "${ceph_versions_found}"
+                bail "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+            fi
         fi
 
         if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -126,9 +126,15 @@ function rookupgrade_10to14_upgrade() {
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
                 # Fail when more than one version is found
                 if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-                    logWarn "Detected multiple Ceph versions"
-                    logWarn "${ceph_versions_found}"
-                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    # Ignore the RookCeph issue scenario when the version is not set
+                    if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                        log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                        echo "${ceph_versions_found}"
+                    else
+                        logWarn "Detected multiple Ceph versions"
+                        logWarn "${ceph_versions_found}"
+                        logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    fi
                 fi
 
                 if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -289,9 +295,15 @@ function rookupgrade_10to14_upgrade() {
                 local ceph_versions_found=
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
                 if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-                    logWarn "Detected multiple Ceph versions"
-                    logWarn "${ceph_versions_found}"
-                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    # Ignore the RookCeph issue scenario when the version is not set
+                    if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                        log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                        echo "${ceph_versions_found}"
+                    else
+                        logWarn "Detected multiple Ceph versions"
+                        logWarn "${ceph_versions_found}"
+                        logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    fi
                 fi
 
                 if [[ "$(echo "${ceph_versions_found}")" == *"15.2.8"* ]]; then


### PR DESCRIPTION
#### What this PR does / why we need it:

RookCeph has some bug where the ceph-version is not set, see for example: https://github.com/rook/rook/search?q=0.0.0-0&type=issues. Therefore,  in some scenarios/versions it seems that not all deployments have the ceph versions (i.e. when we install curl https://staging.kurl.sh/12d35d1 ). 

In this way **when/if we found 2 ceph versions and one of them is `0.0.0-0` we should ignore and does not consider Rook Ceph unhealthy prior upgrade or after when we check if it is health.** 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
Same scenario of : https://github.com/replicatedhq/kURL/pull/4211
But for the upgrades.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes RookCeph healthy checks in the upgrades by ignoring RookCeph issue scenario where the ceph version is not set accordingly to all deployments.    
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
