### PR TITLE
fix: addon-manifest-downloader action containertools path

### DIFF
--- a/.github/actions/addon-manifest-downloader/action.yml
+++ b/.github/actions/addon-manifest-downloader/action.yml
@@ -13,5 +13,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: ${{ github.action_path }}/../../../bin/save-manifest-assets.sh ${{ inputs.package-name }} ${{ inputs.manifest-path }} ${{ inputs.output-path }}
+    - run: |
+        manifest_path=$(realpath ${{ inputs.manifest-path }})
+        output_path=$(realpath ${{ inputs.output-path }})
+        cd ${{ github.action_path }}/../../../
+        ./bin/save-manifest-assets.sh ${{ inputs.package-name }} "$manifest_path" "$output_path"
       shell: bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

kots ci failing with 

```
LINE asset kots.tar.gz bin/kots.tar.gz
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /home/runner/work/kots/kots/bin/containertools: no such file or directory
Error: Process completed with exit code 1.
```