### PR TITLE
fix(rook): multi upgrades not possible to version other than ROOK_STEP_VERSIONS

### DIFF
--- a/scripts/common/common-test.sh
+++ b/scripts/common/common-test.sh
@@ -53,7 +53,7 @@ function test_common_upgrade_step_versions() {
     assertEquals "error major versions" "1" "$(trap "echo_exit_code" EXIT; common_upgrade_step_versions "${step_versions[*]}" "1.1" "2.1"; trap '' EXIT)"
     assertEquals "6 to 4" "" "$(common_upgrade_step_versions "${step_versions[*]}" "1.6" "1.4")"
     assertEquals "9 to 10" "$(echo -e "1.10.11")" "$(common_upgrade_step_versions "${step_versions[*]}" "1.9" "1.10")"
-    assertEquals "1.9.3 to 1.10.9" "$(echo -e "1.10.9")" "$(common_upgrade_step_versions "${step_versions[*]}" "1.9" "1.10.9")"
+    assertEquals "1.9.3 to 1.10.9" "$(echo -e "1.10.9")" "$(common_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.10.9")"
     assertEquals "1.9.3 to 1.11.1" "$(echo -e "1.10.11\n1.11.1")" "$(common_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.11.1")"
     assertEquals "1.9.3 to 1.11.3" "$(echo -e "1.10.11\n1.11.3")" "$(common_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.11.3")"
 }

