### PR TITLE
fix(preflights): do not run in-cluster preflights on upgrade

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -133,7 +133,6 @@ function main() {
     kubernetes_get_packages
     preflights_require_host_packages
     host_preflights "${MASTER:-0}" "1" "1"
-    cluster_preflights "${MASTER:-0}" "1" "1"
     install_host_dependencies
     get_common
     setup_kubeadm_kustomize


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

In cluster preflights are failing on workers with the following error. They are not necessary on upgrades at all since the upgrade command is a task command used by install.sh.

```
⚙  Running on cluster Preflights
W0406 22:21:28.521226   79828 loader.go:222] Config not found: /etc/kubernetes/admin.conf
Error: run preflight: collect results: failed to check RBAC for collectors: failed to run subject review: Post "http://localhost:8080/apis/authorization.k8s.io/v1/selfsubjectaccessreviews": dial tcp 127.0.0.1:8080: connect: connection refused
On cluster Preflights checks have failures that block the installation.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

This was never release so no release note is necessary.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
