### PR TITLE
fix: use kurl-install-directory for host os repos

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -264,9 +264,9 @@ function _yum_install_host_packages_el9() {
     fi
 
     local reponame="$repoprefix.kurl.local"
-    local repopath="/var/lib/kurl.repos/$repoprefix"
+    local repopath="$KURL_INSTALL_DIRECTORY.repos/$repoprefix"
 
-    mkdir -p "/var/lib/kurl.repos"
+    mkdir -p "$KURL_INSTALL_DIRECTORY.repos"
     rm -rf "$repopath"
     cp -r "$fullpath" "$repopath"
 

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -189,6 +189,23 @@ function generate_admin_user() {
 function reset() {
     set +e
 
+    shift # the first param is reset
+    while [ "$1" != "" ]; do
+        _param="$(echo "$1" | cut -d= -f1)"
+        _value="$(echo "$1" | grep '=' | cut -d= -f2-)"
+        case $_param in
+            kurl-install-directory)
+                if [ -n "$_value" ]; then
+                    KURL_INSTALL_DIRECTORY_FLAG="$_value"
+                    KURL_INSTALL_DIRECTORY="$(realpath "$_value")/kurl"
+                fi
+                ;;
+        esac
+        shift
+    done
+
+    maybe_read_kurl_config_from_cluster # sets KURL_INSTALL_DIRECTORY
+
     if [ "$FORCE_RESET" != 1 ]; then
         printf "${YELLOW}"
         printf "WARNING: \n"
@@ -257,7 +274,8 @@ function reset() {
     rm -rf /var/lib/weave
     rm -rf /var/lib/longhorn
     rm -rf /etc/haproxy
-    rm -rf "${KURL_INSTALL_DIRECTORY}"
+    rm -rf "$KURL_INSTALL_DIRECTORY"
+    rm -rf "$KURL_INSTALL_DIRECTORY.repos"
 
     printf "Killing haproxy\n"
     pkill haproxy || true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

- kURL will now use the `kurl-install-directory` specified for host os repositories. Previously this was hardcoded to /var/lib/kurl.
- The tasks.sh reset script will now respect the `kurl-install-directory` flag or discover the directory from the cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* kURL will now use the `kurl-install-directory` specified for host os repositories. Previously this was hardcoded to /var/lib/kurl.
* The tasks.sh reset script will now respect the `kurl-install-directory` flag or discover the directory from the cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE