### PR TITLE
chore: fix testgrid docker specs are not running on rhel 8

### DIFF
--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -20,6 +20,7 @@
       version: latest
 
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -73,11 +74,10 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -132,8 +132,6 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -73,6 +73,8 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
@@ -130,6 +132,8 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -131,6 +131,8 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -131,8 +131,6 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -25,6 +25,7 @@
     kotsadm:
       version: latest
 - name: k8s119-minimal
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -36,8 +37,6 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121
@@ -322,6 +321,7 @@
       ;;
     esac
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -375,7 +375,5 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -375,5 +375,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -24,6 +24,11 @@
   unsupportedOSIDs:
   - ubuntu-2004 # docker 19.03.4 is not available on ubuntu 20.04
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119x
@@ -50,6 +55,11 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd149
@@ -109,11 +119,11 @@
     ekco:
       version: 0.6.0
   unsupportedOSIDs:
-  - centos-81
-  - centos-82
-  - centos-83
-  - centos-84
-  - ol-84
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s120x_docker
@@ -142,6 +152,11 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121x_containerd
@@ -199,6 +214,11 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202
@@ -222,6 +242,11 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.5 is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202_containerd
@@ -323,6 +348,11 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119-airgap
@@ -350,6 +380,11 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd1412
@@ -593,6 +628,11 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x and collectd-v5 are not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_selinux
@@ -616,6 +656,11 @@
       type: targeted
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not supported on ubuntu 22.04
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s120
@@ -737,6 +782,11 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121
@@ -761,6 +811,11 @@
     ekco:
       version: latest
   unsupportedOSIDs:
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121-airgap
@@ -786,6 +841,11 @@
       version: latest
   airgap: true
   unsupportedOSIDs:
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio
@@ -813,6 +873,11 @@
     ekco:
       version: 0.10.1
   unsupportedOSIDs:
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio-airgap
@@ -841,8 +906,13 @@
       version: 0.10.1
   airgap: true
   unsupportedOSIDs:
-  - ol-9 # docker is not supported on rhel 9 variants
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
+  - ol-9 # docker is not supported on rhel 9 variants
 - name: remove_all_object_storage
   cpu: 7
   installerSpec:
@@ -1012,6 +1082,11 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
@@ -1068,6 +1143,11 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "K8s 1.24x Rook"
@@ -1193,6 +1273,11 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  - centos-81 # docker is not supported on rhel 8 variants
+  - centos-82 # docker is not supported on rhel 8 variants
+  - centos-83 # docker is not supported on rhel 8 variants
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Upgrade to 1.26 airgap"

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1,4 +1,5 @@
 - name: k8s121x_docker19034
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -24,14 +25,10 @@
   unsupportedOSIDs:
   - ubuntu-2004 # docker 19.03.4 is not available on ubuntu 20.04
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119x
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -55,11 +52,6 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd149
@@ -89,6 +81,7 @@
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ol-9 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120x_openebs_minio
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.17.13
@@ -119,14 +112,10 @@
     ekco:
       version: 0.6.0
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s120x_docker
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.20.x
@@ -152,11 +141,6 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121x_containerd
@@ -190,6 +174,7 @@
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ol-9 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x-airgap
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -214,14 +199,10 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.18.4
@@ -242,11 +223,6 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.5 is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202_containerd
@@ -325,6 +301,7 @@
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ol-9 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -348,14 +325,10 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119-airgap
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -380,11 +353,6 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd1412
@@ -606,6 +574,7 @@
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ol-9 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_nameserver_collectd_rook_block
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.3
@@ -628,14 +597,10 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x and collectd-v5 are not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s119_selinux
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.3
@@ -656,11 +621,6 @@
       type: targeted
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not supported on ubuntu 22.04
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s120
@@ -782,14 +742,10 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -811,14 +767,10 @@
     ekco:
       version: latest
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s121-airgap
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.21.x
@@ -841,14 +793,10 @@
       version: latest
   airgap: true
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.20.5
@@ -873,14 +821,10 @@
     ekco:
       version: 0.10.1
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio-airgap
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.20.5
@@ -906,11 +850,6 @@
       version: 0.10.1
   airgap: true
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: remove_all_object_storage
@@ -1030,6 +969,7 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -1082,14 +1022,10 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.23.x
@@ -1143,11 +1079,6 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "K8s 1.24x Rook"
@@ -1235,6 +1166,7 @@
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ol-9 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "Upgrade to 1.24, weave to flannel"
+  flags: "yes"
   cpu: 7
   installerSpec:
     kubernetes:
