### PR TITLE
update unsupported tests targeting rocky-91 with rocky-92

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -37,7 +37,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s121
   installerSpec:
     kubernetes:
@@ -375,5 +375,5 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -25,7 +25,7 @@
   unsupportedOSIDs:
   - ubuntu-2004 # docker 19.03.4 is not available on ubuntu 20.04
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s119x
   flags: "yes"
   installerSpec:
@@ -51,7 +51,7 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd149
   installerSpec:
     kubernetes:
@@ -76,7 +76,7 @@
       version: 1.4.9
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s117x_openebs_minio
   flags: "yes"
   installerSpec:
@@ -109,7 +109,7 @@
     ekco:
       version: 0.6.0
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s120x_docker
   flags: "yes"
   installerSpec:
@@ -137,7 +137,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s121x_containerd
   installerSpec:
     kubernetes:
@@ -166,7 +166,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x-airgap
   flags: "yes"
   installerSpec:
@@ -193,7 +193,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202
   flags: "yes"
   installerSpec:
@@ -216,7 +216,7 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.5 is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s1184_1202_containerd
   installerSpec:
     kubernetes:
@@ -238,7 +238,7 @@
       version: 1.6.x
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x_containerd148
   installerSpec:
     kubernetes:
@@ -263,7 +263,7 @@
       version: 1.4.13
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119x_containerd139
   installerSpec:
     kubernetes:
@@ -288,7 +288,7 @@
       version: 1.4.9
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119
   flags: "yes"
   installerSpec:
@@ -314,7 +314,7 @@
       version: 0.6.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s119-airgap
   flags: "yes"
   installerSpec:
@@ -341,7 +341,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not available on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s119_containerd1412
   installerSpec:
     kubernetes:
@@ -366,7 +366,7 @@
       version: 1.4.12
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_containerd146-airgap
   installerSpec:
     kubernetes:
@@ -392,7 +392,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_containerd_rook_block
   cpu: 6
   installerSpec:
@@ -420,7 +420,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_ctrd_longhorn
   installerSpec:
     kubernetes:
@@ -450,7 +450,7 @@
       uiBindPort: 30080
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_ctrd_longhorn-airgap
   installerSpec:
     kubernetes:
@@ -481,7 +481,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_helm
   installerSpec:
     kubernetes:
@@ -537,7 +537,7 @@
                   nodePort: 30443
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120_minimal_containerd1411
   installerSpec:
     kubernetes:
@@ -552,7 +552,7 @@
       version: 1.4.11
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s119_selinux
   flags: "yes"
   installerSpec:
@@ -575,7 +575,7 @@
       type: targeted
   unsupportedOSIDs:
   - ubuntu-2204 # docker 19.x is not supported on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s120
   installerSpec:
     kubernetes:
@@ -602,7 +602,7 @@
       version: 1.1.2
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s120-airgap
   installerSpec:
     kubernetes:
@@ -630,7 +630,7 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: k8s24x_rook_upgrade_17x_110x
   flags: "yes"
   cpu: 6
@@ -693,7 +693,7 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s121
   flags: "yes"
   installerSpec:
@@ -717,7 +717,7 @@
     ekco:
       version: latest
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s121-airgap
   flags: "yes"
   installerSpec:
@@ -742,7 +742,7 @@
       version: latest
   airgap: true
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio
   flags: "yes"
   installerSpec:
@@ -769,7 +769,7 @@
     ekco:
       version: 0.10.1
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: k8s1210_openebs260_minio-airgap
   flags: "yes"
   installerSpec:
@@ -797,7 +797,7 @@
       version: 0.10.1
   airgap: true
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: remove_all_object_storage
   cpu: 7
   installerSpec:
@@ -886,7 +886,7 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "K8s 1.22x Airgap"
   cpu: 6
   installerSpec:
@@ -970,7 +970,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.27 airgap"
   flags: "yes"
   installerSpec:
@@ -1030,7 +1030,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: "K8s 1.24x Rook"
   cpu: 6
   installerSpec:
@@ -1057,7 +1057,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "K8s 1.27x Rook, disableS3"
   cpu: 6
   installerSpec:
@@ -1112,7 +1112,7 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 - name: "Upgrade to 1.24, disable s3, weave to flannel"
   flags: "yes"
   cpu: 7
@@ -1147,7 +1147,7 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: "Upgrade to 1.27 airgap"
   cpu: 6
   installerSpec:
@@ -1718,7 +1718,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
 - name: "containerd upgrade from 1.2.x to 1.4.x"
   installerSpec:
@@ -1748,7 +1748,7 @@
     minio:
       version: latest
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   - centos-74 # containerd 1.2.x does not install on centos-7
   - centos-79 # containerd 1.2.x does not install on centos-7
@@ -1790,7 +1790,7 @@
     minio:
       version: latest
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -1829,7 +1829,7 @@
     minio:
       version: latest
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -1868,7 +1868,7 @@
     minio:
       version: latest
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
@@ -2148,7 +2148,7 @@
     cd /testsymbolic
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-    - rocky-91 # docker is not supported on rhel 9 variants
+    - rocky-92 # docker is not supported on rhel 9 variants
 - name: (k8s 1.27) install addons not deprecated less prometheus, goldpinger
   flags: "yes"
   installerSpec:

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -866,7 +866,7 @@
        exit 1
     fi
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
   - ubuntu-2204 # Docker versions < 20.10.17 not supported on ubuntu 22.04
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
   flags: "yes"
@@ -1020,7 +1020,7 @@
       envoyPodsNotReadyDuration: 5m
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets
@@ -1142,7 +1142,7 @@
   unsupportedOSIDs:
   - ol-8x # The kURL version used in this test, v2022.08.23-0, does not support OL-8.7
   - ubuntu-2204 # docker 19.03.4 is not supported on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets
@@ -1254,7 +1254,7 @@
   unsupportedOSIDs:
   - ol-8x # The kURL version used in this test, v2022.11.10-1, does not support OL-8.7
   - ubuntu-2204 # docker 19.03.10 is not supported on ubuntu 22.04
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets
@@ -1348,7 +1348,7 @@
     flannel:
       version: 0.21.x # (replicated) changed to .x version
   unsupportedOSIDs:
-  - rocky-91 # rocky 9.1 is unsupported on kurl version v2023.02.23-0
+  - rocky-92 # rocky 9.1 is unsupported on kurl version v2023.02.23-0
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets


### PR DESCRIPTION
Follow up of : https://github.com/replicatedhq/kURL/pull/4534
[sc-76521]