### PR TITLE
adds ability to use Preflight API to perform checks on cluster and began to verify if nodes are healthy

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -13,14 +13,16 @@ type CLI interface {
 	GetViper() *viper.Viper
 	GetFS() afero.Fs
 	GetReadline() *readline.Instance
-	GetPreflightRunner() preflight.Runner
+	GetHostPreflightRunner() preflight.RunnerHost
+	GetClusterPreflightRunner() preflight.RunnerCluster
 }
 
 // KurlCLI is the real implementation of the kurl CLI
 type KurlCLI struct {
-	fs              afero.Fs
-	readline        *readline.Instance
-	preflightRunner *preflight.PreflightRunner
+	fs                     afero.Fs
+	readline               *readline.Instance
+	preflightClusterRunner *preflight.RunnerClusterPreflight
+	preflightHostRunner    *preflight.RunnerHostPreflight
 }
 
 // GetViper returns the global viper instance
@@ -38,9 +40,14 @@ func (cli *KurlCLI) GetReadline() *readline.Instance {
 	return cli.readline
 }
 
-// GetPreflightRunner returns the runner for preflight checks
-func (cli *KurlCLI) GetPreflightRunner() preflight.Runner {
-	return cli.preflightRunner
+// GetHostPreflightRunner returns the runner for preflight checks
+func (cli *KurlCLI) GetHostPreflightRunner() preflight.RunnerHost {
+	return cli.preflightHostRunner
+}
+
+// GetClusterPreflightRunner returns the runner for preflight checks
+func (cli *KurlCLI) GetClusterPreflightRunner() preflight.RunnerCluster {
+	return cli.preflightClusterRunner
 }
 
 // NewKurlCLI builds a real kurl CLI object
@@ -50,8 +57,9 @@ func NewKurlCLI() (*KurlCLI, error) {
 		return nil, errors.Wrap(err, "new readline")
 	}
 	return &KurlCLI{
-		fs:              afero.NewOsFs(),
-		readline:        rl,
-		preflightRunner: new(preflight.PreflightRunner),
+		fs:                     afero.NewOsFs(),
+		readline:               rl,
+		preflightHostRunner:    new(preflight.RunnerHostPreflight),
+		preflightClusterRunner: new(preflight.RunnerClusterPreflight),
 	}, nil
 }

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -12,7 +12,9 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	hostCmd.AddCommand(newHostProtectedidCmd(cli))
 	hostCmd.AddCommand(newHostPreflightCmd(cli))
 	hostCmd.AddCommand(newHostnameCmd(cli))
+
 	cmd.AddCommand(hostCmd)
+	cmd.AddCommand(newPreflightCmd(cli))
 
 	rookCmd := NewRookCmd(cli)
 	rookCmd.AddCommand(NewHostpathToBlockCmd(cli))

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -12,9 +12,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	hostCmd.AddCommand(newHostProtectedidCmd(cli))
 	hostCmd.AddCommand(newHostPreflightCmd(cli))
 	hostCmd.AddCommand(newHostnameCmd(cli))
-
 	cmd.AddCommand(hostCmd)
-	cmd.AddCommand(newPreflightCmd(cli))
 
 	rookCmd := NewRookCmd(cli)
 	rookCmd.AddCommand(NewHostpathToBlockCmd(cli))
@@ -34,6 +32,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	clusterCmd := NewClusterCmd(cli)
 	clusterCmd.AddCommand(NewClusterNodesMissingImageCmd(cli))
 	clusterCmd.AddCommand(NewClusterCheckFreeDiskSpaceCmd(cli))
+	clusterCmd.AddCommand(newPreflightCmd(cli))
 	cmd.AddCommand(clusterCmd)
 
 	netutilCmd := newNetutilCommand(cli)

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -28,6 +28,13 @@ const hostPreflightCmdExample = `
   # Installer spec from STDIN
   $ kubectl get installer 6abe39c -oyaml | kurl host preflight -`
 
