### PR TITLE
Increase Flannel waiting and improve log

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -141,9 +141,9 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "waiting for Flannel to become healthy"
-    if ! spinner_until 180 flannel_health_check; then
-        kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10
+    echo "Waiting for Flannel to become healthy up 5 minutes"
+    if ! spinner_until 300 flannel_health_check; then
+        kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."
     fi
 }

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -141,7 +141,7 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting up 5 minutes for Flannel to become healthy"
+    echo "Waiting up to 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -141,7 +141,7 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting for Flannel to become healthy up 5 minutes"
+    echo "Waiting up 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -141,9 +141,9 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "waiting for Flannel to become healthy"
-    if ! spinner_until 180 flannel_health_check; then
-        kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10
+    echo "Waiting for Flannel to become healthy up 5 minutes"
+    if ! spinner_until 300 flannel_health_check; then
+        kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."
     fi
 }

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -141,7 +141,7 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting up 5 minutes for Flannel to become healthy"
+    echo "Waiting up to 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -141,7 +141,7 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting for Flannel to become healthy up 5 minutes"
+    echo "Waiting up 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."


### PR DESCRIPTION
#### What this PR does / why we need it:

See that if the script fails to get the logs:

```
⚙  Addon flannel 0.21.5
namespace/kube-flannel unchanged
serviceaccount/flannel unchanged
clusterrole.rbac.authorization.k8s.io/flannel unchanged
clusterrolebinding.rbac.authorization.k8s.io/flannel unchanged
configmap/kube-flannel-cfg unchanged
secret/flannel-troubleshoot-spec configured
daemonset.apps/kube-flannel-ds unchanged
waiting for Flannel to become healthy
Error from server: Get "https://10.154.0.89:10250/containerLogs/kube-flannel/kube-flannel-ds-bznsb/kube-flannel?tailLines=10": net/http: TLS handshake timeout
An error occurred on line 146
```

It will fail with `An error occurred on line 146` instead of the bail message.
This PR improve the waiting time for 5 minutes and adds || to avoid fails with error script line instead of the bail message

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Increase the Flannel waiting time to check that it is available and improve log in case of failures. This change are valid only for Flannel versions equals and upper than `0.21.5`. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
