### PR TITLE
Adds cluster preflight check to verify if CNI is ready

### DIFF
--- a/pkg/preflight/assets/preflights.yaml
+++ b/pkg/preflight/assets/preflights.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   collectors:
     - clusterResources: {}
+  hostCollectors:
     - run:
         collectorName: journalctl-kubelet
         exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
-        image: busybox:1
         command: [ "journalctl" ]
-        args: [ "-u", "kubelet", "--no-pager", "-S", "7 days ago" ]
+        args: [ "-u", "kubelet", "--no-pager", "-S", "1 day ago" ]
   analyzers:
     - nodeResources:
         checkName: Node status check
@@ -38,5 +38,3 @@ spec:
           - fail:
               when: "true"
               message: "CNI plugin not initialized: there may be a problem with the CNI configuration on the host, check /etc/cni/net.d/*.conflist against a known good configuration"
-          
-          

--- a/pkg/preflight/assets/preflights.yaml
+++ b/pkg/preflight/assets/preflights.yaml
@@ -6,6 +6,12 @@ metadata:
 spec:
   collectors:
     - clusterResources: {}
+    - run:
+        collectorName: journalctl-kubelet
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        image: busybox:1
+        command: [ "journalctl" ]
+        args: [ "-u", "kubelet", "--no-pager", "-S", "7 days ago" ]
   analyzers:
     - nodeResources:
         checkName: Node status check
@@ -19,3 +25,18 @@ spec:
               message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."
+    - textAnalyze:
+        checkName: "Check for CNI 'not ready' messages"
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        file: run/journalctl-kubelet/journalctl-kubelet.logs
+        ignoreIfNoFiles: true
+        regex: "Container runtime network not ready.*cni plugin not initialized"
+        outcomes:
+          - pass:
+              when: "false"
+              message: "CNI is initialized"
+          - fail:
+              when: "true"
+              message: "CNI plugin not initialized: there may be a problem with the CNI configuration on the host, check /etc/cni/net.d/*.conflist against a known good configuration"
+          
+          


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensure that the CNI is ready prior upgrade.
#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

Note that because of bug https://github.com/replicatedhq/troubleshoot/issues/1089 we are facing duplicating results see: 

![Screenshot 2023-05-16 at 18 25 37](https://github.com/replicatedhq/kURL/assets/7708031/eb515426-3c6a-4136-b499-0d7428b49810)

However, it might not be a blocker. 

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight check to verify that CNI is ready prior upgrades. If we found an issue then an failure will be raised.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
