### PR TITLE
fix(kubernetes): build broken change url for gpg key

### DIFF
--- a/bundles/k8s-ubuntu1604/Dockerfile
+++ b/bundles/k8s-ubuntu1604/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update
 RUN mkdir -p /packages/archives

--- a/bundles/k8s-ubuntu1804/Dockerfile
+++ b/bundles/k8s-ubuntu1804/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update
 RUN mkdir -p /packages/archives

--- a/bundles/k8s-ubuntu2004/Dockerfile
+++ b/bundles/k8s-ubuntu2004/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update
 RUN mkdir -p /packages/archives

--- a/bundles/k8s-ubuntu2204/Dockerfile
+++ b/bundles/k8s-ubuntu2204/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get -y install curl apt-transport-https gnupg tzdata
 
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update
 RUN mkdir -p /packages/archives

--- a/packages/kubernetes/template/Dockerfile
+++ b/packages/kubernetes/template/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get -y install curl apt-transport-https gnupg
-RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Follows https://github.com/kubernetes/release/issues/2862#issuecomment-1556165714

Fixes error in CI https://github.com/replicatedhq/kURL/actions/runs/5048223728/jobs/9056138343

```
Reading package lists...
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'http://apt.kubernetes.io/ kubernetes-xenial InRelease' is not signed.
The command '/bin/sh -c apt-get update' returned a non-zero code: 100
```