### PR TITLE
adds health checks from longhorn to rook

### DIFF
--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -947,6 +947,18 @@ function rook_maybe_migrate_from_longhorn() {
 }
 
 function rook_maybe_longhorn_migration_checks() {
+    echo "Running Longhorn to Rook migration checks ..."
+
+    if ! rook_is_healthy_to_upgrade; then
+        bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     local rook_storage_class="$1"
 
     # get the list of StorageClasses that use longhorn
@@ -955,7 +967,6 @@ function rook_maybe_longhorn_migration_checks() {
     longhorn_scs=$(kubectl get storageclass | grep longhorn | grep -v '(default)' | awk '{ print $1}') # any non-default longhorn StorageClasses
     longhorn_default_sc=$(kubectl get storageclass | grep longhorn | grep '(default)' | awk '{ print $1}') # any default longhorn StorageClasses
 
-    echo "Running Longhorn to Rook migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -948,6 +948,18 @@ function rook_maybe_migrate_from_longhorn() {
 }
 
 function rook_maybe_longhorn_migration_checks() {
+    echo "Running Longhorn to Rook migration checks ..."
+
+    if ! rook_is_healthy_to_upgrade; then
+        bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     local rook_storage_class="$1"
 
     # get the list of StorageClasses that use longhorn
@@ -956,7 +968,6 @@ function rook_maybe_longhorn_migration_checks() {
     longhorn_scs=$(kubectl get storageclass | grep longhorn | grep -v '(default)' | awk '{ print $1}') # any non-default longhorn StorageClasses
     longhorn_default_sc=$(kubectl get storageclass | grep longhorn | grep '(default)' | awk '{ print $1}') # any default longhorn StorageClasses
 
-    echo "Running Longhorn to Rook migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -943,6 +943,18 @@ function rook_maybe_migrate_from_longhorn() {
 }
 
 function rook_maybe_longhorn_migration_checks() {
+    echo "Running Longhorn to Rook migration checks ..."
+
+    if ! rook_is_healthy_to_upgrade; then
+        bail "Cannot upgrade from Rook to OpenEBS. Rook Ceph is unhealthy."
+    fi
+
+    log "Awaiting 2 minutes to check Longhorn Pod(s) are Running"
+    if ! spinner_until 120 check_for_running_pods longhorn-system; then
+        logFail "Longhorn has unhealthy Pod(s). Check the namespace longhorn-system"
+        bail "Cannot upgrade from Longhorn to OpenEBS. Longhorn is unhealthy."
+    fi
+
     local rook_storage_class="$1"
 
     # get the list of StorageClasses that use longhorn
@@ -951,7 +963,6 @@ function rook_maybe_longhorn_migration_checks() {
     longhorn_scs=$(kubectl get storageclass | grep longhorn | grep -v '(default)' | awk '{ print $1}') # any non-default longhorn StorageClasses
     longhorn_default_sc=$(kubectl get storageclass | grep longhorn | grep '(default)' | awk '{ print $1}') # any default longhorn StorageClasses
 
-    echo "Running Longhorn to Rook migration checks ..."
     local longhorn_scs_pvmigrate_dryrun_output
     local longhorn_default_sc_pvmigrate_dryrun_output
     for longhorn_sc in $longhorn_scs


### PR DESCRIPTION
#### What this PR does / why we need it:

We need to check if longhorn and rook are healthy prior migrate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-71717]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds checks to ensure that Longhorn and Rook Ceph are healthy prior migration from Longhorn to Rook Ceph.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
