### PR TITLE
regenerate weave 2.8.1-20230417 and 2.6.5-20230417 to allow it works with specific symbolic link scenario

### DIFF
--- a/addons/weave/2.6.5-20230417/patch-daemonset.yaml
+++ b/addons/weave/2.6.5-20230417/patch-daemonset.yaml
@@ -22,3 +22,12 @@ spec:
               value: "kurlsh/weaveexec:2.6.5-20230417-4a9fe55"
         - name: weave-npc
           args: ["--log-level", "info"] # default log level is debug
+      initContainers:
+        - name: weave-init
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /host/opt/cni/bin
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin

--- a/addons/weave/2.8.1-20230417/patch-daemonset.yaml
+++ b/addons/weave/2.8.1-20230417/patch-daemonset.yaml
@@ -22,3 +22,12 @@ spec:
               value: "kurlsh/weaveexec:2.8.1-20230417-4a9fe55"
         - name: weave-npc
           args: ["--log-level", "info"] # default log level is debug
+      initContainers:
+        - name: weave-init
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /host/opt/cni/bin
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin


### PR DESCRIPTION
#### What this PR does / why we need it:

regenerate weave 2.8.1-20230417 and 2.6.5-20230417 to allow it works with specific symbolic link scenario
after the PR: https://github.com/replicatedhq/kURL/pull/4495

#### Which issue(s) this PR fixes:

Fixes # [sc-75641]

#### Special notes for your reviewer:

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes weave `2.8.1-20230417` and `2.6.5-20230417` to not fail when /opt/cni has a symbolic link 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
