### PR TITLE
add RBAC roles required to run openebs+minio->rook migration to ekco

### DIFF
--- a/addons/ekco/template/base/configmap.tmpl.yaml
+++ b/addons/ekco/template/base/configmap.tmpl.yaml
@@ -47,3 +47,5 @@ data:
     minio_namespace: "$MINIO_NAMESPACE"
     minio_util_image: "$KURL_UTIL_IMAGE"
     enable_ha_kotsadm: $EKCO_MAINTAIN_KOTSADM
+    rook_minimum_node_count: ${ROOK_MINIMUM_NODE_COUNT:-0}
+    rook_storage_class: "${STORAGE_CLASS:-distributed}"

--- a/addons/ekco/template/base/deployment.tmpl.yaml
+++ b/addons/ekco/template/base/deployment.tmpl.yaml
@@ -55,6 +55,18 @@ spec:
             - name: certificates-dir
               mountPath: /etc/kubernetes/pki
               readOnly: true
+          ports:
+            - containerPort: 8080
+              name: service
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: service
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       volumes:
         - name: ekco-config
           configMap:

--- a/addons/ekco/template/base/rbac.yaml
+++ b/addons/ekco/template/base/rbac.yaml
@@ -77,6 +77,7 @@ rules:
     verbs:
     - get
     - list
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -106,3 +107,87 @@ rules:
       - pods/exec
     verbs:
       - create
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-pvmigrate
+rules:
+  - apiGroups: [""]
+    resources:
+      - persistentvolumes
+    verbs:
+      - list
+      - get
+      - update
+      - delete
+  - apiGroups: [""]
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - list
+      - get
+      - delete
+      - create
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - update
+      - delete
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - update
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+    verbs:
+      - get
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-kurl
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-velero
+rules:
+  - apiGroups: ["velero.io"]
+    resources:
+      - backupstoragelocations
+      - backuprepositories
+    verbs:
+      - get
+      - update
+---

--- a/addons/ekco/template/base/rolebinding.yaml
+++ b/addons/ekco/template/base/rolebinding.yaml
@@ -12,3 +12,44 @@ subjects:
   - kind: ServiceAccount
     name: ekco
     namespace: kurl
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ekco-pvmigrate
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-pvmigrate
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ekco-kurl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-kurl
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ekco-velero
+  namespace: velero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ekco-velero
+subjects:
+  - kind: ServiceAccount
+    name: ekco
+    namespace: kurl
+---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
This adds the ports/rbac rules/etc required for ekco to migrate data from openebs+minio to rook, as described in [ADR 9](https://github.com/replicatedhq/kURL/blob/main/docs/arch/adr-009-storage-migration.md).

It does not yet _use_ this however, as that will require additional code to setup storageclasses appropriately and to trigger the migration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
