### PR TITLE
wait for flannel pods after deleting them, not before

### DIFF
--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -32,8 +32,6 @@ function flannel() {
     flannel_render_config
 
     kubectl -n kube-flannel apply -k "$dst/"
-
-    flannel_ready_spinner
     
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
@@ -43,6 +41,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -37,8 +37,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -94,9 +94,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -33,8 +33,6 @@ function flannel() {
 
     kubectl -n kube-flannel apply -k "$dst/"
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -43,6 +41,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -37,8 +37,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -94,9 +94,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -265,9 +265,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -265,9 +265,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -263,9 +263,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -263,9 +263,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -263,9 +263,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -263,9 +263,8 @@ function flannel_already_applied() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
-       sleep 60
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -71,8 +71,8 @@ function flannel() {
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
     if [ "$KUBERNETES_UPGRADE" == "1" ]; then
-       log "Deleting pods from kube-flannel namespace"
-       kubectl delete --all pods --namespace=kube-flannel
+       log "Restarting kube-flannel pods"
+       kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
     flannel_ready_spinner

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -67,8 +67,6 @@ function flannel() {
         kubectl -n kube-flannel apply -k "$dst/"
     fi
 
-    flannel_ready_spinner
-
     # We will remove the flannel pods to let it be re-created
     # in order to workaround the issue scenario described in
     # https://github.com/flannel-io/flannel/issues/1721
@@ -77,6 +75,7 @@ function flannel() {
        kubectl delete --all pods --namespace=kube-flannel
     fi
 
+    flannel_ready_spinner
     check_network
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Flannel needs to be restarted after upgrading k8s. This changes the code so that we wait for flannel to be healthy after the restart, not before.

It also replaces `kubectl delete --all pods --namespace=kube-flannel` with `kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds`, which does not take down every flannel pod at once.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
