### PR TITLE
feat(kubernetes): configure max pods per node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.1
-	github.com/replicatedhq/kurlkinds v1.3.5
+	github.com/replicatedhq/kurlkinds v1.3.6
 	github.com/replicatedhq/plumber/v2 v2.2.0
 	github.com/replicatedhq/pvmigrate v0.9.0
 	github.com/replicatedhq/troubleshoot v0.62.1

--- a/go.sum
+++ b/go.sum
@@ -2047,6 +2047,8 @@ github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOe
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/replicatedhq/kurlkinds v1.3.5 h1:tAgQIRbTNcrpzs7hSM/7DUryduVz1E7yL/KrwlLRA5I=
 github.com/replicatedhq/kurlkinds v1.3.5/go.mod h1:c5+hoAkuARgftB2Ft3RCyWRZZPhL0clHEaw7XoGDAg4=
+github.com/replicatedhq/kurlkinds v1.3.6 h1:/dhS32cSSZR4yS4vA8EquBvz+VgJCyTqBO9Xw+6eI4M=
+github.com/replicatedhq/kurlkinds v1.3.6/go.mod h1:c5+hoAkuARgftB2Ft3RCyWRZZPhL0clHEaw7XoGDAg4=
 github.com/replicatedhq/plumber/v2 v2.2.0 h1:vjG8hZKO7tvLdPzWFqLBmjfpNtpSXhWrOmYdwTNdQR0=
 github.com/replicatedhq/plumber/v2 v2.2.0/go.mod h1:seRCMUymCb8PPFw+pH1OefvKVSi5EgSo4HEMYpCW6Io=
 github.com/replicatedhq/pvmigrate v0.9.0 h1:p9+Y4RonMAxs1RoDv6ngZnKq9ACNQrGqGa57WnzcyI0=

--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -129,6 +129,15 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 				return errors.Wrap(err, "invalid container-log-max-files value. must be an integer.")
 			}
 			installer.Spec.Kubernetes.ContainerLogMaxFiles = m
+		case "kubernetes-max-pods-per-node":
+			if installer.Spec.Kubernetes == nil {
+				installer.Spec.Kubernetes = &kurlv1beta1.Kubernetes{}
+			}
+			m, err := strconv.Atoi(split[1])
+			if err != nil {
+				return errors.Wrap(err, "invalid kubernetes-max-pods-per-node value. must be an integer.")
+			}
+			installer.Spec.Kubernetes.MaxPodsPerNode = m
 		case "kubeadm-token":
 			if installer.Spec.Kubernetes == nil {
 				installer.Spec.Kubernetes = &kurlv1beta1.Kubernetes{}

--- a/kurl_util/cmd/yamltobash/main.go
+++ b/kurl_util/cmd/yamltobash/main.go
@@ -220,6 +220,7 @@ func convertToBash(kurlValues map[string]interface{}, fieldsSet map[string]bool)
 		"Kubernetes.ControlPlane":                         "MASTER",
 		"Kubernetes.ContainerLogMaxSize":                  "CONTAINER_LOG_MAX_SIZE",
 		"Kubernetes.ContainerLogMaxFiles":                 "CONTAINER_LOG_MAX_FILES",
+		"Kubernetes.MaxPodsPerNode":                       "KUBERNETES_MAX_PODS_PER_NODE",
 		"Kubernetes.EvictionThresholdResources":           "EVICTION_THRESHOLD",
 		"Kubernetes.HACluster":                            "HA_CLUSTER",
 		"Kubernetes.KubeadmToken":                         "KUBEADM_TOKEN",

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -109,6 +109,8 @@ function get_patch_yaml() {
                 ;;
             container-log-max-files)
                 ;;
+            kubernetes-max-pods-per-node)
+                ;;
             kubeadm-token)
                 ;;
             kubeadm-token-ca-hash)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -166,6 +166,13 @@ function init() {
 
         render_yaml_file $kustomize_kubeadm_init/patch-kubelet-container-log-max-files.tpl > $kustomize_kubeadm_init/patch-kubelet-container-log-max-files.yaml
     fi
+    if [ -n "$KUBERNETES_MAX_PODS_PER_NODE" ]; then
+        insert_patches_strategic_merge \
+            $kustomize_kubeadm_init/kustomization.yaml \
+            patch-kubelet-max-pods.yaml
+
+        render_yaml_file_2 $kustomize_kubeadm_init/patch-kubelet-max-pods.tmpl.yaml > $kustomize_kubeadm_init/patch-kubelet-max-pods.yaml
+    fi
 
     kubernetes_configure_pause_image "$kustomize_kubeadm_init"
 

--- a/scripts/kustomize/kubeadm/init-orig/patch-kubelet-max-pods.tmpl.yaml
+++ b/scripts/kustomize/kubeadm/init-orig/patch-kubelet-max-pods.tmpl.yaml
@@ -1,0 +1,5 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+metadata:
+  name: kubelet-configuration
+maxPods: $KUBERNETES_MAX_PODS_PER_NODE

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -1367,7 +1367,10 @@
       version: latest
     ekco:
       version: latest
-  flags: "labels=disktype=ssd,gpu=enabled exclude-builtin-host-preflights" # TODO: add more flags here
+  flags: "labels=disktype=ssd,gpu=enabled exclude-builtin-host-preflights kubernetes-max-pods-per-node=200"
+  postInstallScript: |
+    kubectl get node -oyaml | grep ' gpu: enabled'
+    kubectl get node -oyaml | grep ' pods: "200"'
 - name: ekco-podimageoverrides
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Adds the ability to configure the maximum number of Pods that can run on each node (default 110) using the spec property `kubernetes.maxPodsPerNode` or the flag `--kubernetes-max-pods-per-node=`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

https://github.com/replicatedhq/kURL-api/pull/235

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds the ability to configure the maximum number of Pods that can run on each node (default 110) using the spec property `kubernetes.maxPodsPerNode` or the flag `--kubernetes-max-pods-per-node=`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
https://github.com/replicatedhq/kurl.sh/pull/965