### PR TITLE
feat: check flannel udp port prior to migrating

### DIFF
--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/0.21.4/install.sh
+++ b/addons/flannel/0.21.4/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/0.21.4/install.sh
+++ b/addons/flannel/0.21.4/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -64,8 +64,7 @@ function flannel_check_nodes_connectivity() {
     fi
 
     log "Verifying if all nodes can communicate with each other through port 8472/UDP."
-    local kurl_util_image="replicatedhq/kurl-util:$KURL_VERSION"
-    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$KURL_UTIL_IMAGE" --proto udp; then
         logFail "Flannel requires UDP port 8472 for communication between nodes."
         logFail "Please make sure this port is open prior to running this upgrade."
         bail "Not migrating from Weave to Flannel"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -33,6 +33,45 @@ function flannel_pre_init() {
     fi
 
     flannel_init_pod_subnet
+
+    if ! flannel_weave_conflict; then
+        return 0
+    fi
+
+    # the code below deals with weave to flannel migration and is not needed for new installs.
+    logWarn "The migration from Weave to Flannel will require whole-cluster downtime."
+    logWarn "Would you like to continue?"
+    if ! confirmY ; then
+        bail "Not migrating from Weave to Flannel"
+    fi
+
+    local node_count
+    node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
+    if [ "$node_count" = "1" ]; then
+        return 0
+    fi
+
+    local kurl_util_image
+    kurl_util_image=$(crictl images 2>/dev/null | grep replicated/kurl-util | sort | tail -1 | awk '//{printf "%s:%s\n",$1,$2;}')
+    if [ -z "$kurl_util_image" ]; then
+        if [ "$AIRGAP" = "1" ]; then
+            logFail "Your airgap installation misses replicated/kurl-util image, please contact support."
+            bail "Not migrating from Weave to Flannel"
+        fi
+        # at this point we haven't found the kurl-util image in the local store, but as this is
+        # not an airgap installation we can still try to pull it.
+        kurl_util_image="replicated/kurl-util:latest"
+        if [ -n "$KURL_VERSION" ]; then
+            kurl_util_image="replicated/kurl-util:$KURL_VERSION"
+        fi
+    fi
+
+    log "Verifying if all nodes can communicate with each other through port 8472/UDP."
+    if ! "$DIR"/bin/kurl netutil nodes-connectivity --port 8472 --image "$kurl_util_image" --proto udp; then
+        logFail "Flannel requires UDP port 8472 for communication between nodes."
+        logFail "Please make sure this port is open prior to running this upgrade."
+        bail "Not migrating from Weave to Flannel"
+    fi
 }
 
 function flannel_join() {
@@ -49,19 +88,6 @@ function flannel() {
     flannel_render_config
 
     if flannel_weave_conflict; then
-        local node_count
-        node_count="$(kubectl get nodes --no-headers 2>/dev/null | wc -l)"
-
-        printf "%bThe migration from Weave to Flannel will require whole-cluster downtime.%b\n" "$YELLOW" "$NC"
-        if [ "$node_count" -gt 1 ]; then
-            printf "%bFlannel requires UDP port 8472 for communication between nodes.%b\n" "$YELLOW" "$NC"
-            printf "%bPlease make sure this port is open prior to running this migration.%b\n" "$YELLOW" "$NC"
-        fi
-        printf "%bWould you like to continue? %b" "$YELLOW" "$NC"
-        if ! confirmY ; then
-            bail "Not migrating from Weave to Flannel"
-        fi
-
         weave_to_flannel
     else
         kubectl -n kube-flannel apply -k "$dst/"

--- a/pkg/static/nodes_connectivity/kustomize/tcp-listeners/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/tcp-listeners/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
 - ../base-listeners
-patchesStrategicMerge:
-- daemonset.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: daemonset.yaml

--- a/pkg/static/nodes_connectivity/kustomize/udp-listeners/kustomization.yaml
+++ b/pkg/static/nodes_connectivity/kustomize/udp-listeners/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
 - ../base-listeners
-patchesStrategicMerge:
-- daemonset.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: daemonset.yaml

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -436,7 +436,7 @@ function report_install_containerd() {
 
     # if the node we are running this script is leveraging docker we also don't need to worry
     # about the version of containerd we are installing, it won't be an upgrade anyways.
-    if containerd_node_is_using_docker ; then
+    if node_is_using_docker ; then
         addon_install "containerd" "$CONTAINERD_VERSION"
         return 0
     fi
@@ -1494,4 +1494,11 @@ function common_prompt_task_missing_assets() {
         "$GREEN" "$prefix" "$task" "$from_version" "$to_version" "$airgap_flag" "$NC"
     printf "Are you ready to continue? "
     confirmY
+}
+
+# node_is_using_docker returns 0 if the current node is using docker as the container runtime.
+function node_is_using_docker() {
+    local node
+    node="$(get_local_node_name)"
+    kubectl get node "$node" -ojsonpath='{.metadata.annotations.kubeadm\.alpha\.kubernetes\.io/cri-socket}' | grep -q "dockershim.sock"
 }

--- a/scripts/common/containerd.sh
+++ b/scripts/common/containerd.sh
@@ -14,13 +14,6 @@ function containerd_patch_for_minor_version() {
     echo ""
 }
 
-# containerd_node_is_using_docker returns 0 if the current node is using docker as the container runtime.
-function containerd_node_is_using_docker() {
-    local node
-    node="$(get_local_node_name)"
-    kubectl get node "$node" -ojsonpath='{.metadata.annotations.kubeadm\.alpha\.kubernetes\.io/cri-socket}' | grep -q "dockershim.sock"
-}
-
 # containerd_migration_steps returns an array with all steps necessary to migrate from the current containerd
 # version to the desired version.
 function containerd_migration_steps() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Before migrating from Weave to Flannel we need to verify if nodes can communicate with each other through port 8472/udp. This PR implements this logic on `flannel_pre_init()` function (the sooner the user knows about a problem the better).

If the port is not available the upgrade is aborted.

This PR depends on https://github.com/replicatedhq/kURL/pull/4376.