### PR TITLE
adds check to verify if pods are running for Rook upgrades from 1.x 1.4.9

### DIFF
--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -7,7 +7,7 @@ function rookupgrade_10to14_upgrade() {
     # if it is less than or equal we re-apply in cause of a failure mid upgrade
     if [ "$(common_upgrade_compare_versions "$from_version" "1.1")" != "1" ]; then
 
-        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
         if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
             logWarn "Rook Ceph has unhealthy Pod(s)"
         fi
@@ -97,7 +97,7 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.1.9
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.1.9
 
-        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
         if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
             logWarn "Rook Ceph has unhealthy Pod(s)"
         fi
@@ -130,7 +130,7 @@ function rookupgrade_10to14_upgrade() {
             kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20201116"}}}'
             kubectl patch deployment -n rook-ceph csi-rbdplugin-provisioner -p '{"spec": {"template": {"spec":{"containers":[{"name":"csi-snapshotter","imagePullPolicy":"IfNotPresent"}]}}}}'
 
-            log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+            log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
             if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
                 logWarn "Rook Ceph has unhealthy Pod(s)"
             fi
@@ -185,7 +185,7 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.7
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.2.7
 
-        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
         if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
             logWarn "Rook Ceph has unhealthy Pod(s)"
         fi
@@ -235,7 +235,7 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.3.11
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.3.11
 
-        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
         if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
             logWarn "Rook Ceph has unhealthy Pod(s)"
         fi
@@ -278,7 +278,7 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.4.9
         kubectl apply -f "$upgrade_files_path/rook-ceph-tools-14.yaml"
 
-        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
         if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
             logWarn "Rook Ceph has unhealthy Pod(s)"
         fi
@@ -319,7 +319,7 @@ function rookupgrade_10to14_upgrade() {
             fi
             rookupgrade_10to14_maybe_scale_pool_device_health_metrics
 
-            log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+            log "Awaiting up to 5 minutes to check Rook Ceph Pod(s) are Running"
             if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
                 logWarn "Rook Ceph has unhealthy Pod(s)"
             fi

--- a/addons/rookupgrade/10to14/install.sh
+++ b/addons/rookupgrade/10to14/install.sh
@@ -6,6 +6,12 @@ function rookupgrade_10to14_upgrade() {
 
     # if it is less than or equal we re-apply in cause of a failure mid upgrade
     if [ "$(common_upgrade_compare_versions "$from_version" "1.1")" != "1" ]; then
+
+        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+            logWarn "Rook Ceph has unhealthy Pod(s)"
+        fi
+
         # this will start the rook toolbox if it doesn't already exist
         log "Waiting for rook to be healthy"
         if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
@@ -91,6 +97,11 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.1.9
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.1.9
 
+        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+            logWarn "Rook Ceph has unhealthy Pod(s)"
+        fi
+
         log "Waiting for Rook 1.1.9 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.1.9" --timeout=1200 ; then
             logWarn "Timeout waiting for Rook version 1.1.9 rolled out"
@@ -118,6 +129,12 @@ function rookupgrade_10to14_upgrade() {
 
             kubectl -n rook-ceph patch CephCluster rook-ceph --type=merge -p '{"spec": {"cephVersion": {"image": "ceph/ceph:v14.2.5-20201116"}}}'
             kubectl patch deployment -n rook-ceph csi-rbdplugin-provisioner -p '{"spec": {"template": {"spec":{"containers":[{"name":"csi-snapshotter","imagePullPolicy":"IfNotPresent"}]}}}}'
+
+            log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+            if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+                logWarn "Rook Ceph has unhealthy Pod(s)"
+            fi
+
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "14.2.5" --timeout=1200 ; then
                 logWarn "Timeout waiting for Ceph version to be rolled out"
                 log "Checking Ceph versions and replicas"
@@ -168,6 +185,11 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.7
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.2.7
 
+        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+            logWarn "Rook Ceph has unhealthy Pod(s)"
+        fi
+
         log "Waiting for Rook 1.2.7 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.2.7" --timeout=1200 ; then
             logWarn "Timeout waiting for Rook version 1.2.7 rolled out"
@@ -213,6 +235,11 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.3.11
         kubectl -n rook-ceph set image deploy/rook-ceph-tools rook-ceph-tools=rook/ceph:v1.3.11
 
+        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+            logWarn "Rook Ceph has unhealthy Pod(s)"
+        fi
+
         log "Waiting for Rook 1.3.11 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.3.11" --timeout=1200 ; then
             logWarn "Timeout waiting for Rook version 1.3.11 rolled out"
@@ -251,6 +278,11 @@ function rookupgrade_10to14_upgrade() {
         kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.4.9
         kubectl apply -f "$upgrade_files_path/rook-ceph-tools-14.yaml"
 
+        log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+        if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+            logWarn "Rook Ceph has unhealthy Pod(s)"
+        fi
+
         log "Waiting for Rook 1.4.9 to rollout throughout the cluster, this may take some time"
         if ! "$DIR"/bin/kurl rook wait-for-rook-version "v1.4.9" --timeout=1200 ; then
             logWarn "Timeout waiting for Rook version 1.4.9 rolled out"
@@ -286,6 +318,11 @@ function rookupgrade_10to14_upgrade() {
                 bail "Timed out waiting for device_health_metrics pool to be created"
             fi
             rookupgrade_10to14_maybe_scale_pool_device_health_metrics
+
+            log "Awaiting up 5 minutes to check Rook Ceph Pod(s) are Running"
+            if ! spinner_until 300 check_for_running_pods "rook-ceph"; then
+                logWarn "Rook Ceph has unhealthy Pod(s)"
+            fi
 
             if ! "$DIR"/bin/kurl rook wait-for-ceph-version "15.2.8-0" --timeout=1200 ; then
                 logWarn "Timeout waiting for Ceph version 15.2.8-0 rolled out"


### PR DESCRIPTION
#### What this PR does / why we need it:

We can check that the upgrades from 1.x to 1.4.9 are falling see: https://testgrid.kurl.sh/run/STAGING-daily-storage-migration-3ca4e34-2023-03-29T01:28:40Z?kurlLogsInstanceId=bwqlgezutlvazwny&nodeId=bwqlgezutlvazwny-initialprimary 

```
2023-03-29 08:40:59+00:00 Waiting for all Rook-Ceph deployments to be using Ceph 14.2.5
2023-03-29 08:40:59+00:00 deployments rook-ceph-mgr-a, rook-ceph-mon-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0
2023-03-29 08:41:29+00:00 deployments rook-ceph-mgr-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0
2023-03-29 08:41:39+00:00 deployments rook-ceph-mgr-a, rook-ceph-mon-b, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0 and deployments rook-ceph-mon-a not ready
2023-03-29 08:41:49+00:00 deployments rook-ceph-mgr-a, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0
2023-03-29 08:41:59+00:00 deployments rook-ceph-mgr-a, rook-ceph-mon-c, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0 and deployments rook-ceph-mon-b not ready
2023-03-29 08:42:09+00:00 deployments rook-ceph-mgr-a, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0 and deployments rook-ceph-mon-c not ready
2023-03-29 08:42:19+00:00 deployments rook-ceph-mgr-a, rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0
2023-03-29 08:42:29+00:00 deployments rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5, rook-ceph-rgw-rook-ceph-store-a still running 14.2.0
2023-03-29 08:58:39+00:00 deployments rook-ceph-osd-3, rook-ceph-osd-4, rook-ceph-osd-5 still running 14.2.0
2023-03-29 09:00:59+00:00 Error: failed to wait for Ceph "14.2.5": timed out waiting for Ceph 14.2.5 to roll out
2023-03-29 09:00:59+00:00 Timeout waiting for Ceph version to be rolled out
2023-03-29 09:00:59+00:00 Checking Ceph versions and replicas
2023-03-29 09:00:59+00:00 rook-ceph-mgr-a  	req/upd/avl: 1/1/1  	ceph-version=14.2.5
2023-03-29 09:00:59+00:00 rook-ceph-mon-a  	req/upd/avl: 1/1/1  	ceph-version=14.2.5
2023-03-29 09:00:59+00:00 rook-ceph-mon-b  	req/upd/avl: 1/1/1  	ceph-version=14.2.5
2023-03-29 09:00:59+00:00 rook-ceph-mon-c  	req/upd/avl: 1/1/1  	ceph-version=14.2.5
2023-03-29 09:00:59+00:00 rook-ceph-osd-3  	req/upd/avl: 1/1/1  	ceph-version=14.2.0
2023-03-29 09:00:59+00:00 rook-ceph-osd-4  	req/upd/avl: 1/1/1  	ceph-version=14.2.0
2023-03-29 09:00:59+00:00 rook-ceph-osd-5  	req/upd/avl: 1/1/1  	ceph-version=14.2.0
2023-03-29 09:00:59+00:00 rook-ceph-rgw-rook-ceph-store-a  	req/upd/avl: 1/1/1  	ceph-version=14.2.5
2023-03-29 09:00:59+00:00 Detected multiple Ceph versions
2023-03-29 09:00:59+00:00 ceph-version=14.2.0
2023-03-29 09:00:59+00:00 ceph-version=14.2.5
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
+ collect_debug_info_after_kurl
2023-03-29 09:00:59+00:00 Failed to verify the Ceph upgrade, multiple Ceph versions detected
+ '[' 1 -ne 0 ']'
```

This PR adds a check to verify if the Pods are running prior verify if the upgrade rolls out. See that we are just warning so that it does not change the current behaviour and allows to verify the scenario as give more time for the upgrade occurs. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds check to verify if the Pod(s) are running for Rook upgrades from 1.x to 1.4.9. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
