### PR TITLE
chore: Cleanup Oracle Linux (OL9) References since it's not supported

### DIFF
--- a/addons/containerd/1.6.10/host-preflight.yaml
+++ b/addons/containerd/1.6.10/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.11/host-preflight.yaml
+++ b/addons/containerd/1.6.11/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.12/host-preflight.yaml
+++ b/addons/containerd/1.6.12/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.13/host-preflight.yaml
+++ b/addons/containerd/1.6.13/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.14/host-preflight.yaml
+++ b/addons/containerd/1.6.14/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.15/host-preflight.yaml
+++ b/addons/containerd/1.6.15/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.16/host-preflight.yaml
+++ b/addons/containerd/1.6.16/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.18/host-preflight.yaml
+++ b/addons/containerd/1.6.18/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.19/host-preflight.yaml
+++ b/addons/containerd/1.6.19/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.20/host-preflight.yaml
+++ b/addons/containerd/1.6.20/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.4/host-preflight.yaml
+++ b/addons/containerd/1.6.4/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.6/host-preflight.yaml
+++ b/addons/containerd/1.6.6/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.7/host-preflight.yaml
+++ b/addons/containerd/1.6.7/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.8/host-preflight.yaml
+++ b/addons/containerd/1.6.8/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/1.6.9/host-preflight.yaml
+++ b/addons/containerd/1.6.9/host-preflight.yaml
@@ -33,11 +33,11 @@ spec:
               when: "rhel = 9"
               message: "containerd addon supports rhel 9"
           - pass:
-              when: "ol = 9"
-              message: "containerd addon supports ol 9"
-          - pass:
               when: "rocky = 9"
               message: "containerd addon supports rocky 9"
+          - fail:
+              when: "ol = 9"
+              message: "containerd addon does not support ol 9"
           - fail:
               when: "ubuntu = 16.04"
               message: "containerd addon does not support ubuntu 16.04"

--- a/addons/containerd/template/script.sh
+++ b/addons/containerd/template/script.sh
@@ -127,13 +127,13 @@ UNSUPPORTED_CONTAINERD_MINORS="01234"
 
 VERSIONS=()
 function find_common_versions() {
-    docker build --pull -t centos7 -f Dockerfile.centos7 .
-    docker build --pull -t centos8 -f Dockerfile.centos8 .
-    docker build --pull -t rhel9 -f Dockerfile.rhel9 .
-    docker build --pull -t ubuntu16 -f Dockerfile.ubuntu16 .
-    docker build --pull -t ubuntu18 -f Dockerfile.ubuntu18 .
-    docker build --pull -t ubuntu20 -f Dockerfile.ubuntu20 .
-    docker build --pull -t ubuntu22 -f Dockerfile.ubuntu22 .
+    docker build --no-cache --pull -t centos7 -f Dockerfile.centos7 .
+    docker build --no-cache --pull -t centos8 -f Dockerfile.centos8 .
+    docker build --no-cache --pull -t rhel9 -f Dockerfile.rhel9 .
+    docker build --no-cache --pull -t ubuntu16 -f Dockerfile.ubuntu16 .
+    docker build --no-cache --pull -t ubuntu18 -f Dockerfile.ubuntu18 .
+    docker build --no-cache --pull -t ubuntu20 -f Dockerfile.ubuntu20 .
+    docker build --no-cache --pull -t ubuntu22 -f Dockerfile.ubuntu22 .
 
     CENTOS7_VERSIONS=($(docker run --rm -i centos7 yum list --showduplicates containerd.io | grep -Eo '1\.[[:digit:]]+\.[[:digit:]]+' | grep -vE '1\.['"$UNSUPPORTED_CONTAINERD_MINORS"']\.' | sort -rV | uniq))
     echo "Found ${#CENTOS7_VERSIONS[*]} containerd versions for CentOS 7: ${CENTOS7_VERSIONS[*]}"
@@ -198,9 +198,11 @@ function find_common_versions() {
         else
             add_supported_os_to_preflight_file "$version" "centos" "9"
             add_supported_os_to_preflight_file "$version" "rhel" "9"
-            add_supported_os_to_preflight_file "$version" "ol" "9"
             add_supported_os_to_preflight_file "$version" "rocky" "9"
             add_supported_os_to_manifest_file "$version" "rhel-9" "Dockerfile.rhel9"
+
+            # exclude Oracle Linux 9 (OL 9) until we officially support it
+            add_unsupported_os_to_preflight_file "$version" "ol" "9"
         fi
 
         if ! contains "$version" ${UBUNTU16_VERSIONS[*]}; then

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -75,7 +75,6 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerSpec:
@@ -133,7 +132,6 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 
 - name: Upgrade Containerd from 1.2.x to __testver__
   installerSpec:
@@ -191,7 +189,6 @@
   - ol-79
   - ubuntu-2204
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 
 - name: Upgrade Containerd from 1.5.x to __testver__
   installerSpec:
@@ -233,7 +230,6 @@
     containerd --version | grep "__testver__"
   unsupportedOSIDs:
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 
 - name: "Upgrade Containerd from current to __testver__"
   installerSpec:

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -107,4 +107,3 @@
       s3Override: "__testdist__"
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -135,7 +135,6 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 
 - name: localpv migrate from Rook 1.0.4 with old versions
   flags: "yes"

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -72,7 +72,7 @@ function bailIfUnsupportedOS() {
             ;;
         amzn2)
             ;;
-        ol7.4|ol7.5|ol7.6|ol7.7|ol7.8|ol7.9|ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7|ol9.0|ol9.1)
+        ol7.4|ol7.5|ol7.6|ol7.7|ol7.8|ol7.9|ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7)
             ;;
         *)
             bail "Kubernetes install is not supported on ${LSB_DIST} ${DIST_VERSION}. The list of supported operating systems can be viewed at https://kurl.sh/docs/install-with-kurl/system-requirements."

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -38,7 +38,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s121
   installerSpec:
     kubernetes:
