### PR TITLE
fix: build is missing addon files

### DIFF
--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -11,7 +11,6 @@ if ! test -f "$MANIFEST_PATH"; then
     exit 1
 fi
 
-rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
 
 function build_rhel_7() {
@@ -199,6 +198,7 @@ function build_deps_rhel_9() {
     fi
 
     if [ ! -f "$outdir/Deps" ]; then
+        rm -rf "$outdir"
         return
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Installations are failing with the following error. The builds are missing all add-on files.

```
2023-03-22 22:47:23+00:00 bash: line 459: ./addons/containerd/1.6.18/install.sh: No such file or directory
```