### PR TITLE
refine new tests add, add unsupported

### DIFF
--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -153,6 +153,8 @@
       version: "2023-05-18T00-05-36Z"
     rook:
       version: "1.11.x"
+  unsupportedOSIDs:
+    - centos-74 # Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported
 - name: "weave to flannel single node, custom IP ranges"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
#### What this PR does / why we need it:
We added new tests to cover weave to flannel and one of them is failing because 

Test: weave to flannel single node with addons and rook

```
2023-05-31 17:16:48+00:00 Rook Pre-init: centos-7.4 Kernel 3.10.0-693.el7.x86_64 is not supported.
2023-05-31 17:16:48+00:00 Rook 1.11.6 will not be installed due to failed preflight checks.
```
This PR marks the test as unsupported.