### PR TITLE
feat(preflights): check load balancer health on upgrades

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -24,6 +24,13 @@ spec:
         timeout: 3m
         # ha and is first master (primary and not join) and not is upgrade
         exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary (not .IsJoin) (not .IsUpgrade) | not }}'
+    - http:
+        collectorName: "Kubernetes API Server Load Balancer Upgrade"
+        get:
+          url: https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress | trimSuffix "/" }}/livez
+          insecureSkipVerify: true
+        # ha and is first master (primary and not join) and is upgrade (the load balancer backend should already be available)
+        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary .IsUpgrade (not .IsJoin) | not }}'
     - tcpPortStatus:
         collectorName: "Kubernetes API TCP Port Status"
         port: 6443
@@ -166,6 +173,19 @@ spec:
               message: Successfully connected to {{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }} via load balancer
           - warn:
               message: Unexpected port status
+    - http:
+        checkName: "Kubernetes API Server Load Balancer Upgrade"
+        collectorName: "Kubernetes API Server Load Balancer Upgrade"
+        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary .IsUpgrade (not .IsJoin) | not }}'
+        outcomes:
+          - fail:
+              when: "error"
+              message: Error connecting to load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
+          - pass:
+              when: "statusCode == 200"
+              message: OK HTTP status response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
+          - fail:
+              message: Unexpected status code response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
     - tcpPortStatus:
         checkName: "Kubernetes API TCP Port Status"
         collectorName: "Kubernetes API TCP Port Status"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -27,7 +27,7 @@ spec:
     - http:
         collectorName: "Kubernetes API Server Load Balancer Upgrade"
         get:
-          url: https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress | trimSuffix "/" }}/livez
+          url: https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress | trimSuffix "/" }}/healthz
           insecureSkipVerify: true
         # ha and is first master (primary and not join) and is upgrade (the load balancer backend should already be available)
         exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary .IsUpgrade (not .IsJoin) | not }}'
@@ -180,12 +180,12 @@ spec:
         outcomes:
           - fail:
               when: "error"
-              message: Error connecting to load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
+              message: Error connecting to load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/healthz
           - pass:
               when: "statusCode == 200"
-              message: OK HTTP status response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
+              message: OK HTTP status response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/healthz
           - fail:
-              message: Unexpected status code response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/livez
+              message: Unexpected status code response from load balancer at https://{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}/healthz
     - tcpPortStatus:
         checkName: "Kubernetes API TCP Port Status"
         collectorName: "Kubernetes API TCP Port Status"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Adds a preflight to connect to the livez endpoint of the load balancer to check for health prior to re-running the install script for upgrades. This should prevent accidental typos when re-running the install script and changing the load balancer address.

```
$ cat install.sh | sudo bash -s ha
⚙  Running install with the argument(s): ha
Please enter a load balancer address to route external and internal traffic to the API servers.
In the absence of a load balancer address, all traffic will be routed to the first master.
Load balancer address:
⚙  Checking required host packages
✔ Required host packages are installed or available
⚙  Running host preflights
[TCP Port Status] Running collector...
[CPU Info] Running collector...
[Amount of Memory] Running collector...
[Block Devices] Running collector...
[Host OS Info] Running collector...
[Ephemeral Disk Usage /var/lib/kubelet] Running collector...
[Kubernetes API Server Load Balancer Upgrade] Running collector...
[Host OS Info] Running collector...
[Host OS Info] Running collector...
I0328 22:54:07.519942  905778 analyzer.go:76] excluding "Ephemeral Disk Usage /var/lib/docker" analyzer
I0328 22:54:07.519963  905778 analyzer.go:76] excluding "Kubernetes API Server Load Balancer" analyzer
I0328 22:54:07.520030  905778 analyzer.go:76] excluding "Kubernetes API TCP Port Status" analyzer
I0328 22:54:07.520047  905778 analyzer.go:76] excluding "ETCD Client API TCP Port Status" analyzer
I0328 22:54:07.520056  905778 analyzer.go:76] excluding "ETCD Server API TCP Port Status" analyzer
I0328 22:54:07.520064  905778 analyzer.go:76] excluding "ETCD Health Server TCP Port Status" analyzer
I0328 22:54:07.520073  905778 analyzer.go:76] excluding "Kubelet Health Server TCP Port Status" analyzer
I0328 22:54:07.520084  905778 analyzer.go:76] excluding "Kubelet API TCP Port Status" analyzer
I0328 22:54:07.520093  905778 analyzer.go:76] excluding "Kube Controller Manager Health Server TCP Port Status" analyzer
I0328 22:54:07.520103  905778 analyzer.go:76] excluding "Kube Scheduler Health Server TCP Port Status" analyzer
I0328 22:54:07.520115  905778 analyzer.go:76] excluding "Kubernetes API TCP Connection Status" analyzer
I0328 22:54:07.520126  905778 analyzer.go:76] excluding "Filesystem Performance" analyzer
I0328 22:54:07.520199  905778 analyzer.go:76] excluding "Docker Support" analyzer
I0328 22:54:07.520215  905778 analyzer.go:76] excluding "Containerd and Weave Compatibility" analyzer
I0328 22:54:07.520313  905778 analyzer.go:76] excluding "Flannel UDP port 8472 status" analyzer
[PASS] Number of CPUs: This server has at least 4 CPU cores
[PASS] Amount of Memory: The system has at least 8G of memory
[PASS] Ephemeral Disk Usage /var/lib/kubelet: The disk containing directory /var/lib/kubelet has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full
[PASS] Kubernetes API Server Load Balancer Upgrade: OK HTTP status response from load balancer at https://10.138.15.193:6443/livez
[PASS] NTP Status: System clock is synchronized
[PASS] NTP Status: Timezone is set to UTC
⚙  Host preflights success
```

