### PR TITLE
reverting changes done for weave 2.6.5-20230417

### DIFF
--- a/addons/weave/2.6.5-20230417/patch-daemonset.yaml
+++ b/addons/weave/2.6.5-20230417/patch-daemonset.yaml
@@ -22,12 +22,3 @@ spec:
               value: "kurlsh/weaveexec:2.6.5-20230417-4a9fe55"
         - name: weave-npc
           args: ["--log-level", "info"] # default log level is debug
-      initContainers:
-        - name: weave-init
-          volumeMounts:
-            - name: cni-bin
-              mountPath: /host/opt/cni/bin
-      volumes:
-        - name: cni-bin
-          hostPath:
-            path: /opt/cni/bin


### PR DESCRIPTION
#### What this PR does / why we need it:

We merged the PR: https://github.com/replicatedhq/kURL/pull/4500/files 
It succeffully worked for 2.8.1 but not for 2.6.5, see the tests: https://testgrid.kurl.sh/run/pr-4500-31e2f79-weave-2.6.5-20230417-k8s-docker-2023-05-16T17:09:10Z



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-75641]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Revert changes for weave 2.6.5-20230417 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
