### PR TITLE
fix velero test which is missing minio

### DIFF
--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -57,6 +57,8 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
+    minio:
+      version: "latest"
 - name: "Velero Remove Object Storage"
   cpu: 6
   installerSpec:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -86,12 +86,8 @@
       version: 1.21.x
     flannel:
       version: latest
-    openebs:
+    longhorn:
       version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio: 
-        version: latest
     registry:
       version: latest
     kotsadm:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -90,6 +90,8 @@
       version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: default
+    minio: 
+        version: latest
     registry:
       version: latest
     kotsadm:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -44,14 +44,16 @@
     velero:
       version: "__testver__"
       s3Override: "__testdist__"
-- name: "Velero Longhorn only"
+- name: "Velero OpenEBS only"
   installerSpec:
     kubernetes:
       version: "latest"
     flannel:
       version: latest
-    longhorn:
-      version: "latest"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
     containerd:
       version: "latest"
     velero:
@@ -84,8 +86,10 @@
       version: 1.21.x
     flannel:
       version: latest
-    longhorn:
+    openebs:
       version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
     registry:
       version: latest
     kotsadm:


### PR DESCRIPTION
#### What this PR does / why we need it:

To vix velero test which is missing an object store and because of this will fail as follows. This PR is required to unblock: https://github.com/replicatedhq/kURL/pull/4270

> + echo 'kubelet journalctl'
> + journalctl -xeu kubelet
> 2023-03-30 08:23:43+00:00 Please, ensure that your installer also provides an object store with either the MinIO or Rook add-on.
> + echo 'docker containers'
> + command_exists docker
> + command -v docker
> + command_exists crictl
> + command -v crictl

See: https://testgrid.kurl.sh/run/pr-4270-c439bb2-velero-1.10.2-k8s-docker-2023-03-30T04:08:54Z?kurlLogsInstanceId=okeeoicnzgskkodt&nodeId=okeeoicnzgskkodt-initialprimary
