### PR TITLE
Adds support to ol8.8 by updating preflight check

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -78,7 +78,7 @@ function bailIfUnsupportedOS() {
             ;;
         amzn2)
             ;;
-        ol7.4|ol7.5|ol7.6|ol7.7|ol7.8|ol7.9|ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7)
+        ol7.4|ol7.5|ol7.6|ol7.7|ol7.8|ol7.9|ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7|ol8.8)
             ;;
         *)
             bail "Kubernetes install is not supported on ${LSB_DIST} ${DIST_VERSION}. The list of supported operating systems can be viewed at https://kurl.sh/docs/install-with-kurl/system-requirements."


### PR DESCRIPTION
#### What this PR does / why we need it:

It shows that a new release was published and the tests are not been executing on it because our preflight will flag as 8.8 as not supported. So, we first need to change the preflight to see if all will work fine expected in order to support this new version. 

#### Which issue(s) this PR fixes:

Fixes # [sc-77478]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for Oracle Linux 8.8 
```


#### Does this PR require documentation?

https://github.com/replicatedhq/kurl.sh/pull/977