### PR TITLE
fix(testgrid): post-upgrade script checks incorrect version of k8s

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1979,7 +1979,7 @@
     validate_read_write_object_store postupgrade upgradefile.txt
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
-    echo $k8sVersion | grep 1.26
+    echo $k8sVersion | grep 1.24
 
     operatorVersion=$(kubectl get deployment -n rook-ceph rook-ceph-operator -o jsonpath='{.spec.template.spec.containers[0].image}')
     echo $operatorVersion | grep 1.5.12


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We have the wrong version in the post upgrade script

```
++ kubectl get nodes -o 'jsonpath={.items[0].status.nodeInfo.kubeletVersion}'
2023-04-20 03:54:05+00:00 upgradefile.txt was successfully stored and retrieved
+ k8sVersion=v1.24.12
+ echo v1.24.12
+ grep 1.26
+ local exit_status=1
+ '[' 1 -ne 0 ']'
```