### PR TITLE
fix daily testgrid:  is missing minio

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1295,6 +1295,8 @@
       version: latest
     ekco:
       version: latest
+    minio:
+      version: latest
 - name: "Upgrade to 1.26 minimal airgap"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:

The test `Upgrade to 1.26 minimal` fails with the error:

```
2023-03-31 09:32:22+00:00 This is a prerelease version of kotsadm and should not be run in production. Continuing because this is testgrid.
2023-03-31 09:32:22+00:00 KOTS with s3 enabled requires an object store.
2023-03-31 09:32:22+00:00 Please ensure that your installer also provides an object store with either the MinIO or Rook add-on.
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
2023-03-31 09:32:22+00:00 
+ echo 'kubelet journalctl
```

Note that `Upgrade to 1.26 minimal aigap` either have minio in the upgrade.therefore, this PR adds minio to the upgrade spec which seems be missing.  For further info see: https://testgrid.kurl.sh/run/STAGING-daily-49d7bcf-2023-03-31T05:27:37Z

<img width="1240" alt="Screenshot 2023-03-31 at 11 46 50" src="https://user-images.githubusercontent.com/7708031/229100112-5b06651f-7703-44f0-a3e3-6522597a4279.png">




