### PR TITLE
fix: does to stop upgrade because was impossible to remove rook

### DIFF
--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -118,6 +118,23 @@ function report_addon_success() {
         $REPLICATED_APP_URL/kurl_metrics/finish_addon/$INSTALLATION_ID/$name || true
 }
 
+function report_addon_fail() {
+    # report that an addon installed successfully
+    local name=$1
+    local version=$2
+
+    # if INSTALLATION_ID is empty reporting is disabled
+    if [ -z "$INSTALLATION_ID" ]; then
+        return 0
+    fi
+
+    local completed=$(date -u +"%Y-%m-%dT%H:%M:%SZ") # rfc3339
+
+    curl -s --output /dev/null -H 'Content-Type: application/json' --max-time 5 \
+        -d "{\"finished\": \"$completed\"}" \
+        $REPLICATED_APP_URL/kurl_metrics/fail_addon/$INSTALLATION_ID/$name || true
+}
+
 function ctrl_c() {
     trap - SIGINT # reset SIGINT handler to default - someone should be able to ctrl+c the support bundle collector
     read line file <<<$(caller)

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -216,7 +216,10 @@ function maybe_cleanup_rook() {
 
         if [ "$DID_MIGRATE_ROOK_PVCS" == "1" ] && [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
             report_addon_start "rook-ceph-removal" "v1"
-            remove_rook_ceph
+            if ! remove_rook_ceph; then
+                logFail "Unable to remove Rook."
+                return
+            fi
             report_addon_success "rook-ceph-removal" "v1"
             return
         fi

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -218,6 +218,7 @@ function maybe_cleanup_rook() {
             report_addon_start "rook-ceph-removal" "v1"
             if ! remove_rook_ceph; then
                 logFail "Unable to remove Rook."
+                report_addon_fail "rook-ceph-removal" "v1"
                 return
             fi
             report_addon_success "rook-ceph-removal" "v1"


### PR DESCRIPTION
#### What this PR does / why we need it:

If in the upgrade we be unable to remove Rook we can still be able to do that manually afterwords or by re-calling the script. However, does not seems make sense we stop the cluster upgrade because did when we could check that we migrated the PVC(s), the ObjectStore successfully. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-70239]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes script stop when the migration from Rook were done successfully but only was not possible to remove Rook. Note that it still possible to call the task `curl <installer>/task.sh | sudo bash -s remove_rook_ceph` to remove Rook manually or just re-run the script to re-try.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
