### PR TITLE
removing weave from the nodes

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -829,9 +829,13 @@ nodeRegistration:
   taints: []
 EOM
 
-    rm -f /opt/cni/bin/weave-*
-    rm -rf /etc/cni/net.d
+    echo "Removing Weave files from the node"
+
     ip link delete weave
+
+    rm -rf /var/lib/weave
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 
     kubeadm join phase control-plane-prepare control-plane --config=/tmp/kubeadm-join.conf
     systemctl restart kubelet containerd


### PR DESCRIPTION
#### What this PR does / why we need it:

Note all files has been removed from the node:

```
$ curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-8d6f16d6/f0a3e1c/tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=837a1a60ef6b88be8cf70ede1edf5b701e7e6f06cbe0e13f75c227028701d006
⚙  Running tasks with the argument(s): weave-to-flannel-primary cert-key=837a1a60ef6b88be8cf70ede1edf5b701e7e6f06cbe0e13f75c227028701d006
W0531 16:27:12.994985   59229 common.go:84] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta2". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
[preflight] Reading configuration from the cluster...
[preflight] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
✔ Successfully updated camila-ubuntu-2004-lts-task-node-a to use Flannel
camila@camila-ubuntu-2004-lts-task-node-a:~$ ls -la /var/lib/weave
total 40
drwxr-xr-x  2 root root  4096 May 31 15:41 .
drwxr-xr-x 48 root root  4096 May 31 15:43 ..
-rw-r-----  1 root root 65536 May 31 16:21 weave-netdata.db
```

Therefore, this PR perform the same changes for master: https://github.com/replicatedhq/kURL/pull/4551

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-77764]

#### Special notes for your reviewer:
- Create a master and 3 nodes to migrate from weave to flannel
- Then, check the files in the node.


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes weave uninstall by removing interfaces first and began to remove lib/weave from nodes when the task is used to update them in the upgrade process. 

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
