### PR TITLE
fix name of the config map to check the migration data

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -357,7 +357,7 @@ function rook_is_healthy_to_upgrade() {
 # Check if the kurl-migration-from-rook exists then, if not creates it
 # To add DID_MIGRATE_ROOK_PVCS = "1" in order to track that the PVCs were migrated
 function add_rook_pvc_migration_status() {
-    if ! kubectl -n kurl get configmap kurl-migration-status; then
+    if ! kubectl -n kurl get configmap kurl-migration-from-rook; then
        kubectl create configmap kurl-migration-from-rook -n kurl
     fi
     kubectl patch configmap kurl-migration-from-rook -n kurl --type merge -p '{"data":{"DID_MIGRATE_ROOK_PVCS":"1"}}'
@@ -367,7 +367,7 @@ function add_rook_pvc_migration_status() {
 # Check if the kurl-migration-from-rook exists then, if not creates it
 # To add DID_MIGRATE_ROOK_PVCS = "1" in order to track that the PVCs were migrated
 function add_rook_store_object_migration_status() {
-    if ! kubectl -n kurl get configmap kurl-migration-status; then
+    if ! kubectl -n kurl get configmap kurl-migration-from-rook; then
        kubectl create configmap kurl-migration-from-rook -n kurl
     fi
     kubectl patch configmap kurl-migration-from-rook -n kurl --type merge -p '{"data":{"DID_MIGRATE_ROOK_OBJECT_STORE":"1"}}'


### PR DESCRIPTION
#### What this PR does / why we need it:

To fix the name of the configmap used.

```sh
        2023-03-24 09:33:27+00:00 Migration from rook-ceph to openebs.io/local completed successfully!
    2023-03-24 09:33:27+00:00 Error from server (NotFound): configmaps "kurl-migration-status" not found
        2023-03-24 09:33:27+00:00 configmap/kurl-migration-from-rook created
        2023-03-24 09:33:27+00:00 configmap/kurl-migration-from-rook patched
```

Follow up https://github.com/replicatedhq/kURL/pull/4239

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-70239]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
