### PR TITLE
Update prompts.sh

### DIFF
--- a/scripts/common/prompts.sh
+++ b/scripts/common/prompts.sh
@@ -154,7 +154,7 @@ function common_prompts() {
 
     prompt_airgap_preload_images
 
-    if [ "$HA_CLUSTER" = "1" ]; then
+    if [ "$HA_CLUSTER" = "1" ] && [ "$EKCO_ENABLE_INTERNAL_LOAD_BALANCER" != "1" ]; then
         prompt_for_load_balancer_address
     fi
 }


### PR DESCRIPTION
Fixes prompt for internal loadbalancer when using the flag ekco-enable-internal-load-balancer [SC-60305](https://app.shortcut.com/replicated/story/60305/ekco-enableinternalloadbalancer-true-should-not-prompt-for-load-balancer)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-60305](https://app.shortcut.com/replicated/story/60305/ekco-enableinternalloadbalancer-true-should-not-prompt-for-load-balancer)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Run installer with `ha ekco-enable-internal-load-balancer` and run installer with `ha`. Only the last one should prompt for a load balancer.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When running the installer with `ekco-enable-internal-load-balancer` it will no longer prompt for a load-balancer.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
