### PR TITLE
fix(ci): use os-latest testgrid spec for pr tests

### DIFF
--- a/.github/actions/addon-testgrid-tester/action.yml
+++ b/.github/actions/addon-testgrid-tester/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         testgrid_os_spec_path="${{ inputs.testgrid-os-spec-path }}"
         if [ -z "$testgrid_os_spec_path" ]; then
-          testgrid_os_spec_path="${{ github.action_path }}/../../../testgrid/specs/os-firstlast.yaml"
+          testgrid_os_spec_path="${{ github.action_path }}/../../../testgrid/specs/os-latest.yaml"
         fi
         ${{ github.action_path }}/../../../bin/test-addon.sh \
           "${{ inputs.addon }}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

us os-latest rather than os-firstlast for on-pr tests. This will remove centos-74, centos-81 and ubuntu-1804 from pr tests. This reduces the grid from 11 to 8 oses.