### PR TITLE
chore: disable containerd 1.2 on centos 74, 79 and ol-79

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1774,6 +1774,9 @@
   unsupportedOSIDs:
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
+  - centos-74 # containerd 1.2.x does not install on centos-7
+  - centos-79 # containerd 1.2.x does not install on centos-7
+  - ol-79 # containerd 1.2.x does not install on oracle-linux-7
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
@@ -1790,7 +1793,7 @@
     flannel:
       version: latest
     containerd:
-      version: 1.2.x
+      version: 1.3.x
     openebs:
       version: latest
       isLocalPVEnabled: true
@@ -1803,7 +1806,7 @@
     flannel:
       version: latest
     containerd:
-      version: 1.4.x
+      version: 1.5.x
     openebs:
       version: latest
       isLocalPVEnabled: true


### PR DESCRIPTION
Attempts to install containerd on these versions fail with

```
2023-04-06 05:30:28+00:00 ⚙  Addon containerd 1.2.13
2023-04-06 05:30:29+00:00 containerd: symbol lookup error: containerd: undefined symbol: seccomp_api_set
2023-04-06 05:30:29+00:00 An error occurred on line 53
+ KURL_EXIT_STATUS=1
```