### PR TITLE
Add new check to avoid an install that is not supported

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -16,7 +16,21 @@ function preflights() {
     bail_when_no_object_store_and_s3_enabled
     bail_if_unsupported_openebs_to_rook_version
     bail_if_kurl_version_is_lower_than_previous_config
+    warn_if_kubectl_is_installed_without_kurl
     return 0
+}
+
+function warn_if_kubectl_is_installed_without_kurl() {
+     if commandExists kubectl && ! ls /etc/kubernetes/admin.conf 2>/dev/null; then
+         logWarn "kubectl was found but was not possible to locate /etc/kubernetes/admin.conf"
+         logWarn "Please, ensure that you have not installed Kubernetes without use this installer and kubectl"
+         logWarn "Be aware that continuing with this condition can result in failures."
+         log ""
+         logWarn "Would you like to continue?"
+         if ! confirmY ; then
+             bail "The installation will not continue"
+         fi
+     fi
 }
 
 function join_preflights() {


### PR DESCRIPTION
#### What this PR does / why we need it:

We check in many places if k8s is installed or not already to know if is a new install or an upgrade.
The installer cannot support upgrades in a pre-existent installation that was not made with and if kubectl be installed previously we cannot either ensure the workflow since kurl is design to be used in a clean envinroment. 

Motivation: https://github.com/replicatedhq/kURL/issues/4259

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce

<img width="1153" alt="Screenshot 2023-03-24 at 23 12 10" src="https://user-images.githubusercontent.com/7708031/227659661-a8e31daf-91d3-4759-96d5-6282f2e6e891.png">

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds check to warning users that the installer should not be used to upgrade an Kubernetes installation that was not made with kURL and it might not work well if kubectl be pre installed on the machine already. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
