### PR TITLE
chore(actions): deprecate set-output

### DIFF
--- a/.github/workflows/cron-rebuild-packages-prod.yaml
+++ b/.github/workflows/cron-rebuild-packages-prod.yaml
@@ -18,7 +18,7 @@ jobs:
           export KURL_UTIL_IMAGE=replicated/kur-util:${tag}
           export KURL_BIN_UTILS_FILE=kurl-bin-utils-${tag}.tar.gz
           OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
-          echo "::set-output name=matrix::$OUTPUT"
+          echo "matrix=$OUTPUT" >> "$GITHUB_OUTPUT"
 
   build-upload-packages:
     needs: build-matrix

--- a/.github/workflows/cron-rebuild-packages-staging.yaml
+++ b/.github/workflows/cron-rebuild-packages-staging.yaml
@@ -20,7 +20,7 @@ jobs:
           export KURL_BIN_UTILS_FILE_LATEST=kurl-bin-utils-latest.tar.gz
 
           OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
-          echo "::set-output name=matrix::$OUTPUT"
+          echo "matrix=$OUTPUT" >> "$GITHUB_OUTPUT"
 
   build-upload-packages:
     needs: build-matrix

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -224,7 +224,7 @@ jobs:
     - name: Get the version
       id: get_tag
       shell: bash
-      run: echo ::set-output name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
+      run: echo "GIT_TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
     - name: Generate Changelog
       run: |
@@ -320,7 +320,7 @@ jobs:
     - name: Get the version
       id: get_tag
       shell: bash
-      run: echo ::set-output name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
+      run: echo "GIT_TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
     - name: Tgrun Queue
       id: queue
@@ -337,5 +337,5 @@ jobs:
             --os-spec ./testgrid/specs/os-latest.yaml \
             --priority 1
         MSG="Testgrid Run(s) Executing @ https://testgrid.kurl.sh/run/${REF}"
-        echo "::set-output name=msg::${MSG}"
+        echo "msg=$MSG" >> "$GITHUB_OUTPUT"
         echo "::notice ::${MSG}"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         git fetch --tags -f
         export VERSION_TAG=$(git tag | grep '^v20' | sort | tail -1)-$(git rev-parse --short HEAD)
-        echo "::set-output name=version_tag::${VERSION_TAG}"
+        echo "version_tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 
   kurl-util-image:
     runs-on: ubuntu-20.04
@@ -62,7 +62,7 @@ jobs:
         export KURL_BIN_UTILS_FILE=kurl-bin-utils-${VERSION_TAG}.tar.gz
         export KURL_BIN_UTILS_FILE_LATEST=kurl-bin-utils-latest.tar.gz
         OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
-        echo "::set-output name=matrix::$OUTPUT"
+        echo "matrix=$OUTPUT" >> "$GITHUB_OUTPUT"
       env:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
@@ -199,7 +199,7 @@ jobs:
             --spec ./testgrid/specs/deploy.yaml \
             --os-spec ./testgrid/specs/os-latest.yaml
         MSG="Testgrid Run(s) Executing @ https://testgrid.kurl.sh/run/${REF}"
-        echo "::set-output name=msg::${MSG}"
+        echo "msg=$MSG" >> "$GITHUB_OUTPUT"
         echo "::notice ::${MSG}"
 
   cleanup-s3:

