### PR TITLE
fix k8s upgrades to properly handle the flag

### DIFF
--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -507,7 +507,13 @@ function upgrade_kubernetes_remote_node() {
 
     local common_flags
     common_flags="${common_flags}$(get_docker_registry_ip_flag "${DOCKER_REGISTRY_IP}")"
-    common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag "${NO_PROXY_ADDRESSES}" "${NO_PROXY_ADDRESSES}")"
+
+    local no_proxy_addresses=""
+    [ -n "$ADDITIONAL_NO_PROXY_ADDRESSES" ] && no_proxy_addresses="$ADDITIONAL_NO_PROXY_ADDRESSES"
+    [ -n "$service_cidr" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}$service_cidr"
+    [ -n "$pod_cidr" ] && no_proxy_addresses="${no_proxy_addresses:+$no_proxy_addresses,}$pod_cidr"
+    [ -n "$no_proxy_addresses" ] && common_flags="${common_flags}$(get_additional_no_proxy_addresses_flag 1 "$no_proxy_addresses")"
+
     common_flags="${common_flags}$(get_kurl_install_directory_flag "${KURL_INSTALL_DIRECTORY_FLAG}")"
     common_flags="${common_flags}$(get_remotes_flags)"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that when we upgrade the k8s version we either will proper handle the additional-no-proxy-addresses flag by:
- not allowing duplications
- but ensuring that we are passing all data

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
**Before the fix**
![Screenshot 2023-05-23 at 14 12 40](https://github.com/replicatedhq/kURL/assets/7708031/39281f13-e0ad-4cae-af33-037213dc6365)

**After this fix**
![Screenshot 2023-05-23 at 14 25 53](https://github.com/replicatedhq/kURL/assets/7708031/007bc883-2ddc-42c4-ab77-37728482db9e)

## Steps to reproduce
- Install with k8s 1.26
- Create a node
- Then, upgrade the k8s install

#### Does this PR introduce a user-facing change?
```release-note
Fixes handling of the additional-no-proxy-addresses flag when upgrade the kubernetes version on installs in multi-node for the command outputted to upgrade remote nodes
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
