### PR TITLE
Adds check to verify if MinIO Pod(s) is running prior migrate object store

### DIFF
--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -246,6 +246,12 @@ function migrate_rgw_to_minio_checks() {
         bail "Cannot upgrade from Rook Ceph Object Store to Minio. Rook Ceph is unhealthy."
     fi
 
+    log "Awaiting 2 minutes to check MinIO Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$MINIO_NAMESPACE"; then
+        logFail "MinIO has unhealthy Pod(s). Check the namespace $MINIO_NAMESPACE "
+        bail "Cannot upgrade from Rook to MinIO. MinIO is unhealthy."
+    fi
+
     logSuccess "Rook Ceph Object Store to Minio migration checks completed successfully."
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Check if Pods are healthy prior migrate from Rook Object Store to MinIO  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-71717]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds check to verify if MinIO Pod(s) is running prior migrate object store from Rook.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
