### PR TITLE
fix storage testgrid : apply same rules migrate from longhorn

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -340,8 +340,6 @@
       version: 1.6.x
     flannel:
       version: 0.21.x
-    registry:
-      version: 2.8.1
     kotsadm:
       version: latest
       disableS3: true
@@ -355,14 +353,12 @@
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-    test_push_image_to_registry
     install_and_customize_kurl_integration_test_application
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     sleep 120
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     pvc_uses_provisioner "migration-test" "default" "openebs"
-    test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
     if kubectl get namespace/longhorn-system ; then
       echo Longhorn namespace found after the upgrade.
@@ -394,8 +390,6 @@
       version: 1.6.x
     flannel:
       version: 0.21.x
-    registry:
-      version: 2.8.1
     kotsadm:
       version: latest
       disableS3: true
@@ -409,14 +403,12 @@
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-    test_push_image_to_registry
     install_and_customize_kurl_integration_test_application
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     sleep 120
     download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
     pvc_uses_provisioner "migration-test" "default" "openebs"
-    test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
     if kubectl get namespace/longhorn-system ; then
       echo Longhorn namespace found after the upgrade.


### PR DESCRIPTION
#### What this PR does / why we need it:

The same rule applied to migrate from Rook without object store is now applied to Longhorn.
Therefore, we are doing here the same changes (removing registry and its specific checks ) from the tests where the upgrade has Registry but has not an Object Store.

Changed done for Migration from Rook
- Same remove Registry and checks : https://github.com/replicatedhq/kURL/pull/4269
- Follow up where we figure out that was missing an step: https://github.com/replicatedhq/kURL/pull/4317/files

Also, check the PR that adds the same check to Longhorn:
- https://github.com/replicatedhq/kURL/pull/4318


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
