### PR TITLE
fix(testgrid): broken kotsadm version prevents installs and upgrades

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -1233,7 +1233,7 @@
     goldpinger:
       version: 3.7.0-5.5.0
     kotsadm:
-      version: 1.93.0
+      version: 1.96.3
     kubernetes:
       version: 1.23.x # (replicated) changed to .x version
     minio:
@@ -1287,7 +1287,7 @@
     goldpinger:
       version: 3.7.0-5.5.0
     kotsadm:
-      version: 1.93.0
+      version: 1.96.3
     kubernetes:
       version: 1.23.15
     kurl:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Kots add-on version 1.93.0 has a bug on multi-node clusters and will fail upgrade with the following error:

```
The kotsadm-rqlite statefulset in the kotsadm addon failed to deploy successfully.
```

this is fixed in 1.96.3

see release note

https://docs.replicated.com/release-notes/rn-app-manager#1962

> Fixes a bug where multi-node embedded cluster installations hang indefinitely with the KOTS add-on.