### PR TITLE
fix(preflights): do not run some preflights on join or upgrade

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -1,4 +1,5 @@
 
+# preflights are run on all nodes for init.sh, join.sh, and upgrade.sh
 function preflights() {
     require64Bit
     bailIfUnsupportedOS
@@ -10,9 +11,14 @@ function preflights() {
     must_disable_selinux
     apply_iptables_config
     cri_preflights
-    kotsadm_prerelease
     host_nameservers_reachable
     allow_remove_docker_new_install
+    return 0
+}
+
+# init_preflights are only run on the first node init.sh
+function init_preflights() {
+    kotsadm_prerelease
     bail_when_no_object_store_and_s3_enabled
     bail_if_kurl_pods_are_unhealthy
     bail_if_unsupported_migration_from_rook_to_openebs
@@ -638,7 +644,7 @@ function cluster_preflights() {
         return
     fi
 
-    logStep "Running on cluster Preflights"
+    logStep "Running in cluster Preflights"
     mkdir -p "${DIR}/${IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR}"
 
     if [ ! "${HOST_PREFLIGHT_ENFORCE_WARNINGS}" = "1" ] ; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -547,6 +547,7 @@ function main() {
     trap ctrl_c SIGINT # trap ctrl+c (SIGINT) and handle it by reporting that the user exited intentionally (along with the line/version/etc)
     trap trap_report_error ERR # trap errors and handle it by reporting the error line and parent function
     preflights
+    init_preflights
     common_prompts
     journald_persistent
     configure_proxy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Separates init preflights from join and upgrade. Only run spec validation and pod health check preflights on init.

Fixes the following issue on upgrading secondary nodes due to pods being down as the node is cordoned and drained:

```
Awaiting 2 minutes to check kURL Pod(s) are Running
Kurl has unhealthy Pod(s). Check the namespace kurl. Restarting the pod may fix the issue.
```

Fixes the following issue on upgrading worker nodes due to 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

This was never release so no release note is necessary.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
