### PR TITLE
add check preflight to ensure that ekco and kurl pods are running

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -15,8 +15,19 @@ function preflights() {
     allow_remove_docker_new_install
     bail_when_no_object_store_and_s3_enabled
     bail_if_unsupported_openebs_to_rook_version
+    bail_if_kurl_pods_are_unhealthy
     bail_if_kurl_version_is_lower_than_previous_config
     return 0
+}
+
+# if kurl pods like ekco not be running then we should bail
+function bail_if_kurl_pods_are_unhealthy() {
+    if commandExists kubectl; then
+      log "Awaiting 2 minutes to check Kulr Pod(s) are Running"
+      if ! spinner_until 120 check_for_running_pods kurl; then
+          bail "Kurl has unhealthy Pod(s). Check the namespace kurl. Restarting the pod may fix the issue."
+      fi
+    fi
 }
 
 function join_preflights() {


### PR DESCRIPTION
#### What this PR does / why we need it:

We need to start to ensure that kURL pods like ekco are running and are OK prior upgrades.

#### Which issue(s) this PR fixes:

Fixes # [sc-71717]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a check to ensure that kURL Pod(s) are running prior upgrades.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