--- a/scripts/common/rook-upgrade-test.sh
+++ b/scripts/common/rook-upgrade-test.sh
@@ -40,6 +40,9 @@ function test_rook_upgrade_step_versions() {
     assertEquals "9 to 11" "$(echo -e "1.9.12\n1.10.11\n1.11.2")" "$(rook_upgrade_step_versions "${step_versions[*]}" "1.9" "1.11")"
     assertEquals "error out of bounds" "1" "$(trap "echo_exit_code" EXIT; rook_upgrade_step_versions "${step_versions[*]}" "1.9" "1.15"; trap '' EXIT)"
     assertEquals "6 to 4" "" "$(rook_upgrade_step_versions "${step_versions[*]}" "1.6" "1.4")"
+    assertEquals "1.9.3 to 1.10.9" "$(echo -e "1.9.12\n1.10.9")" "$(rook_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.10.9")"
+    assertEquals "1.9.3 to 1.11.1" "$(echo -e "1.9.12\n1.10.11\n1.11.1")" "$(rook_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.11.1")"
+    assertEquals "1.9.3 to 1.11.3" "$(echo -e "1.9.12\n1.10.11\n1.11.3")" "$(rook_upgrade_step_versions "${step_versions[*]}" "1.9.3" "1.11.3")"
 }
 
 function test_rook_upgrade_required_disk_space() {

--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -122,35 +122,32 @@ function rook_upgrade_report_upgrade_rook() {
     local from_version=
     from_version="$(common_upgrade_version_to_major_minor "$current_version")"
 
-    local to_version=
-    to_version="$(common_upgrade_version_to_major_minor "$desired_version")"
-
     local rook_upgrade_version="v2.0.0" # if you change this code, change the version
-    report_addon_start "rook_${from_version}_to_${to_version}" "$rook_upgrade_version"
-    export REPORTING_CONTEXT_INFO="rook_${from_version}_to_${to_version} $rook_upgrade_version"
-    rook_upgrade "$from_version" "$to_version"
+    report_addon_start "rook_${from_version}_to_${desired_version}" "$rook_upgrade_version"
+    export REPORTING_CONTEXT_INFO="rook_${from_version}_to_${desired_version} $rook_upgrade_version"
+    rook_upgrade "$current_version" "$desired_version"
     export REPORTING_CONTEXT_INFO=""
-    report_addon_success "rook_${from_version}_to_${to_version}" "$rook_upgrade_version"
+    report_addon_success "rook_${from_version}_to_${desired_version}" "$rook_upgrade_version"
 }
 
 # rook_upgrade upgrades will fetch the add-on and load the images for the upgrade and finally run
 # the upgrade script.
 function rook_upgrade() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
     rook_disable_ekco_operator
 
     # when invoked in a subprocess the failure of this function will not cause the script to exit
     # sanity check that the rook version is valid
-    rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$from_version" "$to_version" 1>/dev/null
+    rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$current_version" "$desired_version" 1>/dev/null
 
-    logStep "Upgrading Rook from $from_version.x to $to_version.x"
-    common_upgrade_print_list_of_minor_upgrades "$from_version" "$to_version"
+    logStep "Upgrading Rook from $current_version to $desired_version"
+    common_upgrade_print_list_of_minor_upgrades "$current_version" "$desired_version"
     echo "This may take some time."
-    rook_upgrade_addon_fetch_and_load "$from_version" "$to_version"
+    rook_upgrade_addon_fetch_and_load "$current_version" "$desired_version"
 
-    rook_upgrade_prompt_missing_images "$from_version" "$to_version"
+    rook_upgrade_prompt_missing_images "$current_version" "$desired_version"
 
     # delete the mutatingwebhookconfiguration and remove the rook-priority.kurl.sh label
     # as the EKCO rook-priority.kurl.sh mutating webhook is no longer necessary passed Rook
@@ -158,30 +155,30 @@ function rook_upgrade() {
     kubectl label namespace rook-ceph rook-priority.kurl.sh-
     kubectl delete mutatingwebhookconfigurations rook-priority.kurl.sh --ignore-not-found
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         addon_source "rookupgrade" "10to14"
-        rookupgrade_10to14_upgrade "$from_version"
+        rookupgrade_10to14_upgrade "$current_version"
 
         # delete both the compressed and decompressed addon files to free up space
         rm -f "$DIR/assets/rookupgrade-10to14.tar.gz"
         rm -rf "$DIR/addons/rookupgrade/10to14"
     fi
 
-    # if to_version is greater than 1.4, then continue with the upgrade
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
-        rook_upgrade_do_rook_upgrade "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version"
+    # if desired_version is greater than 1.4, then continue with the upgrade
+    if [ "$(common_upgrade_compare_versions "$desired_version" "1.4")" = "1" ]; then
+        rook_upgrade_do_rook_upgrade "$(common_upgrade_max_version "1.4" "$current_version")" "$desired_version"
     fi
 
     rook_enable_ekco_operator
 
-    logSuccess "Successfully upgraded Rook from $from_version.x to $to_version.x"
+    logSuccess "Successfully upgraded Rook from $current_version to $desired_version"
 }
 
-# rook_upgrade_do_rook_upgrade will step through each minor version upgrade from $from_version to
-# $to_version
+# rook_upgrade_do_rook_upgrade will step through each minor version upgrade from $current_version to
+# $desired_version
 function rook_upgrade_do_rook_upgrade() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
     local step=
     while read -r step; do
@@ -200,7 +197,7 @@ function rook_upgrade_do_rook_upgrade() {
         if commandExists "rook_should_fail_install" ; then
             # NOTE: there is no way to know this is the correct rook version function
             if rook_should_fail_install ; then
-                bail "Rook $to_version will not be installed due to failed preflight checks"
+                bail "Rook $desired_version will not be installed due to failed preflight checks"
             fi
         fi
         # NOTE: there is no way to know this is the correct rook version function
@@ -208,13 +205,13 @@ function rook_upgrade_do_rook_upgrade() {
         ROOK_VERSION="$old_rook_version"
 
         # if this is not the last version in the loop, then delete the addon files to free up space
-        if ! [[ "$step" =~ $to_version ]]; then
+        if [ "$step" != "$desired_version" ]; then
             rm -f "$DIR/assets/rook-$step.tar.gz"
             rm -rf "$DIR/addons/rook/$step"
         fi
 
         logSuccess "Upgraded to Rook $step successfully"
-    done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$from_version" "$to_version")"
+    done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$current_version" "$desired_version")"
 
     if [ -n "$AIRGAP_MULTI_ADDON_PACKAGE_PATH" ]; then
         # delete the airgap package files to free up space
@@ -222,7 +219,7 @@ function rook_upgrade_do_rook_upgrade() {
     fi
 }
 
-# rook_upgrade_addon_fetch_and_load will fetch all add-on versions from $from_version to $to_version.
+# rook_upgrade_addon_fetch_and_load will fetch all add-on versions from $current_version to $desired_version.
 function rook_upgrade_addon_fetch_and_load() {
     if [ "$AIRGAP" = "1" ]; then
         rook_upgrade_addon_fetch_and_load_airgap "$@"
@@ -231,29 +228,29 @@ function rook_upgrade_addon_fetch_and_load() {
     fi
 }
 
-# rook_upgrade_addon_fetch_and_load_online will fetch all add-on versions, one at a time, from $from_version
-# to $to_version.
+# rook_upgrade_addon_fetch_and_load_online will fetch all add-on versions, one at a time, from $current_version
+# to $desired_version.
 function rook_upgrade_addon_fetch_and_load_online() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
-    logStep "Downloading images required for Rook $from_version to $to_version upgrade"
+    logStep "Downloading images required for Rook $current_version to $desired_version upgrade"
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         rook_upgrade_addon_fetch_and_load_online_step "rookupgrade" "10to14"
     fi
 
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
+    if [ "$(common_upgrade_compare_versions "$desired_version" "1.4")" = "1" ]; then
         local step=
         while read -r step; do
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
                 continue
             fi
             rook_upgrade_addon_fetch_and_load_online_step "rook" "$step"
-        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version")"
+        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$desired_version")"
     fi
 
-    logSuccess "Images loaded for Rook $from_version to $to_version upgrade"
+    logSuccess "Images loaded for Rook $current_version to $desired_version upgrade"
 }
 
 # rook_upgrade_addon_fetch_and_load_online_step will fetch an individual add-on version.
@@ -266,72 +263,80 @@ function rook_upgrade_addon_fetch_and_load_online_step() {
 }
 
 # rook_upgrade_addon_fetch_and_load_airgap will prompt the user to fetch all add-on versions from
-# $from_version to $to_version.
+# $current_version to $desired_version.
 function rook_upgrade_addon_fetch_and_load_airgap() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
-    if rook_upgrade_has_all_addon_version_packages "$from_version" "$to_version" ; then
+     # the last version already included in the airgap bundle
+    local version_less_one=
+    version_less_one="$(common_upgrade_major_minor_less_one "$desired_version")"
+
+    if rook_upgrade_has_all_addon_version_packages "$current_version" "$desired_version" ; then
         local node_missing_images=
         # shellcheck disable=SC2086
-        node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "$(get_local_node_name)" "")
+        node_missing_images=$(rook_upgrade_nodes_missing_images "$current_version" "$desired_version" "$(get_local_node_name)" "")
 
         if [ -z "$node_missing_images" ]; then
-            log "All images required for Rook $from_version to $to_version upgrade are present on this node"
+            log "All images required for Rook $current_version to $desired_version upgrade are present on this node"
             return
         fi
     fi
 
-    logStep "Downloading images required for Rook $from_version to $to_version upgrade"
+    logStep "Downloading images required for Rook $current_version to $desired_version upgrade"
 
     local addon_versions=()
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         addon_versions+=( "rookupgrade-10to14" )
     fi
 
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
+    if [ "$(common_upgrade_compare_versions "$version_less_one" "1.4")" = "1" ]; then
         local step=
         while read -r step; do
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
                 continue
             fi
             addon_versions+=( "rook-$step" )
-        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version")"
+        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$version_less_one")"
     fi
 
     addon_fetch_multiple_airgap "${addon_versions[@]}"
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         addon_load "rookupgrade" "10to14"
     fi
 
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
+    if [ "$(common_upgrade_compare_versions "$version_less_one" "1.4")" = "1" ]; then
         local step=
         while read -r step; do
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
                 continue
             fi
             addon_load "rook" "$step"
-        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version")"
+        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$version_less_one")"
     fi
 
-    logSuccess "Images loaded for Rook $from_version to $to_version upgrade"
+    logSuccess "Images loaded for Rook $current_version to $desired_version upgrade"
 }
 
 # rook_upgrade_has_all_addon_version_packages will return 1 if any add-on versions are missing that
 # are necessary to perform the upgrade.
 function rook_upgrade_has_all_addon_version_packages() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+     # the last version already included in the airgap bundle
+    local version_less_one=
+    version_less_one="$(common_upgrade_major_minor_less_one "$desired_version")"
+
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         if [ ! -f "addons/rookupgrade/10to14/Manifest" ]; then
             return 1
         fi
     fi
 
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
+    if [ "$(common_upgrade_compare_versions "$version_less_one" "1.4")" = "1" ]; then
         local step=
         while read -r step; do
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
@@ -340,7 +345,7 @@ function rook_upgrade_has_all_addon_version_packages() {
             if [ ! -f "addons/rook/$step/Manifest" ]; then
                 return 1
             fi
-        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version")"
+        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$version_less_one")"
     fi
 
     return 0
@@ -349,26 +354,26 @@ function rook_upgrade_has_all_addon_version_packages() {
 # rook_upgrade_prompt_missing_images prompts the user to run the command to load the images on all
 # remote nodes before proceeding.
 function rook_upgrade_prompt_missing_images() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
 
     local node_missing_images=
     # shellcheck disable=SC2086
-    node_missing_images=$(rook_upgrade_nodes_missing_images "$from_version" "$to_version" "" "$(get_local_node_name)")
+    node_missing_images=$(rook_upgrade_nodes_missing_images "$current_version" "$desired_version" "" "$(get_local_node_name)")
 
-    common_prompt_task_missing_assets "$node_missing_images" "$from_version" "$to_version" "Rook" "rook-upgrade-load-images"
+    common_prompt_task_missing_assets "$node_missing_images" "$current_version" "$desired_version" "Rook" "rook-upgrade-load-images"
 }
 
 # rook_upgrade_nodes_missing_images will print a list of nodes that are missing images for the
 # given rook versions.
 function rook_upgrade_nodes_missing_images() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
     local target_host="$3"
     local exclude_hosts="$4"
 
     local images_list=
-    images_list="$(rook_upgrade_images_list "$from_version" "$to_version")"
+    images_list="$(rook_upgrade_images_list "$current_version" "$desired_version")"
 
     if [ -z "$images_list" ]; then
         return
@@ -379,16 +384,20 @@ function rook_upgrade_nodes_missing_images() {
 
 # rook_upgrade_images_list will print a list of images for the given rook versions.
 function rook_upgrade_images_list() {
-    local from_version="$1"
-    local to_version="$2"
+    local current_version="$1"
+    local desired_version="$2"
+
+     # the last version already included in the airgap bundle
+    local version_less_one=
+    version_less_one="$(common_upgrade_major_minor_less_one "$desired_version")"
 
     local images_list=
 
-    if common_upgrade_is_version_included "$from_version" "$to_version" "1.4" ; then
+    if common_upgrade_is_version_included "$current_version" "$desired_version" "1.4" ; then
         images_list="$(rook_upgrade_list_rook_ceph_images_in_manifest_file "addons/rookupgrade/10to14/Manifest")"
     fi
 
-    if [ "$(common_upgrade_compare_versions "$to_version" "1.4")" = "1" ]; then
+    if [ "$(common_upgrade_compare_versions "$version_less_one" "1.4")" = "1" ]; then
         local step=
         while read -r step; do
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
@@ -398,7 +407,7 @@ function rook_upgrade_images_list() {
                 "$images_list" \
                 "$(rook_upgrade_list_rook_ceph_images_in_manifest_file "addons/rook/$step/Manifest")" \
             )"
-        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$from_version")" "$to_version")"
+        done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$version_less_one")"
     fi
 
     echo "$images_list"
@@ -423,12 +432,18 @@ function rook_upgrade_step_versions() {
     local step_versions=
     read -ra step_versions <<< "$1"
     local from_version=$2
-    local to_version=$3
+    local desired_version=$3
 
-    # check that both are major version 1
-    if  [ "$(common_upgrade_major_minor_to_major "$from_version")" != "1" ] || \
-        [ "$(common_upgrade_major_minor_to_major "$to_version")" != "1" ] ; then
-        bail "Upgrade from $from_version to $to_version is not supported."
+    local to_version=
+    to_version=$(common_upgrade_version_to_major_minor "$desired_version")
+
+    # check that major versions are the same
+    local first_major=
+    first_major=$(common_upgrade_major_minor_to_major "$from_version")
+    local last_major=
+    last_major=$(common_upgrade_major_minor_to_major "$to_version")
+    if [ "$first_major" != "$last_major" ]; then
+        bail "Upgrade accross major version from $from_version to $to_version is not supported."
     fi
 
     local first_minor=
@@ -440,37 +455,22 @@ function rook_upgrade_step_versions() {
         bail "Upgrade from $from_version to $to_version is not supported."
     fi
 
+    # if there are no steps to perform, return
+    if [ "$first_minor" -gt "$last_minor" ]; then
+        return
+    fi
+
+    if [ "$desired_version" != "$to_version" ]; then
+        last_minor=$((last_minor - 1)) # last version is the desired version
+    fi
+
     local step=
     for (( step=first_minor ; step<=last_minor ; step++ )); do
         echo "${step_versions[$step]}"
     done
-}
-
-# rook_upgrade_tasks_rook_upgrade is called by tasks.sh to upgrade rook.
-function rook_upgrade_tasks_rook_upgrade() {
-    local to_version=
-    local airgap=
-    common_upgrade_tasks_params "$@"
-
-    common_task_require_param "to-version" "$to_version"
-
-    if [ "$airgap" = "1" ]; then
-        export AIRGAP=1
+    if [ "$desired_version" != "$to_version" ]; then
+        echo "$desired_version"
     fi
-
-    local to_version_major=
-    local to_version_minor=
-    to_version_major=$(common_upgrade_major_minor_to_major "$to_version")
-    to_version_minor=$(common_upgrade_major_minor_to_minor "$to_version")
-
-    # we must go to one version more than specified because the install logic will decrement the
-    # version
-    export ROOK_VERSION="$to_version_major.$((to_version_minor + 1)).999"
-
-    export KUBECONFIG=/etc/kubernetes/admin.conf
-    download_util_binaries
-    
-    rook_upgrade_maybe_report_upgrade_rook
 }
 
 # rook_upgrade_tasks_load_images is called from tasks.sh to load images on remote notes for the

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -82,12 +82,6 @@ function tasks() {
             rook_upgrade_tasks_load_images "from-version=1.0" "to-version=1.4"
             popd_install_directory
             ;;
-        rook-upgrade|rook_upgrade)
-            pushd_install_directory
-            shift # the first param is rook-upgrade|rook_upgrade
-            rook_upgrade_tasks_rook_upgrade "$@"
-            popd_install_directory
-            ;;
         rook-upgrade-load-images|rook_upgrade_load_images)
             pushd_install_directory
             shift # the first param is rook-upgrade-load-images|rook_upgrade_load_images


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When upgrading multiple versions of rook the upgrade will always end at a ROOK_STEP_VERSION. If the target rook version from the spec is not the greatest patch version for a given minor, and thus not in the ROOK_STEP_VERSIONS array, the installer will upgrade passed the target version.

For the given spec

```
apiVersion: "cluster.kurl.sh/v1beta1"
kind: "Installer"
metadata: 
  name: "84efe42"
spec: 
  kubernetes: 
    version: "1.19.16"
  flannel: 
    version: "0.21.4"
  rook: 
    version: "1.11.2"
  registry: 
    version: "2.8.1"
  containerd: 
    version: "1.6.20"
  ekco: 
    version: "0.26.5"
```

Installer output:

```
✔ Upgraded to Rook 1.10.11 successfully
⚙  Upgrading to Rook 1.11.4
Scaling down EKCO deployment to 0 replicas
deployment.apps/ekc-operator scaled
Waiting for ekco pods to be removed
...
⚙  Addon rook 1.11.2
Rook 1.11.4 is already installed, will not upgrade to 1.11.2
configmap/kurl-current-config patched
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue that causes Rook upgrades of more than one version to upgrade to the greatest patch version for the target minor version rather than to the specified patch version.
- (improvement) The rook-upgrade task has been removed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
https://github.com/replicatedhq/kurl.sh/pull/963