### PR TITLE
fix(rook): flexvolume migration fails with error cant scale replicaset

### DIFF
--- a/pkg/rook/flexvolume.go
+++ b/pkg/rook/flexvolume.go
@@ -314,7 +314,7 @@ func validatePodCanScale(pod *corev1.Pod) error {
 	}
 
 	switch ref.Kind {
-	case "StatefulSet", "Deployment":
+	case "StatefulSet", "ReplicaSet":
 		return nil
 	default:
 		return fmt.Errorf("pod %s/%s has unsupported owner %s", pod.Namespace, pod.Name, ref.Kind)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

ReplicaSets are controllers of Pods and Deployments are controllers of ReplicaSets (see the scaleDownPodOwner function)

https://testgrid.kurl.sh/run/ETHAN-202305018-rook-5?kurlLogsInstanceId=ximceipiymmvfsao&nodeId=ximceipiymmvfsao-initialprimary#L3430

```2023-05-19 05:22:22+00:00 ⚙  Migrating Rook Flex volumes to CSI volumes
2023-05-19 05:22:22+00:00 + ./bin/kurl rook flexvolume-to-csi --source-sc default --destination-sc rook-ceph-tmp --node ximceipiymmvfsao-initialprimary --pv-migrator-bin-path /var/lib/kurl/bin/rook-pv-migrator --ceph-migrator-image rook/ceph:v1.7.11
2023-05-19 05:22:22+00:00 Running rook-ceph-migrator deployment ...
2023-05-19 05:22:22+00:00 # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
2023-05-19 05:22:22+00:00 Waiting for rook-ceph-migrator deployment to be ready ...
2023-05-19 05:22:27+00:00 Rook-ceph-migrator deployment is ready
2023-05-19 05:22:27+00:00 Scaling down statefulsets and deployments using storage class default ...
2023-05-19 05:22:27+00:00 Deleting flex migrator ...
2023-05-19 05:22:28+00:00 Deleted flex migrator
2023-05-19 05:22:28+00:00 Error: validate pod default/migration-test-6759bd5795-th9r4 can scale: pod default/migration-test-6759bd5795-th9r4 has unsupported owner ReplicaSet
2023-05-19 05:22:28+00:00 ++ trap_report_error
2023-05-19 05:22:28+00:00 ++ [[ ! ehxBEs =~ e ]]
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes Rook upgrades from 1.0.4 to 1.8.x+ to fail with error "pod has unsupported owner ReplicaSet".
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE