### PR TITLE
feat(cli): Add new kURL CLI command for orchestrating and starting the OpenEBS to Rook migration

### DIFF
--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -35,7 +35,6 @@ type migrateOpts struct {
 }
 
 func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
-	var clientSet kubernetes.Interface
 	opts := migrateOpts{log: cli.Logger()}
 
 	cmd := &cobra.Command{
@@ -46,7 +45,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStorageMigration(cmd.Context(), clientSet, opts)
+			return runStorageMigration(cmd.Context(), opts)
 		},
 	}
 	cmd.Flags().DurationVar(&opts.readyTimeout, "ready-timeout", 10*time.Minute, "Timeout waiting for the cluster to be ready for the storage migration.")
@@ -179,13 +178,13 @@ func continueWithStorageMigration() bool {
 	fmt.Println("    The installer detected both OpenEBS and Rook installations in your cluster. Migration from OpenEBS to Rook")
 	fmt.Println("    is possible now, but it requires scaling down applications using OpenEBS volumes, causing downtime. You can")
 	fmt.Println("    choose to run the migration later if preferred.")
-	fmt.Print("Would you like to continue with the migration now? (Y/n) ")
+	fmt.Print("Would you like to continue with the migration now? (y/N) ")
 	var answer string
 	fmt.Scanln(&answer)
 	return strings.ToLower(answer) == "y"
 }
 
