### PR TITLE
(needs discussion) Add accept rules after flush IP TABLES when we are moving from weave to flannel from WEAVE version 0.21.5

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -377,8 +377,14 @@ function weave_to_flannel() {
     logStep "Restarting kubelet"
     log "Stopping Kubelet"
     systemctl stop kubelet
-    log "Flushing IP Tables"
+
+    logStep "Flushing and deleting Weave entries from IP tables"
     iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
+    iptables -P INPUT ACCEPT
+    iptables -P FORWARD ACCEPT
+    iptables -P OUTPUT ACCEPT
+    logSuccess "All IP tables rules have been successfully flushed"
+
     log "Waiting for containerd to restart"
     restart_systemd_and_wait containerd
     log "Waiting for kubelet to restart"

--- a/addons/flannel/0.22.0/install.sh
+++ b/addons/flannel/0.22.0/install.sh
@@ -377,8 +377,14 @@ function weave_to_flannel() {
     logStep "Restarting kubelet"
     log "Stopping Kubelet"
     systemctl stop kubelet
-    log "Flushing IP Tables"
+
+    logStep "Flushing and deleting Weave entries from IP tables"
     iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
+    iptables -P INPUT ACCEPT
+    iptables -P FORWARD ACCEPT
+    iptables -P OUTPUT ACCEPT
+    logSuccess "All IP tables rules have been successfully flushed"
+
     log "Waiting for containerd to restart"
     restart_systemd_and_wait containerd
     log "Waiting for kubelet to restart"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -377,8 +377,14 @@ function weave_to_flannel() {
     logStep "Restarting kubelet"
     log "Stopping Kubelet"
     systemctl stop kubelet
-    log "Flushing IP Tables"
+
+    logStep "Flushing and deleting Weave entries from IP tables"
     iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
+    iptables -P INPUT ACCEPT
+    iptables -P FORWARD ACCEPT
+    iptables -P OUTPUT ACCEPT
+    logSuccess "All IP tables rules have been successfully flushed"
+
     log "Waiting for containerd to restart"
     restart_systemd_and_wait containerd
     log "Waiting for kubelet to restart"

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -1,180 +1,189 @@
-#- name: "flannel latest single node"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#- name: "flannel latest single node upgrade"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "0.20.x"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#- name: "flannel latest multi node"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  numPrimaryNodes: 1
-#  numSecondaryNodes: 2
-#- name: "flannel airgap latest multi node"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  numPrimaryNodes: 1
-#  numSecondaryNodes: 2
-#  airgap: true
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-#- name: "weave to flannel single node"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    weave:
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#- name: "weave to flannel single node with addons and openebs"
-#  flags: "yes"
-#  cpu: 6
-#  installerSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    weave:
-#      version: "latest"
-#    contour:
-#      version: "latest"
-#    prometheus:
-#      version: "latest"
-#    registry:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    minio:
-#      version: "2023-05-18T00-05-36Z"
-#    openebs:
-#      version: "latest"
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: "local"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    contour:
-#      version: "latest"
-#    prometheus:
-#      version: "latest"
-#    registry:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    minio:
-#      version: "2023-05-18T00-05-36Z"
-#    openebs:
-#      version: "latest"
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: "local"
-#- name: "weave to flannel single node with addons and rook"
-#  flags: "yes"
-#  cpu: 8
-#  installerSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    weave:
-#      version: "latest"
-#    contour:
-#      version: "latest"
-#    prometheus:
-#      version: "latest"
-#    registry:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    minio:
-#      version: "2023-05-18T00-05-36Z"
-#    rook:
-#      version: "1.11.x"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    contour:
-#      version: "latest"
-#    prometheus:
-#      version: "latest"
-#    registry:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    minio:
-#      version: "2023-05-18T00-05-36Z"
-#    rook:
-#      version: "1.11.x"
-#  unsupportedOSIDs:
-#    - centos-74 # Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported
-#- name: "weave to flannel single node, custom IP ranges"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#      serviceCIDR: 172.16.0.0/16
-#    containerd:
-#      version: "latest"
-#    weave:
-#      version: "latest"
-#      podCIDR: 172.17.0.0/16
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#      serviceCIDR: 172.16.0.0/16
-#    containerd:
-#      version: "latest"
-#    flannel:
-#      podCIDR: 172.17.0.0/16
-#      version: "__testver__"
-#      s3Override: "__testdist__"
+- name: "flannel latest single node"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "flannel latest single node upgrade"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "0.20.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "flannel latest multi node"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+- name: "flannel airgap latest multi node"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2
+  airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+- name: "weave to flannel single node"
+  installerSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+- name: "weave to flannel single node with addons and openebs"
+  flags: "yes"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    contour:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    registry:
+      version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2023-05-18T00-05-36Z"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "local"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    contour:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    registry:
+      version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2023-05-18T00-05-36Z"
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "local"
+  postUpgradeScript: |
+    echo "Current iptables rules:"
+    echo "$(iptables -L)"
+- name: "weave to flannel single node with addons and rook"
+  flags: "yes"
+  cpu: 8
+  installerSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+    contour:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    registry:
+      version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2023-05-18T00-05-36Z"
+    rook:
+      version: "1.11.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    containerd:
+      version: "latest"
+    flannel:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    contour:
+      version: "latest"
+    prometheus:
+      version: "latest"
+    registry:
+      version: "latest"
+    ekco:
+      version: "latest"
+    minio:
+      version: "2023-05-18T00-05-36Z"
+    rook:
+      version: "1.11.x"
+  unsupportedOSIDs:
+    - centos-74 # Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported
+  postUpgradeScript: |
+    echo "Current iptables rules:"
+    echo "$(iptables -L)"
+- name: "weave to flannel single node, custom IP ranges"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+      serviceCIDR: 172.16.0.0/16
+    containerd:
+      version: "latest"
+    weave:
+      version: "latest"
+      podCIDR: 172.17.0.0/16
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+      serviceCIDR: 172.16.0.0/16
+    containerd:
+      version: "latest"
+    flannel:
+      podCIDR: 172.17.0.0/16
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postUpgradeScript: |
+    echo "Current iptables rules:"
+    echo "$(iptables -L)"
 - name: "weave to flannel, docker to containerd, single node"
   installerSpec:
     kubernetes:

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -1,180 +1,180 @@
-- name: "flannel latest single node"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-- name: "flannel latest single node upgrade"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "0.20.x"
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-- name: "flannel latest multi node"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  numPrimaryNodes: 1
-  numSecondaryNodes: 2
-- name: "flannel airgap latest multi node"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  numPrimaryNodes: 1
-  numSecondaryNodes: 2
-  airgap: true
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-- name: "weave to flannel single node"
-  installerSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    weave:
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-- name: "weave to flannel single node with addons and openebs"
-  flags: "yes"
-  cpu: 6
-  installerSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    weave:
-      version: "latest"
-    contour:
-      version: "latest"
-    prometheus:
-      version: "latest"
-    registry:
-      version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2023-05-18T00-05-36Z"
-    openebs:
-      version: "latest"
-      isLocalPVEnabled: true
-      localPVStorageClassName: "local"
-  upgradeSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    contour:
-      version: "latest"
-    prometheus:
-      version: "latest"
-    registry:
-      version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2023-05-18T00-05-36Z"
-    openebs:
-      version: "latest"
-      isLocalPVEnabled: true
-      localPVStorageClassName: "local"
-- name: "weave to flannel single node with addons and rook"
-  flags: "yes"
-  cpu: 8
-  installerSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    weave:
-      version: "latest"
-    contour:
-      version: "latest"
-    prometheus:
-      version: "latest"
-    registry:
-      version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2023-05-18T00-05-36Z"
-    rook:
-      version: "1.11.x"
-  upgradeSpec:
-    kubernetes:
-      version: "1.26.x"
-    containerd:
-      version: "latest"
-    flannel:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    contour:
-      version: "latest"
-    prometheus:
-      version: "latest"
-    registry:
-      version: "latest"
-    ekco:
-      version: "latest"
-    minio:
-      version: "2023-05-18T00-05-36Z"
-    rook:
-      version: "1.11.x"
-  unsupportedOSIDs:
-    - centos-74 # Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported
-- name: "weave to flannel single node, custom IP ranges"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-      serviceCIDR: 172.16.0.0/16
-    containerd:
-      version: "latest"
-    weave:
-      version: "latest"
-      podCIDR: 172.17.0.0/16
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-      serviceCIDR: 172.16.0.0/16
-    containerd:
-      version: "latest"
-    flannel:
-      podCIDR: 172.17.0.0/16
-      version: "__testver__"
-      s3Override: "__testdist__"
+#- name: "flannel latest single node"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#- name: "flannel latest single node upgrade"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "0.20.x"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#- name: "flannel latest multi node"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  numPrimaryNodes: 1
+#  numSecondaryNodes: 2
+#- name: "flannel airgap latest multi node"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  numPrimaryNodes: 1
+#  numSecondaryNodes: 2
+#  airgap: true
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+#- name: "weave to flannel single node"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    weave:
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#- name: "weave to flannel single node with addons and openebs"
+#  flags: "yes"
+#  cpu: 6
+#  installerSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    weave:
+#      version: "latest"
+#    contour:
+#      version: "latest"
+#    prometheus:
+#      version: "latest"
+#    registry:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    minio:
+#      version: "2023-05-18T00-05-36Z"
+#    openebs:
+#      version: "latest"
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: "local"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    contour:
+#      version: "latest"
+#    prometheus:
+#      version: "latest"
+#    registry:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    minio:
+#      version: "2023-05-18T00-05-36Z"
+#    openebs:
+#      version: "latest"
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: "local"
+#- name: "weave to flannel single node with addons and rook"
+#  flags: "yes"
+#  cpu: 8
+#  installerSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    weave:
+#      version: "latest"
+#    contour:
+#      version: "latest"
+#    prometheus:
+#      version: "latest"
+#    registry:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    minio:
+#      version: "2023-05-18T00-05-36Z"
+#    rook:
+#      version: "1.11.x"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    contour:
+#      version: "latest"
+#    prometheus:
+#      version: "latest"
+#    registry:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    minio:
+#      version: "2023-05-18T00-05-36Z"
+#    rook:
+#      version: "1.11.x"
+#  unsupportedOSIDs:
+#    - centos-74 # Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported
+#- name: "weave to flannel single node, custom IP ranges"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#      serviceCIDR: 172.16.0.0/16
+#    containerd:
+#      version: "latest"
+#    weave:
+#      version: "latest"
+#      podCIDR: 172.17.0.0/16
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#      serviceCIDR: 172.16.0.0/16
+#    containerd:
+#      version: "latest"
+#    flannel:
+#      podCIDR: 172.17.0.0/16
+#      version: "__testver__"
+#      s3Override: "__testdist__"
 - name: "weave to flannel, docker to containerd, single node"
   installerSpec:
     kubernetes:
@@ -195,6 +195,9 @@
     flannel:
       version: "__testver__"
       s3Override: "__testdist__"
+  postUpgradeScript: |
+    echo "Current iptables rules:"
+    echo "$(iptables -L)"
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
   - centos-81 # docker 20.10.17 is not supported on centos 8.1.


### PR DESCRIPTION
#### What this PR does / why we need it:

When iptables is set with a default ACCEPT policy, this is fine. However, if it is set up with a default DROP policy, this blocks all communications in and out of the machine, making the migration impossible to complete (and taking the system offline at the same time).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-77628]

#### Special notes for your reviewer:

You also can check the logs of the manual tests performed within multi-node scenario to move weave to flannel with docker. See that in the master log we are checking the network connectivity and the IP TABLE values after all.
- [master.logs](https://media.app.shortcut.com/api/attachments/files/clubhouse-assets/5941dba8-210c-44de-a4a5-7573f2f81946/648344d3-9d18-4be7-9c9b-d31e34402d4c/master.logs)
- [node-a.logs](https://media.app.shortcut.com/api/attachments/files/clubhouse-assets/5941dba8-210c-44de-a4a5-7573f2f81946/648344d4-dd9a-431f-b052-bdb23a22022b/node-a.logs)
- [node-b.logs](https://media.app.shortcut.com/api/attachments/files/clubhouse-assets/5941dba8-210c-44de-a4a5-7573f2f81946/648344d4-2c27-431b-9604-d7600d2cea5c/node-b.logs)

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes errors in the migration from weave to flannel when custom IP Tables rules is added by after the flush run configuration to add ACCEPT policies. This change is valid only from Weave versions equals or upper than `0.21.5`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
