### PR TITLE
fix(rook): airgap multi upgrades from versions >= 1.4.x do not prompt to load images on remote nodes

### DIFF
--- a/scripts/common/common-test.sh
+++ b/scripts/common/common-test.sh
@@ -131,6 +131,7 @@ function test_common_list_images_in_manifest_file() {
 
 function test_common_upgrade_merge_images_list() {
     assertEquals "merges two lists" "docker.io/rook/ceph:v1.1.9 docker.io/rook/ceph:v1.2.7 docker.io/rook/ceph:v1.3.11 docker.io/rook/ceph:v1.4.9 docker.io/rook/ceph:v1.9.12" "$(common_upgrade_merge_images_list "docker.io/rook/ceph:v1.1.9 docker.io/rook/ceph:v1.2.7 docker.io/rook/ceph:v1.3.11 docker.io/rook/ceph:v1.4.9" "docker.io/rook/ceph:v1.9.12")"
+    assertEquals "merges two lists first empty" "docker.io/rook/ceph:v1.10.11 docker.io/rook/ceph:v1.9.12"  "$(common_upgrade_merge_images_list "" "docker.io/rook/ceph:v1.10.11 docker.io/rook/ceph:v1.9.12")"
     assertEquals "trims spaces and removes duplicates" "a b c d" "$(common_upgrade_merge_images_list " a   b  c d   " " b  d a c d")"
 }
 

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1340,9 +1340,9 @@ function common_list_images_in_manifest_file() {
 # list and deduplicate the list.
 function common_upgrade_merge_images_list() {
     local images_list=
-    while [ "$1" != "" ]; do
-        images_list="$images_list $1"
-        shift
+    local list=
+    for list in "$@" ; do
+        images_list="$images_list $list"
     done
     echo "$images_list" | tr " " "\n" | sort | uniq | tr "\n" " " | xargs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The image list merge function will always return an empty list if the first argument is empty. Starting from a version > 1.0 this is always the case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue when upgrading multiple versions of Rook starting with a version >= 1.4.x in an airgap environment that causes the script to fail with ImagePullBackoff errors due to the failure to prompt the user to load images on remote nodes.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE