### PR TITLE
feat: support for iptables kube proxy mode

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -86,7 +86,7 @@ function kubernetes_ipvs_modules_available() {
     if modinfo ip_vs &>/dev/null && \
         modinfo ip_vs_rr &>/dev/null && \
         modinfo ip_vs_wrr &>/dev/null && \
-        modinfo ip_vssdf_sh &>/dev/null ; then
+        modinfo ip_vs_sh &>/dev/null ; then
         return 0
     fi
     return 1

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -12,7 +12,9 @@ function kubernetes_host() {
     kubernetes_load_modules
     kubernetes_load_ipv4_modules
     kubernetes_load_ipv6_modules
-    kubernetes_load_ipvs_modules
+    if kubernetes_ipvs_modules_available ; then
+        kubernetes_load_ipvs_modules
+    fi
 
     if [ "$SKIP_KUBERNETES_HOST" = "1" ]; then
         return 0
@@ -47,6 +49,8 @@ function kubernetes_load_ipvs_modules() {
         return
     fi
 
+    echo "Adding kernel modules nf_conntrack_ipv4, ip_vs, ip_vs_rr, ip_vs_wrr, and ip_vs_sh"
+
     if [ "$KERNEL_MAJOR" -gt "4" ] || \
         { [ "$KERNEL_MAJOR" -eq "4" ] && [ "$KERNEL_MINOR" -ge "19" ]; } || \
         {
@@ -54,24 +58,62 @@ function kubernetes_load_ipvs_modules() {
             { [ "$DIST_VERSION_MAJOR" = "8" ] || [ "$DIST_VERSION_MAJOR" = "9" ] || [ "$DIST_VERSION_MINOR"  -gt "2" ]; }; \
         }; then
         modprobe nf_conntrack
+        echo "nf_conntrack" > /etc/modules-load.d/99-replicated-ipvs.conf
     else
         modprobe nf_conntrack_ipv4
+        echo "nf_conntrack_ipv4" > /etc/modules-load.d/99-replicated-ipvs.conf
     fi
 
     rm -f /etc/modules-load.d/replicated-ipvs.conf
 
-    echo "Adding kernel modules ip_vs, ip_vs_rr, ip_vs_wrr, and ip_vs_sh"
     modprobe ip_vs
     modprobe ip_vs_rr
     modprobe ip_vs_wrr
     modprobe ip_vs_sh
 
-    echo "nf_conntrack_ipv4" > /etc/modules-load.d/99-replicated-ipvs.conf
     # shellcheck disable=SC2129
     echo "ip_vs" >> /etc/modules-load.d/99-replicated-ipvs.conf
     echo "ip_vs_rr" >> /etc/modules-load.d/99-replicated-ipvs.conf
     echo "ip_vs_wrr" >> /etc/modules-load.d/99-replicated-ipvs.conf
     echo "ip_vs_sh" >> /etc/modules-load.d/99-replicated-ipvs.conf
+}
+
+# kubernetes_ipvs_modules_available returns 0 if the ipvs modules are available
+function kubernetes_ipvs_modules_available() {
+    if ! modinfo nf_conntrack &>/dev/null || modinfo nf_conntrack_ipv4 &>/dev/null ; then
+        return 1
+    fi
+    if modinfo ip_vs &>/dev/null && \
+        modinfo ip_vs_rr &>/dev/null && \
+        modinfo ip_vs_wrr &>/dev/null && \
+        modinfo ip_vssdf_sh &>/dev/null ; then
+        return 0
+    fi
+    return 1
+}
+
+# kubernetes_iptables_mode_enabled returns 0 if kube-proxy is configured to use iptables
+function kubernetes_iptables_mode_enabled() {
+    kubectl -n kube-system get cm kube-proxy -o jsonpath='{.data.config\.conf}' 2>/dev/null | grep -q 'mode: iptables' || \
+        grep -qs 'mode: iptables' "$DIR/kustomize/kubeadm/init/kubeproxy-config-v1alpha1.yml"
+}
+
+# kubernetes_iptables_mode_enabled returns 0 if kube-proxy is configured to use ipvs
+function kubernetes_ipvs_mode_enabled() {
+    kubectl -n kube-system get cm kube-proxy -o jsonpath='{.data.config\.conf}' 2>/dev/null | grep -q 'mode: ipvs' || \
+        grep -qs 'mode: ipvs' "$DIR/kustomize/kubeadm/init/kubeproxy-config-v1alpha1.yml"
+}
+
+# kubernetes_get_kube_proxy_mode will return ipvs mode if it is enabled or if the ipvs modules are
+# available, otherwise iptables
+function kubernetes_get_kube_proxy_mode() {
+    if kubernetes_iptables_mode_enabled ; then
+        echo "iptables"
+    elif kubernetes_ipvs_mode_enabled || kubernetes_ipvs_modules_available ; then
+        echo "ipvs"
+    else
+        echo "iptables"
+    fi
 }
 
 function kubernetes_load_modules() {

--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -315,7 +315,14 @@ function prompt_for_private_ip() {
         _regex_ipv6="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+inet6 ([[:alnum:]:]+)"
         while read -r _line; do
             [[ $_line =~ $_regex_ipv6 ]]
-            if [ "${BASH_REMATCH[1]}" != "lo" ] && [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && [ "${BASH_REMATCH[1]}" != "docker0" ] && [ "${BASH_REMATCH[1]}" != "weave" ] && [ "${BASH_REMATCH[1]}" != "antrea-gw0" ] && [ "${BASH_REMATCH[1]}" != "flannel.1" ] && [ "${BASH_REMATCH[1]}" != "cni0" ]; then
+            if [ "${BASH_REMATCH[1]}" != "lo" ] && \
+                [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && \
+                [ "${BASH_REMATCH[1]}" != "docker0" ] && \
+                [ "${BASH_REMATCH[1]}" != "weave" ] && \
+                [ "${BASH_REMATCH[1]}" != "antrea-gw0" ] && \
+                [ "${BASH_REMATCH[1]}" != "flannel.1" ] && \
+                [ "${BASH_REMATCH[1]}" != "cni0" ]; then
+
                 _iface_names[$((_count))]=${BASH_REMATCH[1]}
                 _iface_addrs[$((_count))]=${BASH_REMATCH[2]}
                 let "_count += 1"
@@ -325,7 +332,14 @@ function prompt_for_private_ip() {
         _regex_ipv4="^[[:digit:]]+: ([^[:space:]]+)[[:space:]]+[[:alnum:]]+ ([[:digit:].]+)"
         while read -r _line; do
             [[ $_line =~ $_regex_ipv4 ]]
-            if [ "${BASH_REMATCH[1]}" != "lo" ] && [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && [ "${BASH_REMATCH[1]}" != "docker0" ] && [ "${BASH_REMATCH[1]}" != "weave" ] && [ "${BASH_REMATCH[1]}" != "antrea-gw0" ] && [ "${BASH_REMATCH[1]}" != "flannel.1" ] && [ "${BASH_REMATCH[1]}" != "cni0" ]; then
+            if [ "${BASH_REMATCH[1]}" != "lo" ] && \
+            [ "${BASH_REMATCH[1]}" != "kube-ipvs0" ] && \
+            [ "${BASH_REMATCH[1]}" != "docker0" ] && \
+            [ "${BASH_REMATCH[1]}" != "weave" ] && \
+            [ "${BASH_REMATCH[1]}" != "antrea-gw0" ] && \
+            [ "${BASH_REMATCH[1]}" != "flannel.1" ] && \
+            [ "${BASH_REMATCH[1]}" != "cni0" ]; then
+
                 _iface_names[$((_count))]=${BASH_REMATCH[1]}
                 _iface_addrs[$((_count))]=${BASH_REMATCH[2]}
                 let "_count += 1"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,14 @@ function init() {
             kubeadm-init-hostname.patch.yaml
     fi
 
+    local KUBE_PROXY_MODE=${KUBE_PROXY_MODE:-}
+    if [ -z "$KUBE_PROXY_MODE" ]; then
+        KUBE_PROXY_MODE="$(kubernetes_get_kube_proxy_mode)"
+    fi
+    log "Using kube-proxy mode: $KUBE_PROXY_MODE"
+    render_yaml_file_2 "$kustomize_kubeadm_init/kubeproxy-config-v1alpha1.tmpl.yml" \
+        > "$kustomize_kubeadm_init/kubeproxy-config-v1alpha1.yml"
+
     CERT_KEY=
     CERT_KEY_EXPIRY=
     if [ "$HA_CLUSTER" = "1" ]; then

--- a/scripts/kustomize/kubeadm/init-orig/kubeproxy-config-v1alpha1.tmpl.yml
+++ b/scripts/kustomize/kubeadm/init-orig/kubeproxy-config-v1alpha1.tmpl.yml
@@ -3,4 +3,4 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 metadata:
   name: kube-proxy-configuration
-mode: ipvs
+mode: $KUBE_PROXY_MODE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Support for iptables kube-proxy mode when kernel modules are not available to run in ipvs mode.

https://testgrid.kurl.sh/run/ETHAN-rhel9-test-6?kurlLogsInstanceId=lbxfqwpknvzjcdhx&nodeId=lbxfqwpknvzjcdhx-initialprimary#L0

```
2023-03-29 20:06:09+00:00 Adding kernel modules ip_vs, ip_vs_rr, ip_vs_wrr, and ip_vs_sh
+ cat /var/log/cloud-init-output.log
2023-03-29 20:06:09+00:00 modprobe: FATAL: Module ip_vs_wrr not found in directory /lib/modules/5.15.0-3.60.5.1.el9uek.x86_64
+ curl -X PUT -f --data-binary @/tmp/testgrid-node-logs https://api.testgrid.kurl.sh/v1/instance/lbxfqwpknvzjcdhx-initialprimary/node-logs
2023-03-29 20:06:09+00:00 An error occurred on line 2695
2023-03-29 20:06:09+00:00 
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
kURL will now run kube-proxy in iptables mode if ipvs kernel modules are not available.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
