### PR TITLE
fix(testgrid): rhel 9 install host packages

### DIFF
--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -19,16 +19,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
-    . /etc/os-release
-    case "$ID$VERSION_ID" in
-    centos9*|rhel9*|ol9*|rocky9*)
-      # install required host packages
-      yum install -y lvm2 conntrack-tools socat
-      # disable yum repos
-      find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
-      yum clean metadata
-      ;;
-    esac
+    rhel_9_install_host_packages lvm2 conntrack-tools socat
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -89,16 +89,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
-    . /etc/os-release
-    case "$ID$VERSION_ID" in
-    centos9*|rhel9*|ol9*|rocky9*)
-      # install required host packages
-      yum install -y lvm2 conntrack-tools socat
-      # disable yum repos
-      find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
-      yum clean metadata
-      ;;
-    esac
+    rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: k8s122
   installerSpec:
     kubernetes:
@@ -149,16 +140,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
-    . /etc/os-release
-    case "$ID$VERSION_ID" in
-    centos9*|rhel9*|ol9*|rocky9*)
-      # install required host packages
-      yum install -y lvm2 conntrack-tools socat
-      # disable yum repos
-      find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
-      yum clean metadata
-      ;;
-    esac
+    rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: minimal-124
   installerSpec:
     containerd:
@@ -294,16 +276,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
-    . /etc/os-release
-    case "$ID$VERSION_ID" in
-    centos9*|rhel9*|ol9*|rocky9*)
-      # install required host packages
-      yum install -y lvm2 conntrack-tools socat
-      # disable yum repos
-      find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
-      yum clean metadata
-      ;;
-    esac
+    rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: "k8s_126x airgap"
   airgap: true
   installerSpec:
@@ -326,16 +299,7 @@
     kotsadm:
       version: latest
   preInstallScript: |
-    . /etc/os-release
-    case "$ID$VERSION_ID" in
-    centos9*|rhel9*|ol9*|rocky9*)
-      # install required host packages
-      yum install -y lvm2 conntrack-tools socat
-      # disable yum repos
-      find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
-      yum clean metadata
-      ;;
-    esac
+    rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerSpec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

disabling yum repos in the pre install script is too late and the testgrid setup script is failing with error

https://testgrid.kurl.sh/run/STAGING-release-v2023.03.21-0-53077927-20230327232555?kurlLogsInstanceId=bbockuwlmvogoooe&nodeId=bbockuwlmvogoooe-initialprimary#L0

```
Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
```

associated pr in kurl-testgrid will now disable and adds convenience function

https://github.com/replicatedhq/kURL-testgrid/pull/231