### PR TITLE
fix(kubernetes): bundle size calculation rhel 7 error

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -200,7 +200,7 @@ function kubernetes_upgrade_required_archive_size() {
         if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
             continue
         fi
-        total_archive_size=$((total_archive_size + "$bundle_size_upper_bounds"))
+        total_archive_size=$((total_archive_size + bundle_size_upper_bounds))
     done <<< "$(common_upgrade_step_versions "${STEP_VERSIONS[*]}" "$current_version" "$desired_version")"
 
     echo "$total_archive_size"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

```
This script will upgrade Kubernetes from 1.20.15 to 1.21.14.
Upgrading Kubernetes will take some time.
Would you like to continue? (Y/n)
bash: line 7642: total_archive_size + "935": syntax error: operand expected (error token is ""935"")
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue on RHEL 7 based distributions that causes the script to improperly calculate the bundle size when upgrading multiple Kubernetes versions and prints the message 'total_archive_size + "935": syntax error: operand expected (error token is ""935"")'.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE