### PR TITLE
fix: ensure that Rook Data will be cleanup when rook is removed

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -129,7 +129,6 @@ function remove_rook_ceph() {
 
     # print success message
     printf "%bRemoved rook-ceph successfully!\n%b" "$GREEN" "$NC"
-    printf "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed.\n"
 }
 
 # scale down prometheus, move all 'rook-ceph' PVCs to provided storage class, scale up prometheus

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -89,7 +89,7 @@ function remove_rook_ceph() {
     fi
 
     # More info: https://rook.io/docs/rook/v1.10/Getting-Started/ceph-teardown/#delete-the-cephcluster-crd
-    log "Allow RookCeph delete the data"
+    log "Patch Ceph cluster to allow deletion"
     kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"cleanupPolicy":{"confirmation":"yes-really-destroy-data"}}}'
 
     # remove all rook-ceph CR objects

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1577,6 +1577,11 @@
     else
        echo "Namespace rook-ceph was removed"
     fi
+    echo "Verify if Rook data was removed"
+    if [ -d "/var/lib/rook" ] || [ -d "/opt/replicated/rook" ]; then
+        echo "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed."
+        exit 1
+    fi
 - name: less_command
   installerSpec:
     kubernetes:
@@ -1841,4 +1846,9 @@
        exit 1 
     else
        echo "Namespace rook-ceph was removed"
+    fi
+    echo "Verify if Rook data was removed"
+    if [ -d "/var/lib/rook" ] || [ -d "/opt/replicated/rook" ]; then
+        echo "Data within /var/lib/rook, /opt/replicated/rook and any bound disks has not been freed."
+        exit 1 
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, when we are removing Rook we are not removing the data. 
That can cause problems mainly if Rook be re-installed on the cluster. 
Also, uses space in disk which is no longer required. 

#### Which issue(s) this PR fixes:

Fixes # [sc-70238]

#### Special notes for your reviewer:
See that we are also adding the check to the testgrid

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes Rook data not been removed when Rook Ceph is removed from the cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
