### PR TITLE
bug: add https proxy support for add-ons latest versions

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -190,7 +190,7 @@ function weave_to_flannel() {
             printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-primary airgap cert-key=${cert_key}${NC}\n\n"
         else
             local prefix=
-            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
             printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=${cert_key}${NC}\n\n"
         fi
 
@@ -212,7 +212,7 @@ function weave_to_flannel() {
             printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         else
             local prefix=
-            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
             printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         fi
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -190,7 +190,7 @@ function weave_to_flannel() {
             printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-primary airgap cert-key=${cert_key}${NC}\n\n"
         else
             local prefix=
-            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
             printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=${cert_key}${NC}\n\n"
         fi
 
@@ -212,7 +212,7 @@ function weave_to_flannel() {
             printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         else
             local prefix=
-            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
             printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         fi
 

--- a/addons/longhorn/1.3.1/install.sh
+++ b/addons/longhorn/1.3.1/install.sh
@@ -183,7 +183,7 @@ function longhorn_maybe_init_hosts() {
                     printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s longhorn-node-initilize airgap${NC}\n\n"
                 else
                     local prefix=
-                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
                     printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s longhorn-node-initilize${NC}\n\n"
                 fi
 

--- a/addons/longhorn/template/base/install.sh
+++ b/addons/longhorn/template/base/install.sh
@@ -183,7 +183,7 @@ function longhorn_maybe_init_hosts() {
                     printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s longhorn-node-initilize airgap${NC}\n\n"
                 else
                     local prefix=
-                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
                     printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s longhorn-node-initilize${NC}\n\n"
                 fi
 

--- a/addons/velero/1.11.0/install.sh
+++ b/addons/velero/1.11.0/install.sh
@@ -319,15 +319,16 @@ function velero_kotsadm_restore_config() {
 function velero_patch_http_proxy() {
     local src="$1"
     local dst="$2"
-
-    if [ -n "$PROXY_ADDRESS" ]; then
+    if [ -n "$PROXY_ADDRESS" ] || [ -n "$PROXY_HTTPS_ADDRESS" ]; then
+        if [ -z "$PROXY_HTTPS_ADDRESS" ]; then
+            PROXY_HTTPS_ADDRESS="$PROXY_ADDRESS"
+        fi
         render_yaml_file_2 "$src/tmpl-velero-deployment-proxy.yaml" > "$dst/velero-deployment-proxy.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" velero-deployment-proxy.yaml
-    fi
-
-    if [ -n "$PROXY_ADDRESS" ] && [ "$VELERO_DISABLE_RESTIC" != "1" ]; then
-        render_yaml_file_2 "$src/tmpl-node-agent-daemonset-proxy.yaml" > "$dst/node-agent-daemonset-proxy.yaml"
-        insert_patches_strategic_merge "$dst/kustomization.yaml" node-agent-daemonset-proxy.yaml
+        if [ "$VELERO_DISABLE_RESTIC" != "1" ]; then
+            render_yaml_file_2 "$src/tmpl-node-agent-daemonset-proxy.yaml" > "$dst/node-agent-daemonset-proxy.yaml"
+            insert_patches_strategic_merge "$dst/kustomization.yaml" node-agent-daemonset-proxy.yaml
+        fi
     fi
 }
 

--- a/addons/velero/1.11.0/tmpl-kotsadm-restore-config.yaml
+++ b/addons/velero/1.11.0/tmpl-kotsadm-restore-config.yaml
@@ -8,6 +8,6 @@ metadata:
     kurl.sh/restore-kotsadm-plugin: RestoreItemAction
 data:
   HTTP_PROXY: ${PROXY_ADDRESS:-'""'}
-  HTTPS_PROXY: ${PROXY_ADDRESS:-'""'}
+  HTTPS_PROXY: ${PROXY_HTTPS_ADDRESS:-'""'}
   NO_PROXY: ${NO_PROXY_ADDRESSES:-'""'}
   hostCAPath: ${KOTSADM_TRUSTED_CERT_MOUNT:-'""'}

--- a/addons/velero/1.11.0/tmpl-node-agent-daemonset-proxy.yaml
+++ b/addons/velero/1.11.0/tmpl-node-agent-daemonset-proxy.yaml
@@ -12,6 +12,6 @@ spec:
           - name: HTTP_PROXY
             value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: "${PROXY_ADDRESS}"
+            value: "${PROXY_HTTPS_ADDRESS}"
           - name: NO_PROXY
             value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/1.11.0/tmpl-velero-deployment-proxy.yaml
+++ b/addons/velero/1.11.0/tmpl-velero-deployment-proxy.yaml
@@ -12,6 +12,6 @@ spec:
           - name: HTTP_PROXY
             value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: "${PROXY_ADDRESS}"
+            value: "${PROXY_HTTPS_ADDRESS}"
           - name: NO_PROXY
             value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/template/base/install.tmpl.sh
+++ b/addons/velero/template/base/install.tmpl.sh
@@ -319,15 +319,16 @@ function velero_kotsadm_restore_config() {
 function velero_patch_http_proxy() {
     local src="$1"
     local dst="$2"
-
-    if [ -n "$PROXY_ADDRESS" ]; then
+    if [ -n "$PROXY_ADDRESS" ] || [ -n "$PROXY_HTTPS_ADDRESS" ]; then
+        if [ -z "$PROXY_HTTPS_ADDRESS" ]; then
+            PROXY_HTTPS_ADDRESS="$PROXY_ADDRESS"
+        fi
         render_yaml_file_2 "$src/tmpl-velero-deployment-proxy.yaml" > "$dst/velero-deployment-proxy.yaml"
         insert_patches_strategic_merge "$dst/kustomization.yaml" velero-deployment-proxy.yaml
-    fi
-
-    if [ -n "$PROXY_ADDRESS" ] && [ "$VELERO_DISABLE_RESTIC" != "1" ]; then
-        render_yaml_file_2 "$src/tmpl-node-agent-daemonset-proxy.yaml" > "$dst/node-agent-daemonset-proxy.yaml"
-        insert_patches_strategic_merge "$dst/kustomization.yaml" node-agent-daemonset-proxy.yaml
+        if [ "$VELERO_DISABLE_RESTIC" != "1" ]; then
+            render_yaml_file_2 "$src/tmpl-node-agent-daemonset-proxy.yaml" > "$dst/node-agent-daemonset-proxy.yaml"
+            insert_patches_strategic_merge "$dst/kustomization.yaml" node-agent-daemonset-proxy.yaml
+        fi
     fi
 }
 

--- a/addons/velero/template/base/tmpl-kotsadm-restore-config.yaml
+++ b/addons/velero/template/base/tmpl-kotsadm-restore-config.yaml
@@ -8,6 +8,6 @@ metadata:
     kurl.sh/restore-kotsadm-plugin: RestoreItemAction
 data:
   HTTP_PROXY: ${PROXY_ADDRESS:-'""'}
-  HTTPS_PROXY: ${PROXY_ADDRESS:-'""'}
+  HTTPS_PROXY: ${PROXY_HTTPS_ADDRESS:-'""'}
   NO_PROXY: ${NO_PROXY_ADDRESSES:-'""'}
   hostCAPath: ${KOTSADM_TRUSTED_CERT_MOUNT:-'""'}

--- a/addons/velero/template/base/tmpl-node-agent-daemonset-proxy.yaml
+++ b/addons/velero/template/base/tmpl-node-agent-daemonset-proxy.yaml
@@ -12,6 +12,6 @@ spec:
           - name: HTTP_PROXY
             value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: "${PROXY_ADDRESS}"
+            value: "${PROXY_HTTPS_ADDRESS}"
           - name: NO_PROXY
             value: "${NO_PROXY_ADDRESSES}"

--- a/addons/velero/template/base/tmpl-velero-deployment-proxy.yaml
+++ b/addons/velero/template/base/tmpl-velero-deployment-proxy.yaml
@@ -12,6 +12,6 @@ spec:
           - name: HTTP_PROXY
             value: "${PROXY_ADDRESS}"
           - name: HTTPS_PROXY
-            value: "${PROXY_ADDRESS}"
+            value: "${PROXY_HTTPS_ADDRESS}"
           - name: NO_PROXY
             value: "${NO_PROXY_ADDRESSES}"

--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -310,7 +310,7 @@ function addon_outro() {
             printf "\n\t${GREEN}cat ./upgrade.sh | sudo bash -s airgap${common_flags}${NC}\n\n"
         else
             local prefix=
-            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+            prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
 
             printf "\n\t${GREEN}${prefix}upgrade.sh | sudo bash -s${common_flags}${NC}\n\n"
         fi

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -940,15 +940,21 @@ function build_installer_prefix() {
     local kurl_version="$2"
     local kurl_url="$3"
     local proxy_address="$4"
+    local proxy_https_address="$5"
 
     if [ -z "${kurl_url}" ]; then
         echo "cat "
         return
     fi
 
+    local is_https=
     local curl_flags=
-    if [ -n "${proxy_address}" ]; then
+    if [ -n "${proxy_address}" ] || [ -n "${proxy_https_address}" ]; then
         curl_flags=" -x ${proxy_address}"
+        is_https=$(echo "${kurl_url}" | grep -q "^https" && echo "true" || echo "false")
+        if [ -n "${proxy_https_address}" ] && [ "$is_https" = "true" ]; then
+            curl_flags=" -x ${proxy_https_address}"
+        fi
     fi
 
     if [ -n "${kurl_version}" ]; then
@@ -1502,7 +1508,7 @@ function common_prompt_task_missing_assets() {
     if [ "$AIRGAP" = "1" ]; then
         prefix="cat ./"
     else
-        prefix="$(build_installer_prefix "$INSTALLER_ID" "$KURL_VERSION" "$KURL_URL" "$PROXY_ADDRESS")"
+        prefix="$(build_installer_prefix "$INSTALLER_ID" "$KURL_VERSION" "$KURL_URL" "$PROXY_ADDRESS" "$PROXY_HTTPS_ADDRESS")"
     fi
 
     local airgap_flag=

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -523,7 +523,7 @@ function upgrade_kubernetes_remote_node() {
         printf "\t%bcat ./upgrade.sh | sudo bash -s airgap kubernetes-version=%s%s%b\n\n" "$GREEN" "$targetK8sVersion" "$common_flags" "$NC"
     else
         local prefix=
-        prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+        prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
 
         printf "\t%b %supgrade.sh | sudo bash -s kubernetes-version=%s%s%b\n\n" "$GREEN" "$prefix" "$targetK8sVersion" "$common_flags" "$NC"
     fi

--- a/scripts/common/yaml-test.sh
+++ b/scripts/common/yaml-test.sh
@@ -11,7 +11,9 @@ function test_render_yaml_file_2() {
     # shellcheck disable=SC2034
     local PROXY_ADDRESS=a
     # shellcheck disable=SC2034
-    local NO_PROXY_ADDRESSES=b
+    local PROXY_HTTPS_ADDRESS=b
+    # shellcheck disable=SC2034
+    local NO_PROXY_ADDRESSES=c
     local expects="apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,9 +28,9 @@ spec:
           - name: HTTP_PROXY
             value: \"a\"
           - name: HTTPS_PROXY
-            value: \"a\"
+            value: \"b\"
           - name: NO_PROXY
-            value: \"b\""
+            value: \"c\""
     assertEquals "preserves quotes" "$expects" "$(render_yaml_file_2 "./addons/velero/template/base/tmpl-velero-deployment-proxy.yaml")"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -306,7 +306,7 @@ function init() {
                     printf "${GREEN}    cat ./tasks.sh | sudo bash -s set-kubeconfig-server https://${currentLoadBalancerAddress}${NC}\n"
                 else
                     local prefix=
-                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+                    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
 
                     printf "${GREEN}    ${prefix}tasks.sh | sudo bash -s set-kubeconfig-server https://${currentLoadBalancerAddress}${NC}\n"
                 fi
@@ -451,7 +451,7 @@ function outro() {
     printf "\n"
 
     local prefix=
-    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}")"
+    prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
 
     if [ "$HA_CLUSTER" = "1" ]; then
         printf "Master node join commands expire after two hours, and worker node join commands expire after 24 hours.\n"

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -384,7 +384,7 @@ function join_token() {
     common_flags="${common_flags}$(get_ipv6_flag)"
 
     local prefix=
-    prefix="$(build_installer_prefix "${installer_id}" "${KURL_VERSION}" "${kurl_url}" "")"
+    prefix="$(build_installer_prefix "${installer_id}" "${KURL_VERSION}" "${kurl_url}" "" "")"
 
     if [ "$HA_CLUSTER" = "1" ]; then
         printf "Master node join commands expire after two hours, and worker node join commands expire after 24 hours.\n"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds HTTPS proxy awareness for the newest Flannel, Longhorn and Velero add-ons. This PR also adds support for HTTPS proxy on `build_installer_prefix` function.

If HTTPS proxy is not defined HTTP proxy is used instead (backwards compatibility).