@@ -360,4 +359,3 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -26,7 +26,6 @@
   - ubuntu-2004 # docker 19.03.4 is not available on ubuntu 20.04
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s119x
   flags: "yes"
   installerSpec:
@@ -53,7 +52,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd149
   installerSpec:
     kubernetes:
@@ -79,7 +77,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120x_openebs_minio
   flags: "yes"
   installerSpec:
@@ -113,7 +110,6 @@
       version: 0.6.0
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s120x_docker
   flags: "yes"
   installerSpec:
@@ -142,7 +138,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s121x_containerd
   installerSpec:
     kubernetes:
@@ -172,7 +167,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x-airgap
   flags: "yes"
   installerSpec:
@@ -200,7 +194,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202
   flags: "yes"
   installerSpec:
@@ -224,7 +217,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.5 is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202_containerd
   installerSpec:
     kubernetes:
@@ -247,7 +239,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x_containerd148
   installerSpec:
     kubernetes:
@@ -273,7 +264,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x_containerd139
   installerSpec:
     kubernetes:
@@ -299,7 +289,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119
   flags: "yes"
   installerSpec:
@@ -326,7 +315,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s119-airgap
   flags: "yes"
   installerSpec:
@@ -354,7 +342,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd1412
   installerSpec:
     kubernetes:
@@ -380,7 +367,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_containerd146-airgap
   installerSpec:
     kubernetes:
@@ -407,7 +393,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_containerd_rook_block
   cpu: 6
   installerSpec:
@@ -436,7 +421,6 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_ctrd_longhorn
   installerSpec:
     kubernetes:
@@ -467,7 +451,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_ctrd_longhorn-airgap
   installerSpec:
     kubernetes:
@@ -499,7 +482,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_helm
   installerSpec:
     kubernetes:
@@ -556,7 +538,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120_minimal_containerd1411
   installerSpec:
     kubernetes:
@@ -572,7 +553,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_nameserver_collectd_rook_block
   flags: "yes"
   installerSpec:
@@ -598,7 +578,6 @@
   - ubuntu-2204 # docker 19.x and collectd-v5 are not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s119_selinux
   flags: "yes"
   installerSpec:
@@ -622,7 +601,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s120
   installerSpec:
     kubernetes:
@@ -650,7 +628,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120-airgap
   installerSpec:
     kubernetes:
@@ -679,7 +656,6 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s24x_rook_upgrade_17x_110x
   flags: "yes"
   cpu: 6
@@ -743,7 +719,6 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s121
   flags: "yes"
   installerSpec:
@@ -768,7 +743,6 @@
       version: latest
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s121-airgap
   flags: "yes"
   installerSpec:
@@ -794,7 +768,6 @@
   airgap: true
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio
   flags: "yes"
   installerSpec:
@@ -822,7 +795,6 @@
       version: 0.10.1
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio-airgap
   flags: "yes"
   installerSpec:
@@ -851,7 +823,6 @@
   airgap: true
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: remove_all_object_storage
   cpu: 7
   installerSpec:
@@ -941,7 +912,6 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "K8s 1.22x Airgap"
   cpu: 6
   installerSpec:
@@ -1026,7 +996,6 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerSpec:
@@ -1083,7 +1052,6 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: "K8s 1.24x Rook"
   cpu: 6
   installerSpec:
@@ -1111,7 +1079,6 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "K8s 1.26x Rook, disableS3"
   cpu: 6
   installerSpec:
@@ -1167,7 +1134,6 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "Upgrade to 1.24, weave to flannel"
   flags: "yes"
   cpu: 7
@@ -1209,7 +1175,6 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # docker is not supported on rhel 9 variants
-  - ol-91 # docker is not supported on rhel 9 variants
 - name: "Upgrade to 1.26 airgap"
   cpu: 6
   installerSpec:
@@ -1757,4 +1722,3 @@
       version: latest
   unsupportedOSIDs:
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-  - ol-91 # containerd < 1.6 is not supported on rhel 9 variants

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -58,12 +58,6 @@
   name: Rocky Linux
   version: "9.1"
   vmimageuri: https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20230215.0.x86_64.qcow2
-- id: ol-91
-  name: Oracle Linux
-  version: "9.1"
-  vmimageuri: https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow
-  preinit: |
-    yum install -y tar
 - id: ubuntu-1804
   name: Ubuntu
   version: "18.04"

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -874,7 +874,6 @@
        exit 1
     fi
   unsupportedOSIDs:
-  - ol-91 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   - ubuntu-2204 # Docker versions < 20.10.17 not supported on ubuntu 22.04
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
@@ -1026,7 +1025,6 @@
       envoyPodsNotReadyDuration: 5m
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - ol-91 # docker is not supported on rhel 9 variants
   - rocky-91 # docker is not supported on rhel 9 variants
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We initially introduced RHEL9 support in https://github.com/replicatedhq/kURL/pull/4175 and thought we can get Oracle Linux 9 support incidentally. However, OL9 does not work and requires dedicated effort to get it completely working. As a result, this PR removes references/support for OL9.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [sc-50954](https://app.shortcut.com/replicated/story/50954/support-rhel-9)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE