### PR TITLE
fix: cli help should go to stderr

### DIFF
--- a/cmd/kurl/main.go
+++ b/cmd/kurl/main.go
@@ -17,8 +17,6 @@ func main() {
 	}
 
 	cmd := cli.NewKurlCmd(kurlCLI)
-	cmd.SetOut(kurlCLI.Stdout())
-	cmd.SetErr(kurlCLI.Stderr())
 
 	err = cmd.ExecuteContext(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes command help text is going to stdout causing installation errors:

```
s3:
        region: us-east-1
        regionendpoint: http://command/ "format-address" is deprecated, use 'kurl netutil format-ip-address' instead
10.96.3.94
```