### PR TITLE
fix preflight follow up

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -192,7 +192,7 @@ spec:
     - diskUsage:
         checkName: "Ephemeral Disk Usage /var/lib/rook"
         collectorName: "Ephemeral Disk Usage /var/lib/rook"
-        exclude: '{{kurl not .Installer.Spec.Containerd.Version}}'
+        exclude: '{{kurl not .Installer.Spec.Rook.Version}}'
         outcomes:
           - fail:
               when: "used/total > 80%"


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix https://github.com/replicatedhq/kURL/pull/4294 (by appling the review suggestion we did a mistake and the condition get wrong) which is broken the testgrids;

> 2023-03-30 17:46:53+00:00 [FAIL] Ephemeral Disk Usage /var/lib/rook: Analyzer Failed: analyze: failed to get collected file host-collectors/diskUsage/Ephemeral Disk Usage /var/lib/rook.json: file host-collectors/diskUsage/Ephemeral Disk Usage /var/lib/rook.json was not collected
> ...
> 2023-03-30 17:46:53+00:00 Host preflights have failures that block the installation.
> + KURL_EXIT_STATUS=1

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
