### PR TITLE
fix: cron-weave-update action fixes

### DIFF
--- a/.github/workflows/update-weave.yaml
+++ b/.github/workflows/update-weave.yaml
@@ -32,7 +32,7 @@ jobs:
         token: ${{ secrets.AUTOMATED_PR_GH_PAT }}
         commit-message: Create new Weave version
         title: 'Automated Weave version update ${{ steps.update.outputs.weave_version }}'
-        branch: automation/update-weave
+        branch: automation/update-weave-${{ steps.update.outputs.weave_major_minor_version }}
         delete-branch: true
         labels: |
           automated-pr

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -116,9 +116,6 @@ module.exports.InstallerVersions = {
   ],
   weave: [
     // cron-weave-update-265
-    "2.8.1-20230406",
-    "2.8.1-20230324",
-    "2.8.1-20230222",
     "2.6.5-20230222",
     "2.6.5-20221122",
     "2.6.5-20221025",
@@ -129,7 +126,7 @@ module.exports.InstallerVersions = {
     "2.6.5",
     "2.6.4",
     "2.5.2",
-    // cron-weave-update
+    // cron-weave-update-281
     "2.8.1-20230406",
     "2.8.1-20230324",
     "2.8.1-20230222",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The action is inserting 2.8.1 versions twice in the versions.js file.

The weave_version github output is missing.

Additionally this only allows updates to versions 2.6.5 and 2.8.1.

The action was validated and produced the following two prs:
https://github.com/replicatedhq/kURL/pull/4388
https://github.com/replicatedhq/kURL/pull/4389