### PR TITLE
fix(kubernetes): images no longer hosted on k8s.gcr.io

### DIFF
--- a/addons/sonobuoy/0.56.8/install.sh
+++ b/addons/sonobuoy/0.56.8/install.sh
@@ -3,16 +3,19 @@ function sonobuoy() {
     sonobuoy_binary
 
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_already_applied() {
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_join() {
     sonobuoy_binary
 
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_binary() {

--- a/addons/sonobuoy/template/base/install.sh
+++ b/addons/sonobuoy/template/base/install.sh
@@ -3,16 +3,19 @@ function sonobuoy() {
     sonobuoy_binary
 
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_already_applied() {
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_join() {
     sonobuoy_binary
 
     sonobuoy_airgap_maybe_tag_image "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}" "registry.k8s.io/conformance:v${KUBERNETES_VERSION}"
+    sonobuoy_airgap_maybe_tag_image "registry.k8s.io/conformance:v${KUBERNETES_VERSION}" "k8s.gcr.io/conformance:v${KUBERNETES_VERSION}"
 }
 
 function sonobuoy_binary() {

--- a/packages/kubernetes/1.22.17/conformance/Manifest
+++ b/packages/kubernetes/1.22.17/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.22.17
+image conformance registry.k8s.io/conformance:v1.22.17
 image nginx-1-14-1 k8s.gcr.io/e2e-test-images/nginx:1.14-1

--- a/packages/kubernetes/1.23.17/conformance/Manifest
+++ b/packages/kubernetes/1.23.17/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.23.17
+image conformance registry.k8s.io/conformance:v1.23.17
 image nginx-1-14-2 k8s.gcr.io/e2e-test-images/nginx:1.14-2

--- a/packages/kubernetes/1.24.14/conformance/Manifest
+++ b/packages/kubernetes/1.24.14/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.24.14
-image  
+image conformance registry.k8s.io/conformance:v1.24.14
+image nginx-1-14-2 k8s.gcr.io/e2e-test-images/nginx:1.14-2

--- a/packages/kubernetes/1.25.10/conformance/Manifest
+++ b/packages/kubernetes/1.25.10/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.25.10
-image  
+image conformance registry.k8s.io/conformance:v1.25.10
+image nginx-1-14-2 registry.k8s.io/e2e-test-images/nginx:1.14-2

--- a/packages/kubernetes/1.26.5/conformance/Manifest
+++ b/packages/kubernetes/1.26.5/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.26.5
-image  
+image conformance registry.k8s.io/conformance:v1.26.5
+image nginx-1-14-4 registry.k8s.io/e2e-test-images/nginx:1.14-4

--- a/packages/kubernetes/1.27.2/conformance/Manifest
+++ b/packages/kubernetes/1.27.2/conformance/Manifest
@@ -1,2 +1,2 @@
-image conformance k8s.gcr.io/conformance:v1.27.2
-image  
+image conformance registry.k8s.io/conformance:v1.27.2
+image nginx-1-14-4 registry.k8s.io/e2e-test-images/nginx:1.14-4

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -57,7 +57,7 @@ function generate_version_directory() {
     mv kubeadm /tmp
 
     while read -r image; do
-        # k8s.gcr.io/kube-apiserver:v1.20.2 -> kube-apiserver
+        # registry.k8s.io/kube-apiserver:v1.20.2 -> kube-apiserver
         local name=$(echo "$image" | awk -F':' '{ print $1 }' | awk -F '/' '{ print $2 }')
         echo "image ${name} ${image}" >> "../$version/Manifest"
     done < <(/tmp/kubeadm config images list --kubernetes-version=${version})
@@ -94,11 +94,11 @@ function generate_conformance_package() {
 
     # add conformance image for sonobuoy to manifest
     # TODO: in the future change this image to registry.k8s.io
-    echo "image conformance k8s.gcr.io/conformance:v${version}" > "../$version/conformance/Manifest"
+    echo "image conformance registry.k8s.io/conformance:v${version}" > "../$version/conformance/Manifest"
 
 
     # --mode quick image
-    local image="$(docker run --rm --entrypoint e2e.test "k8s.gcr.io/conformance:v${version}" --list-images | grep "nginx" | sort -n | head -n 1)"
+    local image="$(docker run --rm --entrypoint e2e.test "registry.k8s.io/conformance:v${version}" --list-images | grep "nginx" | sort -n | head -n 1)"
     local name="$(echo "$image" | awk -F'[/:]' '{ i = 2; for (--i; i >= 0; i--){ printf "%s-",$(NF-i)} print "" }' | sed 's/\./-/' | sed 's/-$//')"
     echo "image $name $image" >> "../$version/conformance/Manifest"
 
@@ -107,7 +107,7 @@ function generate_conformance_package() {
     # sonobuoy_pull_images "$version" || true
 
     # local image=
-    # for image in $(docker run --rm --entrypoint e2e.test "k8s.gcr.io/conformance:v${version}" --list-images) ; do
+    # for image in $(docker run --rm --entrypoint e2e.test "registry.k8s.io/conformance:v${version}" --list-images) ; do
     #     if docker inspect "$image" >/dev/null 2>&1 ; then
     #         local name="$(echo "$image" | awk -F'[/:]' '{ i = 2; for (--i; i >= 0; i--){ printf "%s-",$(NF-i)} print "" }' | sed 's/\./-/' | sed 's/-$//')"
     #         echo "image $name $image" >> "../$version/conformance/Manifest"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Builds are failing because the images no longer exist on k8s.gcr.io for new k8s versions