+const preflightCmdExample = `
+  # Installer spec from file
+  $ kurl preflight spec.yaml
+
+  # Installer spec from STDIN
+  $ kubectl get installer 6abe39c -oyaml | kurl preflight -`
+
 const (
 	preflightsWarningCode       = 3
 	preflightsIgnoreWarningCode = 2
@@ -76,7 +83,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 
 			if !v.GetBool("exclude-builtin") {
 				builtin := preflight.Builtin()
-				s, err := decodePreflightSpec(builtin, data)
+				s, err := decodeHostPreflightSpec(builtin, data)
 				if err != nil {
 					return errors.Wrap(err, "builtin")
 				}
@@ -89,7 +96,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 					return errors.Wrapf(err, "read spec file %s", filename)
 				}
 
-				decoded, err := decodePreflightSpec(string(spec), data)
+				decoded, err := decodeHostPreflightSpec(string(spec), data)
 				if err != nil {
 					return errors.Wrap(err, filename)
 				}
@@ -129,7 +136,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 			isTerminal := isatty.IsTerminal(os.Stderr.Fd())
 			go writeProgress(cmd.ErrOrStderr(), progressChan, progressCancel, isTerminal)
 
-			results, err := cli.GetPreflightRunner().Run(cmd.Context(), preflightSpec, progressChan)
+			results, err := cli.GetHostPreflightRunner().RunHostPreflights(cmd.Context(), preflightSpec, progressChan)
 			close(progressChan)
 			<-progressContext.Done()
 
@@ -163,6 +170,7 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 				}
 			}
 			return nil
+
 		},
 	}
 
