### PR TITLE
(HOLD)fix: ensure that users are unable to set :6443 as loadBalancer in upgrades either

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -34,8 +34,8 @@ spec:
         port: 6443
         address: {{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}
         timeout: 3m
-        # ha and is first master (primary and not join) and not is upgrade
-        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary (not .IsJoin) (not .IsUpgrade) | not }}'
+        # ha and is first master (primary and not join)
+        exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary (not .IsJoin) | not }}'
     - http:
         collectorName: "Kubernetes API Server Load Balancer Upgrade"
         get:

--- a/pkg/preflight/builtin_test.go
+++ b/pkg/preflight/builtin_test.go
@@ -172,7 +172,7 @@ func TestBuiltinExecuteTemplate(t *testing.T) {
 			want: []jsonquery{
 				{
 					query: ".spec.collectors[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",
-					value: `"true"`,
+					value: `"false"`,
 				},
 				{
 					query: ".spec.analyzers[] | select(.tcpLoadBalancer != null) | .tcpLoadBalancer.exclude",


### PR DESCRIPTION
#### What this PR does / why we need it:

When upgrading a cluster, the value :6443 it does not fail in the preflight checks as it occurs when is a new install. However, the issue lies in the fact that after the upgrade, the ConfigMap kube-system/kurl-config is rendered with an invalid kubernetes_api_address property thus blocking future upgrades:

```
$ kubectl get cm -n kube-system kurl-config -o yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kurl-config
  namespace: kube-system
data:
  kubernetes_api_address: :6443
$ curl https://kurl.sh/450ac41 | sudo bash ha
<redacted>
Drain local node and apply upgrade? (Y/n)
node/ip-172-16-10-70 cordoned
Warning: ignoring DaemonSet-managed Pods: kube-flannel/kube-flannel-ds-v88rp, kube-system/kube-proxy-g2dbd
pod/ekc-operator-74db9bdb55-88pnh deleted
node/ip-172-16-10-70 drained
Waiting for kubernetes api health to report ok
Kubernetes API failed to report healthy
$
```

#### Which issue(s) this PR fixes:

Fixes # [sc-76434]

#### Special notes for your reviewer:

Ensure that we do the same check when we either will upgrade the cluster would avoid this scenario. 
TBD/WIP - It is missing manual test. 

## Steps to reproduce

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix the scenario where the Kubernetes API fails to report as healthy due to an upgrade, it is advisable to enable the preflight check to validate the load-balancer-address=:6443 during the cluster upgrade process. This ensures that the preflight check, which performs this validation, is executed not only for new installations but also during upgrades.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
