### PR TITLE
fix: install failure no gcr.io images

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1076,23 +1076,23 @@ function retag_gcr_images() {
     local image=
     local new_image=
     if [ -n "$DOCKER_VERSION" ]; then
-        images=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep k8s.gcr.io)
+        images=$(docker images --format '{{.Repository}}:{{.Tag}}' | { grep -F k8s.gcr.io || true; })
         for image in $images ; do
             new_image="${image//k8s.gcr.io/registry.k8s.io}"
             docker tag "$image" "$new_image" 2>/dev/null || true
         done
-        images=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep registry.gcr.io)
+        images=$(docker images --format '{{.Repository}}:{{.Tag}}' | { grep -F registry.gcr.io || true; })
         for image in $images ; do
             new_image="${image//registry.k8s.io/k8s.gcr.io}"
             docker tag "$image" "$new_image" 2>/dev/null || true
         done
     else
-        images=$(ctr -n=k8s.io images list --quiet | grep k8s.gcr.io)
+        images=$(ctr -n=k8s.io images list --quiet | { grep -F k8s.gcr.io || true; })
         for image in $images ; do
             new_image="${image//k8s.gcr.io/registry.k8s.io}"
             ctr -n k8s.io images tag "$image" "$new_image" 2>/dev/null || true
         done
-        images=$(ctr -n=k8s.io images list --quiet | grep registry.gcr.io)
+        images=$(ctr -n=k8s.io images list --quiet | { grep -F registry.gcr.io || true; })
         for image in $images ; do
             new_image="${image//registry.k8s.io/k8s.gcr.io}"
             ctr -n k8s.io images tag "$image" "$new_image" 2>/dev/null || true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Install is failing with the following error because the variable declaration and assignment in the same line was masking the error.

```
2023-05-18 20:35:58+00:00 Service containerd restarted.
2023-05-18 20:35:58+00:00 unpacking registry.k8s.io/pause:3.6 (sha256:79b611631c0d19e9a975fb0a8511e5153789b4c26610d1842e9f735c57cc8b13)...done
2023-05-18 20:35:58+00:00 An error occurred on line 1552
+ KURL_EXIT_STATUS=1
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ '[' 1 -eq 0 ']'
```

https://github.com/replicatedhq/kURL/pull/4515