### PR TITLE
fix(containerd): do not wait for k8s to report healthy if not yet installed

### DIFF
--- a/addons/containerd/1.6.19/install.sh
+++ b/addons/containerd/1.6.19/install.sh
@@ -74,13 +74,16 @@ function containerd_install() {
 
     load_images $src/images
 
-    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
-        systemctl start kubelet
-        # If using the internal load balancer the Kubernetes API server will be unavailable until
-        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-        # is available before proceeeding.
-        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service ; then
+        # do not try to start and wait for the kubelet if it is not yet configured
+        if [ -f /etc/kubernetes/kubelet.conf ]; then
+            systemctl start kubelet
+            # If using the internal load balancer the Kubernetes API server will be unavailable until
+            # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+            # is available before proceeeding.
+            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+        fi
     fi
 }
 

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -74,13 +74,16 @@ function containerd_install() {
 
     load_images $src/images
 
-    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service; then
-        systemctl start kubelet
-        # If using the internal load balancer the Kubernetes API server will be unavailable until
-        # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-        # is available before proceeeding.
-        # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-        try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+    if systemctl list-unit-files | grep -v disabled | grep -q kubelet.service ; then
+        # do not try to start and wait for the kubelet if it is not yet configured
+        if [ -f /etc/kubernetes/kubelet.conf ]; then
+            systemctl start kubelet
+            # If using the internal load balancer the Kubernetes API server will be unavailable until
+            # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+            # is available before proceeeding.
+            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+        fi
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

If the kubernetes binaries get installed by kurl but the script fails before we install kubernetes, the script will always fail on re-running as it will wait for the apiserver to report as healthy.

```
✔ Status checked successfully. No broken packages were found.
Restarting containerd...
Service containerd restarted.
unpacking registry.k8s.io/pause:3.6 (sha256:79b611631c0d19e9a975fb0a8511e5153789b4c26610d1842e9f735c57cc8b13)...done

error: stat /etc/kubernetes/kubelet.conf: no such file or directory
spent 5m attempting to run "kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1." without success
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue that could cause re-running the install script to fail if the Kubernetes binaries are installed but the cluster was never installed or configured.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
