### PR TITLE
chore(rook): improve storage migration upgrade tests

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -55,7 +55,7 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: Migrate from Rook 1.10.x to OpenEBS + Minio
+- name: Migrate from Rook 1.11.x to OpenEBS + Minio
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -71,7 +71,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -261,7 +261,7 @@
       echo Rook namespace should NOT be removed after the upgrade. MinIO is NOT selected
       exit 1
     fi
-- name: Migrate from Rook 1.10.x to OpenEBS (S3 disabled)
+- name: Migrate from Rook 1.11.x to OpenEBS (S3 disabled)
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -275,7 +275,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -458,9 +458,9 @@
     pvc_uses_provisioner "migration-test" "default" "openebs"
     test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
-- name: Migrate from Rook 1.0.4 to Rook 1.10.x
+- name: Migrate from Rook 1.0.4 to Rook 1.11.x
   flags: "yes"
-  cpu: 6
+  cpu: 4
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   installerSpec:
@@ -492,8 +492,10 @@
     ekco:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
   postInstallScript: |
+    # wait for ekco to scale up the Ceph cluster
+    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
@@ -506,11 +508,122 @@
     pvc_uses_provisioner "migration-test" "default" "rook"
     test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
-    if [ -d "/var/lib/rook" ] || [ -d "/opt/replicated/rook" ]; then
-       echo  Rook Data directories not removed.
-       exit 1
-    fi
-- name: Migrate from Longhorn + Minio to Rook 1.10.x
+    # rook data directory is not removed but perhaps it should be
+    # if [ -d "/opt/replicated/rook" ]; then
+    #    echo  Rook Data directory not removed.
+    #    exit 1
+    # fi
+- name: Migrate from Rook 1.0.4 to Rook 1.5.x
+  flags: "yes"
+  cpu: 4
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+  installerSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: 1.6.x
+    flannel:
+      version: 0.21.x
+    registry:
+      version: 2.8.1
+    kotsadm:
+      version: latest
+    ekco:
+      version: latest
+    rook:
+      version: 1.0.4
+  upgradeSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: 1.6.x
+    flannel:
+      version: 0.21.x
+    registry:
+      version: 2.8.1
+    kotsadm:
+      version: latest
+    ekco:
+      version: latest
+    rook:
+      version: 1.5.x
+  postInstallScript: |
+    # wait for ekco to scale up the Ceph cluster
+    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
+    source /opt/kurl-testgrid/testhelpers.sh
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    test_push_image_to_registry
+    install_and_customize_kurl_integration_test_application
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    sleep 120
+    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+    pvc_uses_provisioner "migration-test" "default" "rook"
+    test_pull_image_from_registry
+    check_and_customize_kurl_integration_test_application
+    # rook data directory is not removed but perhaps it should be
+    # if [ -d "/opt/replicated/rook" ]; then
+    #    echo  Rook Data directory not removed.
+    #    exit 1
+    # fi
+- name: Migrate from Rook 1.5.x to Rook 1.11.x
+  flags: "yes"
+  cpu: 4
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+  installerSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: 1.6.x
+    flannel:
+      version: 0.21.x
+    registry:
+      version: 2.8.1
+    kotsadm:
+      version: latest
+    ekco:
+      version: latest
+    rook:
+      version: 1.5.x
+  upgradeSpec:
+    kubernetes:
+      version: 1.19.x
+    containerd:
+      version: 1.6.x
+    flannel:
+      version: 0.21.x
+    registry:
+      version: 2.8.1
+    kotsadm:
+      version: latest
+    ekco:
+      version: latest
+    rook:
+      version: 1.11.x
+  postInstallScript: |
+    # wait for ekco to scale up the Ceph cluster
+    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
+    source /opt/kurl-testgrid/testhelpers.sh
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    test_push_image_to_registry
+    install_and_customize_kurl_integration_test_application
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    sleep 120
+    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+    pvc_uses_provisioner "migration-test" "default" "rook"
+    test_pull_image_from_registry
+    check_and_customize_kurl_integration_test_application
+    # rook data directory is not removed but perhaps it should be
+    # if [ -d "/opt/replicated/rook" ]; then
+    #    echo  Rook Data directory not removed.
+    #    exit 1
+    # fi
+- name: Migrate from Longhorn + Minio to Rook 1.11.x
   flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
@@ -546,7 +659,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
@@ -624,7 +737,7 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: Migrate from Rook 1.10.x to OpenEBS + Minio (multi-node)
+- name: Migrate from Rook 1.11.x to OpenEBS + Minio (multi-node)
   flags: "yes"
   cpu: 6
   numPrimaryNodes: 1
@@ -643,7 +756,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -742,7 +855,7 @@
       echo Longhorn namespace found after the upgrade.
       exit 1
     fi
-- name: Migrate from Rook 1.10.x to OpenEBS 3.4.0 with localpv migrate
+- name: Migrate from Rook 1.11.x to OpenEBS 3.4.0 with localpv migrate
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -752,7 +865,7 @@
     containerd:
       version: latest
     rook:
-      version: 1.10.x
+      version: 1.11.x
     kotsadm:
       version: latest
   upgradeSpec:

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -493,6 +493,26 @@
       version: latest
     rook:
       version: 1.8.x