```
$ cat install.sh | sudo bash -s ha
⚙  Running install with the argument(s): ha
Please enter a load balancer address to route external and internal traffic to the API servers.
In the absence of a load balancer address, all traffic will be routed to the first master.
Load balancer address: 1.2.3.4:123
⚙  Checking required host packages
✔ Required host packages are installed or available
⚙  Running host preflights
[TCP Port Status] Running collector...
[CPU Info] Running collector...
[Amount of Memory] Running collector...
[Block Devices] Running collector...
[Host OS Info] Running collector...
[Ephemeral Disk Usage /var/lib/kubelet] Running collector...
[Kubernetes API Server Load Balancer Upgrade] Running collector...
[Host OS Info] Running collector...
[Host OS Info] Running collector...
I0328 22:54:50.031583  906619 analyzer.go:76] excluding "Ephemeral Disk Usage /var/lib/docker" analyzer
I0328 22:54:50.031604  906619 analyzer.go:76] excluding "Kubernetes API Server Load Balancer" analyzer
I0328 22:54:50.031669  906619 analyzer.go:76] excluding "Kubernetes API TCP Port Status" analyzer
I0328 22:54:50.031688  906619 analyzer.go:76] excluding "ETCD Client API TCP Port Status" analyzer
I0328 22:54:50.031697  906619 analyzer.go:76] excluding "ETCD Server API TCP Port Status" analyzer
I0328 22:54:50.031704  906619 analyzer.go:76] excluding "ETCD Health Server TCP Port Status" analyzer
I0328 22:54:50.031715  906619 analyzer.go:76] excluding "Kubelet Health Server TCP Port Status" analyzer
I0328 22:54:50.031730  906619 analyzer.go:76] excluding "Kubelet API TCP Port Status" analyzer
I0328 22:54:50.031738  906619 analyzer.go:76] excluding "Kube Controller Manager Health Server TCP Port Status" analyzer
I0328 22:54:50.031748  906619 analyzer.go:76] excluding "Kube Scheduler Health Server TCP Port Status" analyzer
I0328 22:54:50.031758  906619 analyzer.go:76] excluding "Kubernetes API TCP Connection Status" analyzer
I0328 22:54:50.031767  906619 analyzer.go:76] excluding "Filesystem Performance" analyzer
I0328 22:54:50.031848  906619 analyzer.go:76] excluding "Docker Support" analyzer
I0328 22:54:50.031865  906619 analyzer.go:76] excluding "Containerd and Weave Compatibility" analyzer
I0328 22:54:50.031952  906619 analyzer.go:76] excluding "Flannel UDP port 8472 status" analyzer
[PASS] Number of CPUs: This server has at least 4 CPU cores
[PASS] Amount of Memory: The system has at least 8G of memory
[PASS] Ephemeral Disk Usage /var/lib/kubelet: The disk containing directory /var/lib/kubelet has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full
[FAIL] Kubernetes API Server Load Balancer Upgrade: Error connecting to load balancer at https://1.2.3.4:123/livez
[PASS] NTP Status: System clock is synchronized
[PASS] NTP Status: Timezone is set to UTC
Host preflights have failures that block the installation.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a preflight check to validate Kubernetes API Server load balancer health on upgrades.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
