### PR TITLE
fix: false positives when checking for node missing images

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -31,6 +31,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 
 	clusterCmd := NewClusterCmd(cli)
 	clusterCmd.AddCommand(NewClusterNodesMissingImageCmd(cli))
+	clusterCmd.AddCommand(NewClusterNodeListMissingImageCmd(cli))
 	clusterCmd.AddCommand(NewClusterCheckFreeDiskSpaceCmd(cli))
 	clusterCmd.AddCommand(newPreflightCmd(cli))
 	cmd.AddCommand(clusterCmd)

--- a/scripts/common/kubernetes-test.sh
+++ b/scripts/common/kubernetes-test.sh
@@ -5,44 +5,6 @@ set -e
 . ./scripts/common/common.sh
 . ./scripts/common/kubernetes.sh
 
-function test_kubernetes_node_has_image() {
-    function kubernetes_node_images() {
-        echo "docker.io/org/image-1:1.0
-org/image-2:1.0
-image-3:1.0
-library/image-4:1.0
-quay.io/org/image-5:1.0
-quay.io/org/image-6"
-    }
-    export kubernetes_node_images
-
-    assertEquals "docker.io/org/image-1:1.0 org/image-1:1.0" "0" "$(kubernetes_node_has_image "node-1" "org/image-1:1.0"; echo $?)"
-    assertEquals "docker.io/org/image-1:1.0 docker.io/org/image-1:1.0" "0" "$(kubernetes_node_has_image "node-1" "docker.io/org/image-1:1.0"; echo $?)"
-
-    assertEquals "org/image-2:1.0 org/image-2:1.0" "0" "$(kubernetes_node_has_image "node-1" "org/image-2:1.0"; echo $?)"
-    assertEquals "org/image-2:1.0 docker.io/org/image-2:1.0" "0" "$(kubernetes_node_has_image "node-1" "docker.io/org/image-2:1.0"; echo $?)"
-
-    assertEquals "image-3:1.0 image-3:1.0" "0" "$(kubernetes_node_has_image "node-1" "image-3:1.0"; echo $?)"
-    assertEquals "image-3:1.0 library/image-3:1.0" "0" "$(kubernetes_node_has_image "node-1" "library/image-3:1.0"; echo $?)"
-    assertEquals "image-3:1.0 docker.io/library/image-3:1.0" "0" "$(kubernetes_node_has_image "node-1" "docker.io/library/image-3:1.0"; echo $?)"
-
-    assertEquals "library/image-4:1.0 image-4:1.0" "0" "$(kubernetes_node_has_image "node-1" "image-4:1.0"; echo $?)"
-    assertEquals "library/image-4:1.0 library/image-4:1.0" "0" "$(kubernetes_node_has_image "node-1" "library/image-4:1.0"; echo $?)"
-    assertEquals "library/image-4:1.0 docker.io/library/image-4:1.0" "0" "$(kubernetes_node_has_image "node-1" "docker.io/library/image-4:1.0"; echo $?)"
-
-    assertEquals "quay.io/org/image-5:1.0 quay.io/org/image-5:1.0" "0" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-5:1.0"; echo $?)"
-
-    assertEquals "quay.io/org/image-6 quay.io/org/image-6" "0" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-6"; echo $?)"
-    assertEquals "quay.io/org/image-6 quay.io/org/image-6:latest" "0" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-6:latest"; echo $?)"
-
-    assertEquals "org/image-n:1.0" "1" "$(kubernetes_node_has_image "node-1" "org/image-n:1.0"; echo $?)"
-    assertEquals "image-n:1.0" "1" "$(kubernetes_node_has_image "node-1" "image-n:1.0"; echo $?)"
-    assertEquals "docker.io/org/image-n:1.0" "1" "$(kubernetes_node_has_image "node-1" "docker.io/org/image-n:1.0"; echo $?)"
-    assertEquals "quay.io/org/image-n:1.0" "1" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-n:1.0"; echo $?)"
-    assertEquals "quay.io/org/image-n" "1" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-n"; echo $?)"
-    assertEquals "quay.io/org/image-5:2.0" "1" "$(kubernetes_node_has_image "node-1" "quay.io/org/image-5:2.0"; echo $?)"
-}
-
 function test_kubernetes_version_minor() {
     assertEquals "v1.20.0" "20" "$(kubernetes_version_minor "v1.20.0")"
     assertEquals "v1.20.0" "20" "$(kubernetes_version_minor "1.20.0")"

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -649,7 +649,7 @@ function kubernetes_node_has_all_images() {
     local node_name="$1"
 
     local image_list=
-    image_list="$(kubernetes_node_list_missing_images "$(list_all_required_images | paste -sd " " -)" "$node_name")"
+    image_list="$(kubernetes_node_list_missing_images "$(list_all_required_images)" "$node_name")"
     image_list="$(echo "$image_list" | xargs)" # trim whitespace
 
     if [ -n "$image_list" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The current functionality to list missing images uses the node object which only lists the first 50 images. This creates a false positives if an image does is not in this first 50. The new functionality added leverages the existing job code that mounts the cri socket to get a comprehensive list of images.

See an example false positive below:

```
Have images been loaded on node ethanm-24? (y/N) y

Node ethanm-24 missing image(s) registry.k8s.io/pause:3.6 registry.k8s.io/coredns/coredns:v1.8.6 registry.k8s.io/pause:3.5 registry.k8s.io/pause:3.6 ghcr.io/projectcontour/contour:v1.23.2 haproxy:2.7.6-alpine3.17 docker.io/flannel/flannel-cni-plugin:v1.1.2 rqlite/rqlite:7.10.0 registry:2.8.1 velero/velero-restic-restore-helper:v1.9.5 gcr.io/velero-gcp/velero-restic-restore-helper:v1.9.5 velero/velero-plugin-for-aws:v1.6.0 velero/velero-plugin-for-gcp:v1.6.0 velero/velero-plugin-for-microsoft-azure:v1.6.0
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could cause kURL to erroneously prompt the user to run the load-images task when upgrading clusters that have many container images.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE