### PR TITLE
migrate from longhorn with registry without object store should be blocked

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -789,7 +789,7 @@ function bail_if_unsupported_migration_from_longhorn_to_openebs() {
                 fi
                 # registry + openebs without rook requires minio
                 if [ -n "$REGISTRY_VERSION" ] && [ -z "$MINIO_VERSION" ]; then
-                    logFail "Migration from Longhorn with Registry required an object store."
+                    logFail "Migration from Longhorn with Registry requires an object store."
                     bail "Please ensure that your installer also provides an object store with MinIO add-on."
                 fi
             fi


### PR DESCRIPTION
#### What this PR does / why we need it:

The same check introduced when we are migrating from rook should be made when we are migrating from longhorn since it is the same case scenario. 

https://github.com/replicatedhq/kURL/blob/530779278521ef51285d7e7374d97bffbb811813/scripts/common/preflights.sh#L668-L670

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a preflight check to prevent unsupported migrations from Longhorn to OpenEBS versions earlier than 3.3.0 and without an object store when Registry is set.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
