### PR TITLE
increase the time to wait nodes be ready and output info

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -813,7 +813,7 @@ function check_network() {
     fi
 
     if ! kubernetes_any_node_ready; then
-        echo "Waiting up 10 minutes for node to report Ready"
+        echo "Waiting up to 10 minutes for node to report Ready"
         spinner_until 600 kubernetes_any_node_ready
     fi
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -813,8 +813,8 @@ function check_network() {
     fi
 
     if ! kubernetes_any_node_ready; then
-        echo "Waiting for node to report Ready"
-        spinner_until 300 kubernetes_any_node_ready
+        echo "Waiting to up 10 minutes for node to report Ready"
+        spinner_until 600 kubernetes_any_node_ready
     fi
 
     kubectl delete pods kurlnet-client kurlnet-server --force --grace-period=0 &>/dev/null || true
@@ -915,6 +915,8 @@ function kubernetes_any_node_ready() {
     if kubectl get nodes --no-headers 2>/dev/null | awk '{ print $2 }' | grep -v 'NotReady' | grep -q 'Ready' ; then
         return 0
     fi
+    # Output the nodes for we know more about the problem
+    kubectl get nodes
     return 1
 }
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -813,7 +813,7 @@ function check_network() {
     fi
 
     if ! kubernetes_any_node_ready; then
-        echo "Waiting to up 10 minutes for node to report Ready"
+        echo "Waiting up 10 minutes for node to report Ready"
         spinner_until 600 kubernetes_any_node_ready
     fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

See that we are checking the following issues scenarios in the testgrids: https://testgrid.kurl.sh/run/STAGING-daily-49d7bcf-2023-03-31T05:27:37Z?kurlLogsInstanceId=suaeoqzgwzzhgate&nodeId=suaeoqzgwzzhgate-initialprimary#L832

```
2023-03-31 05:54:41+00:00 ⚙  Checking cluster networking
2023-03-31 05:54:41+00:00 Checking if weave-net binary can be found in the path /opt/cni/bin/
2023-03-31 05:54:41+00:00 Unable to find weave-net binary, deleting weave-net pod so that the binary will be recreated
2023-03-31 05:54:41+00:00 pod "weave-net-prjzs" deleted
2023-03-31 05:54:51+00:00 Waiting for node to report Ready
2023-03-31 06:00:09+00:00  [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]   [|]   [/]   [-]   [\]  An error occurred on line 3457
+ KURL_EXIT_STATUS=1
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl install with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
2023-03-31 06:00:09+00:00 
2023-03-31 06:00:09+00:00 failed kurl install with exit status 1
2023-03-31 06:00:09+00:00 kubelet status
+ echo 'kubelet journalctl'
+ journalctl -xeu kubelet
```

Therefore, this PR increases the time to check if the node is Ready and output the nodes info for we are able to have further information in this case. 

Note that it works fine in the biggest part of the cases which lead us a timeout issue:

<img width="1649" alt="Screenshot 2023-03-31 at 08 18 35" src="https://user-images.githubusercontent.com/7708031/229050908-7beae615-857e-4040-816c-55c9a195a91a.png">


