### PR TITLE
Exclude Rook patches from Kustomize v5 (1.27) behavior

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -31,7 +31,7 @@ function insert_patches_strategic_merge() {
     # Kubernetes 1.27 uses kustomize v5 which dropped support for old, legacy style patches
     # See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1270
     if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge "27" ]; then
-        if [[ $kustomization_file =~ "prometheus" ]]; then
+        if [[ $kustomization_file =~ "prometheus" ]] || [[ $kustomization_file =~ "rook" ]]; then
             # TODO: multi-doc patches is not currently supported in kustomize v5
             # continue using the deprecated 'patchesStrategicMerge' field until this is fixed
             # Ref: https://github.com/kubernetes-sigs/kustomize/issues/5040


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes _K8s 1.27x Rook, disableS3_ test in TestGrid failing with the following kustomize error:
```
++ cat
+ insert_patches_strategic_merge ./kustomize/rook/cluster/kustomization.yaml patches/rbd-storageclass.yaml
+ local kustomization_file=./kustomize/rook/cluster/kustomization.yaml
+ local patch_file=patches/rbd-storageclass.yaml
+ '[' 27 -ge 27 ']'
+ [[ ./kustomize/rook/cluster/kustomization.yaml =~ prometheus ]]
+ grep -q '^patches:' ./kustomize/rook/cluster/kustomization.yaml
+ sed -i '/patches:/a - path: patches/rbd-storageclass.yaml' ./kustomize/rook/cluster/kustomization.yaml
+ return
+ kubernetes_resource_exists rook-ceph cephcluster rook-ceph
+ local namespace=rook-ceph
+ local kind=cephcluster
+ local name=rook-ceph
+ kubectl -n rook-ceph get cephcluster rook-ceph
+ kubectl -n rook-ceph apply -k ./kustomize/rook/cluster/
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
error: trouble configuring builtin PatchTransformer with config: `
path: patches/rbd-storageclass.yaml
`: unable to parse SM or JSON patch from [---
apiVersion: ceph.rook.io/v1
kind: CephBlockPool
metadata:
  name: replicapool
  namespace: rook-ceph
spec:
  replicated:
    size: 1
    requireSafeReplicaSize: false
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: "default"
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
```
https://testgrid.kurl.sh/run/STAGING-daily-64476c9-2023-05-04T01:27:45Z?kurlLogsInstanceId=clydlovgerdxlicz&nodeId=clydlovgerdxlicz-initialprimary#L997](https://testgrid.kurl.sh/run/STAGING-daily-64476c9-2023-05-04T01:27:45Z?kurlLogsInstanceId=clydlovgerdxlicz&nodeId=clydlovgerdxlicz-initialprimary#L997) 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
