### PR TITLE
fix(testgrid): use openebs for weave to flannel migration test

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1134,7 +1134,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
-- name: "Upgrade to 1.24, weave to flannel"
+- name: "Upgrade to 1.24, disable s3, weave to flannel"
   flags: "yes"
   cpu: 7
   installerSpec:
@@ -1144,14 +1144,10 @@
       version: latest
     rook:
       version: 1.9.x
-    registry:
-      version: latest
     kotsadm:
       version: latest
     docker:
       version: 20.10.x
-    velero:
-      version: 1.8.x
     ekco:
       version: latest
   upgradeSpec:
@@ -1159,17 +1155,15 @@
       version: 1.24.x
     flannel:
       version: latest
-    longhorn:
+    openebs:
       version: latest
-    registry:
-      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: local
     kotsadm:
       version: latest
       disableS3: true
     containerd:
       version: latest
-    velero:
-      version: 1.9.x
     ekco:
       version: latest
   unsupportedOSIDs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Tests are failing

https://testgrid.kurl.sh/run/STAGING-daily-0c5e749-2023-04-05T01:22:07Z?kurlLogsInstanceId=mbqxeppnwemxiriw&nodeId=mbqxeppnwemxiriw-initialprimary

```
2023-04-05 07:01:18+00:00 Copying data from default PVCs to longhorn PVCs
2023-04-05 07:01:18+00:00 Copying data from kotsadm-rqlite-kotsadm-rqlite-0 (pvc-04598ff6-37fa-4705-a076-b12e48c75631) to kotsadm-rqlite-kotsadm-rqlite-0-pvcmigrate in default
2023-04-05 07:01:18+00:00 Creating pvc migrator pod on node mbqxeppnwemxiriw-initialprimary
2023-04-05 07:01:18+00:00 waiting for pod migrate-kotsadm-rqlite-kotsadm-rqlite-0 to start in default
+ KURL_EXIT_STATUS=124
```

Customers should no longer be migrating to longhorn. I am trying to eliminate the possibility that longhorn is the issue and instead use openebs.