### PR TITLE
fix: k8s step upgrades fail with missing host packages

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -25,6 +25,11 @@ function kubernetes_get_packages() {
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         kubernetes_get_host_packages_online "$KUBERNETES_VERSION"
         kubernetes_get_conformance_packages_online "$KUBERNETES_VERSION"
+
+        # if we are upgrading two kubernetes versions at once
+        if [ -n "$STEP_VERSION" ]; then
+            kubernetes_get_host_packages_online "$STEP_VERSION"
+        fi
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

K8s step upgrades are missing host packages due to [this](https://github.com/replicatedhq/kURL/pull/4241/files#diff-a1f3c001e0406a79e95cc96411af439600d0a27ce32abcdd6662013918ca4636L70) change.

```
2023-03-27 01:59:27+00:00 find: './packages/kubernetes/1.19.16/images': No such file or directory
2023-03-27 01:59:27+00:00 cp: cannot stat './packages/kubernetes/1.19.16/assets/kubeadm': No such file or directory
2023-03-27 01:59:27+00:00 An error occurred on line 
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
```