### PR TITLE
(chore)Testgrid airgap install with invalid PROXY

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2257,3 +2257,36 @@
     ln -s $FOLDER/var/lib/rook /var/lib/rook
     
     cd /testsymbolic
+- name: "K8s 1.27x Airgap with invalid proxyAddress"
+  cpu: 6
+  airgap: true
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+  installerSpec:
+    kurl:
+      proxyAddress: http://10.128.0.70:3128
+      additionalNoProxyAddresses:
+        - .corporate.internal
+      noProxy: false
+    kubernetes:
+      version: 1.27.x
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+    contour:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    velero:
+      version: latest
+    ekco:
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest


### PR DESCRIPTION
#### What this PR does / why we need it:

We want to ensure that AIRGAP installs are not affected when an invalid PROXY is set
See: https://testgrid.kurl.sh/run/CAMILA-TEST-AIRGAP_INVALID-proxyAddress-May18-Prority-0

#### Which issue(s) this PR fixes:

Partial #[sc-76762]
