### PR TITLE
fix: source testhelpers.hs before pre-install script

### DIFF
--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -19,6 +19,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -89,6 +89,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: k8s122
   installerSpec:
@@ -140,6 +141,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: minimal-124
   installerSpec:
@@ -276,6 +278,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: "k8s_126x airgap"
   airgap: true
@@ -299,6 +302,7 @@
     kotsadm:
       version: latest
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

I forgot to source testhelpers.sh before using it's functionality in the pre-install script

```
+ timeout 30m bash -euxo pipefail /opt/kurl-testgrid/preinstall.sh
+ rhel_9_install_host_packages lvm2 conntrack-tools socat
/opt/kurl-testgrid/preinstall.sh: line 1: rhel_9_install_host_packages: command not found
+ local exit_status=127
+ '[' 127 -ne 0 ']'
```
