### PR TITLE
adds check to avoid issues with weave

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -13,7 +13,29 @@ function preflights() {
     cri_preflights
     host_nameservers_reachable
     allow_remove_docker_new_install
+    check_symbolic_link_for_weave
     return 0
+}
+
+function check_symbolic_link_for_weave() {
+   if [ -n "$WEAVE_VERSION" ]; then
+        log "Checking if the paths used by weave are symbolic links"
+        if [ -h /opt/cni ] || [ -h /opt/cni/bin/ ] || [ -h /var/lib/weave ]; then
+            logWarn "Symbolic links were found in one or more paths: /opt/cni, /opt/cni/bin/, /var/lib/weave"
+            logWarn "Using symbolic links with Weave can cause inconsistencies in network interface naming,"
+            logWarn "leading to disruptions in network connectivity. Symbolic links introduce ambiguity, making it "
+            logWarn "difficult for Weave to establish reliable connections. This can result in errors or improper "
+            logWarn "functioning of Weave."
+            log ""
+            logWarn "To avoid networks connective issues, it is recommended to avoid using symbolic links for"
+            logWarn "network-related configurations with Weave."
+            log ""
+            log "Would you like to continue? "
+            if ! confirmN ; then
+                 bail "Installation has been aborted because symbolic links were found for Weave AddOn."
+            fi
+        fi
+    fi
 }
 
 # init_preflights are only run on the first node init.sh

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -22,13 +22,9 @@ function check_symbolic_link_for_weave() {
         log "Checking if the paths used by weave are symbolic links"
         if [ -h /opt/cni ] || [ -h /opt/cni/bin/ ] || [ -h /var/lib/weave ]; then
             logWarn "Symbolic links were found in one or more paths: /opt/cni, /opt/cni/bin/, /var/lib/weave"
-            logWarn "Using symbolic links with Weave can cause inconsistencies in network interface naming,"
-            logWarn "leading to disruptions in network connectivity. Symbolic links introduce ambiguity, making it "
-            logWarn "difficult for Weave to establish reliable connections. This can result in errors or improper "
-            logWarn "functioning of Weave."
-            log ""
-            logWarn "To avoid networks connective issues, it is recommended to avoid using symbolic links for"
-            logWarn "network-related configurations with Weave."
+            logWarn "The use of symbolic links in conjunction with the Weave Addon could potentially cause inconsistencies, "
+            logWarn "leading to disruptions in network connectivity. To minimize network connectivity issues, it is generally "
+            logWarn "recommended to avoid symbolic links in Weave's network-related configurations. "
             log ""
             log "Would you like to continue? "
             if ! confirmN ; then


### PR DESCRIPTION
#### What this PR does / why we need it:

We could check that Weave might does not work well with symbolic links
We are adding here an check to warning users in this scenario. 

#### Which issue(s) this PR fixes:

Partial Fixes # [sc-75641]

#### Special notes for your reviewer:
See: errors : https://testgrid.kurl.sh/run/full_test_with_simboly_link_only-camila-wed10

## Steps to reproduce
Create the symbolic links and try to do an install with WEAVE



1) create symbolic links 

```sh

$ sudo ./test.sh 
+ FOLDER=/test
+ mkdir -p /test/opt/cni
+ mkdir -p /test/opt/containerd
+ mkdir -p /test/opt/ekco
+ mkdir -p /test/opt/replicated
+ mkdir -p /test/mnt/drivers
+ mkdir -p /test/mnt/tmpfs
+ mkdir -p /test/var/lib/cni
+ mkdir -p /test/var/lib/containerd
+ mkdir -p /test/var/lib/containers
+ mkdir -p /test/var/lib/docker
+ mkdir -p /test/var/lib/dockershim
+ mkdir -p /test/var/lib/etcd
+ mkdir -p /test/var/lib/kubelet
+ mkdir -p /test/var/lib/kurl
+ mkdir -p /test/var/lib/rook
+ mkdir -p /test/var/lib/weave
+ ln -s /test/opt/cni /opt/cni
+ ln -s /test/opt/containerd /opt/containerd
+ ln -s /test/opt/ekco /opt/ekco
+ ln -s /test/opt/replicated /opt/replicated
+ ln -s /test/mnt/drivers /mnt/drivers
+ ln -s /test/mnt/tmpfs /mnt/tmpfs
+ ln -s /test/var/lib/cni /var/lib/cni
+ ln -s /test/var/lib/containerd /var/lib/containerd
+ ln -s /test/var/lib/containers /var/lib/containers
+ ln -s /test/var/lib/docker /var/lib/docker
+ ln -s /test/var/lib/dockershim /var/lib/dockershim
+ ln -s /test/var/lib/etcd /var/lib/etcd
+ ln -s /test/var/lib/kubelet /var/lib/kubelet
+ ln -s /test/var/lib/kurl /var/lib/kurl
+ ln -s /test/var/lib/rook /var/lib/rook
+ ln -s /test/var/lib/weave /var/lib/weave
```


#### Does this PR introduce a user-facing change?

```release-note
Adds check to let users be aware that using symbolic links with Weave can result in errors or improper functioning and an option for they stop the installation before continue. 
```

#### Does this PR require documentation?
https://github.com/replicatedhq/kurl.sh/pull/975