### PR TITLE
fix: k8s upgrades to non-step versions unsupported

### DIFF
--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -129,7 +129,7 @@ export KUBERNETES_UPGRADE=0
 function discoverCurrentKubernetesVersion() {
     local fullCluster="$1"
 
-    CURRENT_KUBERNETES_VERSION=$(maybe discover_local_kuberentes_version)
+    CURRENT_KUBERNETES_VERSION=$(maybe discover_local_kubernetes_version)
 
     if [ -z "$CURRENT_KUBERNETES_VERSION" ]; then
         # This is a new install and no upgrades are required
@@ -172,7 +172,7 @@ function discoverCurrentKubernetesVersion() {
     done
 }
 
-function discover_local_kuberentes_version() {
+function discover_local_kubernetes_version() {
     grep -s ' image: ' /etc/kubernetes/manifests/kube-apiserver.yaml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
 }
 

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -42,6 +42,17 @@ function kubernetes_get_packages() {
     fi
 }
 
+# kubernetes_maybe_get_packages_airgap downloads kubernetes packages if they are not already present
+function kubernetes_maybe_get_packages_airgap() {
+    if [ "$AIRGAP" != "1" ]; then
+        return
+    fi
+    if [ -d "$DIR/packages/kubernetes/$KUBERNETES_VERSION/assets" ]; then
+        return
+    fi
+    addon_fetch_airgap "kubernetes" "$KUBERNETES_VERSION"
+}
+
 function kubernetes_load_ipvs_modules() {
     if lsmod | grep -q ip_vs ; then
         return
@@ -282,6 +293,10 @@ function kubernetes_get_conformance_packages_online() {
 
 function kubernetes_masters() {
     kubectl get nodes --no-headers --selector="$(kubernetes_get_control_plane_label)"
+}
+
+function kubernetes_remote_nodes() {
+    kubectl get nodes --ignore-not-found --no-headers --selector="kubernetes.io/hostname!=$(get_local_node_name)"
 }
 
 function kubernetes_remote_masters() {

--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -356,7 +356,7 @@ function rook_upgrade_prompt_missing_images() {
     # shellcheck disable=SC2086
     node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "" "$(get_local_node_name)")
 
-    common_prompt_task_missing_images "$node_missing_images" "$from_version" "$to_version" "Rook" "rook-upgrade-load-images"
+    common_prompt_task_missing_assets "$node_missing_images" "$from_version" "$to_version" "Rook" "rook-upgrade-load-images"
 }
 
 # rook_upgrade_nodes_missing_images will print a list of nodes that are missing images for the

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -94,10 +94,10 @@ function tasks() {
             rook_upgrade_tasks_load_images "$@"
             popd_install_directory
             ;;
-        kubernetes-upgrade-load-images|kubernetes_upgrade_load_images)
+        kubernetes-upgrade-load-assets|kubernetes_upgrade_load_assets)
             pushd_install_directory
-            shift # the first param is kubernetes-upgrade-load-images|kubernetes_upgrade_load_images
-            kubernetes_upgrade_tasks_load_images "$@"
+            shift # the first param is kubernetes-upgrade-load-assets|kubernetes_upgrade_load_assets
+            kubernetes_upgrade_tasks_load_assets "$@"
             popd_install_directory
             ;;
         weave-to-flannel-primary|weave_to_flannel_primary)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -131,6 +131,7 @@ function main() {
     configure_no_proxy
     ${K8S_DISTRO}_addon_for_each addon_fetch
     kubernetes_get_packages
+    kubernetes_maybe_get_packages_airgap # this is necesssary for step versions for multi-k8s upgrades
     preflights_require_host_packages
     host_preflights "${MASTER:-0}" "1" "1"
     install_host_dependencies


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Currently the step logic always stops at the step version for a given minor upgrade. This change makes it stop at the specified minor.