### PR TITLE
fix testgrid test

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2184,6 +2184,8 @@
       version: "latest"
     kotsadm:
       version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.11.6 will not be installed due to failed preflight checks.
 - name: (k8s 1.27) install addons not deprecated less prometheus, goldpinger with symbolic links
   flags: "yes"
   installerSpec:
@@ -2219,6 +2221,8 @@
       version: "latest"
     kotsadm:
       version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.11.6 will not be installed due to failed preflight checks.
   preInstallScript: |
     FOLDER=/testsymbolic
     


### PR DESCRIPTION
#### What this PR does / why we need it:

We need ignore the following tests against centos-7.4
- (k8s 1.27) install addons not deprecated less prometheus, goldpinger with symbolic links
- (k8s 1.27) install addons not deprecated less prometheus, goldpinger

See that they fail with `Rook 1.11.6 will not be installed due to failed preflight checks.`

```
2023-05-23 21:06:20+00:00 ✔ Host packages libzstd installed
2023-05-23 21:06:20+00:00 Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported.
2023-05-23 21:06:20+00:00 Rook 1.11.6 will not be installed due to failed preflight checks.
+ KURL_EXIT_STATUS=1
+ export KUBECONFIG=/etc/kubernetes/admin.conf
+ KUBECONFIG=/etc/kubernetes/admin.conf
+ export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl install with exit status 1'
+ collect_debug_info_after_kurl
+ '[' 1 -ne 0 ']'
+ echo 'kubelet status'
+ systemctl status kubelet
2023-05-23 21:06:20+00:00 
2023-05-23 21:06:20+00:00 failed kurl install with exit status 1
2023-05-23 21:06:20+00:00 kubelet status

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
