### PR TITLE
For RHEL 8, upgrade package manager before gathering host packages

### DIFF
--- a/bundles/docker-rhel8/Dockerfile
+++ b/bundles/docker-rhel8/Dockerfile
@@ -1,5 +1,7 @@
 FROM rockylinux:8
 
+# Update the packages before continue
+RUN yum -y update
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
 RUN yum install -y yum-utils createrepo
@@ -8,6 +10,7 @@ RUN yum install -y modulemd-tools
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 RUN mkdir -p /packages/archives
 
+RUN yum -y update
 ARG DOCKER_VERSION
 
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \

--- a/bundles/k8s-rhel8/Dockerfile
+++ b/bundles/k8s-rhel8/Dockerfile
@@ -5,8 +5,11 @@ RUN mkdir -p /packages/archives
 
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
+RUN yum -y update
 RUN yum install -y yum-utils createrepo
 RUN yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+
+RUN yum -y update
 RUN yum install -y modulemd-tools
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \


### PR DESCRIPTION
#### What this PR does / why we need it:

Note that the problem is related to the package used. For ubuntu we are upgrading the package manager before we gathering the host packages to ensure that we will get the latest versions. However, for RHEL we are not doing it. Thus, this PR should ensure that we get the latest versions available which might sort out the above scenarios and possible CVEs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-77760]

#### Special notes for your reviewer:

Tested against `centos-stream-8-v20210302` (oldest image available in GCP)


```
INSTALLER_YAML="apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: latest
spec:
  kubernetes:
    version: 1.24.14
  flannel:
    version: 0.21.5
  containerd:
    version: 1.6.21"
```

Note that all was built and tested agains.
 1968  make clean
 1969  make build/packages/kubernetes/1.24.14/rhel-8
 1971  make build/packages/kubernetes/1.24.14/images
 1974  make dist/flannel-0.21.5.tar.gz && tar xzvf dist/flannel-0.21.5.tar.gz
 1975  make dist/containerd-1.6.21.tar.gz && tar xzvf dist/containerd-1.6.21.tar.gz
 
**Logs from the install**

