### PR TITLE
fix: better messaging when kurl-install-directory does not exist

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -758,17 +758,26 @@ function maybe_read_kurl_config_from_cluster() {
 
 KURL_INSTALL_DIRECTORY=/var/lib/kurl
 function pushd_install_directory() {
+    local dir=
+    dir="$(dirname "$KURL_INSTALL_DIRECTORY")"
+    if [ ! -e "$dir" ] ; then
+        bail "kURL installation directory $dir does not exist."
+    fi
+    if [ ! -d "$dir" ] ; then
+        bail "kURL installation directory $dir is not a directory."
+    fi
+
     KURL_INSTALL_DIRECTORY="$(realpath "$KURL_INSTALL_DIRECTORY")"
 
-    local tmpfile
-    tmpfile="${KURL_INSTALL_DIRECTORY}/tmpfile"
-    if ! mkdir -p "${KURL_INSTALL_DIRECTORY}" || ! touch "${tmpfile}" ; then
-        bail "Directory ${KURL_INSTALL_DIRECTORY} is not writeable by this script.
+    local tmpfile=
+    tmpfile="$KURL_INSTALL_DIRECTORY/tmpfile"
+    if ! mkdir -p "$KURL_INSTALL_DIRECTORY" || ! touch "$tmpfile" ; then
+        bail "Directory $KURL_INSTALL_DIRECTORY is not writeable by this script.
 Please either change the directory permissions or override the
 installation directory with the flag \"kurl-install-directory\"."
     fi
-    rm "${tmpfile}"
-    pushd "${KURL_INSTALL_DIRECTORY}" 1>/dev/null
+    rm "$tmpfile"
+    pushd "$KURL_INSTALL_DIRECTORY" 1>/dev/null
 }
 
 function popd_install_directory() {

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1918,6 +1918,7 @@
   flags: "kurl-install-directory=/custom"
   preInstallScript: |
     touch /var/lib/kurl
+    mkdir -p /custom
 - name: "Upgrade Kubernetes from 1.19 to 1.26"
   flags: "yes"
   installerSpec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

fix testgrid test and add better messaging when the custom kurl-install-directory does not exist.

https://testgrid.kurl.sh/run/STAGING-daily-40a66f4-2023-04-20T01:27:37Z?kurlLogsInstanceId=fvzaqbyroyeicdqm&nodeId=fvzaqbyroyeicdqm-initialprimary#L0

```
+ cat install.sh
2023-04-20 04:09:07+00:00 ⚙  Running install with the argument(s): kurl-install-directory=/custom
2023-04-20 04:09:07+00:00 realpath: ‘/custom/kurl’: No such file or directory
+ KURL_EXIT_STATUS=1
```
