### PR TITLE
Fixes weave uninstall by removing interfaces first and began to remove lib/weave 

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -265,10 +265,10 @@ function remove_weave() {
     kubectl -n kube-system delete secret weave-passwd
 
     # all nodes
-    rm -f /opt/cni/bin/weave-*
-    rm -rf /etc/cni/net.d
     ip link delete weave
-
+    rm -rf /var/lib/weave
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 }
 
 function flannel_kubeadm() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -265,10 +265,10 @@ function remove_weave() {
     kubectl -n kube-system delete secret weave-passwd
 
     # all nodes
-    rm -f /opt/cni/bin/weave-*
-    rm -rf /etc/cni/net.d
     ip link delete weave
-
+    rm -rf /var/lib/weave
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 }
 
 function flannel_kubeadm() {


### PR DESCRIPTION
#### What this PR does / why we need it:

By checking the migration from weave to flannel I notice that we are not removing `lib/weave`. Also, it seems that:

- we should first call ip link delete weave before we delete weave bin and etc
- Also, it is missing we delete the weave data : rm -rf /var/lib/weave
- Either I think we should delete rm -rf /etc/cni/net.d/weave and not rm -rf /etc/cni/net.d/ . See that if we delete /etc/cni/net.d/ we might be deleting more than we should.

#### Which issue(s) this PR fixes:

Motivates by # [sc-77764]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes weave uninstall by removing interfaces first and began to remove lib/weave. Bug fixed introduced only to weave `0.21.5`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
