### PR TITLE
fix registry OpenSSL calls in order to provide support for RHEL 9.2

### DIFF
--- a/addons/registry/2.7.1/install.sh
+++ b/addons/registry/2.7.1/install.sh
@@ -242,8 +242,8 @@ EOF
     local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
     local ca_key="$(${K8S_DISTRO}_get_server_ca_key)"
 
-    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -config registry.cnf
-    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf
+    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -sha256 -config registry.cnf
+    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf -sha256
 
     # rotate the cert and restart the pod every time
     kubectl -n kurl delete secret registry-pki &>/dev/null || true

--- a/addons/registry/2.8.1/install.sh
+++ b/addons/registry/2.8.1/install.sh
@@ -241,8 +241,8 @@ EOF
     local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
     local ca_key="$(${K8S_DISTRO}_get_server_ca_key)"
 
-    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -config registry.cnf
-    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf
+    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -sha256 -config registry.cnf
+    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf -sha256
 
     # rotate the cert and restart the pod every time
     kubectl -n kurl delete secret registry-pki &>/dev/null || true

--- a/addons/registry/2.8.2/install.sh
+++ b/addons/registry/2.8.2/install.sh
@@ -241,8 +241,8 @@ EOF
     local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
     local ca_key="$(${K8S_DISTRO}_get_server_ca_key)"
 
-    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -config registry.cnf
-    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf
+    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -sha256 -config registry.cnf
+    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf -sha256
 
     # rotate the cert and restart the pod every time
     kubectl -n kurl delete secret registry-pki &>/dev/null || true

--- a/addons/registry/template/base/install.sh
+++ b/addons/registry/template/base/install.sh
@@ -241,8 +241,8 @@ EOF
     local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
     local ca_key="$(${K8S_DISTRO}_get_server_ca_key)"
 
-    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -config registry.cnf
-    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf
+    openssl req -newkey rsa:2048 -nodes -keyout registry.key -out registry.csr -sha256 -config registry.cnf
+    openssl x509 -req -days 365 -in registry.csr -CA "${ca_crt}" -CAkey "${ca_key}" -CAcreateserial -out registry.crt -extensions v3_ext -extfile registry.cnf -sha256
 
     # rotate the cert and restart the pod every time
     kubectl -n kurl delete secret registry-pki &>/dev/null || true


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is required to fix the issue with OpenSSL and allow us to support RHEL 9.2.

We have added -sha256, which explicitly specifies the digest method. This should prevent OpenSSL from trying to use a default digest, and thereby avoid the error:

```
2023-05-23 05:15:26+00:00 ⚙  Addon registry 2.8.2
2023-05-23 05:16:27+00:00 
2023-05-23 05:16:27+00:00 Error setting context
2023-05-23 05:16:27+00:00 808B3393437F0000:error:0300009E:digital envelope routines:do_sigver_init:no default digest:crypto/evp/m_sigver.c:372:
2023-05-23 05:16:27+00:00 Error setting context
2023-05-23 05:16:27+00:00 802B2EDD2C7F0000:error:0300009E:digital envelope routines:do_sigver_init:no default digest:crypto/evp/m_sigver.c:372:
2023-05-23 05:16:27+00:00 spent 1m attempting to run "object_store_create_bucket docker-registry" without success
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-76521]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes OpenSSL calls used to configure Registry AddOn by explicitly specifying the digest method in order to support RHEL 9.2
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
