### PR TITLE
Fix: Ensure that the Firewalld check verifies if it is enabled and active, and provide more comprehensive information.

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -194,12 +194,14 @@ checkFirewalld() {
     if [ "$BYPASS_FIREWALLD_WARNING" = "1" ]; then
         return
     fi
-    if ! systemctl -q is-active firewalld ; then
+
+    if ! systemctl -q is-enabled firewalld && ! systemctl -q is-active firewalld; then
+        logSuccess "Firewalld is either not enabled or not active."
         return
     fi
 
     if [ "$HARD_FAIL_ON_FIREWALLD" = "1" ]; then
-        printf "${RED}Firewalld is active${NC}\n" 1>&2
+        printf "${RED}Firewalld is currently either enabled or active. Stop (systemctl stop firewalld) and disable Firewalld (systemctl disable firewalld) before proceeding.{NC}\n" 1>&2
         exit 1
     fi
 
@@ -209,14 +211,14 @@ checkFirewalld() {
         return
     fi
    
-    printf "${YELLOW}Firewalld is active, please press Y to disable ${NC}"
+    printf "${YELLOW}Firewalld is currently either enabled or active. To ensure smooth installation and avoid potential issues, it is highly recommended to stop and disable Firewalld. Please press 'Y' to proceed with stopping and disabling Firewalld.${NC}"
     if confirmY ; then
         systemctl stop firewalld
         systemctl disable firewalld
         return
     fi
 
-    printf "${YELLOW}Continue with firewalld active? ${NC}"
+    printf "${YELLOW}Please note that if you choose to continue with Firewalld enabled and active, the installer may encounter unexpected behaviors and may not function properly. Therefore, it is strongly advised to stop and completely disable Firewalld before proceeding.Continue with firewalld enabled and/or active?${NC}"
     if confirmN ; then
         BYPASS_FIREWALLD_WARNING=1
         return


### PR DESCRIPTION
#### What this PR does / why we need it:

See that currently we are NOT:
- Providing a comprehensive info to make clear that Firewalld should be **stopped and disabled**
- We are NOT checking if  Firewalld either is disabled. 

> is-enabled checks if the service is set to start automatically on boot when run is-active just let us know if it is running. In summary, is-active tells you the current runtime status of the service, while is-enabled informs you whether the service is configured to start automatically on boot. We need to check that because otherwise problems will be faced when they re-boot the server.

#### Which issue(s) this PR fixes:

Fixes # [sc-75634]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds fixes to rnsure that the Firewalld check verifies if it is enabled and active, and provide more comprehensive information.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
