### PR TITLE
fix: realpath asset path if not absolute

### DIFF
--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -304,9 +304,12 @@ while read -r line || [ -n "$line" ]; do
             if echo "$asset" | grep -q '^https://' ; then
                 curl -fL -o "$OUT_DIR/assets/$filename" "$asset"
             else
-                # asset is relative to the manifest file
-                manifest_dir="$(dirname "$MANIFEST_PATH")"
-                cp "$(realpath "$manifest_dir/$asset")" "$OUT_DIR/assets/$filename"
+                if [[ "$asset" != /* ]]; then
+                    # asset is relative to the manifest file
+                    manifest_dir="$(dirname "$MANIFEST_PATH")"
+                    asset="$(realpath "$manifest_dir/$asset")"
+                fi
+                cp "$asset" "$OUT_DIR/assets/$filename"
             fi
             ;;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

fix kots kurl release

```
LINE asset kots.tar.gz bin/kots.tar.gz
realpath: /home/runner/work/kots/kots/2023.3.24-b20579-nightly/bin/kots.tar.gz: No such file or directory
cp: cannot stat '': No such file or directory
Error: Process completed with exit code 1.
```