### PR TITLE
fix: invert flag dismiss-host-packages-preflight

### DIFF
--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -209,7 +209,7 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 				installer.Spec.Kurl = &kurlv1beta1.Kurl{}
 			}
 			installer.Spec.Kurl.HostPreflightEnforceWarnings = true
-		case "enforce-host-packages": // possibly add this to the spec
+		case "dismiss-host-packages-preflight": // possibly add this to the spec
 			continue
 		case "preserve-docker-config":
 			if installer.Spec.Docker == nil {

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -401,13 +401,8 @@ function preflights_require_host_packages() {
     if [ "$fail" = "1" ]; then
         echo ""
         log "Host packages are missing. Please install them and re-run the install script."
-        # bail immediately rather than prompting to continue
-        # used by testgrid to ensure that all required packages are installed
-        if [ "$KURL_ENFORCE_HOST_PACKAGES" = "1" ]; then
-            exit 1
-        fi
-        printf "Continue anyway? "
-        if ! confirmN ; then
+        if [ "$KURL_DISMISS_HOST_PACKAGES_PREFLIGHT" != "1" ]; then
+            log "Run the script again with flag \"dismiss-host-packages-preflight\" to continue."
             exit 1
         fi
     else

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -140,9 +140,9 @@ function get_patch_yaml() {
                 ;;
             host-preflight-enforce-warnings)
                 ;;
-            enforce-host-packages) # possibly add this to the spec
+            dismiss-host-packages-preflight) # possibly add this to the spec
                 # shellcheck disable=SC2034
-                KURL_ENFORCE_HOST_PACKAGES=1
+                KURL_DISMISS_HOST_PACKAGES_PREFLIGHT=1
                 ;;
             preserve-docker-config)
                 ;;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Reverts host packages preflight flag to skip preflights rather than enforce.

https://github.com/replicatedhq/kURL-testgrid/pull/228