### PR TITLE
fix: empty kustomize dir causes script to exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean: ## Clean the build directory
 dist/common.tar.gz: build/kustomize build/manifests build/shared build/krew build/kurlkinds build/helm
 	mkdir -p dist
 	tar cf dist/common.tar -C build kustomize
-	tar cf dist/common.tar -C build manifests
+	tar rf dist/common.tar -C build manifests
 	tar rf dist/common.tar -C build shared
 	tar rf dist/common.tar -C build krew
 	tar rf dist/common.tar -C build kurlkinds


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When manifests directory was added it is erasing the kustomize files in the tar resulting in an empty kustomize dir which is causing the script to exit 

https://testgrid.kurl.sh/run/ETHAN-20230502-coredns-2?kurlLogsInstanceId=geuwuekdpdjpsnpl&nodeId=geuwuekdpdjpsnpl-initialprimary#L293

```
2023-05-02 23:46:57+00:00 ⚙  Host preflights success
2023-05-02 23:47:03+00:00 cp: cannot stat './kustomize/kubeadm/init-orig/*': No such file or directory
2023-05-02 23:47:03+00:00 An error occurred on line 8590
+ KURL_EXIT_STATUS=1
```
