### PR TITLE
chore: fix issue with k8s 1.27 (kustomize v5) not supporting multi-doc patches for the Prometheus addon

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -31,10 +31,20 @@ function insert_patches_strategic_merge() {
     # Kubernetes 1.27 uses kustomize v5 which dropped support for old, legacy style patches
     # See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1270
     if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge "27" ]; then
-        if ! grep -q "patches" "$kustomization_file"; then
-            echo "patches:" >> "$kustomization_file"
+        if [[ $kustomization_file =~ "prometheus" ]]; then
+            # TODO: multi-doc patches is not currently supported in kustomize v5
+            # continue using the deprecated 'patchesStrategicMerge' field until this is fixed
+            # Ref: https://github.com/kubernetes-sigs/kustomize/issues/5040
+            if ! grep -q "patchesStrategicMerge" "$kustomization_file"; then
+                echo "patchesStrategicMerge:" >> "$kustomization_file"
+            fi
+            sed -i "/patchesStrategicMerge.*/a - $patch_file" "$kustomization_file"
+        else
+            if ! grep -q "^patches:" "$kustomization_file"; then
+                echo "patches:" >> "$kustomization_file"
+            fi
+            sed -i "/patches:/a - path: $patch_file" "$kustomization_file"
         fi
-        sed -i "/patches.*/a - path: $patch_file" "$kustomization_file"
         return
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

[k8s_27x airgap](https://testgrid.kurl.sh/run/STAGING-release-v2023.04.24-0-6535749d-20230426200603?kurlLogsInstanceId=wqnicfagzvibhjcb&nodeId=wqnicfagzvibhjcb-initialprimary) test was failing due to the following prometheus error:
```
2023-04-26 20:59:50+00:00 Error from server (NotFound): services "prometheus-k8s" not found
2023-04-26 20:59:51+00:00 # Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
2023-04-26 20:59:51+00:00 panic: runtime error: invalid memory address or nil pointer dereference
2023-04-26 20:59:51+00:00 [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x14d5edf]
2023-04-26 20:59:51+00:00 
2023-04-26 20:59:51+00:00 goroutine 1 [running]:
2023-04-26 20:59:51+00:00 sigs.k8s.io/kustomize/api/internal/builtins.(*PatchJson6902TransformerPlugin).Config(0xc002d01f90, 0xc0036b59e0?, {0xc000cb0920?, 0x1c87478?, 0x1c87440?})
2023-04-26 20:59:51+00:00 	vendor/sigs.k8s.io/kustomize/api/internal/builtins/PatchJson6902Transformer.go:34 +0x9f
2023-04-26 20:59:51+00:00 sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).configureBuiltinPlugin(0xc0009c8f00?, {0x7f8389779360, 0xc002d01f90}, {0x1d2d140?, 0xc0036b59e0?}, 0x0?)
2023-04-26 20:59:51+00:00 	vendor/sigs.k8s.io/kustomize/api/internal/target/kusttarget.go:560 +0x21b
2023-04-26 20:59:51+00:00 sigs.k8s.io/kustomize/api/internal/target.glob..func5(0xc0009c8f00, 0xc000225a70?, 0x21d6a18, 0x40e047?)
+ KURL_EXIT_STATUS=1
```

After some digging, I discovered the following:
```
rafael@rafael-k8s127-dev-test-20230426200330:~/kurl/kustomize/prometheus/operator$ kubectl apply -k . --dry-run
W0427 01:17:58.944949   25048 helpers.go:692] --dry-run is deprecated and can be replaced with --dry-run=client.
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
error: trouble configuring builtin PatchTransformer with config: `
path: nodeport-services.yaml
`: unable to parse SM or JSON patch from [apiVersion: v1
kind: Service
metadata:
  name: prometheus-alertmanager
  namespace: monitoring
spec:
  ports:
  - name: web
    port: 9093
    protocol: TCP
    nodePort: 30903
  type: "NodePort"
---
apiVersion: v1
kind: Service
metadata:
  name: prometheus-k8s
  namespace: monitoring
spec:
  ports:
  - name: web
    port: 9090
    nodePort: 30900
  type: "NodePort"
---
apiVersion: v1
kind: Service
metadata:
  name: grafana
  namespace: monitoring
spec:
  type: "NodePort"
  ports:
  - name: service
    port: 80
    protocol: TCP
    nodePort: 30902
]
rafael@rafael-k8s127-dev-test-20230426200330:~/kurl/kustomize/prometheus/operator$ cat kustomization.yaml 
resources:
- grafana-secret.yaml
- default.yaml
- ns.yaml
- adapter.yaml

patchesJson6902:
- target:
    group: apps
    version: v1
    kind: DaemonSet
    name: prometheus-node-exporter
  path: matchlabel-instance.yaml
- target:
    group: apps
    version: v1
    kind: Deployment
    name: prometheus-operator
  path: matchlabel-release.yaml
patches:
- path: nodeport-services.yaml
```
That is, [kustomize v5 does not support](https://github.com/kubernetes-sigs/kustomize/issues/5040) multi-doc patches which the prometheus addon uses. Resolved this by going back to the deprecated `patchesStrategicMerge` field until the issue gets fixed.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
