### PR TITLE
Upgrade go version from 1.19 to 1.20

### DIFF
--- a/.github/workflows/build-package-prod.yaml
+++ b/.github/workflows/build-package-prod.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - name: setup env
         run: |
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - name: setup env
         run: |
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - name: setup env
         run: |

--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -67,7 +67,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
     - name: setup env
       id: env
       run: |
@@ -219,7 +219,7 @@ jobs:
     - name: setup-go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
 
     - name: Get the version
       id: get_tag

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -82,7 +82,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
 
     - name: setup env
       id: env

--- a/.github/workflows/update-openebs.yaml
+++ b/.github/workflows/update-openebs.yaml
@@ -15,7 +15,7 @@ jobs:
     # for installing github.com/go-ksplit/ksplit
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.20'
 
     - name: Create OpenEBS Update
       id: update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ You can check [system requirements](https://kurl.sh/docs/install-with-kurl/syste
 ## Pre-requirements
 
 - npm _(i.e. for mac os: `brew install npm`)_
-- [Golang](https://go.dev/doc/install) >= 1.19+
+- [Golang](https://go.dev/doc/install) >= 1.20+
 - Docker
 
 **If your local environment is OSX:** ensure that you install `gnu-sed` and `md5sha1sum` to be able to run the scripts.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/kurl
 
-go 1.19
+go 1.20
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5


### PR DESCRIPTION
#### What this PR does / why we need it:

To solve tech-debt. We need start to upgrade the go version used. 