### PR TITLE
bump: upgrade replicatedhq/plumber to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.0
 	github.com/replicatedhq/kurlkinds v1.3.0
-	github.com/replicatedhq/plumber v1.16.0
+	github.com/replicatedhq/plumber/v2 v2.0.0
 	github.com/replicatedhq/pvmigrate v0.9.0
 	github.com/replicatedhq/troubleshoot v0.59.0
 	github.com/rook/rook v1.11.2

--- a/go.sum
+++ b/go.sum
@@ -2004,8 +2004,8 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/replicatedhq/kurlkinds v1.3.0 h1:kVdWMJOAB3LMIcMt0TxQWN7fm/ck1ZzqoA/MCwJ9tCo=
 github.com/replicatedhq/kurlkinds v1.3.0/go.mod h1:9Pw0nQLzOoGbjj6Q9FnmSgY128btPjFlP5VOm5YsjUQ=
-github.com/replicatedhq/plumber v1.16.0 h1:PEFbLBJwlAyzrzwl7Cwf4mrV2opUhiaYWQeQ/uZ6Ztg=
-github.com/replicatedhq/plumber v1.16.0/go.mod h1:uKAxJWp60+FNtfm3T5rEPzp9SA2+9icY++KHatQGpy0=
+github.com/replicatedhq/plumber/v2 v2.0.0 h1:Wns7YJJCGmU589Yyo+vmfi8B+1c0R84y68qSRcK4Ghs=
+github.com/replicatedhq/plumber/v2 v2.0.0/go.mod h1:seRCMUymCb8PPFw+pH1OefvKVSi5EgSo4HEMYpCW6Io=
 github.com/replicatedhq/pvmigrate v0.9.0 h1:p9+Y4RonMAxs1RoDv6ngZnKq9ACNQrGqGa57WnzcyI0=
 github.com/replicatedhq/pvmigrate v0.9.0/go.mod h1:RYs9n/dvb2x5hS4ULKxcnUMTlS2lcmK550chaif+ARE=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/pkg/k8sutil/apply.go
+++ b/pkg/k8sutil/apply.go
@@ -6,7 +6,7 @@ import (
 	"embed"
 	"os/exec"
 
-	"github.com/replicatedhq/plumber"
+	"github.com/replicatedhq/plumber/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
@@ -21,7 +21,7 @@ func KubectlApply(ctx context.Context, cli client.Client, resources embed.FS, ov
 		),
 	}, opts...)
 
-	err := plumber.NewRenderer(cli, resources, options...).Render(
+	err := plumber.NewRenderer(cli, resources, options...).Apply(
 		ctx, overlay,
 	)
 	return err

--- a/pkg/rook/flexvolume.go
+++ b/pkg/rook/flexvolume.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kurl/pkg/k8sutil"
 	"github.com/replicatedhq/kurl/pkg/rook/static/flexmigrator"
-	"github.com/replicatedhq/plumber"
+	"github.com/replicatedhq/plumber/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Upgrades to the newer version of plumber as it provides other facilities that are going to be useful.