### PR TITLE
adds status of migration from rook into configmap

### DIFF
--- a/addons/longhorn/1.3.1/install.sh
+++ b/addons/longhorn/1.3.1/install.sh
@@ -214,7 +214,8 @@ function longhorn_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ] && [ -z "$OPENEBS_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             rook_ceph_to_sc_migration "longhorn"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status
         fi
     fi
 }

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -214,7 +214,8 @@ function longhorn_maybe_migrate_from_rook() {
     if [ -z "$ROOK_VERSION" ] && [ -z "$OPENEBS_VERSION" ]; then
         if kubectl get ns | grep -q rook-ceph; then
             rook_ceph_to_sc_migration "longhorn"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status
         fi
     fi
 }

--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -166,7 +166,7 @@ function minio_migrate_from_rgw() {
     fi
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-06-11T19-55-32Z/install.sh
+++ b/addons/minio/2022-06-11T19-55-32Z/install.sh
@@ -166,7 +166,7 @@ function minio_migrate_from_rgw() {
     fi
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-07-06T20-29-49Z/install.sh
+++ b/addons/minio/2022-07-06T20-29-49Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-07-17T15-43-14Z/install.sh
+++ b/addons/minio/2022-07-17T15-43-14Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-08-02T23-59-16Z/install.sh
+++ b/addons/minio/2022-08-02T23-59-16Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-08-22T23-53-06Z/install.sh
+++ b/addons/minio/2022-08-22T23-53-06Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-09-01T23-53-36Z/install.sh
+++ b/addons/minio/2022-09-01T23-53-36Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-09-07T22-25-02Z/install.sh
+++ b/addons/minio/2022-09-07T22-25-02Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-09-17T00-09-45Z/install.sh
+++ b/addons/minio/2022-09-17T00-09-45Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-10-02T19-29-29Z/install.sh
+++ b/addons/minio/2022-10-02T19-29-29Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-10-05T14-58-27Z/install.sh
+++ b/addons/minio/2022-10-05T14-58-27Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-10-08T20-11-00Z/install.sh
+++ b/addons/minio/2022-10-08T20-11-00Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-10-15T19-57-03Z/install.sh
+++ b/addons/minio/2022-10-15T19-57-03Z/install.sh
@@ -191,7 +191,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 function allow_pvc_resize() {

--- a/addons/minio/2022-10-20T00-55-09Z/install.sh
+++ b/addons/minio/2022-10-20T00-55-09Z/install.sh
@@ -211,7 +211,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2022-12-12T19-27-27Z/install.sh
+++ b/addons/minio/2022-12-12T19-27-27Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-02T09-40-09Z/install.sh
+++ b/addons/minio/2023-01-02T09-40-09Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-06T18-11-18Z/install.sh
+++ b/addons/minio/2023-01-06T18-11-18Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-12T02-06-16Z/install.sh
+++ b/addons/minio/2023-01-12T02-06-16Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-18T04-36-38Z/install.sh
+++ b/addons/minio/2023-01-18T04-36-38Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-20T02-05-44Z/install.sh
+++ b/addons/minio/2023-01-20T02-05-44Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-25T00-19-54Z/install.sh
+++ b/addons/minio/2023-01-25T00-19-54Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-01-31T02-24-19Z/install.sh
+++ b/addons/minio/2023-01-31T02-24-19Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-02-09T05-16-53Z/install.sh
+++ b/addons/minio/2023-02-09T05-16-53Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-02-10T18-48-39Z/install.sh
+++ b/addons/minio/2023-02-10T18-48-39Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-02-17T17-52-43Z/install.sh
+++ b/addons/minio/2023-02-17T17-52-43Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-02-22T18-23-45Z/install.sh
+++ b/addons/minio/2023-02-22T18-23-45Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-02-27T18-10-45Z/install.sh
+++ b/addons/minio/2023-02-27T18-10-45Z/install.sh
@@ -235,7 +235,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-03-09T23-16-13Z/install.sh
+++ b/addons/minio/2023-03-09T23-16-13Z/install.sh
@@ -240,7 +240,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-03-13T19-46-17Z/install.sh
+++ b/addons/minio/2023-03-13T19-46-17Z/install.sh
@@ -240,7 +240,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/2023-03-20T20-16-18Z/install.sh
+++ b/addons/minio/2023-03-20T20-16-18Z/install.sh
@@ -240,7 +240,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -240,7 +240,7 @@ function minio_migrate_from_rgw() {
     minio_wait_for_health
 
     migrate_rgw_to_minio
-    export DID_MIGRATE_ROOK_OBJECT_STORE="1"
+    add_rook_store_object_migration_status
 }
 
 # TODO: allow this to work with the HA statefulset

--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -56,7 +56,8 @@ function openebs_maybe_migrate_from_rook() {
             # if there are errors, openebs_maybe_rook_migration_checks() will bail
             openebs_maybe_rook_migration_checks
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS" "1"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
 }

--- a/addons/openebs/3.4.0/install.sh
+++ b/addons/openebs/3.4.0/install.sh
@@ -56,7 +56,8 @@ function openebs_maybe_migrate_from_rook() {
             # if there are errors, openebs_maybe_rook_migration_checks() will bail
             openebs_maybe_rook_migration_checks
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS" "1"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
 }

--- a/addons/openebs/3.5.0/install.sh
+++ b/addons/openebs/3.5.0/install.sh
@@ -56,7 +56,8 @@ function openebs_maybe_migrate_from_rook() {
             # if there are errors, openebs_maybe_rook_migration_checks() will bail
             openebs_maybe_rook_migration_checks
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS" "1"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
 }

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -56,7 +56,8 @@ function openebs_maybe_migrate_from_rook() {
             # if there are errors, openebs_maybe_rook_migration_checks() will bail
             openebs_maybe_rook_migration_checks
             rook_ceph_to_sc_migration "$OPENEBS_LOCALPV_STORAGE_CLASS" "1"
-            DID_MIGRATE_ROOK_PVCS=1 # used to automatically delete rook-ceph if object store data was also migrated
+            # used to automatically delete rook-ceph if object store data was also migrated
+            add_rook_pvc_migration_status # used to automatically delete rook-ceph if object store data was also migrated
         fi
     fi
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

We must start to track the status via configmap so that we do not migrate the object store twice. 

#### Which issue(s) this PR fixes:

Fixes # [sc-70239]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds status of migration from rook into configmap
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
