### PR TITLE
feat: implement node connectivity check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
+	k8s.io/cli-runtime v0.26.2
 	k8s.io/client-go v0.26.3
 	k8s.io/code-generator v0.26.3
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
@@ -250,7 +251,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	k8s.io/apiextensions-apiserver v0.26.3 // indirect
 	k8s.io/apiserver v0.26.3 // indirect
-	k8s.io/cli-runtime v0.26.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230217203603-ff9a8e8fa21d // indirect
 	oras.land/oras-go v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.0
 	github.com/replicatedhq/kurlkinds v1.3.0
-	github.com/replicatedhq/plumber v1.16.0
+	github.com/replicatedhq/plumber/v2 v2.2.0
 	github.com/replicatedhq/pvmigrate v0.9.0
 	github.com/replicatedhq/troubleshoot v0.59.0
 	github.com/rook/rook v1.11.2
@@ -252,7 +252,7 @@ require (
 	k8s.io/apiserver v0.26.3 // indirect
 	k8s.io/cli-runtime v0.26.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3 // indirect
+	k8s.io/kube-openapi v0.0.0-20230217203603-ff9a8e8fa21d // indirect
 	oras.land/oras-go v1.2.2 // indirect
 	periph.io/x/host/v3 v3.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -2004,8 +2004,8 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/replicatedhq/kurlkinds v1.3.0 h1:kVdWMJOAB3LMIcMt0TxQWN7fm/ck1ZzqoA/MCwJ9tCo=
 github.com/replicatedhq/kurlkinds v1.3.0/go.mod h1:9Pw0nQLzOoGbjj6Q9FnmSgY128btPjFlP5VOm5YsjUQ=
-github.com/replicatedhq/plumber v1.16.0 h1:PEFbLBJwlAyzrzwl7Cwf4mrV2opUhiaYWQeQ/uZ6Ztg=
-github.com/replicatedhq/plumber v1.16.0/go.mod h1:uKAxJWp60+FNtfm3T5rEPzp9SA2+9icY++KHatQGpy0=
+github.com/replicatedhq/plumber/v2 v2.2.0 h1:vjG8hZKO7tvLdPzWFqLBmjfpNtpSXhWrOmYdwTNdQR0=
+github.com/replicatedhq/plumber/v2 v2.2.0/go.mod h1:seRCMUymCb8PPFw+pH1OefvKVSi5EgSo4HEMYpCW6Io=
 github.com/replicatedhq/pvmigrate v0.9.0 h1:p9+Y4RonMAxs1RoDv6ngZnKq9ACNQrGqGa57WnzcyI0=
 github.com/replicatedhq/pvmigrate v0.9.0/go.mod h1:RYs9n/dvb2x5hS4ULKxcnUMTlS2lcmK550chaif+ARE=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=
@@ -3270,8 +3270,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lVL/j8QyCCJe8YSMW30QvGZWaCIDIk=
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
-k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3 h1:vV3ZKAUX0nMjTflyfVea98dTfROpIxDaEsQws0FT2Ts=
-k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3/go.mod h1:/BYxry62FuDzmI+i9B+X2pqfySRmSOW2ARmj5Zbqhj0=
+k8s.io/kube-openapi v0.0.0-20230217203603-ff9a8e8fa21d h1:oFDpQ7FfzinCtrFOl4izwOWsdTprlS2A9IXBENMW0UA=
+k8s.io/kube-openapi v0.0.0-20230217203603-ff9a8e8fa21d/go.mod h1:/BYxry62FuDzmI+i9B+X2pqfySRmSOW2ARmj5Zbqhj0=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -39,6 +39,7 @@ func AddCommands(cmd *cobra.Command, cli CLI) {
 	netutilCmd.AddCommand(newNetutilIfaceFromIPCommand(cli))
 	netutilCmd.AddCommand(newNetutilDefaultIfaceCommand(cli))
 	netutilCmd.AddCommand(newNetutilFormatIPAddressCmd(cli))
+	netutilCmd.AddCommand(newNetutilNodesConnectivity(cli))
 	cmd.AddCommand(netutilCmd)
 
 	objectStoreCmd := newObjectStoreCmd(cli)

--- a/pkg/cli/nodes_connectivity.go
+++ b/pkg/cli/nodes_connectivity.go
@@ -156,7 +156,7 @@ func printDaemonsetStatus(ctx context.Context, opts nodeConnectivityOptions, ds 
 		Namespace(opts.namespace).
 		Param("labelSelector", listenersSelector).
 		Param("limit", "500").
-		SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io")
+		SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io")
 	if err := request.Do(ctx).Into(table); err != nil {
 		log.Printf("Failed to list DaemonSet pods: %s", err)
 		return

--- a/pkg/cli/nodes_connectivity.go
+++ b/pkg/cli/nodes_connectivity.go
@@ -1,0 +1,399 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/kustomize/api/types"
+
+	"github.com/google/uuid"
+	"github.com/replicatedhq/plumber/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/replicatedhq/kurl/pkg/k8sutil"
+	"github.com/replicatedhq/kurl/pkg/static/nodes_connectivity"
+)
+
+var usageExamples = `
+# Test if all nodes can reach all other nodes using tcp in port 6472.
+kurl netutil nodes-connectivity --port 6472 --proto tcp
+# Test if all nodes can reach all other nodes using udp in port 7788.
+kurl netutil nodes-connectivity --port 7788 --proto udp
+`
+
+const (
+	listenersSelector = "name=nodes-connectivity-listener"
+	pingerSelector    = "name=nodes-connectivity-pinger"
+)
+
+type logLine struct {
+	message string
+	err     error
+}
+
+type nodeConnectivityOptions struct {
+	namespace string
+	proto     string
+	attempts  int
+	cliset    kubernetes.Interface
+	image     string
+	port      int32
+	cli       client.Client
+	wait      time.Duration
+}
+
+func newNetutilNodesConnectivity(_ CLI) *cobra.Command {
+	var opts nodeConnectivityOptions
+	cmd := &cobra.Command{
+		Use:     "nodes-connectivity",
+		Short:   "Tests if all nodes can reach all other nodes using the provided protocol in the provided port",
+		Example: usageExamples,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+			defer cancel()
+
+			if opts.port == 0 {
+				return fmt.Errorf("--port flag is required.")
+			}
+			opts.proto = strings.ToUpper(opts.proto)
+			proto := corev1.Protocol(opts.proto)
+			if proto != corev1.ProtocolTCP && proto != corev1.ProtocolUDP {
+				return fmt.Errorf("--protocol must be either tcp or udp.")
+			}
+			opts.wait = time.Second
+			if corev1.Protocol(opts.proto) == corev1.ProtocolUDP {
+				opts.wait = 5 * time.Second
+			}
+
+			cli, err := client.New(config.GetConfigOrDie(), client.Options{})
+			if err != nil {
+				return fmt.Errorf("failed to create kubernetes client: %w", err)
+			}
+			opts.cli = cli
+
+			// XXX controller-runtime kubernetes client does not have access to subresources that span beneath
+			// crud objects (e.g. pod logs). we have to create a kubernetes clientset, and that is why we can't
+			// have nice things.
+			cliset, err := kubernetes.NewForConfig(config.GetConfigOrDie())
+			if err != nil {
+				log.Printf("Failed to create kubernetes client set: %s", err)
+				os.Exit(1)
+			}
+			opts.cliset = cliset
+
+			cleanup := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				if err := deleteListeners(ctx, opts); err != nil {
+					log.Printf("Failed to delete daemonset listeners overlay: %v", err)
+				}
+				if err := deletePinger(ctx, opts); err != nil {
+					log.Printf("Failed to delete pinger job: %v", err)
+				}
+			}
+
+			log.Printf("Testing intra nodes connectivity using port %d/%s.", opts.port, opts.proto)
+			log.Printf("Connection between all nodes will be attempted, this can take a while.")
+			if err := deployListenersDaemonset(ctx, opts); err != nil {
+				cleanup()
+				log.Printf("Failed to deploy listeners: %s", err)
+				os.Exit(1)
+			}
+
+			if err := testNodesConnectivity(ctx, opts); err != nil {
+				cleanup()
+				log.Printf("Failed to test nodes connectivity: %s", err)
+				os.Exit(1)
+			}
+
+			cleanup()
+			log.Printf("All nodes can reach all nodes using %s protocol in port %d.", opts.proto, opts.port)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.proto, "proto", "tcp", "The protocol to use for the test (either tcp or udp).")
+	cmd.Flags().StringVar(&opts.namespace, "namespace", "default", "The namespace to use during the test.")
+	cmd.Flags().StringVar(&opts.image, "image", "replicated/kurl-util:latest", "The image to use for the test (image must contain bash, nc and echo).")
+	cmd.Flags().Int32Var(&opts.port, "port", 0, "The port to use for the test.")
+	cmd.Flags().IntVar(&opts.attempts, "udp-attempts", 5, "The number of connection attempts when using udp.")
+	return cmd
+}
+
+// printDaemonsetStatus prints the status of the daemonset. this function also prints the pod statuses.
+func printDaemonsetStatus(ctx context.Context, opts nodeConnectivityOptions, ds *appsv1.DaemonSet) {
+	var gotDS appsv1.DaemonSet
+	if err := opts.cli.Get(ctx, client.ObjectKeyFromObject(ds), &gotDS); err != nil {
+		log.Printf("Failed to get daemonset %s: %v", ds.Name, err)
+		return
+	}
+	pods, err := k8sutil.ListPodsBySelector(ctx, opts.cliset, opts.namespace, listenersSelector)
+	if err != nil {
+		log.Printf("Failed to list daemonset pods: %v", err)
+		return
+	}
+	log.Printf("DaemonSet failed to deploy, that can possibly mean that port %d (%s) is in use.", opts.port, opts.proto)
+	status := gotDS.Status
+	log.Printf("DaemonSet status reports:")
+	log.Printf("Scheduled: %d, Available: %d, Ready: %d", status.CurrentNumberScheduled, status.NumberAvailable, status.NumberReady)
+	log.Printf("")
+	stream := bytes.NewBuffer(nil)
+	tab := tabwriter.NewWriter(stream, 20, 8, 1, ' ', 0)
+	fmt.Fprintln(tab, "POD\tNODE\tCONDITIONTYPE\tCONDITIONSTATUS\tREASON\tMESSAGE")
+	for _, pd := range pods.Items {
+		for _, cd := range pd.Status.Conditions {
+			cols := []string{pd.Name, pd.Spec.NodeName, string(cd.Type), string(cd.Status), cd.Reason, cd.Message}
+			fmt.Fprintf(tab, "%s\n", strings.Join(cols, "\t"))
+		}
+	}
+	tab.Flush()
+	scanner := bufio.NewScanner(stream)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		log.Print(scanner.Text())
+	}
+}
+
+// deployListenersDaemonset deploys a daemonset that will run a pod that listens for udp or tcp packets,
+// on port 9999. a service is created to expose the daemonset pods, this service is of type nodeport and
+// binds to nodeConnectivityOptions.port port.
+func deployListenersDaemonset(ctx context.Context, opts nodeConnectivityOptions) error {
+	log.Printf("Deploying node connectivity listeners daemonset.")
+	options := []plumber.Option{
+		plumber.WithKustomizeMutator(kustomizeMutator(opts)),
+		plumber.WithObjectMutator(func(ctx context.Context, obj client.Object) error {
+			if ds, ok := obj.(*appsv1.DaemonSet); ok {
+				tolerations, err := k8sutil.TolerationsForAllNodes(ctx, opts.cliset)
+				if err != nil {
+					return fmt.Errorf("failed to build tolerations: %v", err)
+				}
+				ds.Spec.Template.Spec.Tolerations = tolerations
+				ds.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "PORT", Value: fmt.Sprintf("%d", opts.port)},
+				}
+			}
+			return nil
+		}),
+		plumber.WithPostApplyAction(func(ctx context.Context, obj client.Object) error {
+			if ds, ok := obj.(*appsv1.DaemonSet); ok {
+				err := k8sutil.WaitForDaemonsetRollout(ctx, opts.cliset, ds, time.Minute)
+				if err != nil {
+					printDaemonsetStatus(ctx, opts, ds)
+					return fmt.Errorf("failed to wait for daemonset rollout: %w", err)
+				}
+			}
+			return nil
+		}),
+	}
+	overlay := fmt.Sprintf("%s-listeners", strings.ToLower(opts.proto))
+	renderer := plumber.NewRenderer(opts.cli, nodes_connectivity.Static, options...)
+	if err := renderer.Apply(ctx, overlay); err != nil {
+		return fmt.Errorf("failed to create listeners daemonset: %w", err)
+	}
+	log.Print("Listeners daemonset deployed successfully.")
+	return nil
+}
+
+func attachToListenersPods(ctx context.Context, opts nodeConnectivityOptions, pods []corev1.Pod) <-chan logLine {
+	var out = make(chan logLine)
+	for _, pod := range pods {
+		go func(pod corev1.Pod) {
+			logopts := &corev1.PodLogOptions{Follow: true}
+			req := opts.cliset.CoreV1().Pods(opts.namespace).GetLogs(pod.Name, logopts)
+			stream, err := req.Stream(ctx)
+			if err != nil {
+				out <- logLine{err: fmt.Errorf("failed to get logs for pod %s: %w", pod.Name, err)}
+				return
+			}
+			defer stream.Close()
+
+			scanner := bufio.NewScanner(stream)
+			scanner.Split(bufio.ScanLines)
+			for scanner.Scan() {
+				out <- logLine{message: scanner.Text()}
+			}
+			if err := scanner.Err(); err != nil {
+				out <- logLine{err: fmt.Errorf("failed to read logs for pod %s: %w", pod.Name, err)}
+			}
+		}(pod)
+	}
+	return out
+}
+
+// kustomizeMutator returns a kustomize mutator that sets the namespace and image.
+func kustomizeMutator(opts nodeConnectivityOptions) plumber.KustomizeMutator {
+	image := types.Image{Name: "nodes-connectivity-image", NewName: opts.image}
+	return func(ctx context.Context, kz *types.Kustomization) error {
+		kz.Namespace = opts.namespace
+		kz.Images = append(kz.Images, image)
+		return nil
+	}
+}
+
+// deletePinger delete the pinger job and all its related pods.
+func deletePinger(ctx context.Context, opts nodeConnectivityOptions) error {
+	opt := plumber.WithKustomizeMutator(kustomizeMutator(opts))
+	renderer := plumber.NewRenderer(opts.cli, nodes_connectivity.Static, opt)
+	if err := renderer.Delete(ctx, "pinger"); err != nil {
+		return fmt.Errorf("failed to delete pinger job: %w", err)
+	}
+	// XXX unfortunately we have to remove all pods manually.
+	pods, err := k8sutil.ListPodsBySelector(ctx, opts.cliset, opts.namespace, pingerSelector)
+	if err != nil {
+		return fmt.Errorf("failed to get pinger pods: %w", err)
+	}
+	for _, pod := range pods.Items {
+		if err := opts.cli.Delete(ctx, &pod); err != nil {
+			return fmt.Errorf("failed to delete pod %s: %v", pod.Name, err)
+		}
+	}
+	return nil
+}
+
+// connectNodeFromNode creates a job that inherit the provided pod affinity and tolerations. this attempts to send an uuid
+// through a network connection to the target ip and configured port/protocol. returns the sent uuid.
+func connectNodeFromNode(ctx context.Context, opts nodeConnectivityOptions, model corev1.Pod, targetIP string) (string, error) {
+	id := uuid.New().String()
+	options := []plumber.Option{
+		plumber.WithKustomizeMutator(kustomizeMutator(opts)),
+		plumber.WithObjectMutator(func(ctx context.Context, obj client.Object) error {
+			if job, ok := obj.(*batchv1.Job); ok {
+				env := []corev1.EnvVar{
+					{Name: "NODEIP", Value: targetIP},
+					{Name: "NODEPORT", Value: fmt.Sprint(opts.port)},
+					{Name: "UUID", Value: id},
+				}
+				args := corev1.EnvVar{Name: "NCARGS", Value: "-w 2"}
+				if corev1.Protocol(opts.proto) == corev1.ProtocolUDP {
+					args = corev1.EnvVar{Name: "NCARGS", Value: "-uw 2"}
+				}
+				env = append(env, args)
+				job.Spec.Template.Spec.Affinity = model.Spec.Affinity
+				//job.Spec.Template.Spec.Tolerations = model.Spec.Tolerations
+				job.Spec.Template.Spec.Containers[0].Env = env
+			}
+			return nil
+		}),
+		plumber.WithPostApplyAction(func(ctx context.Context, obj client.Object) error {
+			if job, ok := obj.(*batchv1.Job); ok {
+				if _, err := k8sutil.WaitForJob(ctx, opts.cliset, job, time.Minute); err != nil {
+					return fmt.Errorf("failed to create job: %s", err)
+				}
+			}
+			return nil
+		}),
+	}
+	renderer := plumber.NewRenderer(opts.cli, nodes_connectivity.Static, options...)
+	if err := renderer.Apply(ctx, "pinger"); err != nil {
+		return "", fmt.Errorf("failed to apply pinger job: %w", err)
+	}
+	return id, nil
+}
+
+// testNodesConnectivity tests the connectivity between the cluster nodes.
+func testNodesConnectivity(ctx context.Context, opts nodeConnectivityOptions) error {
+	pods, err := k8sutil.ListPodsBySelector(ctx, opts.cliset, opts.namespace, listenersSelector)
+	if err != nil {
+		return fmt.Errorf("failed to get listener pods: %w", err)
+	}
+	receiver := attachToListenersPods(ctx, opts, pods.Items)
+	var nodes corev1.NodeList
+	if err := opts.cli.List(ctx, &nodes); err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+	for _, node := range nodes.Items {
+		if err := connectToNodeFromPods(ctx, opts, node, receiver); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// connectToNodeFromPods connects to the provided node by spawning pods in all other nodes and verifying they can reach
+// the destination ip address and port.
+func connectToNodeFromPods(ctx context.Context, opts nodeConnectivityOptions, node corev1.Node, receiver <-chan logLine) error {
+	pods, err := k8sutil.ListPodsBySelector(ctx, opts.cliset, opts.namespace, listenersSelector)
+	if err != nil {
+		return fmt.Errorf("failed to get listener pods: %w", err)
+	}
+	dstIP, err := k8sutil.NodeInternalIP(node)
+	if err != nil {
+		return fmt.Errorf("failed to determine node %s ip: %w", node.Name, err)
+	}
+	attempts := opts.attempts
+	if corev1.Protocol(opts.proto) == corev1.ProtocolTCP {
+		attempts = 1
+	}
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName == node.Name {
+			continue
+		}
+		var success bool
+		src, dst := pod.Spec.NodeName, node.Name
+		for i := 1; i <= attempts; i++ {
+			log.Printf("Testing connection from %s to %s (%d/%d)", src, dst, i, attempts)
+			id, err := connectNodeFromNode(ctx, opts, pod, dstIP)
+			if err != nil {
+				return fmt.Errorf("failed to connect node %s from node %s: %v", src, dst, err)
+			}
+
+			if err := deletePinger(ctx, opts); err != nil {
+				return fmt.Errorf("failed to delete pinger job: %w", err)
+			}
+
+			select {
+			case line := <-receiver:
+				if line.err == nil {
+					success = line.message == id
+					break
+				}
+				return fmt.Errorf("failed to read listener pod output: %w", line.err)
+			case <-time.After(opts.wait):
+			}
+
+			if success {
+				log.Printf("Success, packet received.")
+				break
+			}
+			retrying := "retrying."
+			if i == attempts {
+				retrying = "giving up."
+			}
+			log.Printf("Failed to connect from %s to %s, %s", src, dst, retrying)
+		}
+
+		if success {
+			continue
+		}
+		log.Printf("")
+		log.Printf("Attempt to connect from %s to %s on %d (%s) failed.", src, dst, opts.port, opts.proto)
+		log.Printf("Please verify if the active network policies are not blocking the connection.")
+		return fmt.Errorf("failed to connect from %s to %s", src, dst)
+	}
+	return nil
+}
+
+// deleteListeners deletes the listeners daemonset and service.
+func deleteListeners(ctx context.Context, opts nodeConnectivityOptions) error {
+	opt := plumber.WithKustomizeMutator(kustomizeMutator(opts))
+	overlay := fmt.Sprintf("%s-listeners", strings.ToLower(opts.proto))
+	renderer := plumber.NewRenderer(opts.cli, nodes_connectivity.Static, opt)
+	if err := renderer.Delete(ctx, overlay); err != nil {
+		return fmt.Errorf("failed to delete daemonset listeners overlay: %w", err)
+	}
+	return nil
+}

--- a/pkg/k8sutil/apply.go
+++ b/pkg/k8sutil/apply.go
@@ -6,7 +6,7 @@ import (
 	"embed"
 	"os/exec"
 
-	"github.com/replicatedhq/plumber"
+	"github.com/replicatedhq/plumber/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
@@ -21,7 +21,7 @@ func KubectlApply(ctx context.Context, cli client.Client, resources embed.FS, ov
 		),
 	}, opts...)
 
