### PR TITLE
Adds check to ensure weave removal

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -286,7 +286,7 @@ function remove_weave() {
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
             logWarn "Resource: $resource still exists. Attempting force deletion."
-            if ! spinner_until 30 kubectl -n kube-system delete "$resource" --force --grace-period=0 1>/dev/null; then
+            if ! timeout 30 kubectl -n kube-system delete "$resource" --force --grace-period=0 1>/dev/null; then
                 logWarn "Timeout occurred while force deleting resource: $resource"
             fi
             echo "waiting 30 seconds to check removal"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -286,7 +286,7 @@ function remove_weave() {
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
             logWarn "Resource: $resource still exists. Attempting force deletion."
-            if ! spinner_until 30 kubectl -n kube-system delete "$resource" --force --grace-period=0 1>/dev/null; then
+            if ! timeout 30 kubectl -n kube-system delete "$resource" --force --grace-period=0 1>/dev/null; then
                 logWarn "Timeout occurred while force deleting resource: $resource"
             fi
             echo "waiting 30 seconds to check removal"


### PR DESCRIPTION
#### What this PR does / why we need it:

It seems that weave has not been delete always:

```
Events:
  Type     Reason                  Age                   From               Message
  ----     ------                  ----                  ----               -------
  Normal   Scheduled               34m                   default-scheduler  Successfully assigned default/troubleshoot-copyfromhost-k2z6l-z8mbt to data-plane-6
  Warning  FailedCreatePodSandBox  34m                   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "f844f630ec4a7ea399dd21239bd29297851f42bd336682b70b9e64ae720752b5": plugin type="weave-net" name="weave" failed (add): unable to allocate IP address: Post "http://127.0.0.1:6784/ip/f844f630ec4a7ea399dd21239bd29297851f42bd336682b70b9e64ae720752b5": dial tcp 127.0.0.1:6784: connect: connection refused
  Normal   SandboxChanged          33m (x3 over 34m)     kubelet            Pod sandbox changed, it will be killed and re-created.
  Warning  FailedKillPod           4m4s (x137 over 33m)  kubelet            error killing pod: failed to "KillPodSandbox" for "bc8a5255-e36b-49e6-ab70-dde2b4769a65" with KillPodSandboxError: "rpc error: code = Unknown desc = failed to destroy network for sandbox \"f844f630ec4a7ea399dd21239bd29297851f42bd336682b70b9e64ae720752b5\": plugin type=\"weave-net\" name=\"weave\" failed (delete): Delete \"http://127.0.0.1:6784/ip/f844f630ec4a7ea399dd21239bd29297851f42bd336682b70b9e64ae720752b5\": dial tcp 127.0.0.1:6784: connect: connection refused"
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Motivated by a support case.
Linked to [sc-77764]


#### Special notes for your reviewer:

We are here ONLY checking and ensuring that all kind of resources that should be deleted are properly deleted:

```
$ kubectl get daemonset,rolebinding,role,clusterrolebinding,clusterrole,serviceaccount,secret -n kube-system | grep weave | awk '{print $1}' 
daemonset.apps/weave-net
rolebinding.rbac.authorization.k8s.io/weave-net
role.rbac.authorization.k8s.io/weave-net
clusterrolebinding.rbac.authorization.k8s.io/weave-net
clusterrole.rbac.authorization.k8s.io/weave-net
serviceaccount/weave-net
secret/weave-passwd
```


## Steps to reproduce
We can verify this one by checking the logs of the testgrid. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes issue where weave resources has not been deleting `: plugin type=\"weave-net\" name=\"weave\" failed (delete): Delete ` by checking and forcing when required. This bug fix was introduced for weave version 0.21.5 and future ones.  
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
