### PR TITLE
(Testing) fixes log if previous version of kURL was not find and continue

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -694,9 +694,12 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
        local previous_kurl_version
        previous_kurl_version="$(kurl_get_current_version)"
        if [ -z "$previous_kurl_version" ]; then
-               previous_kurl_version="$(kurl_get_last_version)"
+           previous_kurl_version="$(kurl_get_last_version)"
        fi
-
+       if [ -z "$previous_kurl_version" ]; then
+           logWarn "Unable to obtain the version of the previous installer used"
+           return
+       fi
        semverCompare $(echo "$KURL_VERSION" | sed 's/v//g') "$(echo "$previous_kurl_version" | sed 's/v//g')"
        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 14.2.21
            logFail "The current kURL release version $KURL_VERSION is less than the previously installed version $previous_kurl_version."
@@ -704,6 +707,5 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
        fi
        log "Previous kURL version used to install or update the cluster is $previous_kurl_version"
        log "and the current kURL version used is $KURL_VERSION"
-
     fi
 }

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -692,12 +692,12 @@ function bail_when_no_object_store_and_s3_enabled() {
 function bail_if_kurl_version_is_lower_than_previous_config() {
     if commandExists kubectl; then
        local previous_kurl_version
-       previous_kurl_version="$(kurl_get_current_version)"
+       previous_kurl_version="$(kurl_get_current_version || true)"
        if [ -z "$previous_kurl_version" ]; then
-           previous_kurl_version="$(kurl_get_last_version)"
+           previous_kurl_version="$(kurl_get_last_version || true)"
        fi
        if [ -z "$previous_kurl_version" ]; then
-           logWarn "Unable to obtain the version of the previous installer used"
+           logWarn "Found kubectl installed. However, was not possible to find the previous kURL version used"
            return
        fi
        semverCompare $(echo "$KURL_VERSION" | sed 's/v//g') "$(echo "$previous_kurl_version" | sed 's/v//g')"


### PR DESCRIPTION
#### What this PR does / why we need it:

If be unable to obtain the previous version used then, we just log and continue. 

#### Which issue(s) this PR fixes:

Related to # https://github.com/replicatedhq/kURL/issues

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes problem faced to check the previous kURL version used to do the install. If the installer be unable to obtain this information then it will be outputted and the script will not fail because of it. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
