### PR TITLE
migrations from Longhorn to OpenEBS only require an object store if one already exists

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -789,8 +789,10 @@ function bail_if_unsupported_migration_from_longhorn_to_openebs() {
                 fi
                 # registry + openebs without rook requires minio
                 if [ -n "$REGISTRY_VERSION" ] && [ -z "$MINIO_VERSION" ]; then
-                    logFail "Migration from Longhorn with Registry requires an object store."
-                    bail "Please ensure that your installer also provides an object store with MinIO add-on."
+                    if kubectl get ns | grep -q minio; then
+                        logFail "Migration from Longhorn with Registry requires an object store."
+                        bail "Please ensure that your installer also provides an object store with MinIO add-on."
+                    fi
                 fi
             fi
         fi


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Currently migrations from Longhorn to OpenEBS with a registry but without an object store are blocked. However, when installed in a cluster without an object store, registry will use a PVC.

We block registry migrations from object store to no-object-store because there's no migration path at the moment, but pvc-to-pvc works just fine.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
