### PR TITLE
fix: Fixes log message upgrading from Rook 1.0.4 to 1.4.9 that caused the Rook Ceph bug

### DIFF
--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -126,9 +126,14 @@ function rookupgrade_10to14_upgrade() {
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
                 # Fail when more than one version is found
                 if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-                    logWarn "Detected multiple Ceph versions"
-                    logWarn "${ceph_versions_found}"
-                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                        log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                        echo "${ceph_versions_found}"
+                    else
+                        logWarn "Detected multiple Ceph versions"
+                        logWarn "${ceph_versions_found}"
+                        logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    fi
                 fi
 
                 if [[ "$(echo "${ceph_versions_found}")" == *"${ceph_version}"* ]]; then
@@ -289,9 +294,14 @@ function rookupgrade_10to14_upgrade() {
                 local ceph_versions_found=
                 ceph_versions_found="$(kubectl -n rook-ceph get deployment -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq)"
                 if [ -n "${ceph_versions_found}" ] && [ "$(echo "${ceph_versions_found}" | wc -l)" -gt "1" ]; then
-                    logWarn "Detected multiple Ceph versions"
-                    logWarn "${ceph_versions_found}"
-                    logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    if [ "$(echo "${ceph_versions_found}" | wc -l)" == "2" ] && [ "$(echo "${ceph_versions_found}" | grep "0.0.0-0")" ]; then
+                        log "Found two ceph versions but one of them is 0.0.0-0 which will be ignored"
+                        echo "${ceph_versions_found}"
+                    else
+                        logWarn "Detected multiple Ceph versions"
+                        logWarn "${ceph_versions_found}"
+                        logWarn "Failed to verify the Ceph upgrade, multiple Ceph versions detected"
+                    fi
                 fi
 
                 if [[ "$(echo "${ceph_versions_found}")" == *"15.2.8"* ]]; then

--- a/pkg/rook/testfiles/static.go
+++ b/pkg/rook/testfiles/static.go
@@ -67,6 +67,9 @@ var UpgradedNodeLess50Images []byte
 //go:embed "waitForRookVersionAllReady.json"
 var WaitForRookVersionAllReady []byte
 
+//go:embed "waitForRookVersionAllReady.json"
+var WaitForRookVersionAllReadyWithEmptyVersion []byte
+
 //go:embed "waitForRookVersionOldVersions.json"
 var WaitForRookVersionOldVersions []byte
 

--- a/pkg/rook/testfiles/waitForRookVersionAllReadyWithEmptyVersion.json
+++ b/pkg/rook/testfiles/waitForRookVersionAllReadyWithEmptyVersion.json
@@ -1,0 +1,10801 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "28"
+                },
+                "creationTimestamp": "2022-12-21T23:26:53Z",
+                "generation": 28,
+                "labels": {
+                    "app": "rook-ceph-crashcollector",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "crash",
+                    "crashcollector": "crash",
+                    "kubernetes.io/hostname": "ethanm-rook-21",
+                    "node_name": "ethanm-rook-21",
+                    "rook-version": "v1.8.10",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:crashcollector": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:node_name": {},
+                                    "f:rook-version": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:kubernetes.io/hostname": {},
+                                        "f:node_name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:ceph-version": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:crashcollector": {},
+                                            "f:kubernetes.io/hostname": {},
+                                            "f:node_name": {},
+                                            "f:rook-version": {},
+                                            "f:rook_cluster": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"ceph-crash\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CEPH_ARGS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/crash-collector-keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"make-container-crash-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash-collector-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-21T23:47:37Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:18:23Z"
+                    }
+                ],
+                "name": "rook-ceph-crashcollector-ethanm-rook-21",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "54408",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-crashcollector-ethanm-rook-21",
+                "uid": "df888a79-98e2-44f8-b001-09ad3a95ecd0"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-crashcollector",
+                        "kubernetes.io/hostname": "ethanm-rook-21",
+                        "node_name": "ethanm-rook-21"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-crashcollector",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "crash",
+                            "crashcollector": "crash",
+                            "kubernetes.io/hostname": "ethanm-rook-21",
+                            "node_name": "ethanm-rook-21",
+                            "rook-version": "v1.8.10",
+                            "rook_cluster": "rook-ceph"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "command": [
+                                    "ceph-crash"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring"
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "ceph-crash",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/crash-collector-keyring-store/",
+                                        "name": "rook-ceph-crash-collector-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "/var/lib/ceph/crash/posted"
+                                ],
+                                "command": [
+                                    "mkdir",
+                                    "-p"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "make-container-crash-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-21"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/not-ready",
+                                "operator": "Exists",
+                                "tolerationSeconds": 300
+                            },
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "name": "rook-ceph-crash-collector-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-crash-collector-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:57Z",
+                        "lastUpdateTime": "2022-12-21T23:26:57Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:53Z",
+                        "lastUpdateTime": "2022-12-22T00:18:23Z",
+                        "message": "ReplicaSet \"rook-ceph-crashcollector-ethanm-rook-21-5ddd58db64\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 28,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "11"
+                },
+                "creationTimestamp": "2022-12-21T23:26:53Z",
+                "generation": 11,
+                "labels": {
+                    "app": "rook-ceph-crashcollector",
+                    "ceph-version": "0.0.0-0",
+                    "ceph_daemon_id": "crash",
+                    "crashcollector": "crash",
+                    "kubernetes.io/hostname": "ethanm-rook-22",
+                    "node_name": "ethanm-rook-22",
+                    "rook-version": "v1.8.10",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:crashcollector": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:node_name": {},
+                                    "f:rook-version": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:kubernetes.io/hostname": {},
+                                        "f:node_name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:ceph-version": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:crashcollector": {},
+                                            "f:kubernetes.io/hostname": {},
+                                            "f:node_name": {},
+                                            "f:rook-version": {},
+                                            "f:rook_cluster": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"ceph-crash\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CEPH_ARGS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/crash-collector-keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"make-container-crash-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash-collector-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-21T23:47:37Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:17:45Z"
+                    }
+                ],
+                "name": "rook-ceph-crashcollector-ethanm-rook-22",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "54135",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-crashcollector-ethanm-rook-22",
+                "uid": "760a55c9-a66f-4bd6-9c2a-0c5f1809c438"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-crashcollector",
+                        "kubernetes.io/hostname": "ethanm-rook-22",
+                        "node_name": "ethanm-rook-22"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-crashcollector",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "crash",
+                            "crashcollector": "crash",
+                            "kubernetes.io/hostname": "ethanm-rook-22",
+                            "node_name": "ethanm-rook-22",
+                            "rook-version": "v1.8.10",
+                            "rook_cluster": "rook-ceph"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "command": [
+                                    "ceph-crash"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring"
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "ceph-crash",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/crash-collector-keyring-store/",
+                                        "name": "rook-ceph-crash-collector-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "/var/lib/ceph/crash/posted"
+                                ],
+                                "command": [
+                                    "mkdir",
+                                    "-p"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "make-container-crash-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-22"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/not-ready",
+                                "operator": "Exists",
+                                "tolerationSeconds": 300
+                            },
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 300
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "name": "rook-ceph-crash-collector-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-crash-collector-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:56Z",
+                        "lastUpdateTime": "2022-12-21T23:26:56Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:53Z",
+                        "lastUpdateTime": "2022-12-22T00:17:45Z",
+                        "message": "ReplicaSet \"rook-ceph-crashcollector-ethanm-rook-22-5fcbbdbfd9\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 11,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "16"
+                },
+                "creationTimestamp": "2022-12-21T23:26:53Z",
+                "generation": 16,
+                "labels": {
+                    "app": "rook-ceph-crashcollector",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "crash",
+                    "crashcollector": "crash",
+                    "kubernetes.io/hostname": "ethanm-rook-23",
+                    "node_name": "ethanm-rook-23",
+                    "rook-version": "v1.8.10",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:crashcollector": {},
+                                    "f:kubernetes.io/hostname": {},
+                                    "f:node_name": {},
+                                    "f:rook-version": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:kubernetes.io/hostname": {},
+                                        "f:node_name": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:ceph-version": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:crashcollector": {},
+                                            "f:kubernetes.io/hostname": {},
+                                            "f:node_name": {},
+                                            "f:rook-version": {},
+                                            "f:rook_cluster": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"ceph-crash\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CEPH_ARGS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/crash-collector-keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"make-container-crash-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash-collector-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-21T23:47:37Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:18:19Z"
+                    }
+                ],
+                "name": "rook-ceph-crashcollector-ethanm-rook-23",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "54340",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-crashcollector-ethanm-rook-23",
+                "uid": "c0237520-0282-4b38-a355-5c94fa4473bc"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-crashcollector",
+                        "kubernetes.io/hostname": "ethanm-rook-23",
+                        "node_name": "ethanm-rook-23"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-crashcollector",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "crash",
+                            "crashcollector": "crash",
+                            "kubernetes.io/hostname": "ethanm-rook-23",
+                            "node_name": "ethanm-rook-23",
+                            "rook-version": "v1.8.10",
+                            "rook_cluster": "rook-ceph"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "command": [
+                                    "ceph-crash"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring"
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "ceph-crash",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/crash-collector-keyring-store/",
+                                        "name": "rook-ceph-crash-collector-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "/var/lib/ceph/crash/posted"
+                                ],
+                                "command": [
+                                    "mkdir",
+                                    "-p"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "make-container-crash-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-23"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/not-ready",
+                                "operator": "Exists",
+                                "tolerationSeconds": 300
+                            },
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "name": "rook-ceph-crash-collector-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-crash-collector-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:56Z",
+                        "lastUpdateTime": "2022-12-21T23:26:56Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:26:53Z",
+                        "lastUpdateTime": "2022-12-22T00:18:19Z",
+                        "message": "ReplicaSet \"rook-ceph-crashcollector-ethanm-rook-23-694489f5d6\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 16,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mds\",\"app.kubernetes.io/component\":\"cephfilesystems.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-shared-fs-a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mds\",\"app.kubernetes.io/part-of\":\"rook-shared-fs\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"rook-shared-fs-a\",\"ceph_daemon_type\":\"mds\",\"mds\":\"rook-shared-fs-a\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"},\"name\":\"rook-ceph-mds-rook-shared-fs-a\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephFilesystem\",\"name\":\"rook-shared-fs\",\"uid\":\"5db00e36-ca21-4f0b-b811-23f9bb67d3ea\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mds\",\"ceph_daemon_id\":\"rook-shared-fs-a\",\"mds\":\"rook-shared-fs-a\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mds\",\"app.kubernetes.io/component\":\"cephfilesystems.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-shared-fs-a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mds\",\"app.kubernetes.io/part-of\":\"rook-shared-fs\",\"ceph_daemon_id\":\"rook-shared-fs-a\",\"ceph_daemon_type\":\"mds\",\"mds\":\"rook-shared-fs-a\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"},\"name\":\"rook-ceph-mds-rook-shared-fs-a\",\"namespace\":\"rook-ceph\"},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"rook-ceph-mds\"]}]},\"topologyKey\":\"topology.kubernetes.io/zone\"},\"weight\":100}],\"requiredDuringSchedulingIgnoredDuringExecution\":[{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"rook-ceph-mds\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"}]}},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=rook-shared-fs-a\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--public-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mds\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-a.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"mds\",\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-a.asok status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mds-rook-shared-fs-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-a\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mds/ceph-rook-shared-fs-a\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mds-rook-shared-fs-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-a\",\"name\":\"ceph-daemon-data\"}]}],\"priorityClassName\":\"system-cluster-critical\",\"restartPolicy\":\"Always\",\"tolerations\":[{\"effect\":\"NoExecute\",\"key\":\"node.kubernetes.io/unreachable\",\"operator\":\"Exists\",\"tolerationSeconds\":5}],\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mds-rook-shared-fs-a-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mds-rook-shared-fs-a-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"emptyDir\":{},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "4"
+                },
+                "creationTimestamp": "2022-12-22T00:00:45Z",
+                "generation": 4,
+                "labels": {
+                    "app": "rook-ceph-mds",
+                    "app.kubernetes.io/component": "cephfilesystems.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "rook-shared-fs-a",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mds",
+                    "app.kubernetes.io/part-of": "rook-shared-fs",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "rook-shared-fs-a",
+                    "ceph_daemon_type": "mds",
+                    "mds": "rook-shared-fs-a",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "rook_file_system": "rook-shared-fs"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:mds": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {},
+                                    "f:rook_file_system": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5db00e36-ca21-4f0b-b811-23f9bb67d3ea\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:mds": {},
+                                        "f:rook_cluster": {},
+                                        "f:rook_file_system": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:mds": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {},
+                                            "f:rook_file_system": {}
+                                        },
+                                        "f:name": {},
+                                        "f:namespace": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {
+                                            ".": {},
+                                            "f:podAntiAffinity": {
+                                                ".": {},
+                                                "f:preferredDuringSchedulingIgnoredDuringExecution": {},
+                                                "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                                            }
+                                        },
+                                        "f:containers": {
+                                            "k:{\"name\":\"mds\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-a\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-a\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:priorityClassName": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-mds-rook-shared-fs-a-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:06:39Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Available\"}": {
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:19:35Z"
+                    }
+                ],
+                "name": "rook-ceph-mds-rook-shared-fs-a",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephFilesystem",
+                        "name": "rook-shared-fs",
+                        "uid": "5db00e36-ca21-4f0b-b811-23f9bb67d3ea"
+                    }
+                ],
+                "resourceVersion": "54786",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mds-rook-shared-fs-a",
+                "uid": "cf6fafe7-5327-49c6-aeb8-4097167a243d"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mds",
+                        "ceph_daemon_id": "rook-shared-fs-a",
+                        "mds": "rook-shared-fs-a",
+                        "rook_cluster": "rook-ceph",
+                        "rook_file_system": "rook-shared-fs"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mds",
+                            "app.kubernetes.io/component": "cephfilesystems.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "rook-shared-fs-a",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mds",
+                            "app.kubernetes.io/part-of": "rook-shared-fs",
+                            "ceph_daemon_id": "rook-shared-fs-a",
+                            "ceph_daemon_type": "mds",
+                            "mds": "rook-shared-fs-a",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "rook_file_system": "rook-shared-fs"
+                        },
+                        "name": "rook-ceph-mds-rook-shared-fs-a",
+                        "namespace": "rook-ceph"
+                    },
+                    "spec": {
+                        "affinity": {
+                            "podAntiAffinity": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchExpressions": [
+                                                    {
+                                                        "key": "app",
+                                                        "operator": "In",
+                                                        "values": [
+                                                            "rook-ceph-mds"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "topologyKey": "topology.kubernetes.io/zone"
+                                        },
+                                        "weight": 100
+                                    }
+                                ],
+                                "requiredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "labelSelector": {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "app",
+                                                    "operator": "In",
+                                                    "values": [
+                                                        "rook-ceph-mds"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "topologyKey": "kubernetes.io/hostname"
+                                    }
+                                ]
+                            }
+                        },
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=rook-shared-fs-a",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--public-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mds"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-a.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mds",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-a.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mds-rook-shared-fs-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mds/ceph-rook-shared-fs-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mds/ceph-rook-shared-fs-a"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mds-rook-shared-fs-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mds/ceph-rook-shared-fs-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "priorityClassName": "system-cluster-critical",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mds-rook-shared-fs-a-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mds-rook-shared-fs-a-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "emptyDir": {},
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:19:35Z",
+                        "lastUpdateTime": "2022-12-22T00:19:35Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-22T00:00:45Z",
+                        "lastUpdateTime": "2022-12-22T00:19:35Z",
+                        "message": "ReplicaSet \"rook-ceph-mds-rook-shared-fs-a-6c77cb488\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 4,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mds\",\"app.kubernetes.io/component\":\"cephfilesystems.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-shared-fs-b\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mds\",\"app.kubernetes.io/part-of\":\"rook-shared-fs\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"rook-shared-fs-b\",\"ceph_daemon_type\":\"mds\",\"mds\":\"rook-shared-fs-b\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"},\"name\":\"rook-ceph-mds-rook-shared-fs-b\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephFilesystem\",\"name\":\"rook-shared-fs\",\"uid\":\"5db00e36-ca21-4f0b-b811-23f9bb67d3ea\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mds\",\"ceph_daemon_id\":\"rook-shared-fs-b\",\"mds\":\"rook-shared-fs-b\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mds\",\"app.kubernetes.io/component\":\"cephfilesystems.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-shared-fs-b\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mds\",\"app.kubernetes.io/part-of\":\"rook-shared-fs\",\"ceph_daemon_id\":\"rook-shared-fs-b\",\"ceph_daemon_type\":\"mds\",\"mds\":\"rook-shared-fs-b\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_file_system\":\"rook-shared-fs\"},\"name\":\"rook-ceph-mds-rook-shared-fs-b\",\"namespace\":\"rook-ceph\"},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"rook-ceph-mds\"]}]},\"topologyKey\":\"topology.kubernetes.io/zone\"},\"weight\":100}],\"requiredDuringSchedulingIgnoredDuringExecution\":[{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"app\",\"operator\":\"In\",\"values\":[\"rook-ceph-mds\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"}]}},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=rook-shared-fs-b\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--public-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mds\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-b.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"mds\",\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-b.asok status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mds-rook-shared-fs-b-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-b\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mds/ceph-rook-shared-fs-b\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mds-rook-shared-fs-b-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-b\",\"name\":\"ceph-daemon-data\"}]}],\"priorityClassName\":\"system-cluster-critical\",\"restartPolicy\":\"Always\",\"tolerations\":[{\"effect\":\"NoExecute\",\"key\":\"node.kubernetes.io/unreachable\",\"operator\":\"Exists\",\"tolerationSeconds\":5}],\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mds-rook-shared-fs-b-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mds-rook-shared-fs-b-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"emptyDir\":{},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "4"
+                },
+                "creationTimestamp": "2022-12-22T00:00:52Z",
+                "generation": 6,
+                "labels": {
+                    "app": "rook-ceph-mds",
+                    "app.kubernetes.io/component": "cephfilesystems.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "rook-shared-fs-b",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mds",
+                    "app.kubernetes.io/part-of": "rook-shared-fs",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "rook-shared-fs-b",
+                    "ceph_daemon_type": "mds",
+                    "mds": "rook-shared-fs-b",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "rook_file_system": "rook-shared-fs"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:mds": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {},
+                                    "f:rook_file_system": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5db00e36-ca21-4f0b-b811-23f9bb67d3ea\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:mds": {},
+                                        "f:rook_cluster": {},
+                                        "f:rook_file_system": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:mds": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {},
+                                            "f:rook_file_system": {}
+                                        },
+                                        "f:name": {},
+                                        "f:namespace": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {
+                                            ".": {},
+                                            "f:podAntiAffinity": {
+                                                ".": {},
+                                                "f:preferredDuringSchedulingIgnoredDuringExecution": {},
+                                                "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                                            }
+                                        },
+                                        "f:containers": {
+                                            "k:{\"name\":\"mds\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-b\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mds/ceph-rook-shared-fs-b\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:priorityClassName": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-mds-rook-shared-fs-b-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:08:37Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Available\"}": {
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:20:57Z"
+                    }
+                ],
+                "name": "rook-ceph-mds-rook-shared-fs-b",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephFilesystem",
+                        "name": "rook-shared-fs",
+                        "uid": "5db00e36-ca21-4f0b-b811-23f9bb67d3ea"
+                    }
+                ],
+                "resourceVersion": "55252",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mds-rook-shared-fs-b",
+                "uid": "f997494b-5581-4873-adb8-6b84976e18e1"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mds",
+                        "ceph_daemon_id": "rook-shared-fs-b",
+                        "mds": "rook-shared-fs-b",
+                        "rook_cluster": "rook-ceph",
+                        "rook_file_system": "rook-shared-fs"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mds",
+                            "app.kubernetes.io/component": "cephfilesystems.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "rook-shared-fs-b",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mds",
+                            "app.kubernetes.io/part-of": "rook-shared-fs",
+                            "ceph_daemon_id": "rook-shared-fs-b",
+                            "ceph_daemon_type": "mds",
+                            "mds": "rook-shared-fs-b",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "rook_file_system": "rook-shared-fs"
+                        },
+                        "name": "rook-ceph-mds-rook-shared-fs-b",
+                        "namespace": "rook-ceph"
+                    },
+                    "spec": {
+                        "affinity": {
+                            "podAntiAffinity": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchExpressions": [
+                                                    {
+                                                        "key": "app",
+                                                        "operator": "In",
+                                                        "values": [
+                                                            "rook-ceph-mds"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "topologyKey": "topology.kubernetes.io/zone"
+                                        },
+                                        "weight": 100
+                                    }
+                                ],
+                                "requiredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "labelSelector": {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "app",
+                                                    "operator": "In",
+                                                    "values": [
+                                                        "rook-ceph-mds"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "topologyKey": "kubernetes.io/hostname"
+                                    }
+                                ]
+                            }
+                        },
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=rook-shared-fs-b",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--public-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mds"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-b.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mds",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mds.rook-shared-fs-b.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mds-rook-shared-fs-b-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mds/ceph-rook-shared-fs-b",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mds/ceph-rook-shared-fs-b"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mds-rook-shared-fs-b-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mds/ceph-rook-shared-fs-b",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "priorityClassName": "system-cluster-critical",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mds-rook-shared-fs-b-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mds-rook-shared-fs-b-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "emptyDir": {},
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:20:57Z",
+                        "lastUpdateTime": "2022-12-22T00:20:57Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-22T00:00:52Z",
+                        "lastUpdateTime": "2022-12-22T00:20:57Z",
+                        "message": "ReplicaSet \"rook-ceph-mds-rook-shared-fs-b-5bc7b599b8\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 6,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mgr\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mgr\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"a\",\"ceph_daemon_type\":\"mgr\",\"instance\":\"a\",\"mgr\":\"a\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mgr-a\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mgr\",\"ceph_daemon_id\":\"a\",\"instance\":\"a\",\"mgr\":\"a\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9283\",\"prometheus.io/scrape\":\"true\"},\"labels\":{\"app\":\"rook-ceph-mgr\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mgr\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph_daemon_id\":\"a\",\"ceph_daemon_type\":\"mgr\",\"instance\":\"a\",\"mgr\":\"a\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mgr-a\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=a\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--client-mount-uid=0\",\"--client-mount-gid=0\",\"--foreground\",\"--public-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mgr\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_OPERATOR_NAMESPACE\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_CEPH_CLUSTER_CRD_VERSION\",\"value\":\"v1\"},{\"name\":\"ROOK_CEPH_CLUSTER_CRD_NAME\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mgr.a.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"mgr\",\"ports\":[{\"containerPort\":6800,\"name\":\"mgr\",\"protocol\":\"TCP\"},{\"containerPort\":9283,\"name\":\"http-metrics\",\"protocol\":\"TCP\"},{\"containerPort\":7000,\"name\":\"dashboard\",\"protocol\":\"TCP\"}],\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mgr.a.asok status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mgr-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mgr/ceph-a\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mgr/ceph-a\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mgr-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mgr/ceph-a\",\"name\":\"ceph-daemon-data\"}]}],\"restartPolicy\":\"Always\",\"serviceAccountName\":\"rook-ceph-mgr\",\"tolerations\":[{\"effect\":\"NoExecute\",\"key\":\"node.kubernetes.io/unreachable\",\"operator\":\"Exists\",\"tolerationSeconds\":5}],\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mgr-a-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mgr-a-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"emptyDir\":{},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "25"
+                },
+                "creationTimestamp": "2022-12-21T21:51:36Z",
+                "generation": 28,
+                "labels": {
+                    "app": "rook-ceph-mgr",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "a",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mgr",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "a",
+                    "ceph_daemon_type": "mgr",
+                    "instance": "a",
+                    "mgr": "a",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph"
+                },
+                "name": "rook-ceph-mgr-a",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "56015",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mgr-a",
+                "uid": "c7620e3a-2dbd-4938-9e11-17405c3a1679"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mgr",
+                        "ceph_daemon_id": "a",
+                        "instance": "a",
+                        "mgr": "a",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "prometheus.io/port": "9283",
+                            "prometheus.io/scrape": "true"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mgr",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "a",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mgr",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph_daemon_id": "a",
+                            "ceph_daemon_type": "mgr",
+                            "instance": "a",
+                            "mgr": "a",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph"
+                        },
+                        "name": "rook-ceph-mgr-a"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=a",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--client-mount-uid=0",
+                                    "--client-mount-gid=0",
+                                    "--foreground",
+                                    "--public-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mgr"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_OPERATOR_NAMESPACE",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_CLUSTER_CRD_VERSION",
+                                        "value": "v1"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_CLUSTER_CRD_NAME",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mgr.a.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mgr",
+                                "ports": [
+                                    {
+                                        "containerPort": 6800,
+                                        "name": "mgr",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9283,
+                                        "name": "http-metrics",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 7000,
+                                        "name": "dashboard",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mgr.a.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mgr-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mgr/ceph-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mgr/ceph-a"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mgr-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mgr/ceph-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "serviceAccount": "rook-ceph-mgr",
+                        "serviceAccountName": "rook-ceph-mgr",
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mgr-a-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mgr-a-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "emptyDir": {},
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:23:33Z",
+                        "lastUpdateTime": "2022-12-22T00:23:33Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T21:51:36Z",
+                        "lastUpdateTime": "2022-12-22T00:23:33Z",
+                        "message": "ReplicaSet \"rook-ceph-mgr-a-d589d4c86\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 28,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"a\",\"ceph_daemon_type\":\"mon\",\"mon\":\"a\",\"mon_cluster\":\"rook-ceph\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-a\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mon\",\"ceph_daemon_id\":\"a\",\"mon\":\"a\",\"mon_cluster\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"a\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph_daemon_id\":\"a\",\"ceph_daemon_type\":\"mon\",\"mon\":\"a\",\"mon_cluster\":\"rook-ceph\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-a\",\"namespace\":\"rook-ceph\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=a\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--public-addr=10.96.3.201\",\"--setuser-match-path=/var/lib/ceph/mon/ceph-a/store.db\",\"--public-bind-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.a.asok mon_status\"]},\"initialDelaySeconds\":10},\"name\":\"mon\",\"ports\":[{\"containerPort\":6789,\"name\":\"tcp-msgr1\",\"protocol\":\"TCP\"}],\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.a.asok mon_status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mon/ceph-a\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\",\"name\":\"ceph-daemon-data\"}]},{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=a\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--public-addr=10.96.3.201\",\"--mkfs\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"init-mon-fs\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\",\"name\":\"ceph-daemon-data\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-21\"},\"restartPolicy\":\"Always\",\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mons-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mons-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/var/lib/rook/mon-a/data\"},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "22"
+                },
+                "creationTimestamp": "2022-12-21T21:51:23Z",
+                "generation": 29,
+                "labels": {
+                    "app": "rook-ceph-mon",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "a",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mon",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "a",
+                    "ceph_daemon_type": "mon",
+                    "mon": "a",
+                    "mon_cluster": "rook-ceph",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:mon": {},
+                                    "f:mon_cluster": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:mon": {},
+                                        "f:mon_cluster": {},
+                                        "f:rook_cluster": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:mon": {},
+                                            "f:mon_cluster": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {}
+                                        },
+                                        "f:name": {},
+                                        "f:namespace": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {},
+                                        "f:containers": {
+                                            "k:{\"name\":\"mon\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":6789,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"init-mon-fs\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-a\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-mons-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:09:30Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Available\"}": {
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:17:30Z"
+                    }
+                ],
+                "name": "rook-ceph-mon-a",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "53987",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mon-a",
+                "uid": "60ef7d99-0962-4f20-824c-98711aa7748d"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mon",
+                        "ceph_daemon_id": "a",
+                        "mon": "a",
+                        "mon_cluster": "rook-ceph",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mon",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "a",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mon",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph_daemon_id": "a",
+                            "ceph_daemon_type": "mon",
+                            "mon": "a",
+                            "mon_cluster": "rook-ceph",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph"
+                        },
+                        "name": "rook-ceph-mon-a",
+                        "namespace": "rook-ceph"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=a",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--public-addr=10.96.3.201",
+                                    "--setuser-match-path=/var/lib/ceph/mon/ceph-a/store.db",
+                                    "--public-bind-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.a.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mon",
+                                "ports": [
+                                    {
+                                        "containerPort": 6789,
+                                        "name": "tcp-msgr1",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.a.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mon/ceph-a"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=a",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--public-addr=10.96.3.201",
+                                    "--mkfs"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "init-mon-fs",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-a",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-21"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mons-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mons-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/mon-a/data",
+                                    "type": ""
+                                },
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:17:30Z",
+                        "lastUpdateTime": "2022-12-22T00:17:30Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T21:51:23Z",
+                        "lastUpdateTime": "2022-12-22T00:17:30Z",
+                        "message": "ReplicaSet \"rook-ceph-mon-a-7767bff5cc\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 29,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"b\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"b\",\"ceph_daemon_type\":\"mon\",\"mon\":\"b\",\"mon_cluster\":\"rook-ceph\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-b\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mon\",\"ceph_daemon_id\":\"b\",\"mon\":\"b\",\"mon_cluster\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"b\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph_daemon_id\":\"b\",\"ceph_daemon_type\":\"mon\",\"mon\":\"b\",\"mon_cluster\":\"rook-ceph\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-b\",\"namespace\":\"rook-ceph\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=b\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--public-addr=10.96.2.56\",\"--setuser-match-path=/var/lib/ceph/mon/ceph-b/store.db\",\"--public-bind-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.b.asok mon_status\"]},\"initialDelaySeconds\":10},\"name\":\"mon\",\"ports\":[{\"containerPort\":6789,\"name\":\"tcp-msgr1\",\"protocol\":\"TCP\"}],\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.b.asok mon_status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mon/ceph-b\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\",\"name\":\"ceph-daemon-data\"}]},{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=b\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--public-addr=10.96.2.56\",\"--mkfs\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"init-mon-fs\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\",\"name\":\"ceph-daemon-data\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-22\"},\"restartPolicy\":\"Always\",\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mons-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mons-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/var/lib/rook/mon-b/data\"},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "18"
+                },
+                "creationTimestamp": "2022-12-21T22:03:04Z",
+                "generation": 24,
+                "labels": {
+                    "app": "rook-ceph-mon",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "b",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mon",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "b",
+                    "ceph_daemon_type": "mon",
+                    "mon": "b",
+                    "mon_cluster": "rook-ceph",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:mon": {},
+                                    "f:mon_cluster": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:mon": {},
+                                        "f:mon_cluster": {},
+                                        "f:rook_cluster": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:mon": {},
+                                            "f:mon_cluster": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {}
+                                        },
+                                        "f:name": {},
+                                        "f:namespace": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {},
+                                        "f:containers": {
+                                            "k:{\"name\":\"mon\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":6789,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"init-mon-fs\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-b\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-mons-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:06:47Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Available\"}": {
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:19:13Z"
+                    }
+                ],
+                "name": "rook-ceph-mon-b",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "54665",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mon-b",
+                "uid": "723c6fb6-2e28-46b1-9dc7-da4dfac5657e"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mon",
+                        "ceph_daemon_id": "b",
+                        "mon": "b",
+                        "mon_cluster": "rook-ceph",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mon",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "b",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mon",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph_daemon_id": "b",
+                            "ceph_daemon_type": "mon",
+                            "mon": "b",
+                            "mon_cluster": "rook-ceph",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph"
+                        },
+                        "name": "rook-ceph-mon-b",
+                        "namespace": "rook-ceph"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=b",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--public-addr=10.96.2.56",
+                                    "--setuser-match-path=/var/lib/ceph/mon/ceph-b/store.db",
+                                    "--public-bind-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.b.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mon",
+                                "ports": [
+                                    {
+                                        "containerPort": 6789,
+                                        "name": "tcp-msgr1",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.b.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-b",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mon/ceph-b"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-b",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=b",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--public-addr=10.96.2.56",
+                                    "--mkfs"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "init-mon-fs",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-b",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-22"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mons-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mons-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/mon-b/data",
+                                    "type": ""
+                                },
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:19:13Z",
+                        "lastUpdateTime": "2022-12-22T00:19:13Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T22:03:04Z",
+                        "lastUpdateTime": "2022-12-22T00:19:13Z",
+                        "message": "ReplicaSet \"rook-ceph-mon-b-7f88cfc6fb\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 24,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"c\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"c\",\"ceph_daemon_type\":\"mon\",\"mon\":\"c\",\"mon_cluster\":\"rook-ceph\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-c\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-mon\",\"ceph_daemon_id\":\"c\",\"mon\":\"c\",\"mon_cluster\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-mon\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"c\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-mon\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph_daemon_id\":\"c\",\"ceph_daemon_type\":\"mon\",\"mon\":\"c\",\"mon_cluster\":\"rook-ceph\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\"},\"name\":\"rook-ceph-mon-c\",\"namespace\":\"rook-ceph\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=c\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--public-addr=10.96.2.9\",\"--setuser-match-path=/var/lib/ceph/mon/ceph-c/store.db\",\"--public-bind-addr=$(ROOK_POD_IP)\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_POD_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status\"]},\"initialDelaySeconds\":10},\"name\":\"mon\",\"ports\":[{\"containerPort\":6789,\"name\":\"tcp-msgr1\",\"protocol\":\"TCP\"}],\"resources\":{},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status\"]},\"failureThreshold\":6,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\",\"name\":\"ceph-daemon-data\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/mon/ceph-c\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\",\"name\":\"ceph-daemon-data\"}]},{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=c\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--public-addr=10.96.2.9\",\"--mkfs\"],\"command\":[\"ceph-mon\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"init-mon-fs\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-mons-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\",\"name\":\"ceph-daemon-data\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-23\"},\"restartPolicy\":\"Always\",\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-mons-keyring\",\"secret\":{\"secretName\":\"rook-ceph-mons-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/var/lib/rook/mon-c/data\"},\"name\":\"ceph-daemon-data\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "16"
+                },
+                "creationTimestamp": "2022-12-21T22:03:16Z",
+                "generation": 22,
+                "labels": {
+                    "app": "rook-ceph-mon",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "c",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-mon",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "c",
+                    "ceph_daemon_type": "mon",
+                    "mon": "c",
+                    "mon_cluster": "rook-ceph",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:mon": {},
+                                    "f:mon_cluster": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:mon": {},
+                                        "f:mon_cluster": {},
+                                        "f:rook_cluster": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:mon": {},
+                                            "f:mon_cluster": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {}
+                                        },
+                                        "f:name": {},
+                                        "f:namespace": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {},
+                                        "f:containers": {
+                                            "k:{\"name\":\"mon\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":6789,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:exec": {
+                                                        ".": {},
+                                                        "f:command": {}
+                                                    },
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"init-mon-fs\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/mon/ceph-c\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:nodeSelector": {
+                                            ".": {},
+                                            "f:kubernetes.io/hostname": {}
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-mons-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:08:18Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Available\"}": {
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:21:36Z"
+                    }
+                ],
+                "name": "rook-ceph-mon-c",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "55462",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-mon-c",
+                "uid": "600020e9-7f78-47b2-97f4-f6b7da186460"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-mon",
+                        "ceph_daemon_id": "c",
+                        "mon": "c",
+                        "mon_cluster": "rook-ceph",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-mon",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "c",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-mon",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph_daemon_id": "c",
+                            "ceph_daemon_type": "mon",
+                            "mon": "c",
+                            "mon_cluster": "rook-ceph",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph"
+                        },
+                        "name": "rook-ceph-mon-c",
+                        "namespace": "rook-ceph"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=c",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--public-addr=10.96.2.9",
+                                    "--setuser-match-path=/var/lib/ceph/mon/ceph-c/store.db",
+                                    "--public-bind-addr=$(ROOK_POD_IP)"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_POD_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "mon",
+                                "ports": [
+                                    {
+                                        "containerPort": 6789,
+                                        "name": "tcp-msgr1",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status"
+                                        ]
+                                    },
+                                    "failureThreshold": 6,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-c",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/mon/ceph-c"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-c",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=c",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--public-addr=10.96.2.9",
+                                    "--mkfs"
+                                ],
+                                "command": [
+                                    "ceph-mon"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "init-mon-fs",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-mons-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/mon/ceph-c",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-23"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-mons-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-mons-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/mon-c/data",
+                                    "type": ""
+                                },
+                                "name": "ceph-daemon-data"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:21:36Z",
+                        "lastUpdateTime": "2022-12-22T00:21:36Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T22:03:16Z",
+                        "lastUpdateTime": "2022-12-22T00:21:36Z",
+                        "message": "ReplicaSet \"rook-ceph-mon-c-597d769cc7\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 22,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"3\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"3\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"3\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-21\",\"osd\":\"3\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-21\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd-3\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-osd\",\"ceph-osd-id\":\"3\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"3\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"3\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"3\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-21\",\"osd\":\"3\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-21\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--foreground\",\"--id\",\"3\",\"--fsid\",\"dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--setuser\",\"ceph\",\"--setgroup\",\"ceph\",\"--crush-location=root=default host=ethanm-rook-21\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--ms-learn-addr-from-peer=false\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\"],\"command\":[\"ceph-osd\"],\"env\":[{\"name\":\"ROOK_NODE_NAME\",\"value\":\"ethanm-rook-21\"},{\"name\":\"ROOK_CLUSTER_ID\",\"value\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"},{\"name\":\"ROOK_CLUSTER_NAME\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_PRIVATE_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"ROOK_PUBLIC_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"POD_NAMESPACE\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_MON_ENDPOINTS\",\"valueFrom\":{\"configMapKeyRef\":{\"key\":\"data\",\"name\":\"rook-ceph-mon-endpoints\"}}},{\"name\":\"ROOK_MON_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_USERNAME\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-username\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CONFIG_DIR\",\"value\":\"/var/lib/rook\"},{\"name\":\"ROOK_CEPH_CONFIG_OVERRIDE\",\"value\":\"/etc/rook/config/override.conf\"},{\"name\":\"ROOK_FSID\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"fsid\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"ROOK_CRUSHMAP_ROOT\",\"value\":\"default\"},{\"name\":\"ROOK_CRUSHMAP_HOSTNAME\",\"value\":\"ethanm-rook-21\"},{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_OSDS_PER_DEVICE\",\"value\":\"1\"},{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_OSD_UUID\",\"value\":\"011b8487-af1f-4eb4-b32a-7710cd3cc8a3\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"3\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-86a5ed44-ebe7-4910-ab6e-e6e2cd2a5094/osd-data-02d34404-d54a-4fd4-90f8-03a78ea54d56\"},{\"name\":\"ROOK_CV_MODE\",\"value\":\"lvm\"},{\"name\":\"ROOK_OSD_DEVICE_CLASS\",\"value\":\"ssd\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.3.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"osd\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.3.asok status\"]},\"failureThreshold\":720,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-3\",\"name\":\"activate-osd\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"command\":[\"/bin/bash\",\"-c\",\"\\nset -o errexit\\nset -o pipefail\\nset -o nounset # fail if variables are unset\\nset -o xtrace\\n\\nOSD_ID=\\\"$ROOK_OSD_ID\\\"\\nOSD_UUID=011b8487-af1f-4eb4-b32a-7710cd3cc8a3\\nOSD_STORE_FLAG=\\\"--bluestore\\\"\\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\\\"$OSD_ID\\\"\\nCV_MODE=lvm\\nDEVICE=\\\"$ROOK_BLOCK_PATH\\\"\\n\\n# create new keyring\\nceph -n client.admin auth get-or-create osd.\\\"$OSD_ID\\\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\\n\\n# active the osd with ceph-volume\\nif [[ \\\"$CV_MODE\\\" == \\\"lvm\\\" ]]; then\\n\\tTMP_DIR=$(mktemp -d)\\n\\n\\t# activate osd\\n\\tceph-volume lvm activate --no-systemd \\\"$OSD_STORE_FLAG\\\" \\\"$OSD_ID\\\" \\\"$OSD_UUID\\\"\\n\\n\\t# copy the tmpfs directory to a temporary directory\\n\\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\\n\\t# this will result in the emptydir to be empty when accessed by the main osd container\\n\\tcp --verbose --no-dereference \\\"$OSD_DATA_DIR\\\"/* \\\"$TMP_DIR\\\"/\\n\\n\\t# unmount the tmpfs since we don't need it anymore\\n\\tumount \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# copy back the content of the tmpfs into the original osd directory\\n\\tcp --verbose --no-dereference \\\"$TMP_DIR\\\"/* \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# retain ownership of files to the ceph user/group\\n\\tchown --verbose --recursive ceph:ceph \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# remove the temporary directory\\n\\trm --recursive --force \\\"$TMP_DIR\\\"\\nelse\\n\\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\\n\\t#  returns user-friendly device names which can change when systems reboot. To\\n\\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\\n\\t# block device we have is still correct, and if it isn't correct, we need to\\n\\t# scan all the disks to find the right one.\\n\\tOSD_LIST=\\\"$(mktemp)\\\"\\n\\n\\tfunction find_device() {\\n\\t\\t# jq would be preferable, but might be removed for hardened Ceph images\\n\\t\\t# python3 should exist in all containers having Ceph\\n\\t\\tpython3 -c \\\"\\nimport sys, json\\nfor _, info in json.load(sys.stdin).items():\\n\\tif info['osd_id'] == $OSD_ID:\\n\\t\\tprint(info['device'], end='')\\n\\t\\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\\n\\t\\tsys.exit(0)  # don't keep processing once the disk is found\\nsys.exit('no disk found with OSD ID $OSD_ID')\\n\\\"\\n\\t}\\n\\n\\tceph-volume raw list \\\"$DEVICE\\\" \\u003e \\\"$OSD_LIST\\\"\\n\\tcat \\\"$OSD_LIST\\\"\\n\\n\\tif ! find_device \\u003c \\\"$OSD_LIST\\\"; then\\n\\t\\tceph-volume raw list \\u003e \\\"$OSD_LIST\\\"\\n\\t\\tcat \\\"$OSD_LIST\\\"\\n\\n\\t\\tDEVICE=\\\"$(find_device \\u003c \\\"$OSD_LIST\\\")\\\"\\n\\tfi\\n\\t[[ -z \\\"$DEVICE\\\" ]] \\u0026\\u0026 { echo \\\"no device\\\" ; exit 1 ; }\\n\\n\\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\\n\\tceph-volume raw activate --device \\\"$DEVICE\\\" --no-systemd --no-tmpfs\\nfi\\n\"],\"env\":[{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-86a5ed44-ebe7-4910-ab6e-e6e2cd2a5094/osd-data-02d34404-d54a-4fd4-90f8-03a78ea54d56\"},{\"name\":\"ROOK_METADATA_DEVICE\"},{\"name\":\"ROOK_WAL_DEVICE\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"3\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"activate\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/ceph/osd/ceph-3\",\"name\":\"activate-osd\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/admin-keyring-store/\",\"name\":\"rook-ceph-admin-keyring\",\"readOnly\":true}]},{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-3\",\"name\":\"activate-osd\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-21\"},\"restartPolicy\":\"Always\",\"serviceAccountName\":\"rook-ceph-osd\",\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/rook\"},\"name\":\"rook-data\"},{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/dev\"},\"name\":\"devices\"},{\"hostPath\":{\"path\":\"/run/udev\"},\"name\":\"run-udev\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_011b8487-af1f-4eb4-b32a-7710cd3cc8a3\",\"type\":\"DirectoryOrCreate\"},\"name\":\"activate-osd\"},{\"name\":\"rook-ceph-admin-keyring\",\"secret\":{\"secretName\":\"rook-ceph-admin-keyring\"}}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "15"
+                },
+                "creationTimestamp": "2022-12-21T23:01:16Z",
+                "generation": 16,
+                "labels": {
+                    "app": "rook-ceph-osd",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "3",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-osd",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-osd-id": "3",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "3",
+                    "ceph_daemon_type": "osd",
+                    "failure-domain": "ethanm-rook-21",
+                    "osd": "3",
+                    "portable": "false",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "topology-location-host": "ethanm-rook-21",
+                    "topology-location-root": "default"
+                },
+                "name": "rook-ceph-osd-3",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "56568",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-osd-3",
+                "uid": "3b209433-ddb5-4e21-b8ff-9a60d81bf288"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-osd",
+                        "ceph-osd-id": "3",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-osd",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "3",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-osd",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph-osd-id": "3",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "3",
+                            "ceph_daemon_type": "osd",
+                            "failure-domain": "ethanm-rook-21",
+                            "osd": "3",
+                            "portable": "false",
+                            "rook-version": "v1.8.10",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "topology-location-host": "ethanm-rook-21",
+                            "topology-location-root": "default"
+                        },
+                        "name": "rook-ceph-osd"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--foreground",
+                                    "--id",
+                                    "3",
+                                    "--fsid",
+                                    "dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--setuser",
+                                    "ceph",
+                                    "--setgroup",
+                                    "ceph",
+                                    "--crush-location=root=default host=ethanm-rook-21",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--ms-learn-addr-from-peer=false",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false"
+                                ],
+                                "command": [
+                                    "ceph-osd"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "ROOK_NODE_NAME",
+                                        "value": "ethanm-rook-21"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_ID",
+                                        "value": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_NAME",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_PRIVATE_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_PUBLIC_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_MON_ENDPOINTS",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "key": "data",
+                                                "name": "rook-ceph-mon-endpoints"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_MON_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_USERNAME",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-username",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CONFIG_DIR",
+                                        "value": "/var/lib/rook"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_CONFIG_OVERRIDE",
+                                        "value": "/etc/rook/config/override.conf"
+                                    },
+                                    {
+                                        "name": "ROOK_FSID",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "fsid",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_ROOT",
+                                        "value": "default"
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_HOSTNAME",
+                                        "value": "ethanm-rook-21"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_OSDS_PER_DEVICE",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_UUID",
+                                        "value": "011b8487-af1f-4eb4-b32a-7710cd3cc8a3"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "3"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-86a5ed44-ebe7-4910-ab6e-e6e2cd2a5094/osd-data-02d34404-d54a-4fd4-90f8-03a78ea54d56"
+                                    },
+                                    {
+                                        "name": "ROOK_CV_MODE",
+                                        "value": "lvm"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_DEVICE_CLASS",
+                                        "value": "ssd"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.3.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "osd",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.3.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 720,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-3",
+                                        "name": "activate-osd"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "command": [
+                                    "/bin/bash",
+                                    "-c",
+                                    "\nset -o errexit\nset -o pipefail\nset -o nounset # fail if variables are unset\nset -o xtrace\n\nOSD_ID=\"$ROOK_OSD_ID\"\nOSD_UUID=011b8487-af1f-4eb4-b32a-7710cd3cc8a3\nOSD_STORE_FLAG=\"--bluestore\"\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\"$OSD_ID\"\nCV_MODE=lvm\nDEVICE=\"$ROOK_BLOCK_PATH\"\n\n# create new keyring\nceph -n client.admin auth get-or-create osd.\"$OSD_ID\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\n\n# active the osd with ceph-volume\nif [[ \"$CV_MODE\" == \"lvm\" ]]; then\n\tTMP_DIR=$(mktemp -d)\n\n\t# activate osd\n\tceph-volume lvm activate --no-systemd \"$OSD_STORE_FLAG\" \"$OSD_ID\" \"$OSD_UUID\"\n\n\t# copy the tmpfs directory to a temporary directory\n\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\n\t# this will result in the emptydir to be empty when accessed by the main osd container\n\tcp --verbose --no-dereference \"$OSD_DATA_DIR\"/* \"$TMP_DIR\"/\n\n\t# unmount the tmpfs since we don't need it anymore\n\tumount \"$OSD_DATA_DIR\"\n\n\t# copy back the content of the tmpfs into the original osd directory\n\tcp --verbose --no-dereference \"$TMP_DIR\"/* \"$OSD_DATA_DIR\"\n\n\t# retain ownership of files to the ceph user/group\n\tchown --verbose --recursive ceph:ceph \"$OSD_DATA_DIR\"\n\n\t# remove the temporary directory\n\trm --recursive --force \"$TMP_DIR\"\nelse\n\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\n\t#  returns user-friendly device names which can change when systems reboot. To\n\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\n\t# block device we have is still correct, and if it isn't correct, we need to\n\t# scan all the disks to find the right one.\n\tOSD_LIST=\"$(mktemp)\"\n\n\tfunction find_device() {\n\t\t# jq would be preferable, but might be removed for hardened Ceph images\n\t\t# python3 should exist in all containers having Ceph\n\t\tpython3 -c \"\nimport sys, json\nfor _, info in json.load(sys.stdin).items():\n\tif info['osd_id'] == $OSD_ID:\n\t\tprint(info['device'], end='')\n\t\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\n\t\tsys.exit(0)  # don't keep processing once the disk is found\nsys.exit('no disk found with OSD ID $OSD_ID')\n\"\n\t}\n\n\tceph-volume raw list \"$DEVICE\" \u003e \"$OSD_LIST\"\n\tcat \"$OSD_LIST\"\n\n\tif ! find_device \u003c \"$OSD_LIST\"; then\n\t\tceph-volume raw list \u003e \"$OSD_LIST\"\n\t\tcat \"$OSD_LIST\"\n\n\t\tDEVICE=\"$(find_device \u003c \"$OSD_LIST\")\"\n\tfi\n\t[[ -z \"$DEVICE\" ]] \u0026\u0026 { echo \"no device\" ; exit 1 ; }\n\n\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\n\tceph-volume raw activate --device \"$DEVICE\" --no-systemd --no-tmpfs\nfi\n"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-86a5ed44-ebe7-4910-ab6e-e6e2cd2a5094/osd-data-02d34404-d54a-4fd4-90f8-03a78ea54d56"
+                                    },
+                                    {
+                                        "name": "ROOK_METADATA_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_WAL_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "3"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "activate",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-3",
+                                        "name": "activate-osd"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/admin-keyring-store/",
+                                        "name": "rook-ceph-admin-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-3",
+                                        "name": "activate-osd"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-21"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "serviceAccount": "rook-ceph-osd",
+                        "serviceAccountName": "rook-ceph-osd",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook",
+                                    "type": ""
+                                },
+                                "name": "rook-data"
+                            },
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/dev",
+                                    "type": ""
+                                },
+                                "name": "devices"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/run/udev",
+                                    "type": ""
+                                },
+                                "name": "run-udev"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_011b8487-af1f-4eb4-b32a-7710cd3cc8a3",
+                                    "type": "DirectoryOrCreate"
+                                },
+                                "name": "activate-osd"
+                            },
+                            {
+                                "name": "rook-ceph-admin-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-admin-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:25:13Z",
+                        "lastUpdateTime": "2022-12-22T00:25:13Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:01:16Z",
+                        "lastUpdateTime": "2022-12-22T00:25:13Z",
+                        "message": "ReplicaSet \"rook-ceph-osd-3-cf76746cb\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 16,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"4\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"4\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"4\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-22\",\"osd\":\"4\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-22\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd-4\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-osd\",\"ceph-osd-id\":\"4\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"4\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"4\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"4\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-22\",\"osd\":\"4\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-22\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--foreground\",\"--id\",\"4\",\"--fsid\",\"dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--setuser\",\"ceph\",\"--setgroup\",\"ceph\",\"--crush-location=root=default host=ethanm-rook-22\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--ms-learn-addr-from-peer=false\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\"],\"command\":[\"ceph-osd\"],\"env\":[{\"name\":\"ROOK_NODE_NAME\",\"value\":\"ethanm-rook-22\"},{\"name\":\"ROOK_CLUSTER_ID\",\"value\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"},{\"name\":\"ROOK_CLUSTER_NAME\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_PRIVATE_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"ROOK_PUBLIC_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"POD_NAMESPACE\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_MON_ENDPOINTS\",\"valueFrom\":{\"configMapKeyRef\":{\"key\":\"data\",\"name\":\"rook-ceph-mon-endpoints\"}}},{\"name\":\"ROOK_MON_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_USERNAME\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-username\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CONFIG_DIR\",\"value\":\"/var/lib/rook\"},{\"name\":\"ROOK_CEPH_CONFIG_OVERRIDE\",\"value\":\"/etc/rook/config/override.conf\"},{\"name\":\"ROOK_FSID\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"fsid\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"ROOK_CRUSHMAP_ROOT\",\"value\":\"default\"},{\"name\":\"ROOK_CRUSHMAP_HOSTNAME\",\"value\":\"ethanm-rook-22\"},{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_OSDS_PER_DEVICE\",\"value\":\"1\"},{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_OSD_UUID\",\"value\":\"970d6531-6d6c-46a0-a8ac-f66d924311bd\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"4\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-bed96aa3-3af0-4806-bafb-f44b9f292113/osd-data-00a4d0eb-4a65-458a-b837-e3e6c405c926\"},{\"name\":\"ROOK_CV_MODE\",\"value\":\"lvm\"},{\"name\":\"ROOK_OSD_DEVICE_CLASS\",\"value\":\"ssd\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.4.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"osd\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.4.asok status\"]},\"failureThreshold\":720,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-4\",\"name\":\"activate-osd\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"command\":[\"/bin/bash\",\"-c\",\"\\nset -o errexit\\nset -o pipefail\\nset -o nounset # fail if variables are unset\\nset -o xtrace\\n\\nOSD_ID=\\\"$ROOK_OSD_ID\\\"\\nOSD_UUID=970d6531-6d6c-46a0-a8ac-f66d924311bd\\nOSD_STORE_FLAG=\\\"--bluestore\\\"\\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\\\"$OSD_ID\\\"\\nCV_MODE=lvm\\nDEVICE=\\\"$ROOK_BLOCK_PATH\\\"\\n\\n# create new keyring\\nceph -n client.admin auth get-or-create osd.\\\"$OSD_ID\\\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\\n\\n# active the osd with ceph-volume\\nif [[ \\\"$CV_MODE\\\" == \\\"lvm\\\" ]]; then\\n\\tTMP_DIR=$(mktemp -d)\\n\\n\\t# activate osd\\n\\tceph-volume lvm activate --no-systemd \\\"$OSD_STORE_FLAG\\\" \\\"$OSD_ID\\\" \\\"$OSD_UUID\\\"\\n\\n\\t# copy the tmpfs directory to a temporary directory\\n\\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\\n\\t# this will result in the emptydir to be empty when accessed by the main osd container\\n\\tcp --verbose --no-dereference \\\"$OSD_DATA_DIR\\\"/* \\\"$TMP_DIR\\\"/\\n\\n\\t# unmount the tmpfs since we don't need it anymore\\n\\tumount \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# copy back the content of the tmpfs into the original osd directory\\n\\tcp --verbose --no-dereference \\\"$TMP_DIR\\\"/* \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# retain ownership of files to the ceph user/group\\n\\tchown --verbose --recursive ceph:ceph \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# remove the temporary directory\\n\\trm --recursive --force \\\"$TMP_DIR\\\"\\nelse\\n\\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\\n\\t#  returns user-friendly device names which can change when systems reboot. To\\n\\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\\n\\t# block device we have is still correct, and if it isn't correct, we need to\\n\\t# scan all the disks to find the right one.\\n\\tOSD_LIST=\\\"$(mktemp)\\\"\\n\\n\\tfunction find_device() {\\n\\t\\t# jq would be preferable, but might be removed for hardened Ceph images\\n\\t\\t# python3 should exist in all containers having Ceph\\n\\t\\tpython3 -c \\\"\\nimport sys, json\\nfor _, info in json.load(sys.stdin).items():\\n\\tif info['osd_id'] == $OSD_ID:\\n\\t\\tprint(info['device'], end='')\\n\\t\\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\\n\\t\\tsys.exit(0)  # don't keep processing once the disk is found\\nsys.exit('no disk found with OSD ID $OSD_ID')\\n\\\"\\n\\t}\\n\\n\\tceph-volume raw list \\\"$DEVICE\\\" \\u003e \\\"$OSD_LIST\\\"\\n\\tcat \\\"$OSD_LIST\\\"\\n\\n\\tif ! find_device \\u003c \\\"$OSD_LIST\\\"; then\\n\\t\\tceph-volume raw list \\u003e \\\"$OSD_LIST\\\"\\n\\t\\tcat \\\"$OSD_LIST\\\"\\n\\n\\t\\tDEVICE=\\\"$(find_device \\u003c \\\"$OSD_LIST\\\")\\\"\\n\\tfi\\n\\t[[ -z \\\"$DEVICE\\\" ]] \\u0026\\u0026 { echo \\\"no device\\\" ; exit 1 ; }\\n\\n\\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\\n\\tceph-volume raw activate --device \\\"$DEVICE\\\" --no-systemd --no-tmpfs\\nfi\\n\"],\"env\":[{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-bed96aa3-3af0-4806-bafb-f44b9f292113/osd-data-00a4d0eb-4a65-458a-b837-e3e6c405c926\"},{\"name\":\"ROOK_METADATA_DEVICE\"},{\"name\":\"ROOK_WAL_DEVICE\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"4\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"activate\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/ceph/osd/ceph-4\",\"name\":\"activate-osd\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/admin-keyring-store/\",\"name\":\"rook-ceph-admin-keyring\",\"readOnly\":true}]},{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-4\",\"name\":\"activate-osd\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-22\"},\"restartPolicy\":\"Always\",\"serviceAccountName\":\"rook-ceph-osd\",\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/rook\"},\"name\":\"rook-data\"},{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/dev\"},\"name\":\"devices\"},{\"hostPath\":{\"path\":\"/run/udev\"},\"name\":\"run-udev\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_970d6531-6d6c-46a0-a8ac-f66d924311bd\",\"type\":\"DirectoryOrCreate\"},\"name\":\"activate-osd\"},{\"name\":\"rook-ceph-admin-keyring\",\"secret\":{\"secretName\":\"rook-ceph-admin-keyring\"}}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "15"
+                },
+                "creationTimestamp": "2022-12-21T23:01:18Z",
+                "generation": 16,
+                "labels": {
+                    "app": "rook-ceph-osd",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "4",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-osd",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-osd-id": "4",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "4",
+                    "ceph_daemon_type": "osd",
+                    "failure-domain": "ethanm-rook-22",
+                    "osd": "4",
+                    "portable": "false",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "topology-location-host": "ethanm-rook-22",
+                    "topology-location-root": "default"
+                },
+                "name": "rook-ceph-osd-4",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "56931",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-osd-4",
+                "uid": "667ac400-a349-43ed-a680-2d8e9c00499b"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-osd",
+                        "ceph-osd-id": "4",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-osd",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "4",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-osd",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph-osd-id": "4",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "4",
+                            "ceph_daemon_type": "osd",
+                            "failure-domain": "ethanm-rook-22",
+                            "osd": "4",
+                            "portable": "false",
+                            "rook-version": "v1.8.10",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "topology-location-host": "ethanm-rook-22",
+                            "topology-location-root": "default"
+                        },
+                        "name": "rook-ceph-osd"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--foreground",
+                                    "--id",
+                                    "4",
+                                    "--fsid",
+                                    "dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--setuser",
+                                    "ceph",
+                                    "--setgroup",
+                                    "ceph",
+                                    "--crush-location=root=default host=ethanm-rook-22",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--ms-learn-addr-from-peer=false",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false"
+                                ],
+                                "command": [
+                                    "ceph-osd"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "ROOK_NODE_NAME",
+                                        "value": "ethanm-rook-22"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_ID",
+                                        "value": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_NAME",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_PRIVATE_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_PUBLIC_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_MON_ENDPOINTS",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "key": "data",
+                                                "name": "rook-ceph-mon-endpoints"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_MON_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_USERNAME",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-username",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CONFIG_DIR",
+                                        "value": "/var/lib/rook"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_CONFIG_OVERRIDE",
+                                        "value": "/etc/rook/config/override.conf"
+                                    },
+                                    {
+                                        "name": "ROOK_FSID",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "fsid",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_ROOT",
+                                        "value": "default"
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_HOSTNAME",
+                                        "value": "ethanm-rook-22"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_OSDS_PER_DEVICE",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_UUID",
+                                        "value": "970d6531-6d6c-46a0-a8ac-f66d924311bd"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "4"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-bed96aa3-3af0-4806-bafb-f44b9f292113/osd-data-00a4d0eb-4a65-458a-b837-e3e6c405c926"
+                                    },
+                                    {
+                                        "name": "ROOK_CV_MODE",
+                                        "value": "lvm"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_DEVICE_CLASS",
+                                        "value": "ssd"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.4.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "osd",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.4.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 720,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-4",
+                                        "name": "activate-osd"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "command": [
+                                    "/bin/bash",
+                                    "-c",
+                                    "\nset -o errexit\nset -o pipefail\nset -o nounset # fail if variables are unset\nset -o xtrace\n\nOSD_ID=\"$ROOK_OSD_ID\"\nOSD_UUID=970d6531-6d6c-46a0-a8ac-f66d924311bd\nOSD_STORE_FLAG=\"--bluestore\"\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\"$OSD_ID\"\nCV_MODE=lvm\nDEVICE=\"$ROOK_BLOCK_PATH\"\n\n# create new keyring\nceph -n client.admin auth get-or-create osd.\"$OSD_ID\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\n\n# active the osd with ceph-volume\nif [[ \"$CV_MODE\" == \"lvm\" ]]; then\n\tTMP_DIR=$(mktemp -d)\n\n\t# activate osd\n\tceph-volume lvm activate --no-systemd \"$OSD_STORE_FLAG\" \"$OSD_ID\" \"$OSD_UUID\"\n\n\t# copy the tmpfs directory to a temporary directory\n\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\n\t# this will result in the emptydir to be empty when accessed by the main osd container\n\tcp --verbose --no-dereference \"$OSD_DATA_DIR\"/* \"$TMP_DIR\"/\n\n\t# unmount the tmpfs since we don't need it anymore\n\tumount \"$OSD_DATA_DIR\"\n\n\t# copy back the content of the tmpfs into the original osd directory\n\tcp --verbose --no-dereference \"$TMP_DIR\"/* \"$OSD_DATA_DIR\"\n\n\t# retain ownership of files to the ceph user/group\n\tchown --verbose --recursive ceph:ceph \"$OSD_DATA_DIR\"\n\n\t# remove the temporary directory\n\trm --recursive --force \"$TMP_DIR\"\nelse\n\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\n\t#  returns user-friendly device names which can change when systems reboot. To\n\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\n\t# block device we have is still correct, and if it isn't correct, we need to\n\t# scan all the disks to find the right one.\n\tOSD_LIST=\"$(mktemp)\"\n\n\tfunction find_device() {\n\t\t# jq would be preferable, but might be removed for hardened Ceph images\n\t\t# python3 should exist in all containers having Ceph\n\t\tpython3 -c \"\nimport sys, json\nfor _, info in json.load(sys.stdin).items():\n\tif info['osd_id'] == $OSD_ID:\n\t\tprint(info['device'], end='')\n\t\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\n\t\tsys.exit(0)  # don't keep processing once the disk is found\nsys.exit('no disk found with OSD ID $OSD_ID')\n\"\n\t}\n\n\tceph-volume raw list \"$DEVICE\" \u003e \"$OSD_LIST\"\n\tcat \"$OSD_LIST\"\n\n\tif ! find_device \u003c \"$OSD_LIST\"; then\n\t\tceph-volume raw list \u003e \"$OSD_LIST\"\n\t\tcat \"$OSD_LIST\"\n\n\t\tDEVICE=\"$(find_device \u003c \"$OSD_LIST\")\"\n\tfi\n\t[[ -z \"$DEVICE\" ]] \u0026\u0026 { echo \"no device\" ; exit 1 ; }\n\n\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\n\tceph-volume raw activate --device \"$DEVICE\" --no-systemd --no-tmpfs\nfi\n"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-bed96aa3-3af0-4806-bafb-f44b9f292113/osd-data-00a4d0eb-4a65-458a-b837-e3e6c405c926"
+                                    },
+                                    {
+                                        "name": "ROOK_METADATA_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_WAL_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "4"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "activate",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-4",
+                                        "name": "activate-osd"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/admin-keyring-store/",
+                                        "name": "rook-ceph-admin-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-4",
+                                        "name": "activate-osd"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-22"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "serviceAccount": "rook-ceph-osd",
+                        "serviceAccountName": "rook-ceph-osd",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook",
+                                    "type": ""
+                                },
+                                "name": "rook-data"
+                            },
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/dev",
+                                    "type": ""
+                                },
+                                "name": "devices"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/run/udev",
+                                    "type": ""
+                                },
+                                "name": "run-udev"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_970d6531-6d6c-46a0-a8ac-f66d924311bd",
+                                    "type": "DirectoryOrCreate"
+                                },
+                                "name": "activate-osd"
+                            },
+                            {
+                                "name": "rook-ceph-admin-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-admin-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:26:27Z",
+                        "lastUpdateTime": "2022-12-22T00:26:27Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:01:18Z",
+                        "lastUpdateTime": "2022-12-22T00:26:27Z",
+                        "message": "ReplicaSet \"rook-ceph-osd-4-bdfbc749f\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 16,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"5\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"5\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"5\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-23\",\"osd\":\"5\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-23\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd-5\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephCluster\",\"name\":\"rook-ceph\",\"uid\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-osd\",\"ceph-osd-id\":\"5\",\"rook_cluster\":\"rook-ceph\"}},\"strategy\":{\"type\":\"Recreate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-osd\",\"app.kubernetes.io/component\":\"cephclusters.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"5\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-osd\",\"app.kubernetes.io/part-of\":\"rook-ceph\",\"ceph-osd-id\":\"5\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"5\",\"ceph_daemon_type\":\"osd\",\"failure-domain\":\"ethanm-rook-23\",\"osd\":\"5\",\"portable\":\"false\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"topology-location-host\":\"ethanm-rook-23\",\"topology-location-root\":\"default\"},\"name\":\"rook-ceph-osd\"},\"spec\":{\"affinity\":{},\"containers\":[{\"args\":[\"--foreground\",\"--id\",\"5\",\"--fsid\",\"dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--setuser\",\"ceph\",\"--setgroup\",\"ceph\",\"--crush-location=root=default host=ethanm-rook-23\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--ms-learn-addr-from-peer=false\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\"],\"command\":[\"ceph-osd\"],\"env\":[{\"name\":\"ROOK_NODE_NAME\",\"value\":\"ethanm-rook-23\"},{\"name\":\"ROOK_CLUSTER_ID\",\"value\":\"060c7e95-d314-4e68-8545-7843fb407dbf\"},{\"name\":\"ROOK_CLUSTER_NAME\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_PRIVATE_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"ROOK_PUBLIC_IP\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"status.podIP\"}}},{\"name\":\"POD_NAMESPACE\",\"value\":\"rook-ceph\"},{\"name\":\"ROOK_MON_ENDPOINTS\",\"valueFrom\":{\"configMapKeyRef\":{\"key\":\"data\",\"name\":\"rook-ceph-mon-endpoints\"}}},{\"name\":\"ROOK_MON_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_USERNAME\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-username\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CEPH_SECRET\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"ceph-secret\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"ROOK_CONFIG_DIR\",\"value\":\"/var/lib/rook\"},{\"name\":\"ROOK_CEPH_CONFIG_OVERRIDE\",\"value\":\"/etc/rook/config/override.conf\"},{\"name\":\"ROOK_FSID\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"fsid\",\"name\":\"rook-ceph-mon\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"ROOK_CRUSHMAP_ROOT\",\"value\":\"default\"},{\"name\":\"ROOK_CRUSHMAP_HOSTNAME\",\"value\":\"ethanm-rook-23\"},{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_OSDS_PER_DEVICE\",\"value\":\"1\"},{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_OSD_UUID\",\"value\":\"00c22dd3-41c6-461a-ad65-036fb3c3ae56\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"5\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-a006fbbb-3446-4afe-a890-65c06389a6f8/osd-data-be99ade6-651e-4b0f-9c6f-d42ad401c04a\"},{\"name\":\"ROOK_CV_MODE\",\"value\":\"lvm\"},{\"name\":\"ROOK_OSD_DEVICE_CLASS\",\"value\":\"ssd\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.5.asok status\"]},\"initialDelaySeconds\":10},\"name\":\"osd\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"startupProbe\":{\"exec\":{\"command\":[\"env\",\"-i\",\"sh\",\"-c\",\"ceph --admin-daemon /run/ceph/ceph-osd.5.asok status\"]},\"failureThreshold\":720,\"initialDelaySeconds\":10,\"periodSeconds\":10},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-5\",\"name\":\"activate-osd\"}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"command\":[\"/bin/bash\",\"-c\",\"\\nset -o errexit\\nset -o pipefail\\nset -o nounset # fail if variables are unset\\nset -o xtrace\\n\\nOSD_ID=\\\"$ROOK_OSD_ID\\\"\\nOSD_UUID=00c22dd3-41c6-461a-ad65-036fb3c3ae56\\nOSD_STORE_FLAG=\\\"--bluestore\\\"\\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\\\"$OSD_ID\\\"\\nCV_MODE=lvm\\nDEVICE=\\\"$ROOK_BLOCK_PATH\\\"\\n\\n# create new keyring\\nceph -n client.admin auth get-or-create osd.\\\"$OSD_ID\\\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\\n\\n# active the osd with ceph-volume\\nif [[ \\\"$CV_MODE\\\" == \\\"lvm\\\" ]]; then\\n\\tTMP_DIR=$(mktemp -d)\\n\\n\\t# activate osd\\n\\tceph-volume lvm activate --no-systemd \\\"$OSD_STORE_FLAG\\\" \\\"$OSD_ID\\\" \\\"$OSD_UUID\\\"\\n\\n\\t# copy the tmpfs directory to a temporary directory\\n\\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\\n\\t# this will result in the emptydir to be empty when accessed by the main osd container\\n\\tcp --verbose --no-dereference \\\"$OSD_DATA_DIR\\\"/* \\\"$TMP_DIR\\\"/\\n\\n\\t# unmount the tmpfs since we don't need it anymore\\n\\tumount \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# copy back the content of the tmpfs into the original osd directory\\n\\tcp --verbose --no-dereference \\\"$TMP_DIR\\\"/* \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# retain ownership of files to the ceph user/group\\n\\tchown --verbose --recursive ceph:ceph \\\"$OSD_DATA_DIR\\\"\\n\\n\\t# remove the temporary directory\\n\\trm --recursive --force \\\"$TMP_DIR\\\"\\nelse\\n\\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\\n\\t#  returns user-friendly device names which can change when systems reboot. To\\n\\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\\n\\t# block device we have is still correct, and if it isn't correct, we need to\\n\\t# scan all the disks to find the right one.\\n\\tOSD_LIST=\\\"$(mktemp)\\\"\\n\\n\\tfunction find_device() {\\n\\t\\t# jq would be preferable, but might be removed for hardened Ceph images\\n\\t\\t# python3 should exist in all containers having Ceph\\n\\t\\tpython3 -c \\\"\\nimport sys, json\\nfor _, info in json.load(sys.stdin).items():\\n\\tif info['osd_id'] == $OSD_ID:\\n\\t\\tprint(info['device'], end='')\\n\\t\\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\\n\\t\\tsys.exit(0)  # don't keep processing once the disk is found\\nsys.exit('no disk found with OSD ID $OSD_ID')\\n\\\"\\n\\t}\\n\\n\\tceph-volume raw list \\\"$DEVICE\\\" \\u003e \\\"$OSD_LIST\\\"\\n\\tcat \\\"$OSD_LIST\\\"\\n\\n\\tif ! find_device \\u003c \\\"$OSD_LIST\\\"; then\\n\\t\\tceph-volume raw list \\u003e \\\"$OSD_LIST\\\"\\n\\t\\tcat \\\"$OSD_LIST\\\"\\n\\n\\t\\tDEVICE=\\\"$(find_device \\u003c \\\"$OSD_LIST\\\")\\\"\\n\\tfi\\n\\t[[ -z \\\"$DEVICE\\\" ]] \\u0026\\u0026 { echo \\\"no device\\\" ; exit 1 ; }\\n\\n\\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\\n\\tceph-volume raw activate --device \\\"$DEVICE\\\" --no-systemd --no-tmpfs\\nfi\\n\"],\"env\":[{\"name\":\"CEPH_VOLUME_DEBUG\",\"value\":\"1\"},{\"name\":\"CEPH_VOLUME_SKIP_RESTORECON\",\"value\":\"1\"},{\"name\":\"DM_DISABLE_UDEV\",\"value\":\"1\"},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"CEPH_ARGS\",\"value\":\"-m $(ROOK_CEPH_MON_HOST)\"},{\"name\":\"ROOK_BLOCK_PATH\",\"value\":\"/dev/ceph-a006fbbb-3446-4afe-a890-65c06389a6f8/osd-data-be99ade6-651e-4b0f-9c6f-d42ad401c04a\"},{\"name\":\"ROOK_METADATA_DEVICE\"},{\"name\":\"ROOK_WAL_DEVICE\"},{\"name\":\"ROOK_OSD_ID\",\"value\":\"5\"}],\"envFrom\":[{\"configMapRef\":{\"name\":\"rook-ceph-osd-env-override\",\"optional\":true}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"activate\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/ceph/osd/ceph-5\",\"name\":\"activate-osd\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/admin-keyring-store/\",\"name\":\"rook-ceph-admin-keyring\",\"readOnly\":true}]},{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/rook\",\"name\":\"rook-data\"},{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/dev\",\"name\":\"devices\"},{\"mountPath\":\"/run/udev\",\"name\":\"run-udev\"},{\"mountPath\":\"/var/lib/ceph/osd/ceph-5\",\"name\":\"activate-osd\"}]}],\"nodeSelector\":{\"kubernetes.io/hostname\":\"ethanm-rook-23\"},\"restartPolicy\":\"Always\",\"serviceAccountName\":\"rook-ceph-osd\",\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/rook\"},\"name\":\"rook-data\"},{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"hostPath\":{\"path\":\"/dev\"},\"name\":\"devices\"},{\"hostPath\":{\"path\":\"/run/udev\"},\"name\":\"run-udev\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_00c22dd3-41c6-461a-ad65-036fb3c3ae56\",\"type\":\"DirectoryOrCreate\"},\"name\":\"activate-osd\"},{\"name\":\"rook-ceph-admin-keyring\",\"secret\":{\"secretName\":\"rook-ceph-admin-keyring\"}}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "15"
+                },
+                "creationTimestamp": "2022-12-21T23:01:20Z",
+                "generation": 16,
+                "labels": {
+                    "app": "rook-ceph-osd",
+                    "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "5",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-osd",
+                    "app.kubernetes.io/part-of": "rook-ceph",
+                    "ceph-osd-id": "5",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "5",
+                    "ceph_daemon_type": "osd",
+                    "failure-domain": "ethanm-rook-23",
+                    "osd": "5",
+                    "portable": "false",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "topology-location-host": "ethanm-rook-23",
+                    "topology-location-root": "default"
+                },
+                "name": "rook-ceph-osd-5",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephCluster",
+                        "name": "rook-ceph",
+                        "uid": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                    }
+                ],
+                "resourceVersion": "57351",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-osd-5",
+                "uid": "69ad2b93-a587-4dde-9bb9-f693908c970a"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-osd",
+                        "ceph-osd-id": "5",
+                        "rook_cluster": "rook-ceph"
+                    }
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-osd",
+                            "app.kubernetes.io/component": "cephclusters.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "5",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-osd",
+                            "app.kubernetes.io/part-of": "rook-ceph",
+                            "ceph-osd-id": "5",
+                            "ceph-version": "16.2.9-0",
+                            "ceph_daemon_id": "5",
+                            "ceph_daemon_type": "osd",
+                            "failure-domain": "ethanm-rook-23",
+                            "osd": "5",
+                            "portable": "false",
+                            "rook-version": "v1.8.10",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "topology-location-host": "ethanm-rook-23",
+                            "topology-location-root": "default"
+                        },
+                        "name": "rook-ceph-osd"
+                    },
+                    "spec": {
+                        "affinity": {},
+                        "containers": [
+                            {
+                                "args": [
+                                    "--foreground",
+                                    "--id",
+                                    "5",
+                                    "--fsid",
+                                    "dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--setuser",
+                                    "ceph",
+                                    "--setgroup",
+                                    "ceph",
+                                    "--crush-location=root=default host=ethanm-rook-23",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--ms-learn-addr-from-peer=false",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false"
+                                ],
+                                "command": [
+                                    "ceph-osd"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "ROOK_NODE_NAME",
+                                        "value": "ethanm-rook-23"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_ID",
+                                        "value": "060c7e95-d314-4e68-8545-7843fb407dbf"
+                                    },
+                                    {
+                                        "name": "ROOK_CLUSTER_NAME",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_PRIVATE_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_PUBLIC_IP",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": "rook-ceph"
+                                    },
+                                    {
+                                        "name": "ROOK_MON_ENDPOINTS",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "key": "data",
+                                                "name": "rook-ceph-mon-endpoints"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_MON_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_USERNAME",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-username",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "ceph-secret",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CONFIG_DIR",
+                                        "value": "/var/lib/rook"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_CONFIG_OVERRIDE",
+                                        "value": "/etc/rook/config/override.conf"
+                                    },
+                                    {
+                                        "name": "ROOK_FSID",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "fsid",
+                                                "name": "rook-ceph-mon"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_ROOT",
+                                        "value": "default"
+                                    },
+                                    {
+                                        "name": "ROOK_CRUSHMAP_HOSTNAME",
+                                        "value": "ethanm-rook-23"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_OSDS_PER_DEVICE",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_UUID",
+                                        "value": "00c22dd3-41c6-461a-ad65-036fb3c3ae56"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "5"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-a006fbbb-3446-4afe-a890-65c06389a6f8/osd-data-be99ade6-651e-4b0f-9c6f-d42ad401c04a"
+                                    },
+                                    {
+                                        "name": "ROOK_CV_MODE",
+                                        "value": "lvm"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_DEVICE_CLASS",
+                                        "value": "ssd"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.5.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "osd",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "startupProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "env",
+                                            "-i",
+                                            "sh",
+                                            "-c",
+                                            "ceph --admin-daemon /run/ceph/ceph-osd.5.asok status"
+                                        ]
+                                    },
+                                    "failureThreshold": 720,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-5",
+                                        "name": "activate-osd"
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "command": [
+                                    "/bin/bash",
+                                    "-c",
+                                    "\nset -o errexit\nset -o pipefail\nset -o nounset # fail if variables are unset\nset -o xtrace\n\nOSD_ID=\"$ROOK_OSD_ID\"\nOSD_UUID=00c22dd3-41c6-461a-ad65-036fb3c3ae56\nOSD_STORE_FLAG=\"--bluestore\"\nOSD_DATA_DIR=/var/lib/ceph/osd/ceph-\"$OSD_ID\"\nCV_MODE=lvm\nDEVICE=\"$ROOK_BLOCK_PATH\"\n\n# create new keyring\nceph -n client.admin auth get-or-create osd.\"$OSD_ID\" mon 'allow profile osd' mgr 'allow profile osd' osd 'allow *' -k /etc/ceph/admin-keyring-store/keyring\n\n# active the osd with ceph-volume\nif [[ \"$CV_MODE\" == \"lvm\" ]]; then\n\tTMP_DIR=$(mktemp -d)\n\n\t# activate osd\n\tceph-volume lvm activate --no-systemd \"$OSD_STORE_FLAG\" \"$OSD_ID\" \"$OSD_UUID\"\n\n\t# copy the tmpfs directory to a temporary directory\n\t# this is needed because when the init container exits, the tmpfs goes away and its content with it\n\t# this will result in the emptydir to be empty when accessed by the main osd container\n\tcp --verbose --no-dereference \"$OSD_DATA_DIR\"/* \"$TMP_DIR\"/\n\n\t# unmount the tmpfs since we don't need it anymore\n\tumount \"$OSD_DATA_DIR\"\n\n\t# copy back the content of the tmpfs into the original osd directory\n\tcp --verbose --no-dereference \"$TMP_DIR\"/* \"$OSD_DATA_DIR\"\n\n\t# retain ownership of files to the ceph user/group\n\tchown --verbose --recursive ceph:ceph \"$OSD_DATA_DIR\"\n\n\t# remove the temporary directory\n\trm --recursive --force \"$TMP_DIR\"\nelse\n\t# 'ceph-volume raw list' (which the osd-prepare job uses to report OSDs on nodes)\n\t#  returns user-friendly device names which can change when systems reboot. To\n\t# keep OSD pods from crashing repeatedly after a reboot, we need to check if the\n\t# block device we have is still correct, and if it isn't correct, we need to\n\t# scan all the disks to find the right one.\n\tOSD_LIST=\"$(mktemp)\"\n\n\tfunction find_device() {\n\t\t# jq would be preferable, but might be removed for hardened Ceph images\n\t\t# python3 should exist in all containers having Ceph\n\t\tpython3 -c \"\nimport sys, json\nfor _, info in json.load(sys.stdin).items():\n\tif info['osd_id'] == $OSD_ID:\n\t\tprint(info['device'], end='')\n\t\tprint('found device: ' + info['device'], file=sys.stderr) # log the disk we found to stderr\n\t\tsys.exit(0)  # don't keep processing once the disk is found\nsys.exit('no disk found with OSD ID $OSD_ID')\n\"\n\t}\n\n\tceph-volume raw list \"$DEVICE\" \u003e \"$OSD_LIST\"\n\tcat \"$OSD_LIST\"\n\n\tif ! find_device \u003c \"$OSD_LIST\"; then\n\t\tceph-volume raw list \u003e \"$OSD_LIST\"\n\t\tcat \"$OSD_LIST\"\n\n\t\tDEVICE=\"$(find_device \u003c \"$OSD_LIST\")\"\n\tfi\n\t[[ -z \"$DEVICE\" ]] \u0026\u0026 { echo \"no device\" ; exit 1 ; }\n\n\t# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag\n\tceph-volume raw activate --device \"$DEVICE\" --no-systemd --no-tmpfs\nfi\n"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CEPH_VOLUME_DEBUG",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "CEPH_VOLUME_SKIP_RESTORECON",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "DM_DISABLE_UDEV",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "CEPH_ARGS",
+                                        "value": "-m $(ROOK_CEPH_MON_HOST)"
+                                    },
+                                    {
+                                        "name": "ROOK_BLOCK_PATH",
+                                        "value": "/dev/ceph-a006fbbb-3446-4afe-a890-65c06389a6f8/osd-data-be99ade6-651e-4b0f-9c6f-d42ad401c04a"
+                                    },
+                                    {
+                                        "name": "ROOK_METADATA_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_WAL_DEVICE"
+                                    },
+                                    {
+                                        "name": "ROOK_OSD_ID",
+                                        "value": "5"
+                                    }
+                                ],
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": "rook-ceph-osd-env-override",
+                                            "optional": true
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "activate",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-5",
+                                        "name": "activate-osd"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/admin-keyring-store/",
+                                        "name": "rook-ceph-admin-keyring",
+                                        "readOnly": true
+                                    }
+                                ]
+                            },
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": true,
+                                    "readOnlyRootFilesystem": false,
+                                    "runAsUser": 0
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/rook",
+                                        "name": "rook-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/dev",
+                                        "name": "devices"
+                                    },
+                                    {
+                                        "mountPath": "/run/udev",
+                                        "name": "run-udev"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/osd/ceph-5",
+                                        "name": "activate-osd"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeSelector": {
+                            "kubernetes.io/hostname": "ethanm-rook-23"
+                        },
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "serviceAccount": "rook-ceph-osd",
+                        "serviceAccountName": "rook-ceph-osd",
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook",
+                                    "type": ""
+                                },
+                                "name": "rook-data"
+                            },
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/dev",
+                                    "type": ""
+                                },
+                                "name": "devices"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/run/udev",
+                                    "type": ""
+                                },
+                                "name": "run-udev"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/dc5569de-ce54-4ee7-b2fb-5824b6d439f8_00c22dd3-41c6-461a-ad65-036fb3c3ae56",
+                                    "type": "DirectoryOrCreate"
+                                },
+                                "name": "activate-osd"
+                            },
+                            {
+                                "name": "rook-ceph-admin-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-admin-keyring"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:27:56Z",
+                        "lastUpdateTime": "2022-12-22T00:27:56Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T23:01:20Z",
+                        "lastUpdateTime": "2022-12-22T00:27:56Z",
+                        "message": "ReplicaSet \"rook-ceph-osd-5-5cbb796fcd\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 16,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "banzaicloud.com/last-applied": "{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-rgw\",\"app.kubernetes.io/component\":\"cephobjectstores.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-ceph-store\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-rgw\",\"app.kubernetes.io/part-of\":\"rook-ceph-store\",\"ceph-version\":\"16.2.9-0\",\"ceph_daemon_id\":\"rook-ceph-store\",\"ceph_daemon_type\":\"rgw\",\"rgw\":\"rook-ceph-store\",\"rook-version\":\"v1.8.10\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_object_store\":\"rook-ceph-store\"},\"name\":\"rook-ceph-rgw-rook-ceph-store-a\",\"namespace\":\"rook-ceph\",\"ownerReferences\":[{\"apiVersion\":\"ceph.rook.io/v1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"CephObjectStore\",\"name\":\"rook-ceph-store\",\"uid\":\"096e33ef-0f68-4c09-b688-ffa1ab7b58b8\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"rook-ceph-rgw\",\"ceph_daemon_id\":\"rook-ceph-store\",\"rgw\":\"rook-ceph-store\",\"rook_cluster\":\"rook-ceph\",\"rook_object_store\":\"rook-ceph-store\"}},\"strategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"labels\":{\"app\":\"rook-ceph-rgw\",\"app.kubernetes.io/component\":\"cephobjectstores.ceph.rook.io\",\"app.kubernetes.io/created-by\":\"rook-ceph-operator\",\"app.kubernetes.io/instance\":\"rook-ceph-store\",\"app.kubernetes.io/managed-by\":\"rook-ceph-operator\",\"app.kubernetes.io/name\":\"ceph-rgw\",\"app.kubernetes.io/part-of\":\"rook-ceph-store\",\"ceph_daemon_id\":\"rook-ceph-store\",\"ceph_daemon_type\":\"rgw\",\"rgw\":\"rook-ceph-store\",\"rook.io/operator-namespace\":\"rook-ceph\",\"rook_cluster\":\"rook-ceph\",\"rook_object_store\":\"rook-ceph-store\"},\"name\":\"rook-ceph-rgw-rook-ceph-store-a\"},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchLabels\":{\"app\":\"rook-ceph-rgw\",\"ceph_daemon_id\":\"rook-ceph-store\",\"rgw\":\"rook-ceph-store\",\"rook_cluster\":\"rook-ceph\",\"rook_object_store\":\"rook-ceph-store\"}},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":50}]}},\"containers\":[{\"args\":[\"--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8\",\"--keyring=/etc/ceph/keyring-store/keyring\",\"--log-to-stderr=true\",\"--err-to-stderr=true\",\"--mon-cluster-log-to-stderr=true\",\"--log-stderr-prefix=debug \",\"--default-log-to-file=false\",\"--default-mon-cluster-log-to-file=false\",\"--mon-host=$(ROOK_CEPH_MON_HOST)\",\"--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)\",\"--id=rgw.rook.ceph.store.a\",\"--setuser=ceph\",\"--setgroup=ceph\",\"--ms-bind-ipv4=true\",\"--ms-bind-ipv6=false\",\"--foreground\",\"--rgw-frontends=beast port=8080\",\"--host=$(POD_NAME)\",\"--rgw-mime-types-file=/etc/ceph/rgw/mime.types\",\"--rgw-realm=rook-ceph-store\",\"--rgw-zonegroup=rook-ceph-store\",\"--rgw-zone=rook-ceph-store\"],\"command\":[\"radosgw\"],\"env\":[{\"name\":\"CONTAINER_IMAGE\",\"value\":\"quay.io/ceph/ceph:v16.2.9\"},{\"name\":\"POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}},{\"name\":\"POD_MEMORY_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"limits.memory\"}}},{\"name\":\"POD_MEMORY_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.memory\"}}},{\"name\":\"POD_CPU_LIMIT\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"1\",\"resource\":\"limits.cpu\"}}},{\"name\":\"POD_CPU_REQUEST\",\"valueFrom\":{\"resourceFieldRef\":{\"divisor\":\"0\",\"resource\":\"requests.cpu\"}}},{\"name\":\"ROOK_CEPH_MON_HOST\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_host\",\"name\":\"rook-ceph-config\"}}},{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\",\"valueFrom\":{\"secretKeyRef\":{\"key\":\"mon_initial_members\",\"name\":\"rook-ceph-config\"}}}],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"livenessProbe\":{\"initialDelaySeconds\":10,\"tcpSocket\":{\"port\":8080}},\"name\":\"rgw\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/swift/healthcheck\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":10},\"resources\":{},\"startupProbe\":{\"failureThreshold\":18,\"initialDelaySeconds\":10,\"periodSeconds\":10,\"tcpSocket\":{\"port\":8080}},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-rgw-rook-ceph-store-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/rgw/ceph-rook-ceph-store\",\"name\":\"ceph-daemon-data\"},{\"mountPath\":\"/etc/ceph/rgw\",\"name\":\"rook-ceph-rgw-rook-ceph-store-mime-types\",\"readOnly\":true}],\"workingDir\":\"/var/log/ceph\"}],\"initContainers\":[{\"args\":[\"--verbose\",\"--recursive\",\"ceph:ceph\",\"/var/log/ceph\",\"/var/lib/ceph/crash\",\"/var/lib/ceph/rgw/ceph-rook-ceph-store\"],\"command\":[\"chown\"],\"image\":\"quay.io/ceph/ceph:v16.2.9\",\"name\":\"chown-container-data-dir\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ceph\",\"name\":\"rook-config-override\",\"readOnly\":true},{\"mountPath\":\"/etc/ceph/keyring-store/\",\"name\":\"rook-ceph-rgw-rook-ceph-store-a-keyring\",\"readOnly\":true},{\"mountPath\":\"/var/log/ceph\",\"name\":\"rook-ceph-log\"},{\"mountPath\":\"/var/lib/ceph/crash\",\"name\":\"rook-ceph-crash\"},{\"mountPath\":\"/var/lib/ceph/rgw/ceph-rook-ceph-store\",\"name\":\"ceph-daemon-data\"}]}],\"restartPolicy\":\"Always\",\"tolerations\":[{\"effect\":\"NoExecute\",\"key\":\"node.kubernetes.io/unreachable\",\"operator\":\"Exists\",\"tolerationSeconds\":5}],\"volumes\":[{\"name\":\"rook-config-override\",\"projected\":{\"sources\":[{\"configMap\":{\"items\":[{\"key\":\"config\",\"mode\":292,\"path\":\"ceph.conf\"}],\"name\":\"rook-config-override\"}}]}},{\"name\":\"rook-ceph-rgw-rook-ceph-store-a-keyring\",\"secret\":{\"secretName\":\"rook-ceph-rgw-rook-ceph-store-a-keyring\"}},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/log\"},\"name\":\"rook-ceph-log\"},{\"hostPath\":{\"path\":\"/var/lib/rook/rook-ceph/crash\"},\"name\":\"rook-ceph-crash\"},{\"emptyDir\":{},\"name\":\"ceph-daemon-data\"},{\"configMap\":{\"name\":\"rook-ceph-rgw-rook-ceph-store-mime-types\"},\"name\":\"rook-ceph-rgw-rook-ceph-store-mime-types\"}]}}},\"status\":{}}",
+                    "deployment.kubernetes.io/revision": "15"
+                },
+                "creationTimestamp": "2022-12-21T21:52:36Z",
+                "generation": 20,
+                "labels": {
+                    "app": "rook-ceph-rgw",
+                    "app.kubernetes.io/component": "cephobjectstores.ceph.rook.io",
+                    "app.kubernetes.io/created-by": "rook-ceph-operator",
+                    "app.kubernetes.io/instance": "rook-ceph-store",
+                    "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                    "app.kubernetes.io/name": "ceph-rgw",
+                    "app.kubernetes.io/part-of": "rook-ceph-store",
+                    "ceph-version": "16.2.9-0",
+                    "ceph_daemon_id": "rook-ceph-store",
+                    "ceph_daemon_type": "rgw",
+                    "rgw": "rook-ceph-store",
+                    "rook-version": "v1.8.10",
+                    "rook.io/operator-namespace": "rook-ceph",
+                    "rook_cluster": "rook-ceph",
+                    "rook_object_store": "rook-ceph-store"
+                },
+                "managedFields": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:banzaicloud.com/last-applied": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:ceph-version": {},
+                                    "f:ceph_daemon_id": {},
+                                    "f:ceph_daemon_type": {},
+                                    "f:rgw": {},
+                                    "f:rook-version": {},
+                                    "f:rook.io/operator-namespace": {},
+                                    "f:rook_cluster": {},
+                                    "f:rook_object_store": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"096e33ef-0f68-4c09-b688-ffa1ab7b58b8\"}": {
+                                        ".": {},
+                                        "f:apiVersion": {},
+                                        "f:blockOwnerDeletion": {},
+                                        "f:controller": {},
+                                        "f:kind": {},
+                                        "f:name": {},
+                                        "f:uid": {}
+                                    }
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {
+                                    "f:matchLabels": {
+                                        ".": {},
+                                        "f:app": {},
+                                        "f:ceph_daemon_id": {},
+                                        "f:rgw": {},
+                                        "f:rook_cluster": {},
+                                        "f:rook_object_store": {}
+                                    }
+                                },
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/created-by": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:ceph_daemon_id": {},
+                                            "f:ceph_daemon_type": {},
+                                            "f:rgw": {},
+                                            "f:rook.io/operator-namespace": {},
+                                            "f:rook_cluster": {},
+                                            "f:rook_object_store": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {
+                                            ".": {},
+                                            "f:podAntiAffinity": {
+                                                ".": {},
+                                                "f:preferredDuringSchedulingIgnoredDuringExecution": {}
+                                            }
+                                        },
+                                        "f:containers": {
+                                            "k:{\"name\":\"rgw\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONTAINER_IMAGE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"NODE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_CPU_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_LIMIT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_MEMORY_REQUEST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:resourceFieldRef": {
+                                                                ".": {},
+                                                                "f:divisor": {},
+                                                                "f:resource": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {
+                                                                ".": {},
+                                                                "f:apiVersion": {},
+                                                                "f:fieldPath": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"ROOK_CEPH_MON_INITIAL_MEMBERS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {
+                                                                ".": {},
+                                                                "f:key": {},
+                                                                "f:name": {}
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:tcpSocket": {
+                                                        ".": {},
+                                                        "f:port": {}
+                                                    },
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:tcpSocket": {
+                                                        ".": {},
+                                                        "f:port": {}
+                                                    },
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/rgw\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/rgw/ceph-rook-ceph-store\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:workingDir": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:initContainers": {
+                                            ".": {},
+                                            "k:{\"name\":\"chown-container-data-dir\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:privileged": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/etc/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/ceph/keyring-store/\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/crash\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/lib/ceph/rgw/ceph-rook-ceph-store\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/var/log/ceph\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"ceph-daemon-data\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-crash\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-log\"}": {
+                                                ".": {},
+                                                "f:hostPath": {
+                                                    ".": {},
+                                                    "f:path": {},
+                                                    "f:type": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-ceph-rgw-rook-ceph-store-a-keyring\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"rook-ceph-rgw-rook-ceph-store-mime-types\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"rook-config-override\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:projected": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:sources": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "rook",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:09:04Z"
+                    },
+                    {
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "time": "2022-12-22T00:21:14Z"
+                    }
+                ],
+                "name": "rook-ceph-rgw-rook-ceph-store-a",
+                "namespace": "rook-ceph",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "ceph.rook.io/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "CephObjectStore",
+                        "name": "rook-ceph-store",
+                        "uid": "096e33ef-0f68-4c09-b688-ffa1ab7b58b8"
+                    }
+                ],
+                "resourceVersion": "55343",
+                "selfLink": "/apis/apps/v1/namespaces/rook-ceph/deployments/rook-ceph-rgw-rook-ceph-store-a",
+                "uid": "36ad96c3-e3b6-4e61-83e5-c2e16c744a9a"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rook-ceph-rgw",
+                        "ceph_daemon_id": "rook-ceph-store",
+                        "rgw": "rook-ceph-store",
+                        "rook_cluster": "rook-ceph",
+                        "rook_object_store": "rook-ceph-store"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rook-ceph-rgw",
+                            "app.kubernetes.io/component": "cephobjectstores.ceph.rook.io",
+                            "app.kubernetes.io/created-by": "rook-ceph-operator",
+                            "app.kubernetes.io/instance": "rook-ceph-store",
+                            "app.kubernetes.io/managed-by": "rook-ceph-operator",
+                            "app.kubernetes.io/name": "ceph-rgw",
+                            "app.kubernetes.io/part-of": "rook-ceph-store",
+                            "ceph_daemon_id": "rook-ceph-store",
+                            "ceph_daemon_type": "rgw",
+                            "rgw": "rook-ceph-store",
+                            "rook.io/operator-namespace": "rook-ceph",
+                            "rook_cluster": "rook-ceph",
+                            "rook_object_store": "rook-ceph-store"
+                        },
+                        "name": "rook-ceph-rgw-rook-ceph-store-a"
+                    },
+                    "spec": {
+                        "affinity": {
+                            "podAntiAffinity": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchLabels": {
+                                                    "app": "rook-ceph-rgw",
+                                                    "ceph_daemon_id": "rook-ceph-store",
+                                                    "rgw": "rook-ceph-store",
+                                                    "rook_cluster": "rook-ceph",
+                                                    "rook_object_store": "rook-ceph-store"
+                                                }
+                                            },
+                                            "topologyKey": "kubernetes.io/hostname"
+                                        },
+                                        "weight": 50
+                                    }
+                                ]
+                            }
+                        },
+                        "containers": [
+                            {
+                                "args": [
+                                    "--fsid=dc5569de-ce54-4ee7-b2fb-5824b6d439f8",
+                                    "--keyring=/etc/ceph/keyring-store/keyring",
+                                    "--log-to-stderr=true",
+                                    "--err-to-stderr=true",
+                                    "--mon-cluster-log-to-stderr=true",
+                                    "--log-stderr-prefix=debug ",
+                                    "--default-log-to-file=false",
+                                    "--default-mon-cluster-log-to-file=false",
+                                    "--mon-host=$(ROOK_CEPH_MON_HOST)",
+                                    "--mon-initial-members=$(ROOK_CEPH_MON_INITIAL_MEMBERS)",
+                                    "--id=rgw.rook.ceph.store.a",
+                                    "--setuser=ceph",
+                                    "--setgroup=ceph",
+                                    "--ms-bind-ipv4=true",
+                                    "--ms-bind-ipv6=false",
+                                    "--foreground",
+                                    "--rgw-frontends=beast port=8080",
+                                    "--host=$(POD_NAME)",
+                                    "--rgw-mime-types-file=/etc/ceph/rgw/mime.types",
+                                    "--rgw-realm=rook-ceph-store",
+                                    "--rgw-zonegroup=rook-ceph-store",
+                                    "--rgw-zone=rook-ceph-store"
+                                ],
+                                "command": [
+                                    "radosgw"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONTAINER_IMAGE",
+                                        "value": "quay.io/ceph/ceph:v16.2.9"
+                                    },
+                                    {
+                                        "name": "POD_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "NODE_NAME",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "spec.nodeName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "limits.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_MEMORY_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.memory"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_LIMIT",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "1",
+                                                "resource": "limits.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POD_CPU_REQUEST",
+                                        "valueFrom": {
+                                            "resourceFieldRef": {
+                                                "divisor": "0",
+                                                "resource": "requests.cpu"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_HOST",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_host",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "ROOK_CEPH_MON_INITIAL_MEMBERS",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "mon_initial_members",
+                                                "name": "rook-ceph-config"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "timeoutSeconds": 1
+                                },
+                                "name": "rgw",
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/swift/healthcheck",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "startupProbe": {
+                                    "failureThreshold": 18,
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "tcpSocket": {
+                                        "port": 8080
+                                    },
+                                    "timeoutSeconds": 1
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-rgw-rook-ceph-store-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/rgw/ceph-rook-ceph-store",
+                                        "name": "ceph-daemon-data"
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/rgw",
+                                        "name": "rook-ceph-rgw-rook-ceph-store-mime-types",
+                                        "readOnly": true
+                                    }
+                                ],
+                                "workingDir": "/var/log/ceph"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "initContainers": [
+                            {
+                                "args": [
+                                    "--verbose",
+                                    "--recursive",
+                                    "ceph:ceph",
+                                    "/var/log/ceph",
+                                    "/var/lib/ceph/crash",
+                                    "/var/lib/ceph/rgw/ceph-rook-ceph-store"
+                                ],
+                                "command": [
+                                    "chown"
+                                ],
+                                "image": "quay.io/ceph/ceph:v16.2.9",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "chown-container-data-dir",
+                                "resources": {},
+                                "securityContext": {
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/ceph",
+                                        "name": "rook-config-override",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/ceph/keyring-store/",
+                                        "name": "rook-ceph-rgw-rook-ceph-store-a-keyring",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/log/ceph",
+                                        "name": "rook-ceph-log"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/crash",
+                                        "name": "rook-ceph-crash"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/ceph/rgw/ceph-rook-ceph-store",
+                                        "name": "ceph-daemon-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "node.kubernetes.io/unreachable",
+                                "operator": "Exists",
+                                "tolerationSeconds": 5
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "rook-config-override",
+                                "projected": {
+                                    "defaultMode": 420,
+                                    "sources": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "config",
+                                                        "mode": 292,
+                                                        "path": "ceph.conf"
+                                                    }
+                                                ],
+                                                "name": "rook-config-override"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "rook-ceph-rgw-rook-ceph-store-a-keyring",
+                                "secret": {
+                                    "defaultMode": 420,
+                                    "secretName": "rook-ceph-rgw-rook-ceph-store-a-keyring"
+                                }
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/log",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-log"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/rook/rook-ceph/crash",
+                                    "type": ""
+                                },
+                                "name": "rook-ceph-crash"
+                            },
+                            {
+                                "emptyDir": {},
+                                "name": "ceph-daemon-data"
+                            },
+                            {
+                                "configMap": {
+                                    "defaultMode": 420,
+                                    "name": "rook-ceph-rgw-rook-ceph-store-mime-types"
+                                },
+                                "name": "rook-ceph-rgw-rook-ceph-store-mime-types"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2022-12-22T00:05:59Z",
+                        "lastUpdateTime": "2022-12-22T00:05:59Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2022-12-21T21:52:36Z",
+                        "lastUpdateTime": "2022-12-22T00:21:14Z",
+                        "message": "ReplicaSet \"rook-ceph-rgw-rook-ceph-store-a-5d6557d\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 20,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/pkg/rook/upgrade.go
+++ b/pkg/rook/upgrade.go
@@ -55,6 +55,10 @@ func hasRookOrCephVersion(deployments *appsv1.DeploymentList, desiredVersion str
 	for _, dep := range deployments.Items {
 		rookVer := normalizeRookVersion(dep.Labels[labelKey])
 		if rookVer != desiredVersion {
+			if strings.Contains(rookVer, "0.0.0") || len(rookVer) == 0 {
+				// Ignore this scenario because Rook versions < 1.4.8 has a bug where the version is not set.
+				continue
+			}
 			_, ok := oldVersions[rookVer]
 			if !ok {
 				oldVersions[rookVer] = []string{dep.Name}

--- a/pkg/rook/upgrade.go
+++ b/pkg/rook/upgrade.go
@@ -55,7 +55,7 @@ func hasRookOrCephVersion(deployments *appsv1.DeploymentList, desiredVersion str
 	for _, dep := range deployments.Items {
 		rookVer := normalizeRookVersion(dep.Labels[labelKey])
 		if rookVer != desiredVersion {
-			if strings.Contains(rookVer, "0.0.0") || len(rookVer) == 0 {
+			if strings.Contains(rookVer, "0.0.0") {
 				// Ignore this scenario because Rook versions < 1.4.8 has a bug where the version is not set.
 				continue
 			}

--- a/pkg/rook/upgrade_test.go
+++ b/pkg/rook/upgrade_test.go
@@ -93,6 +93,15 @@ func Test_hasRookOrCephVersion(t *testing.T) {
 			wantOk:       false,
 			wantMessages: []string{"deployments rook-ceph-mds-rook-shared-fs-a, rook-ceph-mds-rook-shared-fs-b not ready"},
 		},
+		{
+			name:           "with ceph version empty",
+			deploymentList: deploymentListFromDeploymentsJson(testfiles.WaitForRookVersionAllReadyWithEmptyVersion),
+			args: args{
+				desiredVersion: "16.2.9-0",
+				labelKey:       "ceph-version",
+			},
+			wantOk: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes log message upgrading when upgrading from Rook 1.0.4 to 1.4.9 that caused the Rook Ceph preflight health check to incorrectly report that Ceph was unhealthy because Ceph version information could not be found. This issue was caused by a bug in Rook Ceph versions earlier than 1.4.8.

Same of : https://github.com/replicatedhq/kURL/pull/4211/files

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
