### PR TITLE
fix Rook OpenSSL calls in order to provide support for RHEL 9.2

### DIFF
--- a/addons/rook/1.0.4-14.2.21/install.sh
+++ b/addons/rook/1.0.4-14.2.21/install.sh
@@ -180,7 +180,7 @@ function rook_create_bucket() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.0.4/install.sh
+++ b/addons/rook/1.0.4/install.sh
@@ -170,7 +170,7 @@ function rook_create_bucket() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -629,7 +629,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -628,7 +628,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -630,7 +630,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.11.2/install.sh
+++ b/addons/rook/1.11.2/install.sh
@@ -625,7 +625,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.11.3/install.sh
+++ b/addons/rook/1.11.3/install.sh
@@ -625,7 +625,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.11.4/install.sh
+++ b/addons/rook/1.11.4/install.sh
@@ -636,7 +636,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.11.5/install.sh
+++ b/addons/rook/1.11.5/install.sh
@@ -645,7 +645,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.11.6/install.sh
+++ b/addons/rook/1.11.6/install.sh
@@ -645,7 +645,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -200,7 +200,7 @@ function rook_create_bucket() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -351,7 +351,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.5.10/install.sh
+++ b/addons/rook/1.5.10/install.sh
@@ -345,7 +345,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -351,7 +351,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -366,7 +366,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -354,7 +354,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --noproxy "*" \

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -427,7 +427,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -602,7 +602,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -635,7 +635,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -633,7 +633,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -645,7 +645,7 @@ function rook_create_bucket() {
     d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/${bucket}"
     local sig
-    sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -X PUT  \
         --globoff \

--- a/scripts/common/object_store.sh
+++ b/scripts/common/object_store.sh
@@ -35,7 +35,7 @@ function _object_store_create_bucket() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="PUT\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     local addr=$($DIR/bin/kurl netutil format-ip-address "$OBJECT_STORE_CLUSTER_IP")
     curl -fsSL -X PUT  \
@@ -53,7 +53,7 @@ function object_store_bucket_exists() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="HEAD\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     local addr=$($DIR/bin/kurl netutil format-ip-address "$OBJECT_STORE_CLUSTER_IP")
     curl -fsSL -I \


### PR DESCRIPTION
#### What this PR does / why we need it:

Same scenario of https://github.com/replicatedhq/kURL/pull/4543

We added digest method to specify the method. 

#### Which issue(s) this PR fixes:
Fixes # [sc-76521]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes OpenSSL calls used to configure Rook AddOn by explicitly specifying the digest method in order to support RHEL 9.2

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
