### PR TITLE
chore: allow s3Override in dev env

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -42,7 +42,7 @@ function package_download() {
     local package="$1"
     local url_override="$2"
 
-    if [ -z "${DIST_URL}" ]; then
+    if [ -z "$url_override" ] && [ -z "${DIST_URL}" ]; then
         logWarn "DIST_URL not set, will not download $1"
         return
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Allows for specs with s3Override in the dev environment. Previously installations would fail with the following error:

```
Previous kURL version used to install or update the cluster is v2023.04.11-0
DIST_URL not set, will not download kotsadm-1.90.0.tar.gz
tar: assets/kotsadm-1.90.0.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
An error occurred on line 252
```