### PR TITLE
chore: add missing post install script

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -1026,6 +1026,13 @@
       envoyPodsNotReadyDuration: 5m
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
+  - ol-91 # docker is not supported on rhel 9 variants
+  - rocky-91 # docker is not supported on rhel 9 variants
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    install_and_customize_kurl_integration_test_application
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
@@ -1040,6 +1047,3 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-  unsupportedOSIDs:
-  - ol-91 # docker is not supported on rhel 9 variants
-  - rocky-91 # docker is not supported on rhel 9 variants


### PR DESCRIPTION
Somehow the `postInstallScript` of one of the storage migration testgrids went missing. This PR re-adds it.