### PR TITLE
chore: add missing "multi-node" to a testgrid name

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -692,7 +692,7 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: Migrate from Longhorn + Minio to OpenEBS + Minio
+- name: Migrate from Longhorn + Minio to OpenEBS + Minio (multi-node)
   flags: "yes"
   cpu: 6
   numPrimaryNodes: 1


### PR DESCRIPTION
We currently have two test grids with the same name, one in single and other in multi node clusters. This commit adds the "multi-node" title to the appropriate test.
