### PR TITLE
Fixes stuck scenarios to delete the Pods to allow them be re-created using Weave

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -239,23 +239,72 @@ function weave_to_flannel() {
     flannel_ready_spinner
 
     logStep "Restarting CSI pods"
-    kubectl -n longhorn-system delete pods --all || true
-    kubectl -n rook-ceph delete pods --all || true
-    kubectl -n openebs delete pods --all || true
+    log "this may take several minutes"
+    # We will try delete the Pods without force it
+    # However, in some cases such as where it has many addons it seems
+    # getting stuck and we force the pods deletion
+    echo "this may take several minutes"
 
+    # List of namespaces
+    namespaces=("longhorn-system" "rook-ceph" "openebs")
+
+    for ns in "${namespaces[@]}"; do
+        # Delete pods with a grace period and timeout, and ignore errors
+        timeout 80 kubectl -n ${ns} delete pods --all --grace-period=60 || logWarn "Timeout reached while trying to delete pods in namespace: ${ns}"
+
+        # Use the spinner_until function to wait until all pods are deleted
+        if ! spinner_until 60 pods_remain ${ns}; then
+            # If pods remain after the timeout, force delete them
+            logWarn "Force deleting remaining pods in namespace: ${ns}"
+            kubectl -n ${ns} delete pods --all --grace-period=0 --force || true
+        fi
+    done
+
+    echo "waiting 60 seconds before continue"
     sleep 60
+
     logStep "Restarting all other pods"
     echo "this may take several minutes"
     local ns=
-    for ns in $(kubectl get ns -o name | grep -Ev '(kube-system|longhorn-system|rook-ceph|openebs|kube-flannel)' | cut -f2 -d'/'); do
-        kubectl delete pods -n "$ns" --all --grace-period=200
+
+    # Get the list of namespaces
+    namespaces=$(kubectl get ns -o name | grep -Ev '(kube-system|longhorn-system|rook-ceph|openebs|kube-flannel)' | cut -f2 -d'/')
+
+    for ns in ${namespaces}; do
+        # Delete pods with a grace period and timeout, and ignore errors
+        timeout 80 kubectl delete pods -n "${ns}" --all --grace-period=60 || logWarn "Timeout reached while trying to delete pods in namespace: ${ns}"
+
+        # Use the spinner_until function to wait until all pods are deleted
+        if ! spinner_until 60 pods_remain "${ns}"; then
+            # If pods remain after the timeout, force delete them
+            logWarn "Force deleting remaining pods in namespace: ${ns}"
+            kubectl -n "${ns}" delete pods --all --grace-period=0 --force || true
+        fi
     done
+
+    echo "waiting 60 seconds before continue"
     sleep 60
+
     log "Awaiting up to 5 minutes to check Flannel Pod(s) are Running"
     if ! spinner_until 300 check_for_running_pods "kube-flannel"; then
         logWarn "Flannel has unhealthy Pod(s)"
     fi
     logSuccess "Migrated from Weave to Flannel"
+}
+
+# Function to check if pods are still present in a namespace
+function pods_remain() {
+    local namespace="$1"
+
+    # Get the status of the pods in the namespace
+    local pod_statuses=$(kubectl -n ${namespace} get pods --no-headers 2>/dev/null | awk '{print $3}' || true)
+
+    # If any pods are in a status 'Terminating' because it get stuck, return 1 (failure)
+    for status in $pod_statuses; do
+        if [[ $status == "Terminating" ]]; then
+            return 1
+        fi
+    done
 }
 
 function remove_weave() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -239,23 +239,72 @@ function weave_to_flannel() {
     flannel_ready_spinner
 
     logStep "Restarting CSI pods"
-    kubectl -n longhorn-system delete pods --all || true
-    kubectl -n rook-ceph delete pods --all || true
-    kubectl -n openebs delete pods --all || true
+    log "this may take several minutes"
+    # We will try delete the Pods without force it
+    # However, in some cases such as where it has many addons it seems
+    # getting stuck and we force the pods deletion
+    echo "this may take several minutes"
 
+    # List of namespaces
+    namespaces=("longhorn-system" "rook-ceph" "openebs")
+
+    for ns in "${namespaces[@]}"; do
+        # Delete pods with a grace period and timeout, and ignore errors
+        timeout 80 kubectl -n ${ns} delete pods --all --grace-period=60 || logWarn "Timeout reached while trying to delete pods in namespace: ${ns}"
+
+        # Use the spinner_until function to wait until all pods are deleted
+        if ! spinner_until 60 pods_remain ${ns}; then
+            # If pods remain after the timeout, force delete them
+            logWarn "Force deleting remaining pods in namespace: ${ns}"
+            kubectl -n ${ns} delete pods --all --grace-period=0 --force || true
+        fi
+    done
+
+    echo "waiting 60 seconds before continue"
     sleep 60
+
     logStep "Restarting all other pods"
     echo "this may take several minutes"
     local ns=
-    for ns in $(kubectl get ns -o name | grep -Ev '(kube-system|longhorn-system|rook-ceph|openebs|kube-flannel)' | cut -f2 -d'/'); do
-        kubectl delete pods -n "$ns" --all --grace-period=200
+
+    # Get the list of namespaces
+    namespaces=$(kubectl get ns -o name | grep -Ev '(kube-system|longhorn-system|rook-ceph|openebs|kube-flannel)' | cut -f2 -d'/')
+
+    for ns in ${namespaces}; do
+        # Delete pods with a grace period and timeout, and ignore errors
+        timeout 80 kubectl delete pods -n "${ns}" --all --grace-period=60 || logWarn "Timeout reached while trying to delete pods in namespace: ${ns}"
+
+        # Use the spinner_until function to wait until all pods are deleted
+        if ! spinner_until 60 pods_remain "${ns}"; then
+            # If pods remain after the timeout, force delete them
+            logWarn "Force deleting remaining pods in namespace: ${ns}"
+            kubectl -n "${ns}" delete pods --all --grace-period=0 --force || true
+        fi
     done
+
+    echo "waiting 60 seconds before continue"
     sleep 60
+
     log "Awaiting up to 5 minutes to check Flannel Pod(s) are Running"
     if ! spinner_until 300 check_for_running_pods "kube-flannel"; then
         logWarn "Flannel has unhealthy Pod(s)"
     fi
     logSuccess "Migrated from Weave to Flannel"
+}
+
+# Function to check if pods are still present in a namespace
+function pods_remain() {
+    local namespace="$1"
+
+    # Get the status of the pods in the namespace
+    local pod_statuses=$(kubectl -n ${namespace} get pods --no-headers 2>/dev/null | awk '{print $3}' || true)
+
+    # If any pods are in a status 'Terminating' because it get stuck, return 1 (failure)
+    for status in $pod_statuses; do
+        if [[ $status == "Terminating" ]]; then
+            return 1
+        fi
+    done
 }
 
 function remove_weave() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Example"


![Screenshot 2023-05-30 at 23 09 21](https://github.com/replicatedhq/kURL/assets/7708031/903f6c8e-4465-4eb3-a50e-74de02523cc0)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-77764]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
Create an GCP VM with ubuntu-20.04
- curl https://kurl.sh/f070e69 | sudo bash -s ha
- join two additional master nodes
- update with curl https://staging.kurl.sh/f0a3e1c | sudo bash -s ha

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes scenario where Pods deletion get stuck and in the migration from Weave to Flannel for weave versions equals or upper than `0.21.5`. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
