### PR TITLE
chore: remove deprecated set-output command.

### DIFF
--- a/.github/workflows/cron-scan-images-daily.yaml
+++ b/.github/workflows/cron-scan-images-daily.yaml
@@ -19,8 +19,9 @@ jobs:
       - id: set-matrix
         name: Build image matrix
         run: |
-          OUTPUT=`./bin/scan-images/matrix.js`
-          echo "::set-output name=matrix::$OUTPUT"
+          echo "matrix<<EOF" >> "$GITHUB_OUTPUT"
+          ./bin/scan-images/matrix.js >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
   scan-images:
     name: ${{ matrix.addon }}:${{ matrix.version }} - ${{ matrix.name }}


### PR DESCRIPTION
As per [documentation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` command has been deprecated and will be removed sooner than later.