### PR TITLE
fix(container): migration from docker on remove nodes fails with downgrade not supported message

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -142,8 +142,6 @@ function upgrade_kubernetes_remote_node_patch() {
     confirmY
     kubernetes_drain "$nodeName"
 
-    maybe_patch_node_cri_socket_annotation "$nodeName"
-
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
     common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${NO_PROXY_ADDRESSES}" "${NO_PROXY_ADDRESSES}")"
@@ -249,8 +247,6 @@ function upgrade_kubernetes_remote_node_minor() {
     printf "\n${YELLOW}Drain node $nodeName to prepare for upgrade? ${NC}"
     confirmY
     kubernetes_drain "$nodeName"
-
-    maybe_patch_node_cri_socket_annotation "$nodeName"
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When migrating from docker to containerd, running the upgrade script on remote nodes fails with error:

```
Downgrading containerd (from v1.6.18 to v1.4.6) is not supported.
```

This is because the primary script [annotates](https://github.com/replicatedhq/kURL/pull/2863/files#diff-a1f3c001e0406a79e95cc96411af439600d0a27ce32abcdd6662013918ca4636R247) the remote nodes (`node/ethanm-swimlane-42 annotated`).

```
Drain node ethanm-swimlane-42 to prepare for upgrade? (Y/n) y
node/ethanm-swimlane-42 cordoned
...
pod/rook-ceph-rgw-rook-ceph-store-a-d868cfbff-lzmdr evicted
node/ethanm-swimlane-42 evicted
node/ethanm-swimlane-42 annotated


	Run the upgrade script on remote node to proceed: ethanm-swimlane-42
```

Then the upgrade script tries to [detect](https://github.com/replicatedhq/kURL/blob/1d2a5f5374c644539d758ab55cb88ee4befdde4d/scripts/common/containerd.sh#L17) if the cri is docker to determine if this is a migration from docker or a containerd upgrade. It determines it is an upgrade (downgrade) and bails.

The code to annotate the node was originally added [here](https://github.com/replicatedhq/kURL/pull/2863) to work around [this](https://github.com/kubernetes/kubeadm/issues/2364) issue in kubeadm. Since that code was added, [more code](https://github.com/replicatedhq/kURL/pull/3452/files#diff-d7e09d279266e8ee992d353f17919f6791ae4e62235c299577d0fd585624c5afR201) was added to patch a different issue but has the same effect. This change will prefer the latter code and remove the former.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

install https://kurl.sh/83a4787 on 2+ nodes
upgrade to https://staging.kurl.sh/10316b5

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes migrations from Docker to Containerd on multi-node clusters to fail with error "Downgrading containerd is not supported"
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE