### PR TITLE
Fixes issue to migrate from weave to flannel by ensuring that the operations to remove weave from the filesystem will only be executed when the files are found in the task executed in the nodes and for weave version equals or upper than `0.21.5` 

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -324,9 +324,7 @@ function remove_weave() {
     fi
 
     # Delete the /var/lib/weave directory, if it exists
-    if [ -d "/var/lib/weave" ]; then
-        rm -rf /var/lib/weave
-    fi
+    rm -rf /var/lib/weave
 
     # Delete any weave files in /etc/cni/net.d
     if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -316,11 +316,27 @@ function remove_weave() {
     kubectl -n kube-system delete serviceaccount weave-net
     kubectl -n kube-system delete secret weave-passwd
 
-    # all nodes
-    ip link delete weave
-    rm -rf /var/lib/weave
-    rm -rf /etc/cni/net.d/*weave*
-    rm -rf /opt/cni/bin/weave*
+    # It should be executed in all nodes either
+    # See that the task used to run in the nodes also has this commands
+    # Delete the weave network interface, if it exists
+    if ip link show weave > /dev/null 2>&1; then
+        ip link delete weave
+    fi
+
+    # Delete the /var/lib/weave directory, if it exists
+    if [ -d "/var/lib/weave" ]; then
+        rm -rf /var/lib/weave
+    fi
+
+    # Delete any weave files in /etc/cni/net.d
+    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
+        rm -rf /etc/cni/net.d/*weave*
+    fi
+
+    # Delete any weave files in /opt/cni/bin
+    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
+        rm -rf /opt/cni/bin/*weave*
+    fi
 }
 
 function flannel_kubeadm() {

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -323,18 +323,9 @@ function remove_weave() {
         ip link delete weave
     fi
 
-    # Delete the /var/lib/weave directory, if it exists
     rm -rf /var/lib/weave
-
-    # Delete any weave files in /etc/cni/net.d
-    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
-        rm -rf /etc/cni/net.d/*weave*
-    fi
-
-    # Delete any weave files in /opt/cni/bin
-    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
-        rm -rf /opt/cni/bin/*weave*
-    fi
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 }
 
 function flannel_kubeadm() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -324,9 +324,7 @@ function remove_weave() {
     fi
 
     # Delete the /var/lib/weave directory, if it exists
-    if [ -d "/var/lib/weave" ]; then
-        rm -rf /var/lib/weave
-    fi
+    rm -rf /var/lib/weave
 
     # Delete any weave files in /etc/cni/net.d
     if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -316,11 +316,27 @@ function remove_weave() {
     kubectl -n kube-system delete serviceaccount weave-net
     kubectl -n kube-system delete secret weave-passwd
 
-    # all nodes
-    ip link delete weave
-    rm -rf /var/lib/weave
-    rm -rf /etc/cni/net.d/*weave*
-    rm -rf /opt/cni/bin/weave*
+    # It should be executed in all nodes either
+    # See that the task used to run in the nodes also has this commands
+    # Delete the weave network interface, if it exists
+    if ip link show weave > /dev/null 2>&1; then
+        ip link delete weave
+    fi
+
+    # Delete the /var/lib/weave directory, if it exists
+    if [ -d "/var/lib/weave" ]; then
+        rm -rf /var/lib/weave
+    fi
+
+    # Delete any weave files in /etc/cni/net.d
+    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
+        rm -rf /etc/cni/net.d/*weave*
+    fi
+
+    # Delete any weave files in /opt/cni/bin
+    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
+        rm -rf /opt/cni/bin/*weave*
+    fi
 }
 
 function flannel_kubeadm() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -323,18 +323,9 @@ function remove_weave() {
         ip link delete weave
     fi
 
-    # Delete the /var/lib/weave directory, if it exists
     rm -rf /var/lib/weave
-
-    # Delete any weave files in /etc/cni/net.d
-    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
-        rm -rf /etc/cni/net.d/*weave*
-    fi
-
-    # Delete any weave files in /opt/cni/bin
-    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
-        rm -rf /opt/cni/bin/*weave*
-    fi
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 }
 
 function flannel_kubeadm() {

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -836,9 +836,7 @@ EOM
     fi
 
     # Delete the /var/lib/weave directory, if it exists
-    if [ -d "/var/lib/weave" ]; then
-        rm -rf /var/lib/weave
-    fi
+    rm -rf /var/lib/weave
 
     # Delete any weave files in /etc/cni/net.d
     if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
@@ -887,9 +885,7 @@ function weave_to_flannel_secondary() {
     fi
 
     # Delete the /var/lib/weave directory, if it exists
-    if [ -d "/var/lib/weave" ]; then
-        rm -rf /var/lib/weave
-    fi
+    rm -rf /var/lib/weave
 
     # Delete any weave files in /etc/cni/net.d
     if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
@@ -900,7 +896,7 @@ function weave_to_flannel_secondary() {
     if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
         rm -rf /opt/cni/bin/*weave*
     fi
-    
+
     systemctl restart kubelet containerd
 
     logSuccess "Successfully updated $(get_local_node_name) to use Flannel"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -830,12 +830,25 @@ nodeRegistration:
 EOM
 
     echo "Removing Weave files from the node"
+    # Delete the weave network interface, if it exists
+    if ip link show weave > /dev/null 2>&1; then
+        ip link delete weave
+    fi
 
-    ip link delete weave
+    # Delete the /var/lib/weave directory, if it exists
+    if [ -d "/var/lib/weave" ]; then
+        rm -rf /var/lib/weave
+    fi
 
-    rm -rf /var/lib/weave
-    rm -rf /etc/cni/net.d/*weave*
-    rm -rf /opt/cni/bin/weave*
+    # Delete any weave files in /etc/cni/net.d
+    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
+        rm -rf /etc/cni/net.d/*weave*
+    fi
+
+    # Delete any weave files in /opt/cni/bin
+    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
+        rm -rf /opt/cni/bin/*weave*
+    fi
 
     kubeadm join phase control-plane-prepare control-plane --config=/tmp/kubeadm-join.conf
     systemctl restart kubelet containerd
@@ -866,9 +879,28 @@ function weave_to_flannel_secondary() {
         flannel_images_present
     fi
 
-    rm -f /opt/cni/bin/weave-*
-    rm -rf /etc/cni/net.d
-    ip link delete weave
+    # It should be executed in all nodes either
+    # See that the task used to run in the nodes also has this commands
+    # Delete the weave network interface, if it exists
+    if ip link show weave > /dev/null 2>&1; then
+        ip link delete weave
+    fi
+
+    # Delete the /var/lib/weave directory, if it exists
+    if [ -d "/var/lib/weave" ]; then
+        rm -rf /var/lib/weave
+    fi
+
+    # Delete any weave files in /etc/cni/net.d
+    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
+        rm -rf /etc/cni/net.d/*weave*
+    fi
+
+    # Delete any weave files in /opt/cni/bin
+    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
+        rm -rf /opt/cni/bin/*weave*
+    fi
+    
     systemctl restart kubelet containerd
 
     logSuccess "Successfully updated $(get_local_node_name) to use Flannel"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -875,19 +875,10 @@ function weave_to_flannel_secondary() {
         ip link delete weave
     fi
 
-    # Delete the /var/lib/weave directory, if it exists
     rm -rf /var/lib/weave
-
-    # Delete any weave files in /etc/cni/net.d
-    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
-        rm -rf /etc/cni/net.d/*weave*
-    fi
-
-    # Delete any weave files in /opt/cni/bin
-    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
-        rm -rf /opt/cni/bin/*weave*
-    fi
-
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
+    
     systemctl restart kubelet containerd
 
     logSuccess "Successfully updated $(get_local_node_name) to use Flannel"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -835,18 +835,9 @@ EOM
         ip link delete weave
     fi
 
-    # Delete the /var/lib/weave directory, if it exists
     rm -rf /var/lib/weave
-
-    # Delete any weave files in /etc/cni/net.d
-    if ls /etc/cni/net.d/*weave* > /dev/null 2>&1; then
-        rm -rf /etc/cni/net.d/*weave*
-    fi
-
-    # Delete any weave files in /opt/cni/bin
-    if ls /opt/cni/bin/*weave* > /dev/null 2>&1; then
-        rm -rf /opt/cni/bin/*weave*
-    fi
+    rm -rf /etc/cni/net.d/*weave*
+    rm -rf /opt/cni/bin/weave*
 
     kubeadm join phase control-plane-prepare control-plane --config=/tmp/kubeadm-join.conf
     systemctl restart kubelet containerd


### PR DESCRIPTION
#### What this PR does / why we need it:

To ensure that the process is idempotent and will just run the commands when required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-77764]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes issue to migrate from weave to flannel by ensuring that the operations to remove weave from the filesystem will only be executed when the files are found in the task executed in the nodes and for weave version equals or upper than `0.21.5` 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
