### PR TITLE
fix(rook): multi upgrades load desired version images

### DIFF
--- a/scripts/common/rook-upgrade.sh
+++ b/scripts/common/rook-upgrade.sh
@@ -313,10 +313,6 @@ function rook_upgrade_addon_fetch_and_load_airgap() {
             if [ -z "$step" ] || [ "$step" = "0.0.0" ]; then
                 continue
             fi
-            # the last version already included in the airgap bundle
-            if [ "$step" = "$desired_version" ]; then
-                continue
-            fi
             addon_load "rook" "$step"
         done <<< "$(rook_upgrade_step_versions "${ROOK_STEP_VERSIONS[*]}" "$(common_upgrade_max_version "1.4" "$current_version")" "$desired_version")"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Loading the airgap bundle happens after the rook upgrade step so my optimization to not load the desired rook version is causing imagepullbackoffs in airgap installs.