@@ -175,7 +183,126 @@ func newHostPreflightCmd(cli CLI) *cobra.Command {
 	cmd.Flags().StringSlice("primary-host", nil, "host or IP of a control plane node running a Kubernetes API server and etcd peer")
 	cmd.Flags().StringSlice("secondary-host", nil, "host or IP of a secondary node running kubelet")
 	cmd.Flags().StringSlice("spec", nil, "host preflight specs")
-	// cmd.MarkFlagRequired("spec")
+	_ = cmd.MarkFlagFilename("spec", "yaml", "yml")
+
+	return cmd
+}
+
+func newPreflightCmd(cli CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "preflight [INSTALLER SPEC FILE|-]",
+		Short:        "Runs kURL preflight checks",
+		Example:      preflightCmdExample,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.PersistentFlags())
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GetViper().BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := cli.GetViper()
+
+			installerSpecData, err := retrieveInstallerSpecDataFromArg(cli.GetFS(), cmd.InOrStdin(), args[0])
+			if err != nil {
+				return errors.Wrap(err, "retrieve installer spec from arg")
+			}
+
+			installerSpec, err := installer.DecodeSpec(installerSpecData)
+			if err != nil {
+				return errors.Wrap(err, "decode installer spec")
+			}
+
+			remotes := append([]string{}, v.GetStringSlice("primary-host")...)
+			remotes = append(remotes, v.GetStringSlice("secondary-host")...)
+			data := installer.TemplateData{
+				Installer:      *installerSpec,
+				IsPrimary:      v.GetBool("is-primary"),
+				IsJoin:         v.GetBool("is-join"),
+				IsUpgrade:      v.GetBool("is-upgrade"),
+				PrimaryHosts:   v.GetStringSlice("primary-host"),
+				SecondaryHosts: v.GetStringSlice("secondary-host"),
+				RemoteHosts:    remotes,
+			}
+
+			preflightSpec := &troubleshootv1beta2.Preflight{}
+
+			if !v.GetBool("exclude-builtin") {
+				builtin := preflight.BuiltinCluster()
+				s, err := decodeClusterPreflightSpec(builtin, data)
+				if err != nil {
+					return errors.Wrap(err, "builtin")
+				}
+				preflightSpec = s
+			}
+
+			for _, filename := range v.GetStringSlice("spec") {
+				spec, err := os.ReadFile(filename)
+				if err != nil {
+					return errors.Wrapf(err, "read spec file %s", filename)
+				}
+
+				decoded, err := decodeClusterPreflightSpec(string(spec), data)
+				if err != nil {
+					return errors.Wrap(err, filename)
+				}
+
+				preflightSpec.Spec.Collectors = append(preflightSpec.Spec.Collectors, decoded.Spec.Collectors...)
+				preflightSpec.Spec.Analyzers = append(preflightSpec.Spec.Analyzers, decoded.Spec.Analyzers...)
+			}
+
+			progressChan := make(chan interface{})
+			progressContext, progressCancel := context.WithCancel(cmd.Context())
+			isTerminal := isatty.IsTerminal(os.Stderr.Fd())
+			go writeProgress(cmd.ErrOrStderr(), progressChan, progressCancel, isTerminal)
+
+			results, err := cli.GetClusterPreflightRunner().RunClusterPreflight(preflightSpec, progressChan)
+			close(progressChan)
+			<-progressContext.Done()
+
+			if err != nil {
+				return errors.Wrap(err, "run preflight")
+			}
+
+			printPreflightResults(cmd.OutOrStdout(), results)
+
+			if v.GetBool("use-exit-codes") {
+				switch {
+				case preflightIsFail(results):
+					os.Exit(preflightsErrorCode)
+				case preflightIsWarn(results):
+					if v.GetBool("ignore-warnings") {
+						os.Exit(preflightsIgnoreWarningCode)
+					}
+					os.Exit(preflightsWarningCode)
+				}
+				return nil
+			}
+
+			switch {
+			case preflightIsFail(results):
+				return errors.New("preflights have failures")
+			case preflightIsWarn(results):
+				if v.GetBool("ignore-warnings") {
+					fmt.Fprintln(cmd.ErrOrStderr(), "Warnings ignored by CLI flag \"ignore-warnings\"")
+				} else {
+					return ErrWarn
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("ignore-warnings", false, "ignore preflight warnings")
+	cmd.Flags().Bool("is-join", false, "set to true if this node is joining an existing cluster (non-primary implies join)")
+	cmd.Flags().Bool("is-primary", true, "set to true if this node is a primary")
+	cmd.Flags().Bool("is-upgrade", false, "set to true if this is an upgrade")
+	cmd.Flags().Bool("exclude-builtin", false, "set to true to exclude builtin preflights")
+	cmd.Flags().Bool("use-exit-codes", true, "set to false to return an error instead of an exit code")
+	cmd.Flags().StringSlice("primary-host", nil, "host or IP of a control plane node running a Kubernetes API server and etcd peer")
+	cmd.Flags().StringSlice("secondary-host", nil, "host or IP of a secondary node running kubelet")
+	cmd.Flags().StringSlice("spec", nil, "preflight specs")
 	_ = cmd.MarkFlagFilename("spec", "yaml", "yml")
 
 	return cmd
@@ -232,14 +359,24 @@ func tcpHostAnalyzer(service, address, port string) *v1beta2.HostAnalyze {
 	}
 }
 
-func decodePreflightSpec(raw string, data installer.TemplateData) (*troubleshootv1beta2.HostPreflight, error) {
+func decodeHostPreflightSpec(raw string, data installer.TemplateData) (*troubleshootv1beta2.HostPreflight, error) {
+	spec, err := installer.ExecuteTemplate("installerSpec", raw, data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "execute installer template")
+	}
+
+	decoded, err := preflight.HostDecode(spec)
+	return decoded, errors.Wrap(err, "decode HostPreflight spec")
+}
+
+func decodeClusterPreflightSpec(raw string, data installer.TemplateData) (*troubleshootv1beta2.Preflight, error) {
 	spec, err := installer.ExecuteTemplate("installerSpec", raw, data)
 	if err != nil {
 		return nil, errors.Wrapf(err, "execute installer template")
 	}
 
 	decoded, err := preflight.Decode(spec)
-	return decoded, errors.Wrap(err, "decode spec")
+	return decoded, errors.Wrap(err, "decode Preflight spec")
 }
 
 var collectorStartRegexp = regexp.MustCompile(`^\[.+\] Running collector\.\.\.$`)

--- a/pkg/cli/host_preflight.go
+++ b/pkg/cli/host_preflight.go
@@ -30,10 +30,10 @@ const hostPreflightCmdExample = `
 
 const preflightCmdExample = `
   # Installer spec from file
-  $ kurl preflight spec.yaml
+  $ kurl cluster preflight spec.yaml
 
   # Installer spec from STDIN
-  $ kubectl get installer 6abe39c -oyaml | kurl preflight -`
+  $ kubectl get installer 6abe39c -oyaml | kurl cluster preflight -`
 
 const (
 	preflightsWarningCode       = 3

--- a/pkg/cli/host_preflight_test.go
+++ b/pkg/cli/host_preflight_test.go
@@ -104,9 +104,9 @@ func TestNewHostPreflightCmd(t *testing.T) {
 			err := afero.WriteFile(fs, installerFilename, []byte(tt.installerYAML), 0666)
 			require.NoError(t, err)
 
-			mockPreflightRunner := mock_preflight.NewMockRunner(mockCtrl)
+			mockPreflightRunner := mock_preflight.NewMockRunnerHost(mockCtrl)
 			mockPreflightRunner.EXPECT().
-				Run(gomock.Any(), gomock.Any(), gomock.Any()).
+				RunHostPreflights(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tt.analyzeResults, error(nil)).
 				Times(1)
 
@@ -122,7 +122,7 @@ func TestNewHostPreflightCmd(t *testing.T) {
 				Return(fs).
 				Times(1)
 			mockCLI.EXPECT().
-				GetPreflightRunner().
+				GetHostPreflightRunner().
 				Return(mockPreflightRunner).
 				Times(1)
 
@@ -140,6 +140,145 @@ func TestNewHostPreflightCmd(t *testing.T) {
 			err = cmd.Execute()
 			if tt.isFail {
 				assert.EqualError(t, err, "host preflights have failures")
+			} else if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			stdout, err := io.ReadAll(bOut)
+			require.NoError(t, err)
+
+			stderr, err := io.ReadAll(bErr)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.stdout, string(stdout))
+			if tt.ignoreWarnings {
+				assert.Equal(t, "Warnings ignored by CLI flag \"ignore-warnings\"\n", string(stderr))
+			} else {
+				assert.Equal(t, tt.stderr, string(stderr))
+			}
+		})
+	}
+}
+
+func TestNewClusterPreflightCmd(t *testing.T) {
+	tests := []struct {
+		name           string
+		installerYAML  string
+		analyzeResults []*analyze.AnalyzeResult
+		isWarn         bool
+		ignoreWarnings bool
+		isFail         bool
+		stdout         string
+		stderr         string
+		wantErr        bool
+	}{
+		{
+			name:          "pass",
+			installerYAML: installerYAML,
+			analyzeResults: []*analyze.AnalyzeResult{
+				{
+					Title:   "Node status check",
+					Message: "All nodes are online",
+					IsPass:  true,
+				},
+			},
+			stdout: OutputPassGreen() + " Node status check: All nodes are online\n",
+			stderr: "",
+		},
+		{
+			name:          "warn",
+			installerYAML: installerYAML,
+			analyzeResults: []*analyze.AnalyzeResult{
+				{
+					Title:   "Number of CPUs",
+					Message: "At least 4 CPU cores are required",
+					IsWarn:  true,
+				},
+			},
+			isWarn:  true,
+			stdout:  OutputWarnYellow() + " Number of CPUs: At least 4 CPU cores are required\n",
+			stderr:  "Error: host preflights have warnings\n",
+			wantErr: true,
+		},
+		{
+			name:          "warn ignore",
+			installerYAML: installerYAML,
+			analyzeResults: []*analyze.AnalyzeResult{
+				{
+					Title:   "Number of CPUs",
+					Message: "At least 4 CPU cores are required",
+					IsWarn:  true,
+				},
+			},
+			isWarn:         true,
+			ignoreWarnings: true,
+			stdout:         OutputWarnYellow() + " Number of CPUs: At least 4 CPU cores are required\n",
+			stderr:         "Warnings ignored by CLI flag \"ignore-warnings\"\n",
+		},
+		{
+			name:          "fail",
+			installerYAML: installerYAML,
+			analyzeResults: []*analyze.AnalyzeResult{
+				{
+					Title:   "Number of CPUs",
+					Message: "At least 4 CPU cores are required",
+					IsFail:  true,
+				},
+			},
+			isFail: true,
+			stdout: OutputFailRed() + " Number of CPUs: At least 4 CPU cores are required\n",
+			stderr: "Error: preflights have failures\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			installerFilename := "/tmp/installer.yaml"
+
+			fs := afero.NewMemMapFs()
+			err := afero.WriteFile(fs, installerFilename, []byte(tt.installerYAML), 0666)
+			require.NoError(t, err)
+
+			mockPreflightRunner := mock_preflight.NewMockRunnerCluster(mockCtrl)
+			mockPreflightRunner.EXPECT().
+				RunClusterPreflight(gomock.Any(), gomock.Any()).
+				Return(tt.analyzeResults, error(nil)).
+				Times(1)
+
+			v := viper.New()
+
+			mockCLI := mock_cli.NewMockCLI(mockCtrl)
+			mockCLI.EXPECT().
+				GetViper().
+				Return(v).
+				Times(3)
+			mockCLI.EXPECT().
+				GetFS().
+				Return(fs).
+				Times(1)
+			mockCLI.EXPECT().
+				GetClusterPreflightRunner().
+				Return(mockPreflightRunner).
+				Times(1)
+
+			cmd := newPreflightCmd(mockCLI)
+
+			bOut, bErr := bytes.NewBufferString(""), bytes.NewBufferString("")
+			cmd.SetOut(bOut)
+			cmd.SetErr(bErr)
+			args := []string{installerFilename, "--use-exit-codes=false"}
+			if tt.ignoreWarnings {
+				args = append(args, "--ignore-warnings")
+			}
+			cmd.SetArgs(args)
+
+			err = cmd.Execute()
+			if tt.isFail {
+				assert.EqualError(t, err, "preflights have failures")
 			} else if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/cli/mock/mock_cli.go
+++ b/pkg/cli/mock/mock_cli.go
@@ -37,6 +37,20 @@ func (m *MockCLI) EXPECT() *MockCLIMockRecorder {
 	return m.recorder
 }
 
+// GetClusterPreflightRunner mocks base method.
+func (m *MockCLI) GetClusterPreflightRunner() preflight.RunnerCluster {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterPreflightRunner")
+	ret0, _ := ret[0].(preflight.RunnerCluster)
+	return ret0
+}
+
+// GetClusterPreflightRunner indicates an expected call of GetClusterPreflightRunner.
+func (mr *MockCLIMockRecorder) GetClusterPreflightRunner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterPreflightRunner", reflect.TypeOf((*MockCLI)(nil).GetClusterPreflightRunner))
+}
+
 // GetFS mocks base method.
 func (m *MockCLI) GetFS() afero.Fs {
 	m.ctrl.T.Helper()
@@ -51,18 +65,18 @@ func (mr *MockCLIMockRecorder) GetFS() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFS", reflect.TypeOf((*MockCLI)(nil).GetFS))
 }
 
-// GetPreflightRunner mocks base method.
-func (m *MockCLI) GetPreflightRunner() preflight.Runner {
+// GetHostPreflightRunner mocks base method.
+func (m *MockCLI) GetHostPreflightRunner() preflight.RunnerHost {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPreflightRunner")
-	ret0, _ := ret[0].(preflight.Runner)
+	ret := m.ctrl.Call(m, "GetHostPreflightRunner")
+	ret0, _ := ret[0].(preflight.RunnerHost)
 	return ret0
 }
 
-// GetPreflightRunner indicates an expected call of GetPreflightRunner.
-func (mr *MockCLIMockRecorder) GetPreflightRunner() *gomock.Call {
+// GetHostPreflightRunner indicates an expected call of GetHostPreflightRunner.
+func (mr *MockCLIMockRecorder) GetHostPreflightRunner() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreflightRunner", reflect.TypeOf((*MockCLI)(nil).GetPreflightRunner))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostPreflightRunner", reflect.TypeOf((*MockCLI)(nil).GetHostPreflightRunner))
 }
 
 // GetReadline mocks base method.

--- a/pkg/preflight/assets/preflights.yaml
+++ b/pkg/preflight/assets/preflights.yaml
@@ -1,0 +1,21 @@
+# https://kurl.sh/docs/install-with-kurl/system-requirements
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: kurl-builtin-oncluster
+spec:
+  collectors:
+    - clusterResources: {}
+  analyzers:
+    - nodeResources:
+        checkName: Node status check
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        outcomes:
+          - fail:
+              when: "nodeCondition(Ready) == False"
+              message: "Not all nodes are online."
+          - fail:
+              when: "nodeCondition(Ready) == Unknown"
+              message: "Not all nodes are online."
+          - pass:
+              message: "All nodes are online."

--- a/pkg/preflight/builtin.go
+++ b/pkg/preflight/builtin.go
@@ -11,3 +11,11 @@ var builtin string
 func Builtin() string {
 	return builtin
 }
+
+//go:embed assets/preflights.yaml
+var builtinCluster string
+
+// Builtin returns the default set of kURL host preflights
+func BuiltinCluster() string {
+	return builtinCluster
+}

--- a/pkg/preflight/mock/mock_runner.go
+++ b/pkg/preflight/mock/mock_runner.go
@@ -13,40 +13,78 @@ import (
 	v1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-// MockRunner is a mock of Runner interface.
-type MockRunner struct {
+// MockRunnerHost is a mock of RunnerHost interface.
+type MockRunnerHost struct {
 	ctrl     *gomock.Controller
-	recorder *MockRunnerMockRecorder
+	recorder *MockRunnerHostMockRecorder
 }
 
-// MockRunnerMockRecorder is the mock recorder for MockRunner.
-type MockRunnerMockRecorder struct {
-	mock *MockRunner
+// MockRunnerHostMockRecorder is the mock recorder for MockRunnerHost.
+type MockRunnerHostMockRecorder struct {
+	mock *MockRunnerHost
 }
 
-// NewMockRunner creates a new mock instance.
-func NewMockRunner(ctrl *gomock.Controller) *MockRunner {
-	mock := &MockRunner{ctrl: ctrl}
-	mock.recorder = &MockRunnerMockRecorder{mock}
+// NewMockRunnerHost creates a new mock instance.
+func NewMockRunnerHost(ctrl *gomock.Controller) *MockRunnerHost {
+	mock := &MockRunnerHost{ctrl: ctrl}
+	mock.recorder = &MockRunnerHostMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
+func (m *MockRunnerHost) EXPECT() *MockRunnerHostMockRecorder {
 	return m.recorder
 }
 
-// Run mocks base method.
-func (m *MockRunner) Run(ctx context.Context, spec *v1beta2.HostPreflight, progressChan chan interface{}) ([]*analyzer.AnalyzeResult, error) {
+// RunHostPreflights mocks base method.
+func (m *MockRunnerHost) RunHostPreflights(ctx context.Context, spec *v1beta2.HostPreflight, progressChan chan interface{}) ([]*analyzer.AnalyzeResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", ctx, spec, progressChan)
+	ret := m.ctrl.Call(m, "RunHostPreflights", ctx, spec, progressChan)
 	ret0, _ := ret[0].([]*analyzer.AnalyzeResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Run indicates an expected call of Run.
-func (mr *MockRunnerMockRecorder) Run(ctx, spec, progressChan interface{}) *gomock.Call {
+// RunHostPreflights indicates an expected call of RunHostPreflights.
+func (mr *MockRunnerHostMockRecorder) RunHostPreflights(ctx, spec, progressChan interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockRunner)(nil).Run), ctx, spec, progressChan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHostPreflights", reflect.TypeOf((*MockRunnerHost)(nil).RunHostPreflights), ctx, spec, progressChan)
+}
+
+// MockRunnerCluster is a mock of RunnerCluster interface.
+type MockRunnerCluster struct {
+	ctrl     *gomock.Controller
+	recorder *MockRunnerClusterMockRecorder
+}
+
+// MockRunnerClusterMockRecorder is the mock recorder for MockRunnerCluster.
+type MockRunnerClusterMockRecorder struct {
+	mock *MockRunnerCluster
+}
+
+// NewMockRunnerCluster creates a new mock instance.
+func NewMockRunnerCluster(ctrl *gomock.Controller) *MockRunnerCluster {
+	mock := &MockRunnerCluster{ctrl: ctrl}
+	mock.recorder = &MockRunnerClusterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRunnerCluster) EXPECT() *MockRunnerClusterMockRecorder {
+	return m.recorder
+}
+
+// RunClusterPreflight mocks base method.
+func (m *MockRunnerCluster) RunClusterPreflight(spec *v1beta2.Preflight, progressChan chan interface{}) ([]*analyzer.AnalyzeResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunClusterPreflight", spec, progressChan)
+	ret0, _ := ret[0].([]*analyzer.AnalyzeResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunClusterPreflight indicates an expected call of RunClusterPreflight.
+func (mr *MockRunnerClusterMockRecorder) RunClusterPreflight(spec, progressChan interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunClusterPreflight", reflect.TypeOf((*MockRunnerCluster)(nil).RunClusterPreflight), spec, progressChan)
 }

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-
 	analyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootclientsetscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	analyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootclientsetscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
+	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/preflight"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -16,8 +18,8 @@ func init() {
 	utilruntime.Must(troubleshootclientsetscheme.AddToScheme(scheme.Scheme))
 }
 
-// Decode decodes preflight spec yaml files
-func Decode(data []byte) (*troubleshootv1beta2.HostPreflight, error) {
+// HostDecode decodes preflight spec yaml files
+func HostDecode(data []byte) (*troubleshootv1beta2.HostPreflight, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, gvk, err := decode(data, nil, nil)
 	if err != nil {
@@ -37,15 +39,34 @@ func Decode(data []byte) (*troubleshootv1beta2.HostPreflight, error) {
 
 // Run collects host preflights and analyzes them, returning the analysis
 func Run(ctx context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error) {
-	collectResults, err := CollectResults(ctx, spec, progressChan)
+	collectResults, err := CollectHostResults(ctx, spec, progressChan)
 	if err != nil {
 		return nil, errors.Wrap(err, "collect results")
 	}
 	return collectResults.Analyze(), nil
 }
 
-// CollectResults collects host preflights, and returns the CollectResult
-func CollectResults(_ context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) (preflight.CollectResult, error) {
+// Decode decodes preflight spec yaml files
+func Decode(data []byte) (*troubleshootv1beta2.Preflight, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, gvk, err := decode(data, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode")
+	}
+
+	if gvk.Group != "troubleshoot.sh" || gvk.Version != "v1beta2" || gvk.Kind != "Preflight" {
+		return nil, errors.Errorf("unexpected gvk %q", gvk)
+	}
+
+	spec, ok := obj.(*troubleshootv1beta2.Preflight)
+	if !ok {
+		return nil, errors.Errorf("unexpected type %T", obj)
+	}
+	return spec, nil
+}
+
+// CollectHostResults collects host preflights, and returns the CollectResult
+func CollectHostResults(_ context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) (preflight.CollectResult, error) {
 	collectOpts := preflight.CollectOpts{
 		ProgressChan: progressChan,
 	}
@@ -54,6 +75,26 @@ func CollectResults(_ context.Context, spec *troubleshootv1beta2.HostPreflight, 
 		return nil, errors.Wrap(err, "collect host")
 	} else if collectResults == nil {
 		return nil, errors.New("no results")
+	}
+
+	return collectResults, nil
+}
+
+// CollectResults collects host preflights, and returns the CollectResult
+func CollectResults(spec *troubleshootv1beta2.Preflight, progressChan chan interface{}) (preflight.CollectResult, error) {
+	restConfig, err := k8sutil.GetRESTConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert kube flags to rest config")
+	}
+
+	collectOpts := preflight.CollectOpts{
+		ProgressChan:         progressChan,
+		KubernetesRestConfig: restConfig,
+	}
+
+	collectResults, err := preflight.CollectWithContext(context.TODO(), collectOpts, spec)
+	if err != nil {
+		return nil, err
 	}
 
 	return collectResults, nil

--- a/pkg/preflight/runner.go
+++ b/pkg/preflight/runner.go
@@ -8,17 +8,33 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-var _ Runner = new(PreflightRunner)
+var _ RunnerHost = new(RunnerHostPreflight)
+var _ RunnerCluster = new(RunnerClusterPreflight)
 
-type Runner interface {
-	Run(ctx context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error)
+type RunnerHost interface {
+	RunHostPreflights(ctx context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error)
 }
 
-type PreflightRunner struct {
+type RunnerCluster interface {
+	RunClusterPreflight(spec *troubleshootv1beta2.Preflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error)
 }
 
-func (r *PreflightRunner) Run(ctx context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error) {
-	collectResults, err := CollectResults(ctx, spec, progressChan)
+type RunnerHostPreflight struct {
+}
+
+type RunnerClusterPreflight struct {
+}
+
+func (r *RunnerHostPreflight) RunHostPreflights(ctx context.Context, spec *troubleshootv1beta2.HostPreflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error) {
+	collectResults, err := CollectHostResults(ctx, spec, progressChan)
+	if err != nil {
+		return nil, errors.Wrap(err, "collect results")
+	}
+	return collectResults.Analyze(), nil
+}
+
+func (r *RunnerClusterPreflight) RunClusterPreflight(spec *troubleshootv1beta2.Preflight, progressChan chan interface{}) ([]*analyze.AnalyzeResult, error) {
+	collectResults, err := CollectResults(spec, progressChan)
 	if err != nil {
 		return nil, errors.Wrap(err, "collect results")
 	}

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -655,12 +655,12 @@ function cluster_preflights() {
 
 
     if [ "${HOST_PREFLIGHT_IGNORE}" = "1" ]; then
-        "${DIR}"/bin/kurl preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
+        "${DIR}"/bin/kurl cluster preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
         host_preflights_mkresults "${out_file}" "${opts}"
         # TODO: report preflight fail
     else
         set +e
-        "${DIR}"/bin/kurl preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
+        "${DIR}"/bin/kurl cluster preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
         local kurl_exit_code="${PIPESTATUS[0]}"
         set -e
 

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -612,6 +612,83 @@ function host_preflights() {
     logStep "Host preflights success"
 }
 
+IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR="in-cluster-preflights"
+function cluster_preflights() {
+    local is_primary="$1"
+    local is_join="$2"
+    local is_upgrade="$3"
+    local opts=
+    local out_file=
+    out_file="${DIR}/${IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR}/results-$(date +%s).txt"
+
+    # Do not run those tests when/if kubernetes is not installed
+    if ! commandExists kubectl; then
+        return
+    fi
+
+    logStep "Running on cluster Preflights"
+    mkdir -p "${DIR}/${IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR}"
+
+    if [ ! "${HOST_PREFLIGHT_ENFORCE_WARNINGS}" = "1" ] ; then
+        opts="${opts} --ignore-warnings"
+    fi
+    if [ "${is_primary}" != "1" ]; then
+        opts="${opts} --is-primary=false"
+    fi
+    if [ "${is_join}" = "1" ]; then
+        opts="${opts} --is-join"
+    fi
+    if [ "${is_upgrade}" = "1" ]; then
+        opts="${opts} --is-upgrade"
+    fi
+
+    if [ "$EXCLUDE_BUILTIN_HOST_PREFLIGHTS" == "1" ]; then
+        opts="${opts} --exclude-builtin"
+    fi
+
+    if [ -n "$PRIMARY_HOST" ]; then
+        opts="${opts} --primary-host=${PRIMARY_HOST}"
+    fi
+    if [ -n "$SECONDARY_HOST" ]; then
+        opts="${opts} --secondary-host=${SECONDARY_HOST}"
+    fi
+
+
+    if [ "${HOST_PREFLIGHT_IGNORE}" = "1" ]; then
+        "${DIR}"/bin/kurl preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
+        host_preflights_mkresults "${out_file}" "${opts}"
+        # TODO: report preflight fail
+    else
+        set +e
+        "${DIR}"/bin/kurl preflight "${MERGED_YAML_SPEC}" ${opts} | tee "${out_file}"
+        local kurl_exit_code="${PIPESTATUS[0]}"
+        set -e
+
+        on_cluster_preflights_mkresults "${out_file}" "${opts}"
+
+        case $kurl_exit_code in
+            3)
+                bail "On cluster Preflights have warnings that block the installation."
+                ;;
+            2)
+                logWarn "Preflights checks executed on cluster have warnings"
+                logWarn "It is highly recommended to sort out the warning conditions before proceeding."
+                logWarn "Be aware that continuing with preflight warnings can result in failures."
+                log ""
+                logWarn "Would you like to continue?"
+                if ! confirmY ; then
+                    bail "The installation will not continue"
+                fi
+                return 0
+                ;;
+            1)
+                bail "On cluster Preflights checks have failures that block the installation."
+                ;;
+        esac
+    fi
+    logStep "On cluster Preflights success"
+}
+
 # host_preflights_mkresults will append cli data to preflight results file
 function host_preflights_mkresults() {
     local out_file="$1"
@@ -622,6 +699,18 @@ function host_preflights_mkresults() {
     tmp_file="$(mktemp)"
     echo -e "[version]\n${kurl_version}\n\n[options]\n${opts}\n\n[results]" | cat - "${out_file}" > "${tmp_file}" && mv "${tmp_file}" "${out_file}"
     chmod -R +r "${DIR}/${HOST_PREFLIGHTS_RESULTS_OUTPUT_DIR}/" # make sure the file is readable by kots support bundle
+    rm -f "${tmp_file}"
+}
+
+function on_cluster_preflights_mkresults() {
+    local out_file="$1"
+    local opts="$2"
+    local kurl_version=
+    kurl_version="$(./bin/kurl version | grep version= | awk 'BEGIN { FS="=" }; { print $2 }')"
+    local tmp_file=
+    tmp_file="$(mktemp)"
+    echo -e "[version]\n${kurl_version}\n\n[options]\n${opts}\n\n[results]" | cat - "${out_file}" > "${tmp_file}" && mv "${tmp_file}" "${out_file}"
+    chmod -R +r "${DIR}/${IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR}/" # make sure the file is readable by kots support bundle
     rm -f "${tmp_file}"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -555,8 +555,10 @@ function main() {
     preflights_require_host_packages
     if [ -z "$CURRENT_KUBERNETES_VERSION" ]; then
         host_preflights "1" "0" "0"
+        cluster_preflights "1" "0" "0"
     else
         host_preflights "1" "0" "1"
+        cluster_preflights "1" "0" "1"
     fi
     install_host_dependencies
     get_common

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -132,6 +132,7 @@ function main() {
     kubernetes_get_packages
     preflights_require_host_packages
     host_preflights "${MASTER:-0}" "1" "1"
+    cluster_preflights "${MASTER:-0}" "1" "1"
     install_host_dependencies
     get_common
     setup_kubeadm_kustomize


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, we are unable to add Preflight checks that will check things out on the cluster.
Therefore, with this PR we are adding a new command to allow us to do the tests as we do using HostPreflight API but within the Preflight kind. So that, we can check Pods, have textAnalizers and etc. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partial Fixes # [sc-71717]

Note that we are ONLY adding a check for the Nodes to see if they are healthy to make easier we move forward. However, as a follow up we mainly can check all that would be beneficial and relevant for example that we can found in the support bundle spec: https://github.com/replicatedhq/troubleshoot-specs/blob/main/in-cluster/default-kurl.yaml.

#### Special notes for your reviewer:

<img width="1003" alt="Screenshot 2023-03-30 at 11 41 49" src="https://user-images.githubusercontent.com/7708031/228812594-fa6c1dfd-0189-46fd-86a4-397ae8d3427f.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight checks to verify if nodes are healthy prior upgrades.  
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
