### PR TITLE
fix flag duplications

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -372,12 +372,13 @@ function join_token() {
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${docker_registry_ip}")"
-    if [ -n "$additional_no_proxy_addresses" ]; then
-        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${ADDITIONAL_NO_PROXY_ADDRESSES}")"
-    fi
-    if [ -n "$service_cidr" ] && [ -n "$pod_cidr" ]; then
-        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${service_cidr},${pod_cidr}")"
-    fi
+
+    local no_proxy_addresses=""
+    [ -n "$additional_no_proxy_addresses" ] && no_proxy_addresses="$additional_no_proxy_addresses"
+    [ -n "$service_cidr" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}$service_cidr"
+    [ -n "$pod_cidr" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}$pod_cidr"
+    [ -n "$no_proxy_addresses" ] && common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag 1 "$no_proxy_addresses")"
+
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${kurl_install_directory}")"
     common_flags="${common_flags}$(get_remotes_flags)"
     common_flags="${common_flags}$(get_ipv6_flag)"


### PR DESCRIPTION
#### What this PR does / why we need it:

Note that currently when we have set additional_no_proxy_addresses the value will appears duplicated.


If additional-no-proxy-addresses is informed we are currently duplicating the tag instead of aggregating the value for the join command. For example, we observe that the following tag is being duplicated:

```
additional-no-proxy-addresses=.corporate.internal additional-no-proxy-addresses=10.96.0.0/22,10.32.0.0/20 primary-host=10.154.0.68
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
