### PR TITLE
(do not merge - Requires discussions to address concerns and a window for automate tests after merge - backlog) replace patchesJson6902 by patches

### DIFF
--- a/addons/prometheus/0.46.0-14.9.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.46.0-14.9.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.46.0-14.9.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.46.0-14.9.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ""
     version: v1 # apiVersion

--- a/addons/prometheus/0.46.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.46.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.46.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.46.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ""
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.2.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.2.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.2.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.2.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ""
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.2.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.2.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.2.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.2.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ""
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.3.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.3.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.0-15.3.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.47.0-15.3.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ""
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.1-16.0.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.47.1-16.0.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.47.1-16.0.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.47.1-16.0.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.48.0-16.1.2/crds/kustomization.yaml
+++ b/addons/prometheus/0.48.0-16.1.2/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.48.0-16.1.2/operator/kustomization.yaml
+++ b/addons/prometheus/0.48.0-16.1.2/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.48.1-16.10.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.48.1-16.10.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.48.1-16.10.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.48.1-16.10.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.48.1-16.12.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.48.1-16.12.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.48.1-16.12.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.48.1-16.12.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.49.0-17.0.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.0.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.49.0-17.0.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.0.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.49.0-17.1.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.1.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.49.0-17.1.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.1.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.49.0-17.1.3/crds/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.1.3/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.49.0-17.1.3/operator/kustomization.yaml
+++ b/addons/prometheus/0.49.0-17.1.3/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.53.1-30.1.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.53.1-30.1.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.53.1-30.1.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.53.1-30.1.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.56.2-35.2.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.56.2-35.2.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.56.2-35.2.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.56.2-35.2.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.57.0-36.0.3/crds/kustomization.yaml
+++ b/addons/prometheus/0.57.0-36.0.3/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.57.0-36.0.3/operator/kustomization.yaml
+++ b/addons/prometheus/0.57.0-36.0.3/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.57.0-36.2.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.57.0-36.2.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.57.0-36.2.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.57.0-36.2.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.58.0-39.11.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.11.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.58.0-39.11.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.11.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.58.0-39.12.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.12.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.58.0-39.12.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.12.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.58.0-39.4.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.4.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.58.0-39.4.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.4.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.58.0-39.9.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.9.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.58.0-39.9.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.58.0-39.9.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.59.1-40.1.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.59.1-40.1.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.59.1-40.1.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.59.1-40.1.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.60.1-41.7.3/crds/kustomization.yaml
+++ b/addons/prometheus/0.60.1-41.7.3/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.60.1-41.7.3/operator/kustomization.yaml
+++ b/addons/prometheus/0.60.1-41.7.3/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.62.0-44.3.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.62.0-44.3.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.62.0-44.3.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.62.0-44.3.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.1.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.1.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.1.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.1.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.1.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.1.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.1.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.1.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.10.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.10.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.10.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.10.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.15.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.15.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.15.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.15.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.19.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.19.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.19.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.19.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.2.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.2.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.2.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.2.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.20.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.20.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.20.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.20.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.21.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.21.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.21.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.21.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.3.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.3.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.3.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.3.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.4.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.4.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.4.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.4.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.5.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.5.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.5.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.5.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.7.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.7.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.7.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.7.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.8.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.8.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.8.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.8.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.8.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.8.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.8.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.8.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.63.0-45.9.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.9.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.63.0-45.9.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.63.0-45.9.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.65.1-45.26.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.26.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.65.1-45.26.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.26.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.65.1-45.27.1/crds/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.27.1/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.65.1-45.27.1/operator/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.27.1/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.65.1-45.27.2/crds/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.27.2/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.65.1-45.27.2/operator/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.27.2/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/0.65.1-45.28.0/crds/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.28.0/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/0.65.1-45.28.0/operator/kustomization.yaml
+++ b/addons/prometheus/0.65.1-45.28.0/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/prometheus/template/base/crds/kustomization.yaml
+++ b/addons/prometheus/template/base/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - crds.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: "apiextensions.k8s.io"
     version: v1 # apiVersion

--- a/addons/prometheus/template/base/operator/kustomization.yaml
+++ b/addons/prometheus/template/base/operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - ns.yaml
 - adapter.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1

--- a/addons/rook/1.10.11/cluster/kustomization.yaml
+++ b/addons/rook/1.10.11/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.10.6/cluster/kustomization.yaml
+++ b/addons/rook/1.10.6/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.10.8/cluster/kustomization.yaml
+++ b/addons/rook/1.10.8/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.11.2/cluster/kustomization.yaml
+++ b/addons/rook/1.11.2/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.11.3/cluster/kustomization.yaml
+++ b/addons/rook/1.11.3/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.11.4/cluster/kustomization.yaml
+++ b/addons/rook/1.11.4/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.11.5/cluster/kustomization.yaml
+++ b/addons/rook/1.11.5/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.4.9/cluster/kustomization.yaml
+++ b/addons/rook/1.4.9/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.5.10/cluster/kustomization.yaml
+++ b/addons/rook/1.5.10/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.5.11/cluster/kustomization.yaml
+++ b/addons/rook/1.5.11/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.5.12/cluster/kustomization.yaml
+++ b/addons/rook/1.5.12/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.5.9/cluster/kustomization.yaml
+++ b/addons/rook/1.5.9/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.6.11/cluster/kustomization.yaml
+++ b/addons/rook/1.6.11/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.7.11/cluster/kustomization.yaml
+++ b/addons/rook/1.7.11/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.8.10/cluster/kustomization.yaml
+++ b/addons/rook/1.8.10/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/1.9.12/cluster/kustomization.yaml
+++ b/addons/rook/1.9.12/cluster/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/addons/rook/template/base/cluster/kustomization.yaml
+++ b/addons/rook/template/base/cluster/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 patchesStrategicMerge:
 - patches/ceph-cluster-tolerate.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: ceph.rook.io
     version: v1

--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -103,12 +103,12 @@ function insert_patches_json_6902() {
     local name="$6"
     local namespace="$7"
 
-    if ! grep -q "patchesJson6902" "$kustomization_file"; then
-        echo "patchesJson6902:" >> "$kustomization_file"
+    if ! grep -q "patches" "$kustomization_file"; then
+        echo "patches:" >> "$kustomization_file"
     fi
 
 # 'fourspace_' and 'twospace_' are used because spaces at the beginning of each line are stripped
-    sed -i "/patchesJson6902.*/a- target:\n\
+    sed -i "/patches.*/a- target:\n\
 fourspace_ group: $group\n\
 fourspace_ version: $version\n\
 fourspace_ kind: $kind\n\


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix patcgesJson6902 which is deprecated

> Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.

#### Which issue(s) this PR fixes:

Fixes # [sc-77464]

#### Special notes for your reviewer:
We will need to check it out in the daily as well. 
So, let's only get merged after the next release

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes warning patchesJson6902 which is deprecated by replacing it for patches. AddOns prometheus versions equals or upper than `0.46.0` and Rook versions equals or upper than  `1.4.9` were changed to receive this fix. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
