### PR TITLE
adds preflights to check disk space for containerd, rook and openebs

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -17,6 +17,18 @@ spec:
         collectorName: "Ephemeral Disk Usage /var/lib/docker"
         path: /var/lib/docker
         exclude: '{{kurl not .Installer.Spec.Docker.Version}}'
+    - diskUsage:
+        collectorName: "Ephemeral Disk Usage /var/lib/containerd"
+        path: /var/lib/containerd
+        exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
+    - diskUsage:
+        collectorName: "Ephemeral Disk Usage /var/lib/rook"
+        path: /var/lib/rook
+        exclude: '{{kurl not .Installer.Spec.Rook.Version}}'
+    - diskUsage:
+        collectorName: "Ephemeral Disk Usage /var/openebs"
+        path: /var/openebs
+        exclude: '{{kurl not .Installer.Spec.OpenEBS.Version}}'
     - tcpLoadBalancer:
         collectorName: "Kubernetes API Server Load Balancer"
         port: 6443
@@ -140,6 +152,45 @@ spec:
               message: The disk containing directory /var/lib/docker has less than 10Gi of disk space available
           - pass:
               message: The disk containing directory /var/lib/docker has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
+    - diskUsage:
+        checkName: "Ephemeral Disk Usage /var/lib/containerd"
+        collectorName: "Ephemeral Disk Usage /var/lib/containerd"
+        exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
+        outcomes:
+          - warn:
+              when: "used/total > 80%"
+              message: The disk containing directory /var/lib/containerd is more than 80% full
+          - warn:
+              when: "available < 10Gi"
+              message: The disk containing directory /var/lib/containerd has less than 10Gi of disk space available
+          - pass:
+              message: The disk containing directory /var/lib/containerd has sufficient space
+    - diskUsage:
+        checkName: "Ephemeral Disk Usage /var/lib/rook"
+        collectorName: "Ephemeral Disk Usage /var/lib/rook"
+        exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
+        outcomes:
+          - warn:
+              when: "used/total > 80%"
+              message: The disk containing directory /var/lib/rook is more than 80% full
+          - warn:
+              when: "available < 10Gi"
+              message: The disk containing directory /var/lib/rook has less than 10Gi of disk space available
+          - pass:
+              message: The disk containing directory /var/lib/rook has sufficient space
+    - diskUsage:
+        checkName: "Ephemeral Disk Usage /var/openebs"
+        collectorName: "Ephemeral Disk Usage /var/openebs"
+        exclude: '{{kurl not .Installer.Spec.OpenEBS.Version}}'
+        outcomes:
+          - warn:
+              when: "used/total > 80%"
+              message: The disk containing directory /var/openebs is more than 80% full
+          - warn:
+              when: "available < 10Gi"
+              message: The disk containing directory /var/openebs has less than 10Gi of disk space available
+          - pass:
+              message: The disk containing directory /var/openebs has sufficient space
     - tcpLoadBalancer:
         checkName: "Kubernetes API Server Load Balancer"
         collectorName: "Kubernetes API Server Load Balancer"
@@ -372,21 +423,21 @@ spec:
     - time:
         checkName: "NTP Status"
         outcomes:
-            - fail:
-                when: "ntp == unsynchronized+inactive"
-                message: "System clock is not synchronized"
-            - warn:
-                when: "ntp == unsynchronized+active"
-                message: System clock not yet synchronized
-            - pass:
-                when: "ntp == synchronized+active"
-                message: "System clock is synchronized"
-            - warn:
-                when: "timezone != UTC"
-                message: "Non UTC timezone can interfere with system function"
-            - pass:
-                when: "timezone == UTC"
-                message: "Timezone is set to UTC"
+          - fail:
+              when: "ntp == unsynchronized+inactive"
+              message: "System clock is not synchronized"
+          - warn:
+              when: "ntp == unsynchronized+active"
+              message: System clock not yet synchronized
+          - pass:
+              when: "ntp == synchronized+active"
+              message: "System clock is synchronized"
+          - warn:
+              when: "timezone != UTC"
+              message: "Non UTC timezone can interfere with system function"
+          - pass:
+              when: "timezone == UTC"
+              message: "Timezone is set to UTC"
     - hostOS:
         checkName: "Collectd Support"
         exclude: '{{kurl not .Installer.Spec.Collectd.Version}}'

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -195,20 +195,14 @@ spec:
         collectorName: "Ephemeral Disk Usage /var/openebs"
         exclude: '{{kurl not .Installer.Spec.OpenEBS.Version}}'
         outcomes:
-          - fail:
-              when: "total < 30Gi"
-              message: The disk containing directory /var/openebs has less than 30Gi of total space
-          - fail:
+          - warn:
               when: "used/total > 80%"
               message: The disk containing directory /var/openebs is more than 80% full
-          - warn:
-              when: "used/total > 60%"
-              message: The disk containing directory /var/openebs is more than 60% full
           - warn:
               when: "available < 10Gi"
               message: The disk containing directory /var/openebs has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/openebs has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
+              message: The disk containing directory /var/openebs has sufficient space
     - tcpLoadBalancer:
         checkName: "Kubernetes API Server Load Balancer"
         collectorName: "Kubernetes API Server Load Balancer"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -177,8 +177,8 @@ spec:
         exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
         outcomes:
           - fail:
-              when: "total < 30Gi"
-              message: The disk containing directory /var/lib/rook has less than 30Gi of total space
+              when: "total < 10Gi"
+              message: The disk containing directory /var/lib/rook has less than 10Gi of total space
           - fail:
               when: "used/total > 80%"
               message: The disk containing directory /var/lib/rook is more than 80% full