-	err := plumber.NewRenderer(cli, resources, options...).Render(
+	err := plumber.NewRenderer(cli, resources, options...).Apply(
 		ctx, overlay,
 	)
 	return err

--- a/pkg/k8sutil/daemonset.go
+++ b/pkg/k8sutil/daemonset.go
@@ -1,0 +1,35 @@
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WaitForDaemonsetRollout waits for a daemonset to rollout.
+func WaitForDaemonsetRollout(ctx context.Context, cli kubernetes.Interface, ds *appsv1.DaemonSet, timeout time.Duration) error {
+	nodes, err := cli.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+	var endAt = time.Now().Add(timeout)
+	healthyCount, desiredCount := 0, 10
+	for {
+		gotDS, err := cli.AppsV1().DaemonSets(ds.Namespace).Get(ctx, ds.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed getting daemonset: %w", err)
+		}
+		if gotDS.Status.NumberReady == int32(len(nodes.Items)) {
+			if healthyCount++; healthyCount == desiredCount {
+				return nil
+			}
+		}
+		if time.Sleep(time.Second); time.Now().After(endAt) {
+			return fmt.Errorf("timeout waiting for daemonset to rollout")
+		}
+	}
+}

--- a/pkg/k8sutil/job.go
+++ b/pkg/k8sutil/job.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// waitForJob waits for a job to finish. returns a boolean indicating if the job succeeded.
-func waitForJob(ctx context.Context, cli kubernetes.Interface, job *batchv1.Job, timeout time.Duration) (bool, error) {
+// WaitForJob waits for a job to finish. returns a boolean indicating if the job succeeded.
+func WaitForJob(ctx context.Context, cli kubernetes.Interface, job *batchv1.Job, timeout time.Duration) (bool, error) {
 	var endAt = time.Now().Add(timeout)
 	for {
 		gotJob, err := cli.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
@@ -59,7 +59,7 @@ func RunJob(ctx context.Context, cli kubernetes.Interface, logger *log.Logger, j
 		}
 	}()
 
-	jobSucceeded, err := waitForJob(ctx, cli, job, timeout)
+	jobSucceeded, err := WaitForJob(ctx, cli, job, timeout)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/k8sutil/node.go
+++ b/pkg/k8sutil/node.go
@@ -1,0 +1,66 @@
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TolerationsForAllNodes(ctx context.Context, cli kubernetes.Interface) ([]corev1.Toleration, error) {
+	nodes, err := cli.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	seen := map[corev1.Toleration]bool{}
+	var tolerations []corev1.Toleration
+	for _, node := range nodes.Items {
+		forNode := TolerationsForNode(node)
+		for _, t := range forNode {
+			if _, ok := seen[t]; ok {
+				continue
+			}
+			seen[t] = true
+			tolerations = append(tolerations, t)
+		}
+	}
+	return tolerations, nil
+}
+
+// TolerationsForNode returns a list of tolerations that matches the provided node.
+func TolerationsForNode(node corev1.Node) []corev1.Toleration {
+	tolerations := []corev1.Toleration{}
+	for _, taint := range node.Spec.Taints {
+		toleration := corev1.Toleration{
+			Key:      taint.Key,
+			Operator: corev1.TolerationOpExists,
+			Effect:   taint.Effect,
+		}
+		tolerations = append(tolerations, toleration)
+	}
+	return tolerations
+}
+
+// NodeInternalIP returns the node internal ip address for the provided node.
+func NodeInternalIP(node corev1.Node) (string, error) {
+	for _, ip := range node.Status.Addresses {
+		if ip.Type != corev1.NodeInternalIP {
+			continue
+		}
+		return ip.Address, nil
+	}
+	return "", fmt.Errorf("failed to determine ip address for node %s", node.Name)
+}
+
+// NodeInternalIPByNodeName returns the node internal ip address for the provided node name.
+func NodeInternalIPByNodeName(nodes []corev1.Node, nodeName string) (string, error) {
+	for _, node := range nodes {
+		if node.Name != nodeName {
+			continue
+		}
+		return NodeInternalIP(node)
+	}
+	return "", fmt.Errorf("failed to find node %s", nodeName)
+}

--- a/pkg/rook/flexvolume.go
+++ b/pkg/rook/flexvolume.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kurl/pkg/k8sutil"
 	"github.com/replicatedhq/kurl/pkg/rook/static/flexmigrator"
-	"github.com/replicatedhq/plumber"
+	"github.com/replicatedhq/plumber/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/static/nodes_connectivity/kustomize/base-listeners/daemonset.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/base-listeners/daemonset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodes-connectivity-listener
+spec:
+  selector:
+    matchLabels:
+      name: nodes-connectivity-listener
+  template:
+    metadata:
+      labels:
+        name: nodes-connectivity-listener
+    spec:
+      hostNetwork: true
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: nodes-connectivity-listener
+        image: nodes-connectivity-image
+        command: [ "/bin/bash", "-c" ]

--- a/pkg/static/nodes_connectivity/kustomize/base-listeners/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/base-listeners/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- daemonset.yaml

--- a/pkg/static/nodes_connectivity/kustomize/pinger/job.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/pinger/job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nodes-connectivity-pinger
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        name: nodes-connectivity-pinger
+    spec:
+      hostNetwork: true
+      restartPolicy: Never
+      containers:
+      - name: nodes-connectivity-pinger
+        image: nodes-connectivity-image
+        command: [ "/bin/bash", "-c" ]
+        args: [ "echo $UUID | /usr/bin/nc $NCARGS $NODEIP $NODEPORT" ]

--- a/pkg/static/nodes_connectivity/kustomize/pinger/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/pinger/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- job.yaml

--- a/pkg/static/nodes_connectivity/kustomize/tcp-listeners/daemonset.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/tcp-listeners/daemonset.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodes-connectivity-listener
+spec:
+  template:
+    spec:
+      containers:
+      - name: nodes-connectivity-listener
+        args: ["/usr/bin/nc -kl $PORT"]

--- a/pkg/static/nodes_connectivity/kustomize/tcp-listeners/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/tcp-listeners/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../base-listeners
+patchesStrategicMerge:
+- daemonset.yaml

--- a/pkg/static/nodes_connectivity/kustomize/udp-listeners/daemonset.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/udp-listeners/daemonset.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodes-connectivity-listener
+spec:
+  template:
+    spec:
+      containers:
+      - name: nodes-connectivity-listener
+        args: ["/usr/bin/nc -kulw 0 $PORT"]

--- a/pkg/static/nodes_connectivity/kustomize/udp-listeners/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/udp-listeners/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../base-listeners
+patchesStrategicMerge:
+- daemonset.yaml

--- a/pkg/static/nodes_connectivity/static.go
+++ b/pkg/static/nodes_connectivity/static.go
@@ -1,0 +1,8 @@
+package nodes_connectivity
+
+import (
+	"embed"
+)
+
+//go:embed kustomize
+var Static embed.FS


### PR DESCRIPTION
### What this PR does / why we need it:

This pull request incorporates a new feature to the `kurl` binary. The feature involves a new command that can be executed to verify if all the nodes in a cluster can effectively communicate with each other through a specific protocol and port. 

### Usage examples:

Tests if port 6472/tcp in all Nodes can be reached from all other Nodes:

```
$ kurl netutil nodes-connectivity --port 6472 --proto tcp
```

Tests using a different Image and deployed to a different Namespace:

```
$ kurl netutil nodes-connectivity \
            --namespace kurl \
            --proto udp \
            --port 7777 \
            --image docker.io/replicated/kurl-util:v2023.03.28-0
````

Tries to send 10 UDP packets before failing:

```
$ kurl netutil nodes-connectivity \
            --port 6472 \
            --proto udp \
            --udp-attempts 10
```

### Sample output

In a three node cluster:

```
$ kurl netutil nodes-connectivity --port 8472 --proto udp --udp-attempts 3
2023-04-13 18:05:03.972595 I | Testing intra nodes connectivity using port 8472/UDP.
2023-04-13 18:05:03.972640 I | Connection between all nodes will be attempted, this can take a while.
2023-04-13 18:05:03.972657 I | Deploying node connectivity listeners DaemonSet.
2023-04-13 18:05:16.610411 I | Listeners DaemonSet deployed successfully.
2023-04-13 18:05:17.019184 I | Testing connection from ip-172-16-10-236 to ip-172-16-10-191 (1/3)
2023-04-13 18:05:24.166496 I | Success, packet received.
2023-04-13 18:05:24.166779 I | Testing connection from ip-172-16-10-93 to ip-172-16-10-191 (1/3)
2023-04-13 18:05:31.310418 I | Success, packet received.
2023-04-13 18:05:31.411774 I | Testing connection from ip-172-16-10-93 to ip-172-16-10-236 (1/3)
2023-04-13 18:05:38.545875 I | Success, packet received.
2023-04-13 18:05:38.545913 I | Testing connection from ip-172-16-10-191 to ip-172-16-10-236 (1/3)
2023-04-13 18:05:45.684999 I | Success, packet received.
2023-04-13 18:05:45.790114 I | Testing connection from ip-172-16-10-236 to ip-172-16-10-93 (1/3)
2023-04-13 18:05:52.947172 I | Success, packet received.
2023-04-13 18:05:52.947455 I | Testing connection from ip-172-16-10-191 to ip-172-16-10-93 (1/3)
2023-04-13 18:06:00.088434 I | Success, packet received.
2023-04-13 18:06:00.402878 I | All nodes can reach all nodes using UDP protocol in port 8472.
$
```
Upon attempting to test connectivity between Nodes where the port is already taken by other process (by `sshd` on this case):

```
$ kurl netutil nodes-connectivity --port 22 --proto tcp
2023-04-13 18:09:29.494325 I | Testing intra nodes connectivity using port 22/TCP.
2023-04-13 18:09:29.494352 I | Connection between all nodes will be attempted, this can take a while.
2023-04-13 18:09:29.494361 I | Deploying node connectivity listeners DaemonSet.
2023-04-13 18:10:30.293238 I | DaemonSet failed to deploy, that can possibly mean that port 22 (TCP) is in use.
2023-04-13 18:10:30.494684 I |
2023-04-13 18:10:30.494712 I | NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
2023-04-13 18:10:30.494715 I | nodes-connectivity-listener   3         3         0       3            0           <none>          61s
2023-04-13 18:10:30.494717 I |
2023-04-13 18:10:30.494720 I | NAME                                READY   STATUS             RESTARTS      AGE   IP              NODE               NOMINATED NODE   READINESS GATES
2023-04-13 18:10:30.494722 I | nodes-connectivity-listener-cczr6   0/1     Error              3 (46s ago)   61s   172.16.10.191   ip-172-16-10-191   <none>           <none>
2023-04-13 18:10:30.494725 I | nodes-connectivity-listener-ms4k4   0/1     CrashLoopBackOff   3 (18s ago)   61s   172.16.10.236   ip-172-16-10-236   <none>           <none>
2023-04-13 18:10:30.494727 I | nodes-connectivity-listener-rcnkf   0/1     Error              3 (42s ago)   61s   172.16.10.93    ip-172-16-10-93    <none>           <none>
2023-04-13 18:10:30.494730 I |
2023-04-13 18:10:30.805840 I | Failed to deploy listeners: failed to create listeners daemonset: error running post apply action: failed to wait for DaemonSet rollout: timeout waiting for daemonset to rollout
$
```

### Tests

Tested over the following CNI versions:

- Weave v2.5.2
- Weave v2.6.5
- Weave v2.7.0
- Weave v2.8.1-20230406
- Flannel v0.21.4