### PR TITLE
fix(testgrid): download k8s bundle for storage migration upgrades

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -1021,6 +1021,10 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info
@@ -1139,6 +1143,10 @@
   - ol-8x # The kURL version used in this test, v2022.08.23-0, does not support OL-8.7
   - ubuntu-2204 # docker 19.03.4 is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rook_ceph_object_store_info
@@ -1244,8 +1252,13 @@
     flannel:
       version: "0.21.x" # (replicated) changed to .x version
   unsupportedOSIDs:
+  - ol-8x # The kURL version used in this test, v2022.11.10-1, does not support OL-8.7
   - ubuntu-2204 # docker 19.03.10 is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
@@ -1336,6 +1349,10 @@
       version: 0.21.x # (replicated) changed to .x version
   unsupportedOSIDs:
   - rocky-91 # rocky 9.1 is unsupported on kurl version v2023.02.23-0
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

We have removed the k8s step version from kurl packages so airgap storage migrations are failing with k8s multi upgrades. This pr will download the k8s bundle prior to upgrade.

https://testgrid.kurl.sh/run/STAGING-daily-storage-migration-7f49cf9-2023-04-21T01:27:44Z?kurlLogsInstanceId=gwbwweycpdjdkawj&nodeId=gwbwweycpdjdkawj-initialprimary

```
2023-04-22 07:16:14+00:00 ⚙  Downloading assets required for Kubernetes 1.21.14 to 1.23.17 upgrade
2023-04-22 07:16:14+00:00 The following packages are not available locally, and are required:
2023-04-22 07:16:14+00:00     kubernetes-1.22.17.tar.gz
+ KURL_EXIT_STATUS=1
```