### PR TITLE
fix: cli SetStderr is set to stdout

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -93,7 +93,7 @@ func (cli *KurlCLI) Stderr() io.Writer {
 
 // SetStderr overrides the writer that writes to stderr
 func (cli *KurlCLI) SetStderr(w io.Writer) {
-	cli.stdout = w
+	cli.stderr = w
 }
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes CLI SetStderr function sets io.Writer to cli.stdout causing failures