### PR TITLE
Adds preflight checks to prevent migrating from Rook to OpenEBS with Registry without MinIO

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -661,8 +661,14 @@ function bail_if_unsupported_openebs_to_rook_version() {
                 semverParse "$OPENEBS_VERSION"
                 # if $OPENEBS_VERSION is less than 3.3.0
                 if [ "$major" -lt "3" ] || { [ "$major" = "3" ] && [ "$minor" -lt "3" ] ; }; then
-                   logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed."
-                   bail "OpenEBS versions less than 3.3.0 do not support migrations from Rook"
+                    logFail "The OpenEBS version $OPENEBS_VERSION cannot be installed."
+                    bail "OpenEBS versions less than 3.3.0 do not support migrations from Rook"
+                fi
+
+                # registry + openebs without rook requires minio
+                if [ -n "$REGISTRY_VERSION" ] && [ -z "$MINIO_VERSION" ]; then
+                    logFail "Migration from Rook with Registry required an object store."
+                    bail "Please ensure that your installer also provides an object store with MinIO add-on."
                 fi
             fi
         fi


### PR DESCRIPTION
#### What this PR does / why we need it:

To prevent migrating from Rook to OpenEBS with Registry without MinIO


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-70234]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight checks to prevent migrating from Rook to OpenEBS with Registry without MinIO
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
