### PR TITLE
fix: rhel 9 deplist missing noarch packages

### DIFF
--- a/bin/containertools/builddeps.sh
+++ b/bin/containertools/builddeps.sh
@@ -15,7 +15,7 @@ EOF
 available_packages="$(yum -q --disablerepo=* --enablerepo=kurl.local --releasever=/ --installroot=/tmp/empty-directory list available \
     | grep -v "Available Packages" | awk '{ print $1 }' | sed 's/\.x86_64//')"
 depslist="$(echo "$available_packages" \
-    | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --resolve --depends \
+    | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --arch=noarch --resolve --requires \
     | awk 'NF{NF-=2}1' FS='-' OFS='-')" # strip last two fields
 for package in $available_packages ; do
     # remove packages that in the first level dependency provides

--- a/bundles/k8s-rhel9/containertools/builddeps.sh
+++ b/bundles/k8s-rhel9/containertools/builddeps.sh
@@ -15,7 +15,7 @@ EOF
 available_packages="$(yum -q --disablerepo=* --enablerepo=kurl.local --releasever=/ --installroot=/tmp/empty-directory list available \
     | grep -v "Available Packages" | awk '{ print $1 }' | sed 's/\.x86_64//')"
 depslist="$(echo "$available_packages" \
-    | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --resolve --depends \
+    | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --arch=noarch --resolve --requires \
     | awk 'NF{NF-=2}1' FS='-' OFS='-')" # strip last two fields
 for package in $available_packages ; do
     # remove packages that in the first level dependency provides


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

In filtering out packages for the x86 architecture we are also filtering out packages that are required for all architectures "noarch". This is causing preflights to miss packages.

```
2023-03-28 18:29:50+00:00 ⚙  Installing host packages containerd.io
2023-03-28 18:29:50+00:00 kURL containerd-1.6.19 Local Repo               297 kB/s | 1.8 kB     00:00    
2023-03-28 18:29:50+00:00 Error: 
2023-03-28 18:29:50+00:00  Problem: conflicting requests
2023-03-28 18:29:50+00:00   - nothing provides container-selinux >= 2:2.74 needed by containerd.io-1.6.19-3.1.el9.x86_64
2023-03-28 18:29:50+00:00 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
2023-03-28 18:29:50+00:00 An error occurred on line 2479
```