```
[camila@camila-centos-stream-8-v20210302 ~]$ cat install.sh | sudo bash -s yes
⚙  Running install with the argument(s): yes
Firewalld is currently either enabled or active. To ensure smooth installation and avoid potential issues, it is highly recommended to stop and disable Firewalld. Please press 'Y' to proceed with stopping and disabling Firewalld.(Y/n) Y
Removed /etc/systemd/system/multi-user.target.wants/firewalld.service.
Removed /etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service.

Kubernetes is incompatible with SELinux. Disable SELinux to continue? (Y/n) Y
The installer will use network interface 'eth0' (with IP address '10.154.0.2')
Not using proxy address
⚙  Running host preflights
[TCP Port Status] Running collector...
[CPU Info] Running collector...
[Amount of Memory] Running collector...
[Block Devices] Running collector...
[Host OS Info] Running collector...
[Ephemeral Disk Usage /var/lib/kubelet] Running collector...
[Ephemeral Disk Usage /var/lib/containerd] Running collector...
[Kubernetes API TCP Port Status] Running collector...
[ETCD Client API TCP Port Status] Running collector...
[ETCD Server API TCP Port Status] Running collector...
[ETCD Health Server TCP Port Status] Running collector...
[Kubelet Health Server TCP Port Status] Running collector...
[Kubelet API TCP Port Status] Running collector...
[Kube Controller Manager Health Server TCP Port Status] Running collector...
[Kube Scheduler Health Server TCP Port Status] Running collector...
[Filesystem Latency Two Minute Benchmark] Running collector...
[Host OS Info] Running collector...
[Flannel UDP port 8472] Running collector...
[Host OS Info] Running collector...
I0531 10:13:32.004365  240743 analyzer.go:77] excluding "Certificate Key Pair" analyzer
I0531 10:13:32.004383  240743 analyzer.go:77] excluding "Certificate Key Pair" analyzer
I0531 10:13:32.004391  240743 analyzer.go:77] excluding "Kubernetes API Health" analyzer
I0531 10:13:32.004462  240743 analyzer.go:77] excluding "Ephemeral Disk Usage /var/lib/docker" analyzer
I0531 10:13:32.004483  240743 analyzer.go:77] excluding "Ephemeral Disk Usage /var/lib/rook" analyzer
I0531 10:13:32.004489  240743 analyzer.go:77] excluding "Ephemeral Disk Usage /var/openebs" analyzer
I0531 10:13:32.004495  240743 analyzer.go:77] excluding "Kubernetes API Server Load Balancer" analyzer
I0531 10:13:32.004500  240743 analyzer.go:77] excluding "Kubernetes API Server Load Balancer Upgrade" analyzer
I0531 10:13:32.004555  240743 analyzer.go:77] excluding "Kubernetes API TCP Connection Status" analyzer
I0531 10:13:32.004642  240743 analyzer.go:77] excluding "Docker Support" analyzer
I0531 10:13:32.004653  240743 analyzer.go:77] excluding "Containerd and Weave Compatibility" analyzer
[PASS] Number of CPUs: This server has at least 4 CPU cores
[PASS] Amount of Memory: The system has at least 8G of memory
[PASS] Ephemeral Disk Usage /var/lib/kubelet: The disk containing directory /var/lib/kubelet has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full
[PASS] Ephemeral Disk Usage /var/lib/containerd: The disk containing directory /var/lib/containerd has at least 30Gi of total space, has at least 10Gi of disk space available, and is less than 60% full.
[PASS] Kubernetes API TCP Port Status: Port 6443 is open
[PASS] ETCD Client API TCP Port Status: Port 2379 is open
[PASS] ETCD Server API TCP Port Status: Port 2380 is open
[PASS] ETCD Health Server TCP Port Status: Port 2381 is available
[PASS] Kubelet Health Server TCP Port Status: Port 10248 is available
[PASS] Kubelet API TCP Port Status: Port 10250 is open
[PASS] Kube Controller Manager Health Server TCP Port Status: Port 10257 is available
[PASS] Kube Scheduler Health Server TCP Port Status: Port 10259 is available
[PASS] Filesystem Performance: Write latency is ok (p99 target < 10ms, actual: 3.770352ms)
[PASS] NTP Status: System clock is synchronized
[PASS] NTP Status: Timezone is set to UTC
[PASS] Host OS Info: containerd addon supports centos 8
[PASS] Flannel UDP port 8472 status: Port is open
[PASS] Host OS Info: containerd addon supports centos 8
✔ Host preflights success
Found pod network: 10.32.0.0/20
Found service network: 10.96.0.0/22
⚙  Addon containerd 1.6.21
⚙  Installing host packages containerd.io
Cache was expired
39 files removed
kURL Local Repo                                  25 MB/s | 260 kB     00:00    
Metadata cache created.
Last metadata expiration check: 0:00:01 ago on Wed 31 May 2023 10:13:33 UTC.
Dependencies resolved.
==================================================================================================
 Package                        Arch    Version                                  Repository   Size
==================================================================================================
Installing:
 containerd.io                  x86_64  1.6.21-3.1.el8                           kurl.local   34 M
Upgrading:
 libsemanage                    x86_64  2.9-9.el8_6                              kurl.local  167 k
Installing dependencies:
 checkpolicy                    x86_64  2.9-1.el8                                kurl.local  345 k
 container-selinux              noarch  2:2.205.0-2.module+el8.8.0+1265+fa25dd7a kurl.local   63 k
 policycoreutils-python-utils   noarch  2.9-24.el8                               kurl.local  253 k
 python3-audit                  x86_64  3.0.7-4.el8                              kurl.local   86 k
 python3-libsemanage            x86_64  2.9-9.el8_6                              kurl.local  127 k
 python3-policycoreutils        noarch  2.9-24.el8                               kurl.local  2.2 M
 python3-setools                x86_64  4.3.0-3.el8                              kurl.local  623 k
Enabling module streams:
 kurl.local                             stable                                                    

Transaction Summary
==================================================================================================
Install  8 Packages
Upgrade  1 Package

Total size: 38 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Upgrading        : libsemanage-2.9-9.el8_6.x86_64                        1/10 
  Installing       : python3-libsemanage-2.9-9.el8_6.x86_64                2/10 
  Installing       : python3-setools-4.3.0-3.el8.x86_64                    3/10 
  Installing       : python3-audit-3.0.7-4.el8.x86_64                      4/10 
  Installing       : checkpolicy-2.9-1.el8.x86_64                          5/10 
  Installing       : python3-policycoreutils-2.9-24.el8.noarch             6/10 
  Installing       : policycoreutils-python-utils-2.9-24.el8.noarch        7/10 
  Running scriptlet: container-selinux-2:2.205.0-2.module+el8.8.0+1265+    8/10 
  Installing       : container-selinux-2:2.205.0-2.module+el8.8.0+1265+    8/10 
  Running scriptlet: container-selinux-2:2.205.0-2.module+el8.8.0+1265+    8/10 
  Installing       : containerd.io-1.6.21-3.1.el8.x86_64                   9/10 
  Running scriptlet: containerd.io-1.6.21-3.1.el8.x86_64                   9/10 
  Cleanup          : libsemanage-2.9-9.el8.x86_64                         10/10 
  Running scriptlet: container-selinux-2:2.205.0-2.module+el8.8.0+1265+   10/10 
  Running scriptlet: libsemanage-2.9-9.el8.x86_64                         10/10 
  Verifying        : checkpolicy-2.9-1.el8.x86_64                          1/10 
  Verifying        : container-selinux-2:2.205.0-2.module+el8.8.0+1265+    2/10 
  Verifying        : containerd.io-1.6.21-3.1.el8.x86_64                   3/10 
  Verifying        : policycoreutils-python-utils-2.9-24.el8.noarch        4/10 
  Verifying        : python3-audit-3.0.7-4.el8.x86_64                      5/10 
  Verifying        : python3-libsemanage-2.9-9.el8_6.x86_64                6/10 
  Verifying        : python3-policycoreutils-2.9-24.el8.noarch             7/10 
  Verifying        : python3-setools-4.3.0-3.el8.x86_64                    8/10 
  Verifying        : libsemanage-2.9-9.el8_6.x86_64                        9/10 
  Verifying        : libsemanage-2.9-9.el8.x86_64                         10/10 

Upgraded:
  libsemanage-2.9-9.el8_6.x86_64                                                
Installed:
  checkpolicy-2.9-1.el8.x86_64                                                  
  container-selinux-2:2.205.0-2.module+el8.8.0+1265+fa25dd7a.noarch             
  containerd.io-1.6.21-3.1.el8.x86_64                                           
  policycoreutils-python-utils-2.9-24.el8.noarch                                
  python3-audit-3.0.7-4.el8.x86_64                                              
  python3-libsemanage-2.9-9.el8_6.x86_64                                        
  python3-policycoreutils-2.9-24.el8.noarch                                     
  python3-setools-4.3.0-3.el8.x86_64                                            

Complete!
Cache was expired
6 files removed
CentOS Stream 8 - AppStream                      31 MB/s |  29 MB     00:00    
CentOS Stream 8 - BaseOS                         26 MB/s |  36 MB     00:01    
CentOS Stream 8 - Extras                        405 kB/s |  18 kB     00:00    
CentOS Stream 8 - Extras common packages        126 kB/s | 6.6 kB     00:00    
Google Compute Engine                           8.8 kB/s |  10 kB     00:01    
Google Cloud SDK                                 40 MB/s | 113 MB     00:02    
Dependencies resolved.
================================================================================
 Package           Architecture     Version             Repository         Size
================================================================================
Resetting modules:
 kurl.local                                                                    

Transaction Summary
================================================================================

Complete!
✔ Host packages containerd.io installed
⚙  Containerd configuration
Enabling containerd
Created symlink /etc/systemd/system/multi-user.target.wants/containerd.service → /usr/lib/systemd/system/containerd.service.
Enabling containerd crictl
Checks if the file /etc/crictl.yaml exist
Creates /etc/crictl.yaml
Checking for containerd custom settings
Creating /etc/systemd/system/containerd.service.d
Checking for proxy set
Checking registry configuration for the distro kubeadm and if Docker registry IP is set
Checking if containerd requires to be re-started
Re-starting containerd
Restarting containerd...
Service containerd restarted.
✔ Containerd is successfully configured
Checking if is required to migrate images from Docker
unpacking registry.k8s.io/pause:3.6 (sha256:79b611631c0d19e9a975fb0a8511e5153789b4c26610d1842e9f735c57cc8b13)...done
Checking if the kubelet service is enabled
Adding kernel module br_netfilter
Adding kernel module ip_tables
* Applying /usr/lib/sysctl.d/10-default-yama-scope.conf ...
kernel.yama.ptrace_scope = 0
* Applying /usr/lib/sysctl.d/50-coredump.conf ...
kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %e
kernel.core_pipe_limit = 16
* Applying /usr/lib/sysctl.d/50-default.conf ...
kernel.sysrq = 16
kernel.core_uses_pid = 1
kernel.kptr_restrict = 1
net.ipv4.conf.all.rp_filter = 1
net.ipv4.conf.all.accept_source_route = 0
net.ipv4.conf.all.promote_secondaries = 1
net.core.default_qdisc = fq_codel
fs.protected_hardlinks = 1
fs.protected_symlinks = 1
* Applying /usr/lib/sysctl.d/50-libkcapi-optmem_max.conf ...
net.core.optmem_max = 81920
* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
kernel.pid_max = 4194304
* Applying /etc/sysctl.d/60-gce-network-security.conf ...
net.ipv4.tcp_syncookies = 1
net.ipv4.conf.all.accept_source_route = 0
net.ipv4.conf.default.accept_source_route = 0
net.ipv4.conf.all.accept_redirects = 0
net.ipv4.conf.default.accept_redirects = 0
net.ipv4.conf.all.secure_redirects = 1
net.ipv4.conf.default.secure_redirects = 1
net.ipv4.ip_forward = 0
net.ipv4.conf.all.send_redirects = 0
net.ipv4.conf.default.send_redirects = 0
net.ipv4.conf.all.rp_filter = 1
net.ipv4.conf.default.rp_filter = 1
net.ipv4.icmp_echo_ignore_broadcasts = 1
net.ipv4.icmp_ignore_bogus_error_responses = 1
net.ipv4.conf.all.log_martians = 1
net.ipv4.conf.default.log_martians = 1
kernel.randomize_va_space = 2
kernel.panic = 10
* Applying /etc/sysctl.d/99-replicated-ipv4.conf ...
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.conf.all.forwarding = 1
* Applying /etc/sysctl.d/99-sysctl.conf ...
* Applying /etc/sysctl.conf ...
Adding kernel modules ip_vs, ip_vs_rr, ip_vs_wrr, and ip_vs_sh
⚙  Install kubelet, kubectl and cni host packages
kubelet command missing - will install host components
⚙  Installing host packages kubelet-1.24.14 kubectl-1.24.14 git
Cache was expired
39 files removed
kURL Local Repo                                  25 MB/s | 306 kB     00:00    
Metadata cache created.
Dependencies resolved.
==========================================================================================
 Package                  Arch    Version                                Repository   Size
==========================================================================================
Installing:
 git                      x86_64  2.39.3-1.el8_8                         kurl.local  103 k
 kubectl                  x86_64  1.24.14-0                              kurl.local   10 M
 kubelet                  x86_64  1.24.14-0                              kurl.local   21 M
Installing dependencies:
 conntrack-tools          x86_64  1.4.4-11.el8                           kurl.local  203 k
 emacs-filesystem         noarch  1:26.1-10.el8_8.2                      kurl.local   69 k
 git-core                 x86_64  2.39.3-1.el8_8                         kurl.local   11 M
 git-core-doc             noarch  2.39.3-1.el8_8                         kurl.local  3.0 M
 kubernetes-cni           x86_64  1.2.0-0                                kurl.local   17 M
 libnetfilter_cthelper    x86_64  1.0.0-15.el8                           kurl.local   23 k
 libnetfilter_cttimeout   x86_64  1.0.0-11.el8                           kurl.local   23 k
 libnetfilter_queue       x86_64  1.0.4-3.el8                            kurl.local   30 k
 perl-Carp                noarch  1.42-396.el8                           kurl.local   29 k
 perl-Data-Dumper         x86_64  2.167-399.el8                          kurl.local   57 k
 perl-Digest              noarch  1.17-395.el8                           kurl.local   26 k
 perl-Digest-MD5          x86_64  2.55-396.el8                           kurl.local   36 k
 perl-Encode              x86_64  4:2.97-3.el8                           kurl.local  1.5 M
 perl-Errno               x86_64  1.28-422.el8                           kurl.local   75 k
 perl-Error               noarch  1:0.17025-2.el8                        kurl.local   45 k
 perl-Exporter            noarch  5.72-396.el8                           kurl.local   33 k
 perl-File-Path           noarch  2.15-2.el8                             kurl.local   37 k
 perl-File-Temp           noarch  0.230.600-1.el8                        kurl.local   62 k
 perl-Getopt-Long         noarch  1:2.50-4.el8                           kurl.local   62 k
 perl-Git                 noarch  2.39.3-1.el8_8                         kurl.local   78 k
 perl-HTTP-Tiny           noarch  0.074-1.el8                            kurl.local   57 k
 perl-IO                  x86_64  1.38-422.el8                           kurl.local  141 k
 perl-MIME-Base64         x86_64  3.15-396.el8                           kurl.local   30 k
 perl-Net-SSLeay          x86_64  1.88-2.module_el8+339+1ec643e0         kurl.local  402 k
 perl-PathTools           x86_64  3.74-1.el8                             kurl.local   89 k
 perl-Pod-Escapes         noarch  1:1.07-395.el8                         kurl.local   19 k
 perl-Pod-Perldoc         noarch  3.28-396.el8                           kurl.local   85 k
 perl-Pod-Simple          noarch  1:3.35-395.el8                         kurl.local  212 k
 perl-Pod-Usage           noarch  4:1.69-395.el8                         kurl.local   33 k
 perl-Scalar-List-Utils   x86_64  3:1.49-2.el8                           kurl.local   67 k
 perl-Socket              x86_64  4:2.027-3.el8                          kurl.local   58 k
 perl-Storable            x86_64  1:3.11-3.el8                           kurl.local   97 k
 perl-Term-ANSIColor      noarch  4.06-396.el8                           kurl.local   45 k
 perl-Term-Cap            noarch  1.17-395.el8                           kurl.local   22 k
 perl-TermReadKey         x86_64  2.37-7.el8                             kurl.local   39 k
 perl-Text-ParseWords     noarch  3.30-395.el8                           kurl.local   17 k
 perl-Text-Tabs+Wrap      noarch  2013.0523-395.el8                      kurl.local   23 k
 perl-Time-Local          noarch  1:1.280-1.el8                          kurl.local   32 k
 perl-URI                 noarch  1.73-3.el8                             kurl.local  115 k
 perl-Unicode-Normalize   x86_64  1.25-396.el8                           kurl.local   81 k
 perl-constant            noarch  1.33-396.el8                           kurl.local   24 k
 perl-interpreter         x86_64  4:5.26.3-422.el8                       kurl.local  6.3 M
 perl-libnet              noarch  3.11-3.el8                             kurl.local  120 k
 perl-libs                x86_64  4:5.26.3-422.el8                       kurl.local  1.6 M
 perl-macros              x86_64  4:5.26.3-422.el8                       kurl.local   71 k
 perl-parent              noarch  1:0.237-1.el8                          kurl.local   19 k
 perl-podlators           noarch  4.11-1.el8                             kurl.local  117 k
 perl-threads             x86_64  1:2.21-2.el8                           kurl.local   60 k
 perl-threads-shared      x86_64  1.58-2.el8                             kurl.local   47 k
 socat                    x86_64  1.7.4.1-1.el8                          kurl.local  322 k
Installing weak dependencies:
 perl-IO-Socket-IP        noarch  0.39-5.el8                             kurl.local   46 k
 perl-IO-Socket-SSL       noarch  2.066-4.module_el8+339+1ec643e0        kurl.local  304 k
 perl-Mozilla-CA          noarch  20160104-7.module+el8.6.0+965+850557f9 kurl.local   14 k
Enabling module streams:
 kurl.local                       stable                                                  

Transaction Summary
==========================================================================================
Install  56 Packages

Total size: 74 M
Installed size: 286 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : perl-Digest-1.17-395.el8.noarch                       1/56 
  Installing       : perl-Digest-MD5-2.55-396.el8.x86_64                   2/56 
  Installing       : perl-Data-Dumper-2.167-399.el8.x86_64                 3/56 
  Installing       : perl-libnet-3.11-3.el8.noarch                         4/56 
  Installing       : perl-Net-SSLeay-1.88-2.module_el8+339+1ec643e0.x86    5/56 
  Installing       : perl-URI-1.73-3.el8.noarch                            6/56 
  Installing       : perl-Pod-Escapes-1:1.07-395.el8.noarch                7/56 
  Installing       : perl-IO-Socket-IP-0.39-5.el8.noarch                   8/56 
  Installing       : perl-Mozilla-CA-20160104-7.module+el8.6.0+965+8505    9/56 
  Installing       : perl-Time-Local-1:1.280-1.el8.noarch                 10/56 
  Installing       : perl-IO-Socket-SSL-2.066-4.module_el8+339+1ec643e0   11/56 
  Installing       : perl-Term-ANSIColor-4.06-396.el8.noarch              12/56 
  Installing       : perl-Term-Cap-1.17-395.el8.noarch                    13/56 
  Installing       : perl-File-Temp-0.230.600-1.el8.noarch                14/56 
  Installing       : perl-HTTP-Tiny-0.074-1.el8.noarch                    15/56 
  Installing       : perl-Pod-Simple-1:3.35-395.el8.noarch                16/56 
  Installing       : perl-Pod-Perldoc-3.28-396.el8.noarch                 17/56 
  Installing       : perl-podlators-4.11-1.el8.noarch                     18/56 
  Installing       : perl-Text-ParseWords-3.30-395.el8.noarch             19/56 
  Installing       : perl-Pod-Usage-4:1.69-395.el8.noarch                 20/56 
  Installing       : perl-MIME-Base64-3.15-396.el8.x86_64                 21/56 
  Installing       : perl-Storable-1:3.11-3.el8.x86_64                    22/56 
  Installing       : perl-Getopt-Long-1:2.50-4.el8.noarch                 23/56 
  Installing       : perl-Errno-1.28-422.el8.x86_64                       24/56 
  Installing       : perl-Socket-4:2.027-3.el8.x86_64                     25/56 
  Installing       : perl-Encode-4:2.97-3.el8.x86_64                      26/56 
  Installing       : perl-Exporter-5.72-396.el8.noarch                    27/56 
  Installing       : perl-Scalar-List-Utils-3:1.49-2.el8.x86_64           28/56 
  Installing       : perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch         29/56 
  Installing       : perl-Unicode-Normalize-1.25-396.el8.x86_64           30/56 
  Installing       : perl-File-Path-2.15-2.el8.noarch                     31/56 
  Installing       : perl-IO-1.38-422.el8.x86_64                          32/56 
  Installing       : perl-PathTools-3.74-1.el8.x86_64                     33/56 
  Installing       : perl-constant-1.33-396.el8.noarch                    34/56 
  Installing       : perl-macros-4:5.26.3-422.el8.x86_64                  35/56 
  Installing       : perl-parent-1:0.237-1.el8.noarch                     36/56 
  Installing       : perl-libs-4:5.26.3-422.el8.x86_64                    37/56 
  Installing       : perl-Carp-1.42-396.el8.noarch                        38/56 
  Installing       : perl-threads-1:2.21-2.el8.x86_64                     39/56 
  Installing       : perl-threads-shared-1.58-2.el8.x86_64                40/56 
  Installing       : perl-interpreter-4:5.26.3-422.el8.x86_64             41/56 
  Installing       : git-core-2.39.3-1.el8_8.x86_64                       42/56 
  Installing       : git-core-doc-2.39.3-1.el8_8.noarch                   43/56 
  Installing       : perl-Error-1:0.17025-2.el8.noarch                    44/56 
  Installing       : perl-TermReadKey-2.37-7.el8.x86_64                   45/56 
  Installing       : socat-1.7.4.1-1.el8.x86_64                           46/56 
  Installing       : libnetfilter_queue-1.0.4-3.el8.x86_64                47/56 
  Running scriptlet: libnetfilter_queue-1.0.4-3.el8.x86_64                47/56 
  Installing       : libnetfilter_cttimeout-1.0.0-11.el8.x86_64           48/56 
  Running scriptlet: libnetfilter_cttimeout-1.0.0-11.el8.x86_64           48/56 
  Installing       : libnetfilter_cthelper-1.0.0-15.el8.x86_64            49/56 
  Running scriptlet: libnetfilter_cthelper-1.0.0-15.el8.x86_64            49/56 
  Installing       : conntrack-tools-1.4.4-11.el8.x86_64                  50/56 
  Running scriptlet: conntrack-tools-1.4.4-11.el8.x86_64                  50/56 
  Installing       : kubelet-1.24.14-0.x86_64                             51/56 
  Installing       : kubernetes-cni-1.2.0-0.x86_64                        52/56 
  Installing       : emacs-filesystem-1:26.1-10.el8_8.2.noarch            53/56 
  Installing       : perl-Git-2.39.3-1.el8_8.noarch                       54/56 
  Installing       : git-2.39.3-1.el8_8.x86_64                            55/56 
  Installing       : kubectl-1.24.14-0.x86_64                             56/56 
  Running scriptlet: kubectl-1.24.14-0.x86_64                             56/56 
  Verifying        : kubernetes-cni-1.2.0-0.x86_64                         1/56 
  Verifying        : kubectl-1.24.14-0.x86_64                              2/56 
  Verifying        : conntrack-tools-1.4.4-11.el8.x86_64                   3/56 
  Verifying        : kubelet-1.24.14-0.x86_64                              4/56 
  Verifying        : emacs-filesystem-1:26.1-10.el8_8.2.noarch             5/56 
  Verifying        : git-2.39.3-1.el8_8.x86_64                             6/56 
  Verifying        : git-core-2.39.3-1.el8_8.x86_64                        7/56 
  Verifying        : git-core-doc-2.39.3-1.el8_8.noarch                    8/56 
  Verifying        : libnetfilter_cthelper-1.0.0-15.el8.x86_64             9/56 
  Verifying        : libnetfilter_cttimeout-1.0.0-11.el8.x86_64           10/56 
  Verifying        : libnetfilter_queue-1.0.4-3.el8.x86_64                11/56 
  Verifying        : perl-Carp-1.42-396.el8.noarch                        12/56 
  Verifying        : perl-Data-Dumper-2.167-399.el8.x86_64                13/56 
  Verifying        : perl-Digest-1.17-395.el8.noarch                      14/56 
  Verifying        : perl-Digest-MD5-2.55-396.el8.x86_64                  15/56 
  Verifying        : perl-Encode-4:2.97-3.el8.x86_64                      16/56 
  Verifying        : perl-Errno-1.28-422.el8.x86_64                       17/56 
  Verifying        : perl-Error-1:0.17025-2.el8.noarch                    18/56 
  Verifying        : perl-Exporter-5.72-396.el8.noarch                    19/56 
  Verifying        : perl-File-Path-2.15-2.el8.noarch                     20/56 
  Verifying        : perl-File-Temp-0.230.600-1.el8.noarch                21/56 
  Verifying        : perl-Getopt-Long-1:2.50-4.el8.noarch                 22/56 
  Verifying        : perl-Git-2.39.3-1.el8_8.noarch                       23/56 
  Verifying        : perl-HTTP-Tiny-0.074-1.el8.noarch                    24/56 
  Verifying        : perl-IO-1.38-422.el8.x86_64                          25/56 
  Verifying        : perl-IO-Socket-IP-0.39-5.el8.noarch                  26/56 
  Verifying        : perl-IO-Socket-SSL-2.066-4.module_el8+339+1ec643e0   27/56 
  Verifying        : perl-MIME-Base64-3.15-396.el8.x86_64                 28/56 
  Verifying        : perl-Mozilla-CA-20160104-7.module+el8.6.0+965+8505   29/56 
  Verifying        : perl-Net-SSLeay-1.88-2.module_el8+339+1ec643e0.x86   30/56 
  Verifying        : perl-PathTools-3.74-1.el8.x86_64                     31/56 
  Verifying        : perl-Pod-Escapes-1:1.07-395.el8.noarch               32/56 
  Verifying        : perl-Pod-Perldoc-3.28-396.el8.noarch                 33/56 
  Verifying        : perl-Pod-Simple-1:3.35-395.el8.noarch                34/56 
  Verifying        : perl-Pod-Usage-4:1.69-395.el8.noarch                 35/56 
  Verifying        : perl-Scalar-List-Utils-3:1.49-2.el8.x86_64           36/56 
  Verifying        : perl-Socket-4:2.027-3.el8.x86_64                     37/56 
  Verifying        : perl-Storable-1:3.11-3.el8.x86_64                    38/56 
  Verifying        : perl-Term-ANSIColor-4.06-396.el8.noarch              39/56 
  Verifying        : perl-Term-Cap-1.17-395.el8.noarch                    40/56 
  Verifying        : perl-TermReadKey-2.37-7.el8.x86_64                   41/56 
  Verifying        : perl-Text-ParseWords-3.30-395.el8.noarch             42/56 
  Verifying        : perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch         43/56 
  Verifying        : perl-Time-Local-1:1.280-1.el8.noarch                 44/56 
  Verifying        : perl-URI-1.73-3.el8.noarch                           45/56 
  Verifying        : perl-Unicode-Normalize-1.25-396.el8.x86_64           46/56 
  Verifying        : perl-constant-1.33-396.el8.noarch                    47/56 
  Verifying        : perl-interpreter-4:5.26.3-422.el8.x86_64             48/56 
  Verifying        : perl-libnet-3.11-3.el8.noarch                        49/56 
  Verifying        : perl-libs-4:5.26.3-422.el8.x86_64                    50/56 
  Verifying        : perl-macros-4:5.26.3-422.el8.x86_64                  51/56 
  Verifying        : perl-parent-1:0.237-1.el8.noarch                     52/56 
  Verifying        : perl-podlators-4.11-1.el8.noarch                     53/56 
  Verifying        : perl-threads-1:2.21-2.el8.x86_64                     54/56 
  Verifying        : perl-threads-shared-1.58-2.el8.x86_64                55/56 
  Verifying        : socat-1.7.4.1-1.el8.x86_64                           56/56 

Installed:
  conntrack-tools-1.4.4-11.el8.x86_64                                           
  emacs-filesystem-1:26.1-10.el8_8.2.noarch                                     
  git-2.39.3-1.el8_8.x86_64                                                     
  git-core-2.39.3-1.el8_8.x86_64                                                
  git-core-doc-2.39.3-1.el8_8.noarch                                            
  kubectl-1.24.14-0.x86_64                                                      
  kubelet-1.24.14-0.x86_64                                                      
  kubernetes-cni-1.2.0-0.x86_64                                                 
  libnetfilter_cthelper-1.0.0-15.el8.x86_64                                     
  libnetfilter_cttimeout-1.0.0-11.el8.x86_64                                    
  libnetfilter_queue-1.0.4-3.el8.x86_64                                         
  perl-Carp-1.42-396.el8.noarch                                                 
  perl-Data-Dumper-2.167-399.el8.x86_64                                         
  perl-Digest-1.17-395.el8.noarch                                               
  perl-Digest-MD5-2.55-396.el8.x86_64                                           
  perl-Encode-4:2.97-3.el8.x86_64                                               
  perl-Errno-1.28-422.el8.x86_64                                                
  perl-Error-1:0.17025-2.el8.noarch                                             
  perl-Exporter-5.72-396.el8.noarch                                             
  perl-File-Path-2.15-2.el8.noarch                                              
  perl-File-Temp-0.230.600-1.el8.noarch                                         
  perl-Getopt-Long-1:2.50-4.el8.noarch                                          
  perl-Git-2.39.3-1.el8_8.noarch                                                
  perl-HTTP-Tiny-0.074-1.el8.noarch                                             
  perl-IO-1.38-422.el8.x86_64                                                   
  perl-IO-Socket-IP-0.39-5.el8.noarch                                           
  perl-IO-Socket-SSL-2.066-4.module_el8+339+1ec643e0.noarch                     
  perl-MIME-Base64-3.15-396.el8.x86_64                                          
  perl-Mozilla-CA-20160104-7.module+el8.6.0+965+850557f9.noarch                 
  perl-Net-SSLeay-1.88-2.module_el8+339+1ec643e0.x86_64                         
  perl-PathTools-3.74-1.el8.x86_64                                              
  perl-Pod-Escapes-1:1.07-395.el8.noarch                                        
  perl-Pod-Perldoc-3.28-396.el8.noarch                                          
  perl-Pod-Simple-1:3.35-395.el8.noarch                                         
  perl-Pod-Usage-4:1.69-395.el8.noarch                                          
  perl-Scalar-List-Utils-3:1.49-2.el8.x86_64                                    
  perl-Socket-4:2.027-3.el8.x86_64                                              
  perl-Storable-1:3.11-3.el8.x86_64                                             
  perl-Term-ANSIColor-4.06-396.el8.noarch                                       
  perl-Term-Cap-1.17-395.el8.noarch                                             
  perl-TermReadKey-2.37-7.el8.x86_64                                            
  perl-Text-ParseWords-3.30-395.el8.noarch                                      
  perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch                                  
  perl-Time-Local-1:1.280-1.el8.noarch                                          
  perl-URI-1.73-3.el8.noarch                                                    
  perl-Unicode-Normalize-1.25-396.el8.x86_64                                    
  perl-constant-1.33-396.el8.noarch                                             
  perl-interpreter-4:5.26.3-422.el8.x86_64                                      
  perl-libnet-3.11-3.el8.noarch                                                 
  perl-libs-4:5.26.3-422.el8.x86_64                                             
  perl-macros-4:5.26.3-422.el8.x86_64                                           
  perl-parent-1:0.237-1.el8.noarch                                              
  perl-podlators-4.11-1.el8.noarch                                              
  perl-threads-1:2.21-2.el8.x86_64                                              
  perl-threads-shared-1.58-2.el8.x86_64                                         
  socat-1.7.4.1-1.el8.x86_64                                                    

Complete!
Cache was expired
6 files removed
CentOS Stream 8 - AppStream                      33 MB/s |  29 MB     00:00    
CentOS Stream 8 - BaseOS                         21 MB/s |  36 MB     00:01    
CentOS Stream 8 - Extras                         90 kB/s |  18 kB     00:00    
CentOS Stream 8 - Extras common packages         12 kB/s | 6.6 kB     00:00    
Google Compute Engine                           9.6 kB/s |  10 kB     00:01    
Google Cloud SDK                                 32 MB/s | 113 MB     00:03    
Dependencies resolved.
================================================================================
 Package           Architecture     Version             Repository         Size
================================================================================
Resetting modules:
 kurl.local                                                                    

Transaction Summary
================================================================================

Complete!
✔ Host packages kubelet-1.24.14 kubectl-1.24.14 git installed
Restarting Kubelet
Created symlink /etc/systemd/system/multi-user.target.wants/kubelet.service → /usr/lib/systemd/system/kubelet.service.
✔ Kubernetes host packages installed
unpacking registry.k8s.io/coredns/coredns:v1.8.6 (sha256:7aba92733295a77c554e143d7a625c5cad620944b5bce174faeb512f9c61c277)...done
unpacking registry.k8s.io/etcd:3.5.6-0 (sha256:00e797072c1d464279130edbd58cbe862ff94972b82aeac5c0786b6278e21455)...done
unpacking registry.k8s.io/kube-apiserver:v1.24.14 (sha256:b9b5488e9b5d7e3347050d407447ea66c97c1a2889ad55406e54cdaf951dcd13)...done
unpacking registry.k8s.io/kube-controller-manager:v1.24.14 (sha256:d6ee090b3d34787285689d1728892df6388c1e07e9e37e419ba941e1a46f29e3)...done
unpacking registry.k8s.io/kube-proxy:v1.24.14 (sha256:8500c9ec76a555c9fa666d5648db2f0056e129038521686cfe92605238e40a29)...done
unpacking registry.k8s.io/kube-scheduler:v1.24.14 (sha256:1a6a204408416bd3698d111bfb13e1ad0ab9960c4763837963c4144196bf1619)...done
unpacking registry.k8s.io/pause:3.7 (sha256:1a24781ac4acfd4aaa676368d4a01ed4ad3366b90e97ce3f447ea682e75e224d)...done
/home/camila/kurl/krew /home/camila/kurl /home/camila
/home/camila/kurl /home/camila
/home/camila/kurl/packages/kubernetes/1.24.14/assets /home/camila/kurl /home/camila
/home/camila/kurl /home/camila
unpacking registry.k8s.io/pause:3.6 (sha256:79b611631c0d19e9a975fb0a8511e5153789b4c26610d1842e9f735c57cc8b13)...done
unpacking docker.io/flannel/flannel-cni-plugin:v1.1.2 (sha256:539d3bf046c8581557f0747dbad9d3b78a4de112d3c0bf9d291651593060fc9f)...done
unpacking docker.io/flannel/flannel:v0.21.5 (sha256:6f2d991efb758c5530e7de90761dfb29637b7604a807d431312e20189e09f9e6)...done
⚙  Initialize Kubernetes
⚙  generate kubernetes bootstrap token
Kubernetes bootstrap token: 8ytadu.3oiiipulwcl5y3ir
This token will expire in 24 hours
W0531 10:17:28.359301  246225 common.go:84] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta2". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
W0531 10:17:28.360369  246225 common.go:84] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta2". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
[init] Using Kubernetes version: v1.24.14
[preflight] Running pre-flight checks
	[WARNING FileExisting-tc]: tc not found in system path
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[certs] Using certificateDir folder "/etc/kubernetes/pki"
[certs] Generating "ca" certificate and key
[certs] Generating "apiserver" certificate and key
[certs] apiserver serving cert is signed for DNS names [camila-centos-stream-8-v20210302 kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local] and IPs [10.96.0.1 10.154.0.2 35.189.121.242]
[certs] Generating "apiserver-kubelet-client" certificate and key
[certs] Generating "front-proxy-ca" certificate and key
[certs] Generating "front-proxy-client" certificate and key
[certs] Generating "etcd/ca" certificate and key
[certs] Generating "etcd/server" certificate and key
[certs] etcd/server serving cert is signed for DNS names [camila-centos-stream-8-v20210302 localhost] and IPs [10.154.0.2 127.0.0.1 ::1]
[certs] Generating "etcd/peer" certificate and key
[certs] etcd/peer serving cert is signed for DNS names [camila-centos-stream-8-v20210302 localhost] and IPs [10.154.0.2 127.0.0.1 ::1]
[certs] Generating "etcd/healthcheck-client" certificate and key
[certs] Generating "apiserver-etcd-client" certificate and key
[certs] Generating "sa" key and public key
[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
[kubeconfig] Writing "admin.conf" kubeconfig file
[kubeconfig] Writing "kubelet.conf" kubeconfig file
[kubeconfig] Writing "controller-manager.conf" kubeconfig file
[kubeconfig] Writing "scheduler.conf" kubeconfig file
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Starting the kubelet
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests". This can take up to 4m0s
[apiclient] All control plane components are healthy after 6.502715 seconds
[upload-config] Storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
[kubelet] Creating a ConfigMap "kubelet-config" in namespace kube-system with the configuration for the kubelets in the cluster
[upload-certs] Skipping phase. Please see --upload-certs
[mark-control-plane] Marking the node camila-centos-stream-8-v20210302 as control-plane by adding the labels: [node-role.kubernetes.io/control-plane node.kubernetes.io/exclude-from-external-load-balancers]
[bootstrap-token] Using token: 8ytadu.3oiiipulwcl5y3ir
[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles
[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to get nodes
[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials
[bootstrap-token] Configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token
[bootstrap-token] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster
[bootstrap-token] Creating the "cluster-info" ConfigMap in the "kube-public" namespace
[kubelet-finalize] Updating "/etc/kubernetes/kubelet.conf" to point to a rotatable kubelet client certificate and key
[addons] Applied essential addon: CoreDNS
[addons] Applied essential addon: kube-proxy

Your Kubernetes control-plane has initialized successfully!

To start using your cluster, you need to run the following as a regular user:

  mkdir -p $HOME/.kube
  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
  sudo chown $(id -u):$(id -g) $HOME/.kube/config

Alternatively, if you are the root user, you can run:

  export KUBECONFIG=/etc/kubernetes/admin.conf

You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
  https://kubernetes.io/docs/concepts/cluster-administration/addons/

Then you can join any number of worker nodes by running the following on each as root:

kubeadm join 10.154.0.2:6443 --token 8ytadu.3oiiipulwcl5y3ir \
	--discovery-token-ca-cert-hash sha256:b66d8b51db6a6b7c1dda9cc4a7baf1f51d3352f9ff621693d4e9502f65acef8b 
node/camila-centos-stream-8-v20210302 already uncordoned
Waiting for kubernetes api health to report ok
node/camila-centos-stream-8-v20210302 labeled
✔ Kubernetes Master Initialized
Kubernetes control plane is running at https://10.154.0.2:6443
CoreDNS is running at https://10.154.0.2:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
namespace/kurl created
✔ Cluster Initialized
secret/kurl-troubleshoot-spec created
customresourcedefinition.apiextensions.k8s.io/installers.cluster.kurl.sh created
installer.cluster.kurl.sh/latest created
configmap/kurl-last-config created
configmap/kurl-current-config created
⚙  Addon flannel 0.21.5
namespace/kube-flannel created
serviceaccount/flannel created
clusterrole.rbac.authorization.k8s.io/flannel created
clusterrolebinding.rbac.authorization.k8s.io/flannel created
configmap/kube-flannel-cfg created
secret/flannel-troubleshoot-spec created
daemonset.apps/kube-flannel-ds created
waiting for Flannel to become healthy
⚙  Checking cluster networking
Waiting up to 10 minutes for node to report Ready
service/kurlnet created
pod/kurlnet-server created
pod/kurlnet-client created
Waiting for kurlnet-client pod to start
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "kurlnet-client" force deleted
pod "kurlnet-server" force deleted
service "kurlnet" deleted
configmap/kurl-current-config patched
⚙  Persisting the kurl installer spec
configmap/kurl-config created
✔ Kurl installer spec was successfully persisted in the kurl configmap
⚙  Checking proxy configuration with Containerd
Skipping test. No HTTP proxy configuration found.

No resources found

		Installation
		  Complete ✔

To access the cluster with kubectl:

    bash -l
Kurl uses /etc/kubernetes/admin.conf, you might want to unset KUBECONFIG to use .kube/config:

    echo unset KUBECONFIG >> ~/.bash_profile



Node join commands expire after 24 hours.

To generate new node join commands, run cat tasks.sh | sudo bash -s join_token on this node.

To add worker nodes to this installation, run the following script on your other nodes:
    cat join.sh | sudo bash -s kubernetes-master-address=10.154.0.2:6443 kubeadm-token=8ytadu.3oiiipulwcl5y3ir kubeadm-token-ca-hash=sha256:b66d8b51db6a6b7c1dda9cc4a7baf1f51d3352f9ff621693d4e9502f65acef8b kubernetes-version=1.24.14 additional-no-proxy-addresses=10.96.0.0/22,10.32.0.0/20 primary-host=10.154.0.2
```


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