--- a/addons/antrea/template/generate.sh
+++ b/addons/antrea/template/generate.sh
@@ -42,7 +42,7 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=antrea_version::$VERSION"
+    echo "antrea_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/containerd/template/script.sh
+++ b/addons/containerd/template/script.sh
@@ -316,7 +316,7 @@ function main() {
         fi
     done
 
-    echo "::set-output name=containerd_version::$GREATEST_VERSION"
+    echo "containerd_version=$GREATEST_VERSION" >> "$GITHUB_OUTPUT"
 
     update_available_versions
     generate_step_versions

--- a/addons/contour/template/script.sh
+++ b/addons/contour/template/script.sh
@@ -26,7 +26,7 @@ upstreamContourVersionPattern='/projectcontour/contour:v([0-9]+\.[0-9]+\.[0-9]+)
 CONTOUR_VERSION="${BASH_REMATCH[1]}" # 1.11.0
 
 echo "contour version: $CONTOUR_VERSION"
-echo "::set-output name=contour_version::$CONTOUR_VERSION"    
+echo "contour_version=$CONTOUR_VERSION" >> "$GITHUB_OUTPUT"
 
 # Hack: backported images changes starting at 1.13.1 and don't carry forward
 # Remove this after the next version is released. 

--- a/addons/ekco/template/generate.sh
+++ b/addons/ekco/template/generate.sh
@@ -89,7 +89,7 @@ function main() {
 
     add_as_only_version
 
-    echo "::set-output name=ekco_version::$VERSION"
+    echo "ekco_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/flannel/template/generate.sh
+++ b/addons/flannel/template/generate.sh
@@ -85,7 +85,7 @@ function main() {
     generate "$version"
     add_as_latest "$version"
 
-    echo "::set-output name=flannel_version::$version"
+    echo "flannel_version=$version" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/goldpinger/template/generate.sh
+++ b/addons/goldpinger/template/generate.sh
@@ -51,7 +51,7 @@ function main() {
 
     generate
 
-    echo "::set-output name=goldpinger_version::$VERSION-$CHARTVERSION"
+    echo "goldpinger_version=$VERSION-$CHARTVERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/longhorn/template/generate.sh
+++ b/addons/longhorn/template/generate.sh
@@ -128,7 +128,7 @@ function main() {
 
     generate
 
-    echo "::set-output name=longhorn_version::$VERSION"
+    echo "longhorn_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/metrics-server/template/generate.sh
+++ b/addons/metrics-server/template/generate.sh
@@ -85,7 +85,7 @@ function main() {
     generate "$version"
     add_as_latest "$version"
 
-    echo "::set-output name=metrics_server_version::$version"
+    echo "metrics_server_version=$version" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/minio/template/generate.sh
+++ b/addons/minio/template/generate.sh
@@ -46,7 +46,7 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=minio_version::$VERSION"
+    echo "minio_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/openebs/template/generate.sh
+++ b/addons/openebs/template/generate.sh
@@ -120,7 +120,7 @@ function main() {
     generate
     add_as_latest
 
-    echo "::set-output name=openebs_version::$version"
+    echo "openebs_version=$version" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/prometheus/template/generate.sh
+++ b/addons/prometheus/template/generate.sh
@@ -134,7 +134,7 @@ function main() {
 
     generate
 
-    echo "::set-output name=prometheus_version::$VERSION-$CHARTVERSION"
+    echo "prometheus_version=$VERSION-$CHARTVERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/registry/template/generate.sh
+++ b/addons/registry/template/generate.sh
@@ -55,7 +55,7 @@ function main() {
         add_as_latest
     fi
 
-    echo "::set-output name=registry_version::$VERSION"
+    echo "registry_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/rook/template/generate.sh
+++ b/addons/rook/template/generate.sh
@@ -175,7 +175,7 @@ function main() {
 
     generate_step_versions
 
-    echo "::set-output name=rook_version::$VERSION"
+    echo "rook_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/sonobuoy/template/generate.sh
+++ b/addons/sonobuoy/template/generate.sh
@@ -78,7 +78,7 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=sonobuoy_version::$VERSION"
+    echo "sonobuoy_version=$VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/velero/template/generate.sh
+++ b/addons/velero/template/generate.sh
@@ -89,7 +89,7 @@ function main() {
         add_as_latest
     fi
 
-    echo "::set-output name=velero_version::$VELERO_VERSION"
+    echo "velero_version=$VELERO_VERSION" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/addons/weave/template/generate.sh
+++ b/addons/weave/template/generate.sh
@@ -94,8 +94,8 @@ function main() {
 
     add_as_latest
 
-    echo "::set-output name=weave_version::$ADDON_VERSION"
-    echo "::set-output name=weave_major_minor_version::$(echo "$ADDON_VERSION" | awk -F'.' '{ print $1 "." $2 }')"
+    echo "weave_version=$ADDON_VERSION" >> "$GITHUB_OUTPUT"
+    echo "weave_major_minor_version=$(echo "$ADDON_VERSION" | awk -F'.' '{ print $1 "." $2 }')" >> "$GITHUB_OUTPUT"
 }
 
 main "$@"

--- a/bin/addon-has-changes-matrix.sh
+++ b/bin/addon-has-changes-matrix.sh
@@ -79,7 +79,7 @@ function main() {
 
   if [ "${#ADDONS_AVAILBLE[@]}" -gt "0" ]; then
     echo "Modified addons detected. Continuing with action..."
-    echo "::set-output name=addons::{\"include\":[$(join_array_by ',' "${ADDONS_AVAILBLE[@]}")]}"
+    echo "addons={\"include\":[$(join_array_by ',' "${ADDONS_AVAILBLE[@]}")]}" >> "$GITHUB_OUTPUT"
   else
     echo "No changed addons detected, addon is currently in the ADDON_DENY_LIST, or addon does not have a TestGrid template."
   fi

--- a/bin/build-addon-package.sh
+++ b/bin/build-addon-package.sh
@@ -29,7 +29,7 @@ function build_addon() {
   aws s3 cp "$tmpdir/$addon-$version.tar.gz" "s3://${S3_BUCKET}/$s3_key" --region us-east-1
 
   echo "Package pushed to: s3://${S3_BUCKET}/$s3_key"
-  echo "::set-output name=addon_package_url::https://$S3_BUCKET.s3.amazonaws.com/$s3_key"
+  echo "addon_package_url=https://$S3_BUCKET.s3.amazonaws.com/$s3_key" >> "$GITHUB_OUTPUT"
 }
 
 function main() {

--- a/bin/test-addon.sh
+++ b/bin/test-addon.sh
@@ -85,7 +85,7 @@ function main() {
   done
   shopt -u nullglob
 
-  echo "::set-output name=message::${MSG}"
+  echo "message=$MSG" >> "$GITHUB_OUTPUT"
   echo "::notice ::${MSG}"
   echo "Run completed."
 }

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -212,7 +212,7 @@ function main() {
         generate_version_directory "${version}"
         generate_conformance_package "${version}"
     done
-    echo "::set-output name=kubernetes_version::${VERSIONS[*]}"
+    echo "kubernetes_version=${VERSIONS[*]}" >> "$GITHUB_OUTPUT"
 
     update_available_versions
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

A workflow using save-state or set-output like the following should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/