### PR TITLE
proper handle additional-no-proxy-addresses flag on upgrade

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -293,10 +293,13 @@ function addon_outro() {
     if [ "$ADDONS_HAVE_HOST_COMPONENTS" = "1" ] && kubernetes_has_remotes; then
         local common_flags
         common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-        if [ -n "$ADDITIONAL_NO_PROXY_ADDRESSES" ]; then
-            common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "1" "${ADDITIONAL_NO_PROXY_ADDRESSES}")"
-        fi
-        common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${PROXY_ADDRESS}" "${SERVICE_CIDR},${POD_CIDR}")"
+
+        local no_proxy_addresses=""
+        [ -n "$ADDITIONAL_NO_PROXY_ADDRESSES" ] && no_proxy_addresses="$ADDITIONAL_NO_PROXY_ADDRESSES"
+        [ -n "${SERVICE_CIDR}" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}${SERVICE_CIDR}"
+        [ -n "${POD_CIDR}" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}${POD_CIDR}"
+        [ -n "$no_proxy_addresses" ] && common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag 1 "$no_proxy_addresses")"
+
         common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
         common_flags="${common_flags}$(get_skip_system_package_install_flag)"
         common_flags="${common_flags}$(get_exclude_builtin_host_preflights_flag)"


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that when we upgrade we either will proper handle the additional-no-proxy-addresses flag by:
- not allowing duplications
- but ensuring that we are passing all data

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

**Before the fix**
![Screenshot 2023-05-22 at 23 43 53](https://github.com/replicatedhq/kURL/assets/7708031/6509cf67-65f9-448c-b67e-02ffd68d02bf)

**After the fix**
![Screenshot 2023-05-22 at 23 48 51](https://github.com/replicatedhq/kURL/assets/7708031/c710148a-5865-469b-962e-df26fe4726d8)

## Steps to reproduce
- Install an release with an value for additional-no-proxy-addresses:

```yaml
spec:
  kurl:
    ...
    additionalNoProxyAddresses:
    - .corporate.internal
``` 

- Add a node
- Then, re-run/upgrade the install (without change the k8s version)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes handling of the additional-no-proxy-addresses flag when upgrade installs in multi-node for the command outputted to upgrade remote nodes
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