+  postInstallScript: |
+    # wait for ekco to scale up the Ceph cluster
+    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
+    source /opt/kurl-testgrid/testhelpers.sh
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    test_push_image_to_registry
+    install_and_customize_kurl_integration_test_application
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    sleep 120
+    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+    pvc_uses_provisioner "migration-test" "default" "rook"
+    test_pull_image_from_registry
+    check_and_customize_kurl_integration_test_application
+    # rook data directory is not removed but perhaps it should be
+    # if [ -d "/opt/replicated/rook" ]; then
+    #    echo  Rook Data directory not removed.
+    #    exit 1
+    # fi
 - name: Migrate from Rook 1.8.x to Rook 1.11.x
   flags: "yes"
   cpu: 4
@@ -550,7 +570,7 @@
     # fi
 - name: Migrate from Longhorn + Minio to Rook 1.11.x
   flags: "yes"
-  cpu: 6
+  cpu: 4
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   installerSpec:
@@ -604,7 +624,7 @@
     fi
 - name: Migrate from Rook 1.0.4 to OpenEBS + Minio (multi-node)
   flags: "yes"
-  cpu: 6
+  cpu: 4
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   installerSpec:
@@ -664,7 +684,7 @@
     fi
 - name: Migrate from Rook 1.11.x to OpenEBS + Minio (multi-node)
   flags: "yes"
-  cpu: 6
+  cpu: 4
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   installerSpec:
@@ -724,7 +744,7 @@
     fi
 - name: Migrate from Longhorn + Minio to OpenEBS + Minio (multi-node)
   flags: "yes"
-  cpu: 6
+  cpu: 4
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   installerSpec:

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -458,7 +458,7 @@
     pvc_uses_provisioner "migration-test" "default" "openebs"
     test_pull_image_from_registry
     check_and_customize_kurl_integration_test_application
-- name: Migrate from Rook 1.0.4 to Rook 1.11.x
+- name: Migrate from Rook 1.0.4 to Rook 1.8.x
   flags: "yes"
   cpu: 4
   numPrimaryNodes: 1
@@ -471,7 +471,7 @@
     flannel:
       version: 0.21.x
     registry:
-      version: 2.8.1
+      version: 2.8.x
     kotsadm:
       version: latest
     ekco:
@@ -486,34 +486,14 @@
     flannel:
       version: 0.21.x
     registry:
-      version: 2.8.1
+      version: 2.8.x
     kotsadm:
       version: latest
     ekco:
       version: latest
     rook:
-      version: 1.11.x
-  postInstallScript: |
-    # wait for ekco to scale up the Ceph cluster
-    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
-    source /opt/kurl-testgrid/testhelpers.sh
-    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
-    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-    test_push_image_to_registry
-    install_and_customize_kurl_integration_test_application
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    sleep 120
-    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
-    pvc_uses_provisioner "migration-test" "default" "rook"
-    test_pull_image_from_registry
-    check_and_customize_kurl_integration_test_application
-    # rook data directory is not removed but perhaps it should be
-    # if [ -d "/opt/replicated/rook" ]; then
-    #    echo  Rook Data directory not removed.
-    #    exit 1
-    # fi
-- name: Migrate from Rook 1.0.4 to Rook 1.5.x
+      version: 1.8.x
+- name: Migrate from Rook 1.8.x to Rook 1.11.x
   flags: "yes"
   cpu: 4
   numPrimaryNodes: 1
@@ -526,13 +506,13 @@
     flannel:
       version: 0.21.x
     registry:
-      version: 2.8.1
+      version: 2.8.x
     kotsadm:
       version: latest
     ekco:
       version: latest
     rook:
-      version: 1.0.4
+      version: 1.8.x
   upgradeSpec:
     kubernetes:
       version: 1.19.x
@@ -541,62 +521,7 @@
     flannel:
       version: 0.21.x
     registry:
-      version: 2.8.1
-    kotsadm:
-      version: latest
-    ekco:
-      version: latest
-    rook:
-      version: 1.5.x
-  postInstallScript: |
-    # wait for ekco to scale up the Ceph cluster
-    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
-    source /opt/kurl-testgrid/testhelpers.sh
-    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
-    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-    test_push_image_to_registry
-    install_and_customize_kurl_integration_test_application
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    sleep 120
-    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
-    pvc_uses_provisioner "migration-test" "default" "rook"
-    test_pull_image_from_registry
-    check_and_customize_kurl_integration_test_application
-    # rook data directory is not removed but perhaps it should be
-    # if [ -d "/opt/replicated/rook" ]; then
-    #    echo  Rook Data directory not removed.
-    #    exit 1
-    # fi
-- name: Migrate from Rook 1.5.x to Rook 1.11.x
-  flags: "yes"
-  cpu: 4
-  numPrimaryNodes: 1
-  numSecondaryNodes: 2
-  installerSpec:
-    kubernetes:
-      version: 1.19.x
-    containerd:
-      version: 1.6.x
-    flannel:
-      version: 0.21.x
-    registry:
-      version: 2.8.1
-    kotsadm:
-      version: latest
-    ekco:
-      version: latest
-    rook:
-      version: 1.5.x
-  upgradeSpec:
-    kubernetes:
-      version: 1.19.x
-    containerd:
-      version: 1.6.x
-    flannel:
-      version: 0.21.x
-    registry:
-      version: 2.8.1
+      version: 2.8.x
     kotsadm:
       version: latest
     ekco:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes and improves rook upgrade tests. Splits tests into two. 1.0.4 to 1.8.x will test loopback to block device and flex volume to csi migrations. 1.0.4 all the way to 1.11.x takes more than 3 hours as seen [here](https://testgrid.kurl.sh/run/ETHAN-20230523-rook-1?kurlLogsInstanceId=kxkcpspnoqbyvnlc&nodeId=kxkcpspnoqbyvnlc-initialprimary#L0).

Bumps rook tests to 1.11.x.

Reduces cpus to 4 for multi node tests