### PR TITLE
weave to flannel getting stuck to delete the pods

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -251,6 +251,10 @@ function weave_to_flannel() {
         kubectl delete pods -n "$ns" --all --grace-period=200
     done
     sleep 60
+    log "Awaiting up to 5 minutes to check Flannel Pod(s) are Running"
+    if ! spinner_until 300 check_for_running_pods "kube-flannel"; then
+        logWarn "Flannel has unhealthy Pod(s)"
+    fi
     logSuccess "Migrated from Weave to Flannel"
 }
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -251,6 +251,10 @@ function weave_to_flannel() {
         kubectl delete pods -n "$ns" --all --grace-period=200
     done
     sleep 60
+    log "Awaiting up to 5 minutes to check Flannel Pod(s) are Running"
+    if ! spinner_until 300 check_for_running_pods "kube-flannel"; then
+        logWarn "Flannel has unhealthy Pod(s)"
+    fi
     logSuccess "Migrated from Weave to Flannel"
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, the script has been getting stuck to delete some pods. Example:

```
⚙  Restarting kubelet
waiting for containerd to restart
Restarting containerd...
Service containerd restarted.
waiting for kubelet to restart
Restarting kubelet...
Service kubelet restarted.
⚙  Restarting pods in kube-system
pod "coredns-57575c5f89-28klv" deleted
pod "coredns-57575c5f89-5q2td" deleted
pod "coredns-57575c5f89-jcmzv" deleted
pod "coredns-57575c5f89-thptt" deleted
pod "etcd-camila-ubuntu-2004-master-weave" deleted
pod "etcd-camila-ubuntu-2004-node-1-weave" deleted
pod "etcd-camila-ubuntu-2004-node-2-weave" deleted
pod "haproxy-camila-ubuntu-2004-master-weave" deleted
pod "haproxy-camila-ubuntu-2004-node-1-weave" deleted
pod "haproxy-camila-ubuntu-2004-node-2-weave" deleted
pod "kube-apiserver-camila-ubuntu-2004-master-weave" deleted
pod "kube-apiserver-camila-ubuntu-2004-node-1-weave" deleted
pod "kube-apiserver-camila-ubuntu-2004-node-2-weave" deleted
pod "kube-controller-manager-camila-ubuntu-2004-master-weave" deleted
pod "kube-controller-manager-camila-ubuntu-2004-node-1-weave" deleted
pod "kube-controller-manager-camila-ubuntu-2004-node-2-weave" deleted
pod "kube-proxy-nwrmp" deleted
pod "kube-proxy-rv9mc" deleted
pod "kube-proxy-v4pc4" deleted
pod "kube-scheduler-camila-ubuntu-2004-master-weave" deleted
pod "kube-scheduler-camila-ubuntu-2004-node-1-weave" deleted
pod "kube-scheduler-camila-ubuntu-2004-node-2-weave" deleted
pod "metrics-server-845b6874dc-l7bp2" deleted
pod "metrics-server-845b6874dc-plhs9" deleted
```

#### Which issue(s) this PR fixes:

Motivated by (it might not fully fixed the internal ticket) #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
- Run: curl https://kurl.sh/f070e69 | sudo bash -s ha
- Create 2 master nodes
- Upgrade:curl https://kurl.sh/f0a3e1c | sudo bash -s ha

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes issue where script get stuck to delete Pods when it is migrating from weave to flannel. Bug fixed addressed only to 0.21.5.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
