### PR TITLE
chore: cluster and instance identifier improvements

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -871,12 +871,18 @@ MACHINE_ID=
 KURL_INSTANCE_UUID=
 function get_machine_id() {
     MACHINE_ID="$(${DIR}/bin/kurl host protectedid || true)"
-    if [ -f /var/lib/kurl/uuid ]; then
-        KURL_INSTANCE_UUID="$(cat /var/lib/kurl/uuid)"
+    if [ -f /etc/kurl/uuid ]; then
+        KURL_INSTANCE_UUID="$(cat /etc/kurl/uuid)"
     else
-        KURL_INSTANCE_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
-        mkdir -p /var/lib/kurl
-        echo "$KURL_INSTANCE_UUID" > /var/lib/kurl/uuid
+        if [ -f /var/lib/kurl/uuid ]; then
+            KURL_INSTANCE_UUID="$(cat /var/lib/kurl/uuid)"
+            rm -f /var/lib/kurl/uuid
+        else
+            KURL_INSTANCE_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
+        fi
+        # use /etc/kurl to persist the instance id "machine id" across cluster reset
+        mkdir -p /etc/kurl
+        echo "$KURL_INSTANCE_UUID" > /etc/kurl/uuid
     fi
 }
 

--- a/scripts/common/reporting.sh
+++ b/scripts/common/reporting.sh
@@ -266,18 +266,30 @@ function stacktrace {
     echo "$totalStack"
 }
 
-# if the kurl_cluster_uuid configmap exists, set the KURL_CLUSTER_UUID env var to the value in the configmap.
-# if it does not exist, make a new UUID for KURL_CLUSTER_UUID.
+# attempt_get_cluster_id will get the cluster uuid from the kurl_cluster_uuid configmap and set the
+# KURL_CLUSTER_UUID env var. If it does not exist or the cluster is down, check the disk to see if
+# it is persisted there, otherwise make a new UUID for KURL_CLUSTER_UUID and save to disk.
 function attempt_get_cluster_id() {
-    if ! kubernetes_resource_exists kurl configmap kurl-cluster-uuid; then
-        KURL_CLUSTER_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
-        return 0
+    if ! kubernetes_resource_exists kurl configmap kurl-cluster-uuid ; then
+        # If the cluster is down, check to see if this is an etcd member and the cluster uuid is
+        # persisted to disk.
+        if [ -d /var/lib/etcd/member ] && [ -f /var/lib/kurl/clusteruuid ]; then
+            KURL_CLUSTER_UUID=$(cat /var/lib/kurl/clusteruuid)
+        else
+            KURL_CLUSTER_UUID=$(< /dev/urandom tr -dc a-z0-9 | head -c32)
+        fi
+    else
+        KURL_CLUSTER_UUID=$(kubectl get configmap -n kurl kurl-cluster-uuid -o jsonpath='{.data.kurl_cluster_uuid}')
     fi
 
-    KURL_CLUSTER_UUID=$(kubectl get configmap -n kurl kurl-cluster-uuid -o jsonpath='{.data.kurl_cluster_uuid}')
+    # Persist the cluster uuid to disk in case the cluster is down.
+    # The tasks.sh reset command will remove the /var/lib/kurl directory and the cluster uuid will
+    # be regenerated if reset.
+    echo "$KURL_CLUSTER_UUID" > /var/lib/kurl/clusteruuid
 }
 
-# if the kurl_cluster_uuid configmap does not exist, create it using the KURL_CLUSTER_UUID env var
+# maybe_set_kurl_cluster_uuid will create the kurl_cluster_uuid configmap using the
+# KURL_CLUSTER_UUID env var if it does not already exist.
 function maybe_set_kurl_cluster_uuid() {
     if [ -z "$KURL_CLUSTER_UUID" ]; then
         return 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

I am not sure that we need this as this is up for discussion. This pr attempts to solve 2 problems:

1. The instance ID should persist across resets for the possibility of reporting a better time to live
2. The cluster ID should not regenerate if the apiserver happens to be unreachable at the start of the script 
