### PR TITLE
fix: multi-kubernetes airgap upgrade fixes

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -167,18 +167,24 @@ function addon_fetch_airgap() {
         # the package already exists, no need to download it
         printf "The package %s %s is already available locally.\n" "$name" "$version"
     else
-        # prompt the user to give us the package
-        printf "The package %s %s is not available locally, and is required.\n" "$name" "$version"
-        printf "\nYou can download it with the following command:\n"
-        printf "\n${GREEN}    curl -LO %s${NC}\n\n" "$(get_dist_url)/$package_name"
+        package_path="$(find assets/*"$name-$version"*.tar.gz 2>/dev/null | head -n 1)"
+        if [ -n "$package_path" ]; then
+            # the package already exists, no need to download it
+            printf "The package %s is already available locally.\n" "$(basename "$package_path")"
+        else
+            # prompt the user to give us the package
+            printf "The package %s %s is not available locally, and is required.\n" "$name" "$version"
+            printf "\nYou can download it with the following command:\n"
+            printf "\n${GREEN}    curl -LO %s${NC}\n\n" "$(get_dist_url)/$package_name"
 
-        addon_fetch_airgap_prompt_for_package "$package_name"
+            addon_fetch_airgap_prompt_for_package "$package_name"
+        fi
     fi
 
     printf "Unpacking %s %s...\n" "$name" "$version"
     tar xf "$package_path"
 
-    addon_source "$name" "$version"
+    # do not source the addon here as the kubernetes "addon" uses this function but is not an addon
 }
 
 # addon_fetch_multiple_airgap checks if the files are already present - if they are, use that

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -29,10 +29,19 @@ function kubernetes_host() {
 
 function kubernetes_load_images() {
     local version="$1"
+
+    local varname="KUBERNETES_IMAGES_LOADED_${version//./_}"
+    if [ "${!varname:-}" = "1" ]; then
+        # images already loaded for this version
+        return 0
+    fi
+
     load_images "$DIR/packages/kubernetes/$version/images"
     if [ -n "$SONOBUOY_VERSION" ] && [ -d "$DIR/packages/kubernetes-conformance/$version/images" ]; then
         load_images "$DIR/packages/kubernetes-conformance/$version/images"
     fi
+
+    declare -g "$varname"=1
 }
 
 function kubernetes_get_packages() {
@@ -149,7 +158,7 @@ function kubernetes_install_host_packages() {
 
         # less command is broken if libtinfo.so.5 is missing in amazon linux 2
         if [ "$LSB_DIST" == "amzn" ] && [ "$AIRGAP" != "1" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
-            if [ -d "$DIR/packages/kubernetes/${k8sVersion}" ]; then
+            if [ -d "$DIR/packages/kubernetes/${k8sVersion}/assets" ]; then
                 install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" ncurses-compat-libs
             fi
         fi

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -125,7 +125,7 @@ function kubernetes_upgrade_do_kubernetes_upgrade() {
         if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
             continue
         fi
-        if [ ! -d "$DIR/packages/kubernetes/$step" ] ; then
+        if [ ! -d "$DIR/packages/kubernetes/$step/assets" ] ; then
             bail "Kubernetes version $step not found"
         fi
         logStep "Upgrading cluster to Kubernetes version $step"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -54,6 +54,8 @@ maybe_upgrade() {
     if [ "$kubeletMinor" -lt "$KUBERNETES_TARGET_VERSION_MINOR" ] || ([ "$kubeletMinor" -eq "$KUBERNETES_TARGET_VERSION_MINOR" ] && [ "$kubeletPatch" -lt "$KUBERNETES_TARGET_VERSION_PATCH" ]); then
         logStep "Kubernetes version v$kubeletVersion detected, upgrading node to version v$KUBERNETES_VERSION"
 
+        kubernetes_load_images "$KUBERNETES_VERSION"
+
         upgrade_kubeadm "$KUBERNETES_VERSION"
 
         ( set -x; kubeadm upgrade node )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes multiple issues:

- The package that is downloaded is a multi-package bundle and is not detected by the addon_fetch_airgap function so the user is prompted a second time
- addon_fetch_airgap calls addon_source but the kubernetes "add-on" is not an add-on and this fails. this function is not called anywhere else.
- kubernetes_load_images is called too late
- kubernetes_load_images is called multiple times