### PR TITLE
Adds log to inform what resources are holding the rook-ceph namespace deletion when it fails

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -121,9 +121,11 @@ function remove_rook_ceph() {
     log "Removing the rook-ceph Namespace"
     if ! kubectl delete ns rook-ceph --timeout=60s; then
         logFail "Unable to delete the rook-ceph Namespace"
+        logFail "Check the resources which are holding the namespace get deleted"
+        kubectl api-resources --verbs=list --namespaced -o name \
+                          | xargs -n 1 kubectl get --show-kind --ignore-not-found -n rook-ceph
         return 1
     fi
-
     
     # scale ekco back to 1 replicas if it exists
     if kubernetes_resource_exists kurl deployment ekc-operator; then

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -121,7 +121,7 @@ function remove_rook_ceph() {
     log "Removing the rook-ceph Namespace"
     if ! kubectl delete ns rook-ceph --timeout=60s; then
         logFail "Unable to delete the rook-ceph Namespace"
-        logFail "Check the resources which are holding the namespace get deleted"
+        logFail "These resources are preventing the namespace's deletion:"
         kubectl api-resources --verbs=list --namespaced -o name \
                           | xargs -n 1 kubectl get --show-kind --ignore-not-found -n rook-ceph
         return 1


### PR DESCRIPTION
#### What this PR does / why we need it:

adds logs to know what resources are handle the rook namespace

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:


## Steps to reproduce

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds log to inform what resources are holding the rook-ceph namespace deletion when it fails.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
