### PR TITLE
 fix rook upgrade 1.9 which is missing workaround for bug fix

### DIFF
--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -293,6 +293,11 @@ function rook_cluster_deploy_upgrade() {
         fi
     fi
 
+    # Allows Ceph Pacific to fix the following error:
+    # "all OSDs are running pacific or later but require_osd_release < pacific"
+    # https://github.com/rook/rook/issues/10084
+    kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd require-osd-release pacific
+
     # 5. https://rook.io/docs/rook/v1.6/ceph-upgrade.html#5-verify-the-updated-cluster
     echo "Awaiting Ceph healthy"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Because the workaround for the bug fix when we upgrade to rook 1.9 is not set causing:

```
1. 2023-05-16 22:40:18+00:00 Awaiting Rook pods to transition to Running
2. 2023-05-16 22:40:28+00:00 ✔ Upgraded to Rook 1.8.10 successfully
3. 2023-05-16 22:40:28+00:00 ⚙  Upgrading to Rook 1.9.12
.......
144. 2023-05-16 23:12:54+00:00 Error: failed to wait for Ceph "16.2.10-0": timed out waiting for Ceph 16.2.10-0 to roll out
145. 2023-05-16 23:12:54+00:00 Timeout waiting for Ceph version to be rolled out
146. 2023-05-16 23:12:54+00:00 Checking Ceph versions and replicas
147. 2023-05-16 23:12:55+00:00 rook-ceph-crashcollector-qcdpznuaavzybnek-initialprimary  	req/upd/avl: 1/1/1  	ceph-version=16.2.10-0
148. 2023-05-16 23:12:55+00:00 rook-ceph-crashcollector-qcdpznuaavzybnek-secondary-0  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
149. 2023-05-16 23:12:55+00:00 rook-ceph-crashcollector-qcdpznuaavzybnek-secondary-1  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
150. 2023-05-16 23:12:55+00:00 rook-ceph-mds-rook-shared-fs-a  	req/upd/avl: 1/1/1  	ceph-version=16.2.10-0
151. 2023-05-16 23:12:55+00:00 rook-ceph-mds-rook-shared-fs-b  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
152. 2023-05-16 23:12:55+00:00 rook-ceph-mgr-a  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
153. 2023-05-16 23:12:55+00:00 rook-ceph-mon-a  	req/upd/avl: 1/1/1  	ceph-version=16.2.10-0
154. 2023-05-16 23:12:55+00:00 rook-ceph-mon-b  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
155. 2023-05-16 23:12:55+00:00 rook-ceph-mon-c  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
156. 2023-05-16 23:12:55+00:00 rook-ceph-osd-0  	req/upd/avl: 1/1/1  	ceph-version=16.2.10-0
157. 2023-05-16 23:12:55+00:00 rook-ceph-osd-1  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
158. 2023-05-16 23:12:55+00:00 rook-ceph-osd-2  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
159. 2023-05-16 23:12:55+00:00 rook-ceph-rgw-rook-ceph-store-a  	req/upd/avl: 1/1/  	ceph-version=16.2.10-0
160. 2023-05-16 23:12:55+00:00 Ceph version found ceph-version=16.2.10-0. New Ceph version 16.2.10 failed to deploy
161. 2023-05-16 23:12:55+00:00 New Ceph version failed to deploy
162. + KURL_EXIT_STATUS=1
163. + '[' 1 -eq 0 ']'
164. + echo ''
165. + echo 'failed kurl upgrade with exit status 1'
166. + collect_debug_info_after_kurl
167. + '[' 1 -ne 0 ']'
168. + echo 'kubelet status'
169. + systemctl status kubelet
170. 2023-05-16 23:12:55+00:00 
171. 2023-05-16 23:12:55+00:00 failed kurl upgrade with exit status 1
172. 2023-05-16 23:12:55+00:00 kubelet status
173. + echo 'kubelet journalctl'
174. + journalctl -xeu kubelet
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
