### PR TITLE
fix: pin k8s amazon linux build to amazonlinux:2

### DIFF
--- a/bundles/k8s-rhel7-force/Dockerfile
+++ b/bundles/k8s-rhel7-force/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 ARG KUBERNETES_VERSION
 COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN mkdir -p /packages/archives


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Installations on amazon linux are failing with error "cpio: bad magic" due to amazon image not being pinned to 2.

https://testgrid.kurl.sh/run/STAGING-release-v2023.03.13-0-93f6e828-20230320125234