### PR TITLE
fix migration store check

### DIFF
--- a/addons/minio/2020-01-25T02-50-51Z/install.sh
+++ b/addons/minio/2020-01-25T02-50-51Z/install.sh
@@ -165,8 +165,9 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-06-11T19-55-32Z/install.sh
+++ b/addons/minio/2022-06-11T19-55-32Z/install.sh
@@ -165,8 +165,9 @@ function minio_migrate_from_rgw() {
         return
     fi
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-07-06T20-29-49Z/install.sh
+++ b/addons/minio/2022-07-06T20-29-49Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-07-17T15-43-14Z/install.sh
+++ b/addons/minio/2022-07-17T15-43-14Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-08-02T23-59-16Z/install.sh
+++ b/addons/minio/2022-08-02T23-59-16Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-08-22T23-53-06Z/install.sh
+++ b/addons/minio/2022-08-22T23-53-06Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-09-01T23-53-36Z/install.sh
+++ b/addons/minio/2022-09-01T23-53-36Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-09-07T22-25-02Z/install.sh
+++ b/addons/minio/2022-09-07T22-25-02Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-09-17T00-09-45Z/install.sh
+++ b/addons/minio/2022-09-17T00-09-45Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-09-25T15-44-53Z/install.sh
+++ b/addons/minio/2022-09-25T15-44-53Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-10-02T19-29-29Z/install.sh
+++ b/addons/minio/2022-10-02T19-29-29Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-10-05T14-58-27Z/install.sh
+++ b/addons/minio/2022-10-05T14-58-27Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-10-08T20-11-00Z/install.sh
+++ b/addons/minio/2022-10-08T20-11-00Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-10-15T19-57-03Z/install.sh
+++ b/addons/minio/2022-10-15T19-57-03Z/install.sh
@@ -190,8 +190,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-10-20T00-55-09Z/install.sh
+++ b/addons/minio/2022-10-20T00-55-09Z/install.sh
@@ -210,8 +210,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2022-12-12T19-27-27Z/install.sh
+++ b/addons/minio/2022-12-12T19-27-27Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-02T09-40-09Z/install.sh
+++ b/addons/minio/2023-01-02T09-40-09Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-06T18-11-18Z/install.sh
+++ b/addons/minio/2023-01-06T18-11-18Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-12T02-06-16Z/install.sh
+++ b/addons/minio/2023-01-12T02-06-16Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-18T04-36-38Z/install.sh
+++ b/addons/minio/2023-01-18T04-36-38Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-20T02-05-44Z/install.sh
+++ b/addons/minio/2023-01-20T02-05-44Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-25T00-19-54Z/install.sh
+++ b/addons/minio/2023-01-25T00-19-54Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-01-31T02-24-19Z/install.sh
+++ b/addons/minio/2023-01-31T02-24-19Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-02-09T05-16-53Z/install.sh
+++ b/addons/minio/2023-02-09T05-16-53Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-02-10T18-48-39Z/install.sh
+++ b/addons/minio/2023-02-10T18-48-39Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-02-17T17-52-43Z/install.sh
+++ b/addons/minio/2023-02-17T17-52-43Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-02-22T18-23-45Z/install.sh
+++ b/addons/minio/2023-02-22T18-23-45Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-02-27T18-10-45Z/install.sh
+++ b/addons/minio/2023-02-27T18-10-45Z/install.sh
@@ -234,8 +234,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-03-09T23-16-13Z/install.sh
+++ b/addons/minio/2023-03-09T23-16-13Z/install.sh
@@ -239,8 +239,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-03-13T19-46-17Z/install.sh
+++ b/addons/minio/2023-03-13T19-46-17Z/install.sh
@@ -239,8 +239,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/2023-03-20T20-16-18Z/install.sh
+++ b/addons/minio/2023-03-20T20-16-18Z/install.sh
@@ -239,8 +239,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return

--- a/addons/minio/template/base/install.sh
+++ b/addons/minio/template/base/install.sh
@@ -239,8 +239,9 @@ function minio_migrate_from_rgw() {
 
     minio_wait_for_health
 
+    log "Check if object store was migrated previously"
     export DID_MIGRATE_ROOK_OBJECT_STORE=0
-    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
+    DID_MIGRATE_ROOK_OBJECT_STORE=$(kubectl -n kurl get --ignore-not-found configmap kurl-migration-from-rook -o jsonpath='{ .data.DID_MIGRATE_ROOK_OBJECT_STORE }')
     if [ "$DID_MIGRATE_ROOK_OBJECT_STORE" == "1" ]; then
         logWarn "Object store is set as migrated previously. Not migrating object store again."
         return


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the migration store check to verify if the migration was done previously. 

Example of the error:

```sh
⚙  Addon minio 2023-03-13T19-46-17Z
Awaiting for minio deployment to rollout
Getting Minio storage format
namespace/minio unchanged
secret/minio-credentials configured
service/ha-minio unchanged
service/minio unchanged
deployment.apps/minio configured
persistentvolumeclaim/minio-pv-claim unchanged
awaiting minio deployment
awaiting minio readiness
awaiting minio endpoint
awaiting minio deployment
awaiting minio readiness
awaiting minio endpoint
Error from server (NotFound): configmaps "kurl-migration-from-rook" not found  # See that we are returning an empty value and it fails in the check.
An error occurred on line 243
```

Follow up: https://github.com/replicatedhq/kURL/pull/4239


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-70240]

#### Special notes for your reviewer:

You can check that the fix work by verifying the test `migrate from rook-ceph object store to minio` in https://testgrid.kurl.sh/run/pr-4272-23c9725-minio-2023-03-24T21-41-23Z-k8s-docker-2023-03-27T10:39:27Z

<img width="1649" alt="Screenshot 2023-03-27 at 13 09 33" src="https://user-images.githubusercontent.com/7708031/227937870-22cc6633-95e7-4c73-8bb5-35df49f7979b.png">



## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
None because it is only in main branch so far.

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
