### PR TITLE
🐛 fix in cluster preflights which cannot be executed because was not possible to find the config

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -644,6 +644,11 @@ function cluster_preflights() {
         return
     fi
 
+    if [ ! -f /etc/kubernetes/admin.conf ]; then
+        log "In cluster Preflights will not be executed because /etc/kubernetes/admin.conf is not found"
+        return
+    fi
+
     logStep "Running in cluster Preflights"
     mkdir -p "${DIR}/${IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR}"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Because of the error: 

> ⚙  Running in cluster Preflights
> W0505 12:27:25.525100  126811 loader.go:222] Config not found: /etc/kubernetes/admin.conf
> Error: run preflight: collect results: failed to check RBAC for collectors: failed to run subject review: Post "http://localhost:8080/apis/authorization.k8s.io/v1/selfsubjectaccessreviews": dial tcp 127.0.0.1:8080: connect: connection refused

#### Which issue(s) this PR fixes:

Fixes # 

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes the in cluster preflights check error `Error: run preflight: collect results: failed to check RBAC for collectors` which makes the installation fails when the config `/etc/kubernetes/admin.conf` is not found. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