-func runStorageMigration(ctx context.Context, kcli kubernetes.Interface, opts migrateOpts) error {
+func runStorageMigration(ctx context.Context, opts migrateOpts) error {
 
 	// check if migration already completed or if there's one already in progress
 	if status, err := getEkcoMigrationStatus(opts); err != nil {
@@ -261,7 +260,7 @@ func getEkcoStorageMigrationAuthToken(ctx context.Context) (string, error) {
 	// retrieve configmap
 	ekcoConfig, err := clientSet.CoreV1().ConfigMaps("kurl").Get(ctx, "ekco-config", metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("get ekco-config configmap in kurl namespace: %v", err)
+		return "", fmt.Errorf("failed to get ekco-config configmap in kurl namespace: %v", err)
 	}
 
 	// get authentication token

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -33,7 +33,7 @@ type migrateOpts struct {
 	readyTimeout   time.Duration
 	migrateTimeout time.Duration
 	checkStatus    bool
-	runMigration   bool
+	assumeYes      bool
 }
 
 func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
@@ -55,7 +55,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "localhost:31880", "The address of the ekco operator.")
 	cmd.Flags().StringVar(&opts.authToken, "ekco-auth-token", "", "The auth token to use to authenticate with the ekco operator.")
 	cmd.Flags().BoolVar(&opts.checkStatus, "check-status", false, "Check the status of the storage migration, but do not run it if available.")
-	cmd.Flags().BoolVar(&opts.runMigration, "run-migration", false, "Run the storage migration if available without prompting.")
+	cmd.Flags().BoolVar(&opts.assumeYes, "assume-yes", false, "Run the storage migration if available without prompting.")
 	return cmd
 }
 
@@ -211,7 +211,7 @@ func runStorageMigration(ctx context.Context, opts migrateOpts) error {
 		return nil
 	}
 
-	if opts.runMigration {
+	if opts.assumeYes {
 		opts.log.Printf("starting cluster storage migration.")
 	} else if !continueWithStorageMigration() {
 		return nil

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,7 +55,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 	cmd.Flags().DurationVar(&opts.readyTimeout, "ready-timeout", 10*time.Minute, "Timeout waiting for the cluster to be ready for the storage migration.")
 	cmd.Flags().DurationVar(&opts.migrateTimeout, "migrate-timeout", 8*time.Hour, "Timeout waiting for the storage migration to finish.")
 	cmd.Flags().IntVar(&opts.minimumNrNodes, "minimum-number-of-nodes", 0, "Indicates the desired minimum number of nodes to start the migration.")
-	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "", "The address of the ekco operator.")
+	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "ecko.kurl:"+strconv.Itoa(ekcoPort), "The address of the ekco operator.")
 	cmd.Flags().StringVar(&opts.authToken, "ekco-auth-token", "", "The auth token to use to authenticate with the ekco operator.")
 	return cmd
 }
@@ -92,9 +93,10 @@ func getEkcoMigrationStatus(opts migrateOpts) (string, error) {
 // MigrationReady represents the status of the migration readiness check, includes a reason and also the number of
 // nodes in the cluster.
 type MigrationReadyStatus struct {
-	Ready   bool   `json:"ready"`
-	Reason  string `json:"reason"`
-	NrNodes int    `json:"nrNodes"`
+	Ready           bool   `json:"ready"`
+	Reason          string `json:"reason"`
+	NrNodes         int    `json:"nrNodes"`
+	RequiredNrNodes int    `json:"requiredNrNodes"`
 }
 
 func isEkcoReadyForStorageMigration(opts migrateOpts) (*MigrationReadyStatus, error) {

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -52,7 +52,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 	cmd.Flags().DurationVar(&opts.readyTimeout, "ready-timeout", 10*time.Minute, "Timeout waiting for the cluster to be ready for the storage migration.")
 	cmd.Flags().DurationVar(&opts.migrateTimeout, "migrate-timeout", 8*time.Hour, "Timeout waiting for the storage migration to finish.")
 	cmd.Flags().IntVar(&opts.minimumNrNodes, "minimum-number-of-nodes", 0, "Indicates the desired minimum number of nodes to start the migration.")
-	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "ecko-operator.kurl:"+strconv.Itoa(ekcoPort), "The address of the ekco operator.")
+	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "ekc-operator.kurl:"+strconv.Itoa(ekcoPort), "The address of the ekco operator.")
 	cmd.Flags().StringVar(&opts.authToken, "ekco-auth-token", "", "The auth token to use to authenticate with the ekco operator.")
 	return cmd
 }

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -147,7 +147,7 @@ func continueWithStorageMigration() bool {
 	fmt.Print("Would you like to continue with the migration now? (Y/n) ")
 	var answer string
 	fmt.Scanln(&answer)
-	return answer == "" || strings.ToLower(answer) == "y"
+	return strings.ToLower(answer) == "y"
 }
 
 func runStorageMigration(ctx context.Context, opts migrateOpts) error {

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -52,7 +52,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 	cmd.Flags().DurationVar(&opts.readyTimeout, "ready-timeout", 10*time.Minute, "Timeout waiting for the cluster to be ready for the storage migration.")
 	cmd.Flags().DurationVar(&opts.migrateTimeout, "migrate-timeout", 8*time.Hour, "Timeout waiting for the storage migration to finish.")
 	cmd.Flags().IntVar(&opts.minimumNrNodes, "minimum-number-of-nodes", 0, "Indicates the desired minimum number of nodes to start the migration.")
-	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "ecko.kurl:"+strconv.Itoa(ekcoPort), "The address of the ekco operator.")
+	cmd.Flags().StringVar(&opts.ekcoAddress, "ekco-address", "ecko-operator.kurl:"+strconv.Itoa(ekcoPort), "The address of the ekco operator.")
 	cmd.Flags().StringVar(&opts.authToken, "ekco-auth-token", "", "The auth token to use to authenticate with the ekco operator.")
 	return cmd
 }

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -42,9 +42,6 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 			if opts.minimumNrNodes <= 0 {
 				return fmt.Errorf("--minimum-number-of-nodes flag is required to be > 0.")
 			}
-			if opts.ekcoAddress == "" {
-				return fmt.Errorf("--ekco-address flag is required.")
-			}
 			cmd.SilenceUsage = true
 			return nil
 		},


### PR DESCRIPTION
#### What this PR does / why we need it:

Since the `join.sh` script does not have access to a kubeconfig file, querying the cluster for information such as the number of nodes, the ekco authentication token, and the ekco pod IP address is not possible.

With the implementation of this pull request, these parameters will need to be provided as command line flags to the script. `join.sh` will receive them as arguments as well, these are going to rendered by the `install.sh`.

This depends on:
- https://github.com/replicatedhq/ekco/pull/137
- https://github.com/replicatedhq/ekco/pull/121