### PR TITLE
revert gracePeriod added in PR 4553

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -233,8 +233,8 @@ function weave_to_flannel() {
     restart_systemd_and_wait kubelet
 
     logStep "Restarting pods in kube-system"
-    kubectl -n kube-system delete pods --all --grace-period=200
-    kubectl -n kube-flannel delete pods --all --grace-period=200
+    kubectl -n kube-system delete pods --all
+    kubectl -n kube-flannel delete pods --all
     flannel_ready_spinner
 
     logStep "Restarting CSI pods"


### PR DESCRIPTION
#### What this PR does / why we need it:

We added a gracePeriod at https://github.com/replicatedhq/kURL/pull/4553
However, it is due a misunderstand of how it works.

The gracePeriod cannot help us here because k8s does not force the Pod get Terminate 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to # [sc-77764]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
