### PR TITLE
fix(kots): prerelease message always shows in testgrid

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -373,15 +373,15 @@ selinux_enforced() {
 }
 
 function kotsadm_prerelease() {
-    if [ -n "$TESTGRID_ID" ]; then
-        printf "\n${YELLOW}This is a prerelease version of kotsadm and should not be run in production. Continuing because this is testgrid.${NC}\n"
-        return 0
-    fi
-
     if [ "$KOTSADM_VERSION" = "alpha" ] || [ "$KOTSADM_VERSION" = "nightly" ]; then
-        printf "\n${YELLOW}This is a prerelease version of kotsadm and should not be run in production. Press Y to continue.${NC} "
-        if ! confirmN; then
-            bail "\nWill not install prerelease version of kotsadm."
+        if [ -n "$TESTGRID_ID" ]; then
+            printf "\n${YELLOW}This is a prerelease version of kotsadm and should not be run in production. Continuing because this is testgrid.${NC}\n"
+            return 0
+        else
+            printf "\n${YELLOW}This is a prerelease version of kotsadm and should not be run in production. Press Y to continue.${NC} "
+            if ! confirmN; then
+                bail "\nWill not install prerelease version of kotsadm."
+            fi
         fi
     fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The message "This is a prerelease version of kotsadm..." would always show in testgrid whether or not the kots addon is included in the spec or if it is a prelease version.