### PR TITLE
Adds collectd to ubuntu 22.04 and tests

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -537,13 +537,6 @@ spec:
               when: "timezone == UTC"
               message: "Timezone is set to UTC"
     - hostOS:
-        checkName: "Collectd Support"
-        exclude: '{{kurl not .Installer.Spec.Collectd.Version}}'
-        outcomes:
-          - fail:
-              when: "ubuntu = 22.04"
-              message: "Collectd addon not supported on ubuntu 22.04"
-    - hostOS:
         checkName: "Docker Support"
         exclude: '{{kurl or (not .Installer.Spec.Docker.Version) (semverCompare ">= 20.10.17" .Installer.Spec.Docker.Version) }}'
         outcomes:

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -376,3 +376,4 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
+

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2060,3 +2060,34 @@
     validate_read_write_object_store rwtest testfile.txt
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+- name: "1.27 with all metrics and kots"
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: "latest"
+    contour:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    registry:
+      version: "latest"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "latest"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "local"
+    collectd:
+      version: "latest"
+    metricsServer:
+      version: "latest"
+    goldpinger:
+      version: "latest"
+    kotsadm:
+      version: "latest"


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, the usage of the Collectd AddOn on Ubuntu 22.04 is not supported due to a failed host preflight check [(more information can be found here)](https://github.com/replicatedhq/kURL/pull/3272).

This limitation was originally implemented because Collectd did not have support for Ubuntu 22.04 at that time. However, it appears that the situation has changed,see: https://manpages.ubuntu.com/manpages/jammy/man1/collectd.1.html

Therefore, it seems appropriate to reconsider the restriction on using the Collectd AddOn with Ubuntu 22.04, since the latest information suggests that support is now available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-76651]

#### Special notes for your reviewer:

Remove the preflight and adds checks to cover this addon and all metrics ones enabled with kots

We will need to re-check the testgrid after it get merged. However, you can see that the install was done with success with k8s 1.27 in : https://testgrid.kurl.sh/run/test-task-enable-collectd-camila-more-memoryandcepu-2-12. Because of know scenario the test added is using 1.26.

Note that the scenarios were checked in : https://testgrid.kurl.sh/run/CAMILA-TEST-METRICSADDONS-COLLECTD-May15-Prority-0 . The install occurs with success and the error faced is `Failed Sonobuoy Run` which does has relation within the changes. 

## Steps to reproduce

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Enable collectd usage within ubuntu 22.04
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
