### PR TITLE
Adds a check to verify if OpenEBS and Rook Pod(s) are healthy prior migrate from Rook to OpenEBS.

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -69,6 +69,12 @@ function openebs_maybe_rook_migration_checks() {
         bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
     fi
 
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
     # get the list of StorageClasses that use rook-ceph
     local rook_scs
     local rook_default_sc

--- a/addons/openebs/3.4.0/install.sh
+++ b/addons/openebs/3.4.0/install.sh
@@ -69,6 +69,12 @@ function openebs_maybe_rook_migration_checks() {
         bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
     fi
 
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
     # get the list of StorageClasses that use rook-ceph
     local rook_scs
     local rook_default_sc

--- a/addons/openebs/3.5.0/install.sh
+++ b/addons/openebs/3.5.0/install.sh
@@ -69,6 +69,12 @@ function openebs_maybe_rook_migration_checks() {
         bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
     fi
 
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
     # get the list of StorageClasses that use rook-ceph
     local rook_scs
     local rook_default_sc

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -69,6 +69,12 @@ function openebs_maybe_rook_migration_checks() {
         bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
     fi
 
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
     # get the list of StorageClasses that use rook-ceph
     local rook_scs
     local rook_default_sc

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -351,6 +351,12 @@ function rook_operator_ready() {
 }
 
 function rook_is_healthy_to_upgrade() {
+    log "Awaiting 2 minutes to check Rook Ceph Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "rook-ceph"; then
+        logFail "Rook Ceph has unhealthy Pod(s)"
+        return 1
+    fi
+
     log "Awaiting Rook Ceph health ..."
     if ! $DIR/bin/kurl rook wait-for-health 600 ; then
         kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status


### PR DESCRIPTION
#### What this PR does / why we need it:

Check if Pods are healthy prior migrate from Rook to OpenEBS 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-71717]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a check to verify if OpenEBS and Rook Pod(s) are healthy prior migrate from Rook to OpenEBS
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
