### PR TITLE
Always re-apply addons

### DIFF
--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -11,7 +11,11 @@ function containerd_pre_init() {
         cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    containerd_host_init
+    # preserve containerd config
+    if addon_has_been_applied "containerd"; then
+        CONTAINERD_PRESERVE_CONFIG=1
+        log "Preserving containerd $CONTAINERD_VERSION config"
+    fi
 }
 
 function containerd_join() {
@@ -34,7 +38,18 @@ function containerd_install() {
 
     containerd_migrate_from_docker
 
-    install_host_packages "$src" containerd.io
+    # only install if package is not present
+    if [ "$CONTAINERD_PRESERVE_CONFIG" = "1" ]; then
+        log "Skipping host package installation for containerd: $CONTAINERD_VERSION already intalled"
+    else
+        install_host_packages "$src" containerd.io
+    fi
+
+    case "$LSB_DIST" in
+        centos|rhel|amzn|ol)
+            yum_install_host_archives "$src" libzstd
+            ;;
+    esac
 
     chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
     # If the runc binary is executing the cp command will fail with "text file busy" error.

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -10,12 +10,6 @@ function containerd_pre_init() {
     if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
         cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
-
-    # preserve containerd config
-    if addon_has_been_applied "containerd"; then
-        CONTAINERD_PRESERVE_CONFIG=1
-        log "Preserving containerd $CONTAINERD_VERSION config"
-    fi
 }
 
 function containerd_join() {
@@ -38,12 +32,7 @@ function containerd_install() {
 
     containerd_migrate_from_docker
 
-    # only install if package is not present
-    if [ "$CONTAINERD_PRESERVE_CONFIG" = "1" ]; then
-        log "Skipping host package installation for containerd: $CONTAINERD_VERSION already intalled"
-    else
-        install_host_packages "$src" containerd.io
-    fi
+    install_host_packages "$src" containerd.io
 
     case "$LSB_DIST" in
         centos|rhel|amzn|ol)

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -10,6 +10,8 @@ function containerd_pre_init() {
     if [ -d "$DIR/kustomize/kubeadm/init-patches" ]; then
         cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
+
+    containerd_host_init
 }
 
 function containerd_join() {
@@ -33,12 +35,6 @@ function containerd_install() {
     containerd_migrate_from_docker
 
     install_host_packages "$src" containerd.io
-
-    case "$LSB_DIST" in
-        centos|rhel|amzn|ol)
-            yum_install_host_archives "$src" libzstd
-            ;;
-    esac
 
     chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
     # If the runc binary is executing the cp command will fail with "text file busy" error.

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -11,8 +11,10 @@ function containerd_pre_init() {
         cp "$src/kubeadm-init-config-v1beta2.yaml" "$DIR/kustomize/kubeadm/init-patches/containerd-kubeadm-init-config-v1beta2.yml"
     fi
 
-    if containerd_is_installed ; then
-        SKIP_CONTAINERD_INSTALL=1
+    # preserve containerd config
+    if addon_has_been_applied "containerd"; then
+        CONTAINERD_PRESERVE_CONFIG=1
+        log "Preserving containerd $CONTAINERD_VERSION config"
     fi
 }
 
@@ -37,7 +39,7 @@ function containerd_install() {
     containerd_migrate_from_docker
 
     # only install if package is not present
-    if [ "$SKIP_CONTAINERD_INSTALL" = "1" ]; then
+    if [ "$CONTAINERD_PRESERVE_CONFIG" = "1" ]; then
         log "Skipping host package installation for containerd: $CONTAINERD_VERSION already intalled"
     else
         install_host_packages "$src" containerd.io
@@ -124,31 +126,24 @@ function containerd_configure() {
         echo "Skipping containerd configuration"
         return
     fi
+    mkdir -p /etc/containerd
+    containerd config default > /etc/containerd/config.toml
 
-    if [ "$CONTAINERD_ALREADY_INSTALLED" = "1" ]; then
-        log "Skipping default containerd configuration: $CONTAINERD_VERSION already intalled"
-    else
-        mkdir -p /etc/containerd
-        containerd config default > /etc/containerd/config.toml
-
-        sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
-        sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
-        sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
-        cat >> /etc/containerd/config.toml <<EOF
+    sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
+    sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
+    sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
+    cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-SystemdCgroup = true
+  SystemdCgroup = true
 EOF
-        CONTAINERD_NEEDS_RESTART=1
-    fi
 
 	if [ -n "$CONTAINERD_TOML_CONFIG" ]; then
-        log "Applying user provided Containerd config"
         local tmp=$(mktemp)
         echo "$CONTAINERD_TOML_CONFIG" > "$tmp"
         "$DIR/bin/toml" -basefile=/etc/containerd/config.toml -patchfile="$tmp"
-
-        CONTAINERD_NEEDS_RESTART=1
     fi
+
+    CONTAINERD_NEEDS_RESTART=1
 }
 
 function containerd_configure_ctl() {
@@ -313,23 +308,6 @@ function containerd_migrate_images_from_docker() {
     _containerd_migrate_images_from_docker "$tmpdir" || errcode="$?"
     rm -rf "$tmpdir"
     return "$errcode"
-}
-
-function containerd_current_version() {
-    if commandExists containerd; then
-        containerd --version | awk '{print $3}'
-    fi
-}
-
-function containerd_is_installed() {
-    local current_version
-    current_version="$(containerd_current_version)"
-
-    if [ "$current_version" = "$CONTAINERD_VERSION" ]; then
-        return 0
-    fi
-
-    return 1
 }
 
 function _containerd_migrate_images_from_docker() {

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -264,7 +264,7 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 			continue
 		case "secondary-host":
 			continue
-		case "force-reapply-addons":
+		case "force-reapply-addons": // no longer supported
 			continue
 		case "ipv6":
 			if installer.Spec.Kurl == nil {

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -264,6 +264,8 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 			continue
 		case "secondary-host":
 			continue
+		case "force-reapply-addons":
+			continue
 		case "ipv6":
 			if installer.Spec.Kurl == nil {
 				installer.Spec.Kurl = &kurlv1beta1.Kurl{}

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -264,8 +264,6 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 			continue
 		case "secondary-host":
 			continue
-		case "force-reapply-addons":
-			continue
 		case "ipv6":
 			if installer.Spec.Kurl == nil {
 				installer.Spec.Kurl = &kurlv1beta1.Kurl{}

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -291,6 +291,7 @@ function addon_outro() {
         fi
         common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
         common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
+        common_flags="${common_flags}$(get_force_reapply_addons_flag)"
         common_flags="${common_flags}$(get_skip_system_package_install_flag)"
         common_flags="${common_flags}$(get_exclude_builtin_host_preflights_flag)"
         common_flags="${common_flags}$(get_remotes_flags)"

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -15,28 +15,17 @@ function addon_install() {
 
     rm -rf $DIR/kustomize/$name
     mkdir -p $DIR/kustomize/$name
+    
+    export REPORTING_CONTEXT_INFO="addon $name $version"
 
-    # if the addon has already been applied and addons are not being forcibly reapplied
-    if addon_has_been_applied $name && [ -z "$FORCE_REAPPLY_ADDONS" ]; then
-        export REPORTING_CONTEXT_INFO="addon already applied $name $version"
-        # shellcheck disable=SC1090
-        addon_source "$name" "$version"
+    # shellcheck disable=SC1090
+    addon_source "$name" "$version"
 
-        if commandExists ${name}_already_applied; then
-            ${name}_already_applied
-        fi
-        export REPORTING_CONTEXT_INFO=""
+    # containerd is a special case because there is also a binary named containerd on the host
+    if [ "$name" = "containerd" ]; then
+        containerd_install
     else
-        export REPORTING_CONTEXT_INFO="addon $name $version"
-        # shellcheck disable=SC1090
-        addon_source "$name" "$version"
-        # containerd is a special case because there is also a binary named containerd on the host
-        if [ "$name" = "containerd" ]; then
-            containerd_install
-        else
-            $name
-        fi
-        export REPORTING_CONTEXT_INFO=""
+        $name
     fi
 
     addon_set_has_been_applied $name

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -27,6 +27,7 @@ function addon_install() {
     else
         $name
     fi
+    export REPORTING_CONTEXT_INFO=""
 
     addon_set_has_been_applied $name
 

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -291,7 +291,6 @@ function addon_outro() {
         fi
         common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
         common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
-        common_flags="${common_flags}$(get_force_reapply_addons_flag)"
         common_flags="${common_flags}$(get_skip_system_package_install_flag)"
         common_flags="${common_flags}$(get_exclude_builtin_host_preflights_flag)"
         common_flags="${common_flags}$(get_remotes_flags)"

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -768,13 +768,6 @@ function get_docker_registry_ip_flag() {
     echo " docker-registry-ip=${docker_registry_ip}"
 }
 
-function get_force_reapply_addons_flag() {
-    if [ "${FORCE_REAPPLY_ADDONS}" != "1" ]; then
-        return
-    fi
-    echo " force-reapply-addons"
-}
-
 function get_skip_system_package_install_flag() {
     if [ "${SKIP_SYSTEM_PACKAGE_INSTALL}" != "1" ]; then
         return

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -768,6 +768,13 @@ function get_docker_registry_ip_flag() {
     echo " docker-registry-ip=${docker_registry_ip}"
 }
 
+function get_force_reapply_addons_flag() {
+    if [ "${FORCE_REAPPLY_ADDONS}" != "1" ]; then
+        return
+    fi
+    echo " force-reapply-addons"
+}
+
 function get_skip_system_package_install_flag() {
     if [ "${SKIP_SYSTEM_PACKAGE_INSTALL}" != "1" ]; then
         return

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -175,9 +175,6 @@ function get_patch_yaml() {
                     SECONDARY_HOST="$SECONDARY_HOST,$_value"
                 fi
                 ;;
-            force-reapply-addons)
-                FORCE_REAPPLY_ADDONS=1
-                ;;
             skip-system-package-install)
                 SKIP_SYSTEM_PACKAGE_INSTALL=1
                 ;;

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -175,6 +175,9 @@ function get_patch_yaml() {
                     SECONDARY_HOST="$SECONDARY_HOST,$_value"
                 fi
                 ;;
+            force-reapply-addons)
+                FORCE_REAPPLY_ADDONS=1
+                ;;
             skip-system-package-install)
                 SKIP_SYSTEM_PACKAGE_INSTALL=1
                 ;;

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -175,8 +175,10 @@ function get_patch_yaml() {
                     SECONDARY_HOST="$SECONDARY_HOST,$_value"
                 fi
                 ;;
+            # deprecated flag
             force-reapply-addons)
                 FORCE_REAPPLY_ADDONS=1
+                logWarn "WARN: 'force-reapply-addon' option is deprecated"
                 ;;
             skip-system-package-install)
                 SKIP_SYSTEM_PACKAGE_INSTALL=1

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -177,7 +177,6 @@ function get_patch_yaml() {
                 ;;
             # deprecated flag
             force-reapply-addons)
-                FORCE_REAPPLY_ADDONS=1
                 logWarn "WARN: 'force-reapply-addon' option is deprecated"
                 ;;
             skip-system-package-install)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Part of the kURL addon lifecyle includes an `addon_already_applied` phase which attempts to avoid deploying the addon again. For certain addons there is a complexity overhead to keep to use of this logic and in certain scenarios there are issues with simply just re-configuring an existing addon when the kURL installer is re-run which leads to an inconsistent state of the cluster.

Moreover, the `--force-reapply-addon` flag will no longer be supported as this will now be the default behavior:
```sh
$ cat install.sh | sudo bash -s force-reapply-addons
⚙  Running install with the argument(s): force-reapply-addons
Error: unknown parameter "force-reapply-addons"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  [sc-70122](https://app.shortcut.com/replicated/story/70122/addon-already-applied-has-potential-to-break-things-especially-when-upgrading-some-but-not-all-add-ons)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The kURL installer will now force reapply addons by default deprecating the usage of the `force-reapply-addons` options. 
```

#### Does this PR require documentation?
https://github.com/replicatedhq/kurl.sh/pull/950
