### PR TITLE
chore: Removing multinode from tests done against each PR

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -89,11 +89,9 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: "Upgrade to 1.22 to 1.24, Migrate from Longhorn + Minio to OpenEBS + Minio (multi-node)"
+- name: "Migrate from Longhorn + Minio to OpenEBS + Minio"
   flags: "yes"
   cpu: 6
-  numPrimaryNodes: 1
-  numSecondaryNodes: 2
   installerSpec:
     kubernetes:
       version: 1.22.x


### PR DESCRIPTION
#### What this PR does / why we need it:

The tests for each PR to just do an basic coverage still getting to long to occur
Either this check has been failing and by looking that issues it seems a testgrid issue scenario and not a problem with the spec. 

see: https://testgrid.kurl.sh/run/STAGING-release-v2023.05.25-0-ab9b6733-20230528174245