@@ -189,7 +189,7 @@ spec:
               when: "available < 10Gi"
               message: The disk containing directory /var/lib/rook has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/rook has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
+              message: The disk containing directory /var/lib/rook has at least 10Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/openebs"
         collectorName: "Ephemeral Disk Usage /var/openebs"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -157,40 +157,58 @@ spec:
         collectorName: "Ephemeral Disk Usage /var/lib/containerd"
         exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
         outcomes:
-          - warn:
+          - fail:
+              when: "total < 30Gi"
+              message: The disk containing directory /var/lib/containerd has less than 30Gi of total space
+          - fail:
               when: "used/total > 80%"
               message: The disk containing directory /var/lib/containerd is more than 80% full
+          - warn:
+              when: "used/total > 60%"
+              message: The disk containing directory /var/lib/containerd is more than 60% full
           - warn:
               when: "available < 10Gi"
               message: The disk containing directory /var/lib/containerd has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/containerd has sufficient space
+              message: The disk containing directory /var/lib/containerd has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/lib/rook"
         collectorName: "Ephemeral Disk Usage /var/lib/rook"
         exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
         outcomes:
-          - warn:
+          - fail:
+              when: "total < 30Gi"
+              message: The disk containing directory /var/lib/rook has less than 30Gi of total space
+          - fail:
               when: "used/total > 80%"
               message: The disk containing directory /var/lib/rook is more than 80% full
+          - warn:
+              when: "used/total > 60%"
+              message: The disk containing directory /var/lib/rook is more than 60% full
           - warn:
               when: "available < 10Gi"
               message: The disk containing directory /var/lib/rook has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/rook has sufficient space
+              message: The disk containing directory /var/lib/rook has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/openebs"
         collectorName: "Ephemeral Disk Usage /var/openebs"
         exclude: '{{kurl not .Installer.Spec.OpenEBS.Version}}'
         outcomes:
-          - warn:
+          - fail:
+              when: "total < 30Gi"
+              message: The disk containing directory /var/openebs has less than 30Gi of total space
+          - fail:
               when: "used/total > 80%"
               message: The disk containing directory /var/openebs is more than 80% full
+          - warn:
+              when: "used/total > 60%"
+              message: The disk containing directory /var/openebs is more than 60% full
           - warn:
               when: "available < 10Gi"
               message: The disk containing directory /var/openebs has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/openebs has sufficient space
+              message: The disk containing directory /var/openebs has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
     - tcpLoadBalancer:
         checkName: "Kubernetes API Server Load Balancer"
         collectorName: "Kubernetes API Server Load Balancer"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -171,25 +171,19 @@ spec:
               message: The disk containing directory /var/lib/containerd has less than 10Gi of disk space available
           - pass:
               message: The disk containing directory /var/lib/containerd has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
-    - diskUsage:
+   - diskUsage:
         checkName: "Ephemeral Disk Usage /var/lib/rook"
         collectorName: "Ephemeral Disk Usage /var/lib/rook"
         exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
         outcomes:
           - fail:
-              when: "total < 10Gi"
-              message: The disk containing directory /var/lib/rook has less than 10Gi of total space
-          - fail:
               when: "used/total > 80%"
               message: The disk containing directory /var/lib/rook is more than 80% full
-          - warn:
-              when: "used/total > 60%"
-              message: The disk containing directory /var/lib/rook is more than 60% full
-          - warn:
+          - fail:
               when: "available < 10Gi"
               message: The disk containing directory /var/lib/rook has less than 10Gi of disk space available
           - pass:
-              message: The disk containing directory /var/lib/rook has at least 10Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
+              message: The disk containing directory /var/lib/rook has sufficient space
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/openebs"
         collectorName: "Ephemeral Disk Usage /var/openebs"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -91,8 +91,26 @@ spec:
         backgroundWriteIOPSJobs: 6
         backgroundReadIOPS: 50
         backgroundReadIOPSJobs: 1
-
+    - http:
+        collectorName: "Kubernetes API Health"
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        get:
+          url: https://localhost:6443/healthz
+          insecureSkipVerify: true
   analyzers:
+    - http:
+        checkName: "Kubernetes API Health"
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        collectorName: "Kubernetes API Health"
+        outcomes:
+          - warn:
+              when: "error"
+              message: Error connecting to Kubernetes API at https://localhost:6443/healthz
+          - pass:
+              when: "statusCode == 200"
+              message: OK HTTP status response from Kubernetes API at https://localhost:6443/healthz
+          - warn:
+              message: Unexpected status code response from Kubernetes API at https://localhost:6443/healthz
     - cpu:
         checkName: "Number of CPUs"
         outcomes:
@@ -171,7 +189,7 @@ spec:
               message: The disk containing directory /var/lib/containerd has less than 10Gi of disk space available
           - pass:
               message: The disk containing directory /var/lib/containerd has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
-   - diskUsage:
+    - diskUsage:
         checkName: "Ephemeral Disk Usage /var/lib/rook"
         collectorName: "Ephemeral Disk Usage /var/lib/rook"
         exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that the disk has enough space for the add-ons containerd, rook and openebs

#### Which issue(s) this PR fixes:

Motivates by # [sc-71717]

#### Special notes for your reviewer:
<img width="979" alt="Screenshot 2023-03-29 at 11 23 29" src="https://user-images.githubusercontent.com/7708031/228505049-ce2bec77-1f9f-4fea-b4f9-b0af98347e60.png">

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds host preflight check to verify ephemeral disk space for the add-on(s) containerd, rook and openebs
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
