### PR TITLE
OL 8.7 is unsupported for kURL version v2022.08.23-0

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -1144,6 +1144,7 @@
     weave:
       version: 2.6.5-20221025
   unsupportedOSIDs:
+  - ol-8x # The kURL version used in this test, v2022.08.23-0, does not support OL-8.7
   - ubuntu-2204 # docker 19.03.4 is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
   postInstallScript: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fix testgrid test, _Cust 1 - Migrate from Rook+OpenEBS 1.6.0 to OpenEBS 3.3.0 (Kubernetes 1.19.x to 1.21.x)_ in the daily storage migration by marking it `Unsupported` for Oracle Linux 8x.

https://testgrid.kurl.sh/run/STAGING-daily-storage-migration-8726614-2023-04-11T01:27:46Z?kurlLogsInstanceId=tzvpapoamucslcpo&nodeId=tzvpapoamucslcpo-initialprimary#L7854

<img width="2077" alt="image" src="https://user-images.githubusercontent.com/6497491/231226861-a8b460c7-8c35-4094-ac27-54ff17e842d5.png">
 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
