### PR TITLE
fix: storage test Migrate from Rook 1.0.4 to OpenEBS + Minio (Docker config) into unbuntu 22.04

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -896,6 +896,7 @@
   unsupportedOSIDs:
   - ol-91 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants
+  - ubuntu-2204 # Docker versions < 20.10.17 not supported on ubuntu 22.04
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
   flags: "yes"
   installerSpec:


### PR DESCRIPTION
#### What this PR does / why we need it:

The spec is not supported into ubuntu 22.04:

[FAIL] Docker Support: Docker versions < 20.10.17 not supported on ubuntu 22.04


<img width="1620" alt="Screenshot 2023-03-30 at 22 17 33" src="https://user-images.githubusercontent.com/7708031/228966967-b68020cd-0ee7-444b-90ef-cd734b2f49cd.png">
