### PR TITLE
fix: dev env upgrade from prod

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -831,11 +831,15 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
         return
     fi
 
-    semverCompare "$(echo "$KURL_VERSION" | sed 's/v//g')" "$(echo "$previous_kurl_version" | sed 's/v//g')"
-    if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 14.2.21
-        logFail "The current kURL release version $KURL_VERSION is less than the previously installed version $previous_kurl_version."
-        bail "Please use a kURL release version which is equal to or greater than the version used previously."
+    if [ -n "$KURL_VERSION" ]; then
+        semverCompare "$(echo "$KURL_VERSION" | sed 's/v//g')" "$(echo "$previous_kurl_version" | sed 's/v//g')"
+        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 14.2.21
+            logFail "The current kURL release version $KURL_VERSION is less than the previously installed version $previous_kurl_version."
+            bail "Please use a kURL release version which is equal to or greater than the version used previously."
+        fi
     fi
     log "Previous kURL version used to install or update the cluster is $previous_kurl_version"
-    log "and the current kURL version used is $KURL_VERSION"
+    if [ -n "$KURL_VERSION" ]; then
+        log "and the current kURL version used is $KURL_VERSION"
+    fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes an issue where installing with prod or staging and upgrading with the dev env fails with the following error:

```
$ cat install.sh | sudo bash -s ha
⚙  Running install with the argument(s): ha
SELinux is not installed: no configuration will be applied
Awaiting 2 minutes to check kURL Pod(s) are Running
The current kURL release version  is less than the previously installed version v2023.04.11-0.
Please use a kURL release version which is equal to or greater than the version used previously.
```