### PR TITLE
fix(testgrid): install required deps for rhel-9 airgap

### DIFF
--- a/addons/antrea/template/testgrid/tests.yaml
+++ b/addons/antrea/template/testgrid/tests.yaml
@@ -30,6 +30,9 @@
     antrea:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 
 - name: openebs and kotsadm upgrade
   installerSpec:

--- a/addons/cert-manager/template/testgrid/k8s-docker.yaml
+++ b/addons/cert-manager/template/testgrid/k8s-docker.yaml
@@ -56,6 +56,9 @@
     certManager:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
     kubectl get crds
     kubectl get all -n cert-manager

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -46,6 +46,9 @@
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: "weave to flannel single node"
   installerSpec:
     kubernetes:

--- a/addons/goldpinger/template/testgrid/tests.yaml
+++ b/addons/goldpinger/template/testgrid/tests.yaml
@@ -101,6 +101,9 @@
     goldpinger:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
     # find the goldpinger endpoint
     export GP_ENDPOINT=$(kubectl get endpoints -n kurl goldpinger | grep -v NAME | awk '{ print $2 }')

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -225,6 +225,9 @@
     longhorn:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -83,6 +83,9 @@
       namespace: openebs
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -98,3 +98,6 @@
       version: "__testver__"
       s3Override: "__testdist__"
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -258,6 +258,9 @@
     registry:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
 
     # wait for the pod to be ready

--- a/addons/rook/template/testgrid/k8s-docker.yaml
+++ b/addons/rook/template/testgrid/k8s-docker.yaml
@@ -20,7 +20,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info

--- a/addons/sonobuoy/template/testgrid/k8s-docker.yaml
+++ b/addons/sonobuoy/template/testgrid/k8s-docker.yaml
@@ -33,3 +33,6 @@
       version: "__testver__"
       s3Override: "__testdist__"
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -25,6 +25,9 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: "Velero DisableS3 - Rook"
   installerSpec:
     kubernetes:

--- a/addons/weave/template/testgrid/k8s-docker.yaml
+++ b/addons/weave/template/testgrid/k8s-docker.yaml
@@ -42,3 +42,6 @@
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -90,7 +90,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: k8s122
   installerSpec:
     kubernetes:
@@ -142,7 +142,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: minimal-124
   installerSpec:
     containerd:
@@ -279,7 +279,7 @@
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: "k8s_126x airgap"
   airgap: true
   installerSpec:
@@ -303,7 +303,7 @@
       version: latest
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerSpec:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -966,6 +966,9 @@
     ekco:
       version: latest
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
@@ -1252,6 +1255,9 @@
     ekco:
       version: latest
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: "Upgrade to 1.26 minimal"
   installerSpec:
     kubernetes:
@@ -1329,6 +1335,9 @@
     ekco:
       version: latest
   airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 - name: k8s121-with-flags
   installerSpec:
     kubernetes:
@@ -1688,6 +1697,9 @@
     minio:
       version: "latest"
   preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+
     # download the file that the airgap upgrade requires, and place it in the correct location
     curl -LO https://s3-staging.kurl.sh/staging/rookupgrade-10to14.tar.gz
     curl -LO https://s3-staging.kurl.sh/staging/rook-1.4.9.tar.gz


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes

```
2023-03-29 22:32:07+00:00 ⚙  Checking required host packages
2023-03-29 22:32:08+00:00 
2023-03-29 22:32:08+00:00 Host package container-selinux is required by containerd 1.6.19
2023-03-29 22:32:10+00:00 Host package git is required by kubernetes 1.26.3
2023-03-29 22:32:10+00:00 
2023-03-29 22:32:10+00:00 Host packages are missing. Please install them and re-run the install script.
2023-03-29 22:32:10+00:00 Run the script again with flag "dismiss-host-packages-preflight" to continue.
+ KURL_EXIT_STATUS=1
```
