### PR TITLE
Improve log message to know when the host preflights were ignored and has or not failures

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -629,7 +629,25 @@ function host_preflights() {
                 ;;
         esac                                       
     fi
-    logStep "Host preflights success"
+    if [ "${HOST_PREFLIGHT_IGNORE}" = "1" ]; then
+       logWarn "Using host-preflight-ignore flag to disregard any failures during the pre-flight checks"
+
+       case $kurl_exit_code in
+           3)
+               logFail "Host preflights have warnings that should block the installation."
+               return
+               ;;
+           2)
+               logWarn "Host preflights have warnings which is highly recommended to sort out the conditions before proceeding."
+               return
+               ;;
+           1)
+               logFail "Host preflights have failures that should block the installation."
+               return
+               ;;
+       esac
+    fi
+    logSuccess "Host preflights success"
 }
 
 IN_CLUSTER_PREFLIGHTS_RESULTS_OUTPUT_DIR="in-cluster-preflights"
@@ -711,7 +729,24 @@ function cluster_preflights() {
                 ;;
         esac
     fi
-    logStep "On cluster Preflights success"
+    if [ "${HOST_PREFLIGHT_IGNORE}" = "1" ]; then
+         logWarn "Using host-preflight-ignore flag to disregard any failures during the pre-flight checks"
+         case $kurl_exit_code in
+             3)
+                 logFail "On cluster preflights have warnings that should block the installation."
+                 return
+                 ;;
+             2)
+                 logWarn "On cluster preflights have warnings which is highly recommended to sort out the conditions before proceeding."
+                 return
+                 ;;
+             1)
+                 logFail "On cluster preflights have failures that should block the installation."
+                 return
+                 ;;
+         esac
+    fi
+    logSuccess "On cluster Preflights success"
 }
 
 # host_preflights_mkresults will append cli data to preflight results file


### PR DESCRIPTION
#### What this PR does / why we need it:

When using host-preflight-ignore, we incorrectly say the preflights pass, when they really fail; we're just ignoring them. We need to be accurate. It  either does not help us in the support.

#### Which issue(s) this PR fixes:

Fixes # [sc-56563]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
$ cat install.sh | sudo bash -s host-preflight-ignore
![Screenshot 2023-05-25 at 09 35 46](https://github.com/replicatedhq/kURL/assets/7708031/21db64ec-1b81-499c-b7a6-baefd3ea58b3)



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes message used to inform when the preflights checks were succeed or ignored. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
