### PR TITLE
recreate flannel pods after upgrading k8s on each node

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -91,7 +91,7 @@ function upgrade_kubernetes_local_master_patch() {
 
     spinner_kubernetes_api_stable
     kubectl uncordon "$node"
-    delete_node_flannel "$node"
+    upgrade_delete_node_flannel "$node"
 
     spinner_until 120 kubernetes_node_has_version "$node" "$k8sVersion"
     spinner_until 120 kubernetes_all_nodes_ready
@@ -164,7 +164,7 @@ function upgrade_kubernetes_remote_node_patch() {
     logSuccess "Kubernetes $KUBERNETES_VERSION detected on $nodeName"
 
     kubectl uncordon "$nodeName"
-    delete_node_flannel "$nodeName"
+    upgrade_delete_node_flannel "$nodeName"
 }
 
 function upgrade_kubernetes_local_master_minor() {
@@ -199,7 +199,7 @@ function upgrade_kubernetes_local_master_minor() {
 
     spinner_kubernetes_api_stable
     kubectl uncordon "$node"
-    delete_node_flannel "$node"
+    upgrade_delete_node_flannel "$node"
 
     # force deleting the cache because the api server will use the stale API versions after kubeadm upgrade
     rm -rf $HOME/.kube
@@ -275,7 +275,7 @@ function upgrade_kubernetes_remote_node_minor() {
     logSuccess "Kubernetes $targetK8sVersion detected on $nodeName"
 
     kubectl uncordon "$nodeName"
-    delete_node_flannel "$nodeName"
+    upgrade_delete_node_flannel "$nodeName"
     spinner_until 120 kubernetes_all_nodes_ready
 }
 
@@ -321,7 +321,8 @@ function upgrade_maybe_remove_kubeadm_network_plugin_flag() {
 }
 
 # delete the flannel pod on the node so that CNI plugin binaries are recreated
-function delete_node_flannel() {
+# workaround for https://github.com/kubernetes/kubernetes/issues/115629
+function upgrade_delete_node_flannel() {
     local node="$1"
 
     if kubectl get ns kube-flannel 2>/dev/null; then

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -325,6 +325,6 @@ function delete_node_flannel() {
     local node="$1"
 
     if kubectl get ns kube-flannel 2>/dev/null; then
-        kubectl get pod -n kube-flannel -o name --field-selector="spec.nodeName=$node" | xargs -I {} kubectl delete -n kube-flannel {}
+        kubectl delete pod -n kube-flannel --field-selector="spec.nodeName=$node"
     fi
 }

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -91,6 +91,7 @@ function upgrade_kubernetes_local_master_patch() {
 
     spinner_kubernetes_api_stable
     kubectl uncordon "$node"
+    delete_node_flannel "$node"
 
     spinner_until 120 kubernetes_node_has_version "$node" "$k8sVersion"
     spinner_until 120 kubernetes_all_nodes_ready
@@ -163,6 +164,7 @@ function upgrade_kubernetes_remote_node_patch() {
     logSuccess "Kubernetes $KUBERNETES_VERSION detected on $nodeName"
 
     kubectl uncordon "$nodeName"
+    delete_node_flannel "$nodeName"
 }
 
 function upgrade_kubernetes_local_master_minor() {
@@ -197,6 +199,7 @@ function upgrade_kubernetes_local_master_minor() {
 
     spinner_kubernetes_api_stable
     kubectl uncordon "$node"
+    delete_node_flannel "$node"
 
     # force deleting the cache because the api server will use the stale API versions after kubeadm upgrade
     rm -rf $HOME/.kube
@@ -272,6 +275,7 @@ function upgrade_kubernetes_remote_node_minor() {
     logSuccess "Kubernetes $targetK8sVersion detected on $nodeName"
 
     kubectl uncordon "$nodeName"
+    delete_node_flannel "$nodeName"
     spinner_until 120 kubernetes_all_nodes_ready
 }
 
@@ -314,4 +318,13 @@ function upgrade_maybe_remove_kubeadm_network_plugin_flag() {
         return
     fi
     sed -i 's/ \?--network-plugin \?[^ "]*//' /var/lib/kubelet/kubeadm-flags.env
+}
+
+# delete the flannel pod on the node so that CNI plugin binaries are recreated
+function delete_node_flannel() {
+    local node="$1"
+
+    if kubectl get ns kube-flannel 2>/dev/null; then
+        kubectl get pod -n kube-flannel -o name --field-selector="spec.nodeName=$node" | xargs -I {} kubectl delete -n kube-flannel {}
+    fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

If kubernetes-cni is upgraded, then the flannel plugin binaries are deleted.

Recreating the pod recreates the binaries.

This happens today, but as part of the flannel addon process, which happens after _all_ nodes have been updated - leading to network downtime.

This PR adds a step to clear the flannel pod(s) on a node after _that particular node_ has been updated, preventing all nodes from losing networking at once.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
