### PR TITLE
adds preflight check to warning unhealthy pods in the upgrades

### DIFF
--- a/pkg/preflight/assets/preflights.yaml
+++ b/pkg/preflight/assets/preflights.yaml
@@ -22,10 +22,22 @@ spec:
               message: "All nodes are online."
     - clusterPodStatuses:
         checkName: Pods status check
+        namespace:
+          - kube-flannel
+          - default
+          - kube-node-lease
+          - kube-public
+          - kube-system
+          - kurl
+          - projectcontour
+          - rook-ceph
+          - velero
+          - longhorn-system
+          - openebs
         exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
         outcomes:
+          - pass:
+              message: "The Pod {{ .Name }} into the namespace {{ .Namespace }} is OK."
           - warn:
               when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
               message: "A Pod, {{ .Name }} into the namespace {{ .Namespace }}, is unhealthy with a status of: {{ .Status.Reason }}. Restarting the pod may fix the issue."
-          - pass:
-              message: "All Pods are OK."

--- a/pkg/preflight/assets/preflights.yaml
+++ b/pkg/preflight/assets/preflights.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   collectors:
     - clusterResources: {}
+    - clusterInfo: {}
   analyzers:
     - nodeResources:
         checkName: Node status check
@@ -19,3 +20,12 @@ spec:
               message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."
+    - clusterPodStatuses:
+        checkName: Pods status check
+        exclude: '{{kurl or (not .IsPrimary) (not .IsUpgrade) }}'
+        outcomes:
+          - warn:
+              when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
+              message: "A Pod, {{ .Name }} into the namespace {{ .Namespace }}, is unhealthy with a status of: {{ .Status.Reason }}. Restarting the pod may fix the issue."
+          - pass:
+              message: "All Pods are OK."


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds check to allow users know what are the Pods which are unhealthy prior upgrades


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
The following result was changed to show the name and namespace of the POD that is OK. 

![Screenshot 2023-05-16 at 19 09 35](https://github.com/replicatedhq/kURL/assets/7708031/5a6a5b09-accc-4d19-8a30-938f8582a92e)

## Steps to reproduce

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds preflight check healthy state of all Pods in the namespaces (kube-flannel, default, kube-node-lease, kube-public, kube-system, kurl, projectcontour, rook-ceph, velero, longhorn-system, openebs) prior upgrades. If a Pod not be healthy then a warning will be raised. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
