### PR TITLE
chore: bring missing test command back.

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -248,6 +248,7 @@
       localPVStorageClassName: local
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     install_and_customize_kurl_integration_test_application
   postUpgradeScript: |
@@ -297,6 +298,7 @@
       localPVStorageClassName: local
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     install_and_customize_kurl_integration_test_application
   postUpgradeScript: |


### PR DESCRIPTION
these commands were removed by mistake. bringing them back should make some of our current test grid failures to dissappear.