### PR TITLE
fix: rhel 9 missing kubernetes git dep

### DIFF
--- a/bundles/k8s-rhel9/Dockerfile
+++ b/bundles/k8s-rhel9/Dockerfile
@@ -15,4 +15,6 @@ RUN /opt/containertools/builddeps.sh > /packages/archives/Deps \
 	&& sort /packages/archives/Deps | uniq | grep -v '^[[:space:]]*$' > /packages/archives/Deps.tmp \
 	&& mv /packages/archives/Deps.tmp /packages/archives/Deps
 
+RUN echo "git" >> /packages/archives/Deps
+
 CMD cp -r /packages/archives/* /out/

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -1,3 +1,12 @@
+#!/bin/bash
+
+function kubernetes_pre_init() {
+    if is_rhel_9_variant ; then
+        # git is packaged in the bundle and installed in other oses by
+        # kubernetes_install_host_packages
+        yum_ensure_host_package git
+    fi
+}
 
 function kubernetes_host() {
     kubernetes_load_modules
@@ -165,7 +174,12 @@ EOF
         ;;
     esac
 
-    install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}" git
+    if is_rhel_9_variant ; then
+        # ensure git in kubernetes_pre_init
+        install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}"
+    else
+        install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}" git
+    fi
 
     # Update crictl: https://listman.redhat.com/archives/rhsa-announce/2019-October/msg00038.html 
     tar -C /usr/bin -xzf "$DIR/packages/kubernetes/${k8sVersion}/assets/crictl-linux-amd64.tar.gz"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -562,6 +562,7 @@ function main() {
     get_common
     setup_kubeadm_kustomize
     rook_upgrade_maybe_report_upgrade_rook
+    kubernetes_pre_init
     ${K8S_DISTRO}_addon_for_each addon_pre_init
     discover_pod_subnet
     discover_service_subnet

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -178,6 +178,7 @@ function main() {
     setup_kubeadm_kustomize
     install_cri
     get_shared
+    kubernetes_pre_init
     ${K8S_DISTRO}_addon_for_each addon_join
     helm_load
     kubernetes_host

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -137,6 +137,7 @@ function main() {
     setup_kubeadm_kustomize
     install_cri
     get_shared
+    kubernetes_pre_init
     ${K8S_DISTRO}_addon_for_each addon_join
     maybe_upgrade
     kubernetes_configure_pause_image_upgrade


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

In the case of rhel 9 we do not package git with the bundle so we must add it to the Deps manifest and install it like other sub-dependencies.

https://testgrid.kurl.sh/run/ETHAN-rhel9-test-2?kurlLogsInstanceId=vujxmqkinpgmcfzs&nodeId=vujxmqkinpgmcfzs-initialprimary#L0

```
2023-03-29 02:03:00+00:00 ⚙  Install kubelet, kubectl and cni host packages
2023-03-29 02:03:00+00:00 kubelet command missing - will install host components
2023-03-29 02:03:00+00:00 ⚙  Installing host packages kubelet-1.26.3 kubectl-1.26.3 git
2023-03-29 02:03:00+00:00 kURL kubernetes-1.26.3 Local Repo               353 kB/s | 2.2 kB     00:00    
2023-03-29 02:03:00+00:00 No match for argument: git
2023-03-29 02:03:00+00:00 Error: Unable to find a match: git
2023-03-29 02:03:00+00:00 An error occurred on line 2479
```
