### PR TITLE
change check to allow Registry without Minio without kots or with kots and disable33 = true

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -665,8 +665,8 @@ function bail_if_unsupported_openebs_to_rook_version() {
                 fi
 
                 # registry + openebs without rook requires minio
-                if [ -n "$REGISTRY_VERSION" ] && [ -z "$MINIO_VERSION" ]; then
-                    logFail "Migration from Rook with Registry required an object store."
+                if [ -n "$REGISTRY_VERSION" ] && [ -z "$MINIO_VERSION" ] &&  [ -n "$KOTSADM_VERSION" ] && [ "$KOTSADM_DISABLE_S3" != "1" ]; then
+                    logFail "Migration from Rook with Registry when KOTS has s3 enabled requires an object store."
                     bail "Please ensure that your installer also provides an object store with MinIO add-on."
                 fi
             fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We are not allowing move from Rook when has Registry and minio is not selected.
This PR changes the check to not allow it just if kots is select and disableS3 is not true. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-70234]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
