### PR TITLE
chore: skip flannel tests with docker on unsupported envs

### DIFF
--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -107,3 +107,6 @@
       s3Override: "__testdist__"
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
+  - centos-81 # docker 20.10.17 is not supported on centos 8.1.
+  - centos-84 # docker 20.10.17 is not supported on centos 8.4.
+  - ol-8x # docker 20.10.17 is not supported on ol 8.7.


### PR DESCRIPTION
docker, that is being used for this test, is unsupported on the following OS:

- centos-81
- centos-84
- ol-8x

the error being shown during testgrid execution is:

```
Docker 20.10.17 is not supported on centos 8.1.
```