### PR TITLE
chore: standardize logging and example

### DIFF
--- a/cmd/kurl/main.go
+++ b/cmd/kurl/main.go
@@ -15,7 +15,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = cli.NewKurlCmd(kurlCLI).ExecuteContext(ctx)
+
+	cmd := cli.NewKurlCmd(kurlCLI)
+	cmd.SetOut(kurlCLI.Stdout())
+	cmd.SetErr(kurlCLI.Stderr())
+
+	err = cmd.ExecuteContext(ctx)
 	if err != nil {
 		if errors.Is(err, cli.ErrWarn) {
 			os.Exit(3)

--- a/pkg/cli/longhorn_test.go
+++ b/pkg/cli/longhorn_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"io"
+	"log"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +16,8 @@ import (
 )
 
 func Test_scaleDownReplicas(t *testing.T) {
+	discardLogger := log.New(io.Discard, "", 0)
+
 	scaleDownReplicasWaitTime = 0
 	volumes := []client.Object{
 		&lhv1b1.Volume{
@@ -48,7 +52,7 @@ func Test_scaleDownReplicas(t *testing.T) {
 	scheme := runtime.NewScheme()
 	lhv1b1.AddToScheme(scheme)
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(volumes...).Build()
-	scaled, err := scaleDownReplicas(context.Background(), cli)
+	scaled, err := scaleDownReplicas(context.Background(), discardLogger, cli)
 	assert.True(t, scaled)
 	assert.NoError(t, err)
 
@@ -63,6 +67,8 @@ func Test_scaleDownReplicas(t *testing.T) {
 }
 
 func Test_unhealthyVolumes(t *testing.T) {
+	discardLogger := log.New(io.Discard, "", 0)
+
 	for _, tt := range []struct {
 		name     string
 		expected []string
@@ -192,7 +198,7 @@ func Test_unhealthyVolumes(t *testing.T) {
 			scheme := runtime.NewScheme()
 			lhv1b1.AddToScheme(scheme)
 			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
-			result, err := unhealthyVolumes(context.Background(), cli)
+			result, err := unhealthyVolumes(context.Background(), discardLogger, cli)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -200,6 +206,8 @@ func Test_unhealthyVolumes(t *testing.T) {
 }
 
 func Test_unhealthyNodes(t *testing.T) {
+	discardLogger := log.New(io.Discard, "", 0)
+
 	for _, tt := range []struct {
 		name     string
 		expected []string
@@ -477,7 +485,7 @@ func Test_unhealthyNodes(t *testing.T) {
 			scheme := runtime.NewScheme()
 			lhv1b1.AddToScheme(scheme)
 			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
-			result, err := unhealthyNodes(context.Background(), cli)
+			result, err := unhealthyNodes(context.Background(), discardLogger, cli)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/cli/mock/mock_cli.go
+++ b/pkg/cli/mock/mock_cli.go
@@ -5,6 +5,8 @@
 package mock_cli
 
 import (
+	io "io"
+	log "log"
 	reflect "reflect"
 
 	readline "github.com/chzyer/readline"
@@ -35,6 +37,20 @@ func NewMockCLI(ctrl *gomock.Controller) *MockCLI {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCLI) EXPECT() *MockCLIMockRecorder {
 	return m.recorder
+}
+
+// DebugLogger mocks base method.
+func (m *MockCLI) DebugLogger() *log.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DebugLogger")
+	ret0, _ := ret[0].(*log.Logger)
+	return ret0
+}
+
+// DebugLogger indicates an expected call of DebugLogger.
+func (mr *MockCLIMockRecorder) DebugLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DebugLogger", reflect.TypeOf((*MockCLI)(nil).DebugLogger))
 }
 
 // GetClusterPreflightRunner mocks base method.
@@ -105,4 +121,46 @@ func (m *MockCLI) GetViper() *viper.Viper {
 func (mr *MockCLIMockRecorder) GetViper() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetViper", reflect.TypeOf((*MockCLI)(nil).GetViper))
+}
+
+// Logger mocks base method.
+func (m *MockCLI) Logger() *log.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logger")
+	ret0, _ := ret[0].(*log.Logger)
+	return ret0
+}
+
+// Logger indicates an expected call of Logger.
+func (mr *MockCLIMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockCLI)(nil).Logger))
+}
+
+// Stderr mocks base method.
+func (m *MockCLI) Stderr() io.Writer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stderr")
+	ret0, _ := ret[0].(io.Writer)
+	return ret0
+}
+
+// Stderr indicates an expected call of Stderr.
+func (mr *MockCLIMockRecorder) Stderr() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stderr", reflect.TypeOf((*MockCLI)(nil).Stderr))
+}
+
+// Stdout mocks base method.
+func (m *MockCLI) Stdout() io.Writer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stdout")
+	ret0, _ := ret[0].(io.Writer)
+	return ret0
+}
+
+// Stdout indicates an expected call of Stdout.
+func (mr *MockCLIMockRecorder) Stdout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stdout", reflect.TypeOf((*MockCLI)(nil).Stdout))
 }

--- a/pkg/cli/netutil.go
+++ b/pkg/cli/netutil.go
@@ -23,7 +23,7 @@ func newNetutilCommand(cli CLI) *cobra.Command {
 	return cmd
 }
 
-func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
+func newNetutilIfaceFromIPCommand(cli CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "iface-from-ip IP",
 		Short: "Gets the interface name for a given IP address",
@@ -35,7 +35,7 @@ func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
 			}
 			iface, err := netutils.GetInterfaceByIPv6(ip)
 			if err == nil {
-				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
+				fmt.Fprintln(cli.Stdout(), iface.Name)
 				return nil
 			}
 			if ip.To4() != nil {
@@ -43,7 +43,7 @@ func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
+				fmt.Fprintln(cli.Stdout(), iface.Name)
 				return nil
 			}
 			return err
@@ -52,7 +52,7 @@ func newNetutilIfaceFromIPCommand(_ CLI) *cobra.Command {
 	return cmd
 }
 
-func newNetutilDefaultIfaceCommand(_ CLI) *cobra.Command {
+func newNetutilDefaultIfaceCommand(cli CLI) *cobra.Command {
 	ipv6 := false
 	cmd := &cobra.Command{
 		Use:   "default-gateway-iface",
@@ -63,17 +63,18 @@ func newNetutilDefaultIfaceCommand(_ CLI) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
+				fmt.Fprintln(cli.Stdout(), iface.Name)
 				return nil
 			}
 			iface, err := netutils.GetDefaultGatewayInterface()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), iface.Name)
+			fmt.Fprintln(cli.Stdout(), iface.Name)
 			return nil
 		},
 	}
+
 	cmd.Flags().BoolVar(&ipv6, "ipv6", false, "Get the default IPv6 interface")
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This change proposes a standard for logging in the kurl cli. It tries to disambiguate between logging and command output. It does not change behavior, as log statements will continue to go to stderr with timestamps. Additionally it adds a debug logger for verbose output.