@@ -1273,11 +1205,6 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - centos-81 # docker is not supported on rhel 8 variants
-  - centos-82 # docker is not supported on rhel 8 variants
-  - centos-83 # docker is not supported on rhel 8 variants
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ol-9 # docker is not supported on rhel 9 variants
 - name: "Upgrade to 1.26 airgap"

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -1,5 +1,5 @@
 - name: Migrate from Rook 1.0.4 to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -56,7 +56,7 @@
        exit 1
     fi
 - name: Migrate from Rook 1.10.x to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.26.x
@@ -113,7 +113,7 @@
        exit 1
     fi
 - name: Migrate from Longhorn (S3 disabled) to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -161,7 +161,7 @@
       exit 1
     fi
 - name: Migrate from Longhorn + Minio to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -216,7 +216,7 @@
       exit 1
     fi
 - name: Migrate from Rook 1.0.4 to OpenEBS (S3 disabled)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -272,7 +272,7 @@
        exit 1
     fi
 - name: Migrate from Rook 1.10.x to OpenEBS (S3 disabled)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.26.x
@@ -328,7 +328,7 @@
        exit 1
     fi
 - name: Migrate from Longhorn (S3 disabled) to OpenEBS (S3 disabled)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -381,7 +381,7 @@
       exit 1
     fi
 - name: Migrate from Longhorn + Minio to OpenEBS (S3 disabled)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -435,7 +435,7 @@
       exit 1
     fi
 - name: Migrate from OpenEBS + Minio to OpenEBS (S3 disabled)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.26.x
@@ -487,7 +487,7 @@
     test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
 - name: Migrate from Rook 1.0.4 to Rook 1.10.x
-  flags: yes
+  flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
   numSecondaryNodes: 2
@@ -539,7 +539,7 @@
        exit 1
     fi
 - name: Migrate from Longhorn + Minio to Rook 1.10.x
-  flags: yes
+  flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
   numSecondaryNodes: 2
@@ -593,7 +593,7 @@
       exit 1
     fi
 - name: Migrate from Rook 1.0.4 to OpenEBS + Minio (multi-node)
-  flags: yes
+  flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
   numSecondaryNodes: 2
@@ -653,7 +653,7 @@
        exit 1
     fi
 - name: Migrate from Rook 1.10.x to OpenEBS + Minio (multi-node)
-  flags: yes
+  flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
   numSecondaryNodes: 2
@@ -713,7 +713,7 @@
        exit 1
     fi
 - name: Migrate from Longhorn + Minio to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
   numSecondaryNodes: 2
@@ -771,7 +771,7 @@
       exit 1
     fi
 - name: Migrate from Rook 1.10.x to OpenEBS 3.4.0 with localpv migrate
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -821,7 +821,7 @@
        exit 1
     fi
 - name: Migrate from Rook 1.0.4 to OpenEBS + Minio (Docker config)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -894,12 +894,10 @@
        exit 1
     fi
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - ol-9 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.26.x
@@ -951,7 +949,7 @@
     test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
 - name: Migrate from Rook+OpenEBS to OpenEBS (Kubernetes 1.19.x to 1.21.x, Docker to Containerd)
-  flags: yes
+  flags: "yes"
   installerSpec:
     kubernetes:
       version: 1.19.x
@@ -1062,7 +1060,5 @@
        exit 1
     fi
   unsupportedOSIDs:
-  - centos-84 # docker is not supported on rhel 8 variants
-  - ol-8x # docker is not supported on rhel 8 variants
   - ol-9 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -894,6 +894,8 @@
        exit 1
     fi
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - ol-9 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
@@ -1060,5 +1062,7 @@
        exit 1
     fi
   unsupportedOSIDs:
+  - centos-84 # docker is not supported on rhel 8 variants
+  - ol-8x # docker is not supported on rhel 8 variants
   - ol-9 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

```
2023-03-24 20:23:36+00:00 ⚙  Running install with the argument(s): airgap
2023-03-24 20:23:36+00:00 Docker 20.10.17 is not supported on centos 8.4.
2023-03-24 20:23:36+00:00 The containerd addon is recommended. https://kurl.sh/docs/add-ons/containerd
2023-03-24 20:23:36+00:00 Continue? (y/N) main: line 4824: /dev/tty: No such device or address
+ KURL_EXIT_STATUS=1
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl install with exit status 1'
```

also yaml `yes` is `true` not `"yes"`