### PR TITLE
adds checks to ensure that longhorn and openebs are healthy prior migration

### DIFF
--- a/addons/openebs/3.3.0/install.sh
+++ b/addons/openebs/3.3.0/install.sh
@@ -333,6 +333,20 @@ function openebs_maybe_migrate_from_longhorn() {
 }
 
 function openebs_maybe_longhorn_migration_checks() {
+    logStep "Running Longhorn to OpenEBS migration checks"
+
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     # get the list of StorageClasses that use longhorn
     local longhorn_scs
     local longhorn_default_sc
@@ -343,7 +357,7 @@ function openebs_maybe_longhorn_migration_checks() {
     log "Awaiting openebs-localpv-provisioner deployment"
     spinner_until 120 deployment_fully_updated openebs openebs-localpv-provisioner
 
-    log "Running Longhorn to OpenEBS migration checks ..."
+
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs

--- a/addons/openebs/3.4.0/install.sh
+++ b/addons/openebs/3.4.0/install.sh
@@ -333,6 +333,20 @@ function openebs_maybe_migrate_from_longhorn() {
 }
 
 function openebs_maybe_longhorn_migration_checks() {
+    logStep "Running Longhorn to OpenEBS migration checks"
+
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     # get the list of StorageClasses that use longhorn
     local longhorn_scs
     local longhorn_default_sc
@@ -343,7 +357,6 @@ function openebs_maybe_longhorn_migration_checks() {
     log "Awaiting openebs-localpv-provisioner deployment"
     spinner_until 120 deployment_fully_updated openebs openebs-localpv-provisioner
 
-    log "Running Longhorn to OpenEBS migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs

--- a/addons/openebs/3.5.0/install.sh
+++ b/addons/openebs/3.5.0/install.sh
@@ -333,6 +333,20 @@ function openebs_maybe_migrate_from_longhorn() {
 }
 
 function openebs_maybe_longhorn_migration_checks() {
+    logStep "Running Longhorn to OpenEBS migration checks"
+
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     # get the list of StorageClasses that use longhorn
     local longhorn_scs
     local longhorn_default_sc
@@ -343,7 +357,6 @@ function openebs_maybe_longhorn_migration_checks() {
     log "Awaiting openebs-localpv-provisioner deployment"
     spinner_until 120 deployment_fully_updated openebs openebs-localpv-provisioner
 
-    log "Running Longhorn to OpenEBS migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -333,6 +333,20 @@ function openebs_maybe_migrate_from_longhorn() {
 }
 
 function openebs_maybe_longhorn_migration_checks() {
+    logStep "Running Longhorn to OpenEBS migration checks"
+
+    log "Awaiting 2 minutes to check OpenEBS Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods "$OPENEBS_NAMESPACE"; then
+        logFail "OpenEBS has unhealthy Pod(s). Check the namespace $OPENEBS_NAMESPACE "
+        bail "Cannot upgrade from Rook to OpenEBS. OpenEBS is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     # get the list of StorageClasses that use longhorn
     local longhorn_scs
     local longhorn_default_sc
@@ -343,7 +357,6 @@ function openebs_maybe_longhorn_migration_checks() {
     log "Awaiting openebs-localpv-provisioner deployment"
     spinner_until 120 deployment_fully_updated openebs openebs-localpv-provisioner
 
-    log "Running Longhorn to OpenEBS migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs


### PR DESCRIPTION
#### What this PR does / why we need it:

Longhorn is deprecated. However, we should also check if it and OpenEBS are healthy prior the migrations. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-71717]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds checks to ensure that Longhorn and OpenEBS are healthy prior migration from Longhorn to OpenEBS.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
