### PR TITLE
fix: asset path is relative to manifest

### DIFF
--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -299,11 +299,14 @@ while read -r line || [ -n "$line" ]; do
             mkdir -p "$OUT_DIR/assets"
             filename=$(echo "$line" | awk '{ print $2 }')
             asset=$(echo "$line" | awk '{ print $3 }')
+
             # we support both http and local assets
             if echo "$asset" | grep -q '^https://' ; then
                 curl -fL -o "$OUT_DIR/assets/$filename" "$asset"
             else
-                cp "$asset" "$OUT_DIR/assets/$filename"
+                # asset is relative to the manifest file
+                manifest_dir="$(dirname "$MANIFEST_PATH")"
+                cp "$(realpath "$manifest_dir/$asset")" "$OUT_DIR/assets/$filename"
             fi
             ;;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

kots ci failing with

```
LINE asset kots.tar.gz bin/kots.tar.gz
cp: cannot stat 'bin/kots.tar.gz': No such file or directory
Error: Process completed with exit code 1.
```