### PR TITLE
Fix Weave to Flanel with Rook on the spec

### DIFF
--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -41,8 +41,22 @@ function flannel_pre_init() {
             bail "Not migrating from Weave to Flannel"
         fi
         flannel_check_nodes_connectivity
+        flannel_check_rook_ceph_status
     fi
 }
+
+function flannel_check_rook_ceph_status() {
+    if kubectl get namespace/rook-ceph ; then
+       logStep "Checking Rook Status prior migrate from Weave to Flannel"
+       if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
+           kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+           bail "Failed to verify Rook, Ceph is not healthy. The migration from Weave to Flannel can not be performed"
+           bail "Please, ensure that Rook Ceph is healthy."
+       fi
+       logSuccess "Rook Ceph is healthy"
+    fi
+}
+
 
 # flannel_check_nodes_connectivity verifies that all nodes in the cluster can reach each other through
 # port 8472/UDP (this communication is a flannel requirement).
@@ -141,11 +155,12 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting up to 5 minutes for Flannel to become healthy"
+    logSubstep "Waiting up to 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."
     fi
+    logSuccess "Flannel is healthy"
 }
 
 function flannel_weave_conflict() {
@@ -156,17 +171,143 @@ function flannel_antrea_conflict() {
     ls /etc/cni/net.d/*antrea* >/dev/null 2>&1
 }
 
+function flannel_scale_down_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    if [ "$(kubectl -n kurl get deployments ekc-operator -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+    logSubstep "Scaling down Ekco Operator"
+    kubectl -n kurl scale deployment ekc-operator --replicas=0
+
+    log "Waiting for ekco pods to be removed"
+    if ! spinner_until 300 ekco_pods_gone; then
+        bail "Unable to scale down ekco operator"
+    fi
+    logSuccess "Ecko Operator is scaled down"
+}
+
+# rook_scale_up_ekco will scale up ekco to 1 replica
+function flannel_scale_up_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    logSubstep "Scaling up Ecko Operator"
+    if ! timeout 120 kubectl -n kurl scale deployment ekc-operator --replicas=1 1>/dev/null; then
+        logWarn "Failed to scale down Ecko Operator within the timeout period."
+        return
+    fi
+
+    logSuccess "Ecko is scaled up"
+}
+
+
+# rook_scale_down_prometheus will scale down prometheus to 0 replicas
+function flannel_scale_down_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    if [ "$(kubectl -n monitoring get prometheus k8s -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    logSubstep "Scaling down Prometheus"
+
+    log "Patching prometheus to scale down"
+    if ! timeout 120 kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]' 1>/dev/null; then
+        logWarn "Failed to patch Prometheus to scale down within the timeout period."
+    fi
+
+    log "Waiting 30 seconds to let Prometheus scale down"
+    sleep 30
+
+    log "Waiting for prometheus pods to be removed"
+    if ! spinner_until 300 prometheus_pods_gone; then
+        logWarn "Prometheus pods still running. Trying once more"
+        kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+        if ! spinner_until 300 prometheus_pods_gone; then
+            bail "Unable to scale down prometheus"
+        fi
+    fi
+    logSuccess "Prometheus is scaled down"
+}
+
+# flannel_scale_up_prometheus will scale up prometheus replicas to 2
+function flannel_scale_up_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    logSubstep "Scaling up Prometheus"
+    if ! timeout 120 kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]' 1>/dev/null; then
+        logWarn "Failed to patch Prometheus to scale up within the timeout period."
+    fi
+
+    log "Awaiting Prometheus pods to transition to Running"
+    if ! spinner_until 300 check_for_running_pods "monitoring"; then
+        logWarn "Prometheus scale up did not complete within the allotted time"
+        return
+    fi
+
+    logSuccess "Prometheus is scaled up"
+}
+
+function flannel_scale_down_rook() {
+    if ! kubernetes_resource_exists rook-ceph deployment rook-ceph-operator; then
+        return
+    fi
+
+    logSubstep "Scaling down Rook Ceph for the migration from Weave to Flannel"
+    log "Scaling down Rook Operator"
+    if ! timeout 300 kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=0 1>/dev/null; then
+        kubectl logs -n rook-ceph -l app=rook-ceph-operator --all-containers --tail 10 || true
+        bail "The Rook Ceph operator failed to scale down within the timeout period."
+    fi
+
+    logSuccess "Rook Ceph is scaled down"
+}
+
+function flannel_scale_up_rook() {
+    if ! kubernetes_resource_exists rook-ceph deployment rook-ceph-operator; then
+        return
+    fi
+
+    logSubstep "Scaling up Rook Ceph"
+    if ! timeout 120 kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=1 1>/dev/null; then
+        logWarn "Failed to scale up Rook Operator within the timeout period."
+    fi
+
+    log "Waiting Ceph become healthy"
+    if ! "$DIR"/bin/kurl rook wait-for-health 1200 ; then
+        kubectl logs -n rook-ceph -l app=rook-ceph-operator --all-containers --tail 10 || true
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        logWarn "RookCeph is not healthy. Migration from Weave to Flannel does not seems to be completed successfully"
+        return
+    fi
+
+    logSuccess "Rook Ceph is scale up"
+}
+
 function weave_to_flannel() {
     local dst="$DIR/kustomize/flannel"
 
-    logStep "Removing Weave to install Flannel"
-    remove_weave
+    logStep "Scale down services prior remove Weave"
+    flannel_scale_down_ekco
+    flannel_scale_down_rook
+    flannel_scale_down_prometheus
+    logSuccess "Services scaled down successfully"
 
-    logStep "Updating kubeadm to use Flannel"
+    remove_weave
     flannel_kubeadm
 
     logStep "Applying Flannel"
     kubectl -n kube-flannel apply -k "$dst/"
+    logSuccess "Flannel applied successfully"
+
 
     # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
     local master_node_count=
@@ -174,6 +315,8 @@ function weave_to_flannel() {
     local master_node_names=
     master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$master_node_count" -gt 1 ]; then
+        logStep "Required to remove Weave from Primary Nodes"
+
         local other_master_nodes=
         other_master_nodes=$(echo "$master_node_names" | grep -v "$(get_local_node_name)")
         printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
@@ -196,6 +339,9 @@ function weave_to_flannel() {
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"
         prompt
+
+        logSuccess "User confirmation about nodes execution."
+        log "Deleting Pods from kube-flannel"
         kubectl -n kube-flannel delete pods --all
     fi
 
@@ -204,6 +350,8 @@ function weave_to_flannel() {
     local worker_node_names=
     worker_node_names=$(kubectl get nodes --no-headers --selector='!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$worker_node_count" -gt 0 ]; then
+        logStep "Required to remove Weave from Nodes"
+
         printf "${YELLOW}Moving from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
         printf "${YELLOW}Please run the following command on each of the listed secondary nodes:${NC}\n\n"
         printf "${worker_node_names}\n"
@@ -221,19 +369,26 @@ function weave_to_flannel() {
         kubectl -n kube-flannel delete pods --all
     fi
 
-    echo "waiting for kube-flannel-ds to become healthy in kube-flannel"
-    spinner_until 240 daemonset_fully_updated "kube-flannel" "kube-flannel-ds"
+    log "Waiting for kube-flannel-ds to become healthy in kube-flannel"
+    if ! spinner_until 240 daemonset_fully_updated "kube-flannel" "kube-flannel-ds"; then
+       logWarn "Unable to fully update Kube Flannel daemonset"
+    fi
 
     logStep "Restarting kubelet"
+    log "Stopping Kubelet"
     systemctl stop kubelet
+    log "Flushing IP Tables"
     iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
-    echo "waiting for containerd to restart"
+    log "Waiting for containerd to restart"
     restart_systemd_and_wait containerd
-    echo "waiting for kubelet to restart"
+    log "Waiting for kubelet to restart"
     restart_systemd_and_wait kubelet
 
     logStep "Restarting pods in kube-system"
+    log "it may take several minutes to delete all pods"
     kubectl -n kube-system delete pods --all
+
+    logStep "Restarting pods in kube-flannel"
     kubectl -n kube-flannel delete pods --all
     flannel_ready_spinner
 
@@ -251,10 +406,18 @@ function weave_to_flannel() {
     done
 
     sleep 60
-    logSuccess "Migrated from Weave to Flannel"
+
+    logStep "Scale up services"
+    flannel_scale_up_ekco
+    flannel_scale_up_prometheus
+    flannel_scale_up_rook
+    logSuccess "Services scaled up successfully"
+
+    logSuccess "Migration from Weave to Flannel finished"
 }
 
 function remove_weave() {
+    logStep "Removing Weave to install Flannel"
     local resources=("daemonset.apps/weave-net"
                      "rolebinding.rbac.authorization.k8s.io/weave-net"
                      "role.rbac.authorization.k8s.io/weave-net"
@@ -262,6 +425,12 @@ function remove_weave() {
                      "clusterrole.rbac.authorization.k8s.io/weave-net"
                      "serviceaccount/weave-net"
                      "secret/weave-passwd")
+
+    # Seems that we need to delete first the daemonset
+    log "Remove weave resources"
+    if ! timeout 60 kubectl delete daemonset.apps/weave-net -n kube-system --ignore-not-found 1>/dev/null; then
+         logWarn "Timeout occurred while delete  daemonset.apps/weave-net"
+    fi
 
     # Check if resource exists before deleting it
     for resource in "${resources[@]}"; do
@@ -272,7 +441,14 @@ function remove_weave() {
         fi
     done
 
-    # Delete the weave network interface, if it exists
+    if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --ignore-not-found &> /dev/null; then
+        logWarn "Timeout occurred while deleting weave Pods. Attempting force deletion."
+        if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --force --grace-period=0 1>/dev/null; then
+             logWarn "Timeout occurred while force Weave Pods deletion"
+        fi
+    fi
+
+    log "Delete the weave network interface, if it exists"
     if ip link show weave > /dev/null 2>&1; then
         ip link delete weave
     fi
@@ -282,7 +458,6 @@ function remove_weave() {
     rm -rf /opt/cni/bin/weave*
 
     logStep "Verifying Weave removal"
-
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
             logWarn "Resource: $resource still exists. Attempting force deletion."
@@ -294,17 +469,30 @@ function remove_weave() {
         fi
     done
 
+    if kubectl get pods -n kube-system -l name=weave-net 2>/dev/null | grep -q .; then
+        logWarn "Forcing deletion of Weave Pods"
+        if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --force 1>/dev/null; then
+             logWarn "Timeout occurred while force Weave Pods deletion"
+        fi
+        echo "waiting 30 seconds to check removal"
+        sleep 30
+    fi
+
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
-            logWarn "Unable to remove resource: $resource"
-            return
+            bail "Unable to remove Weave resources to move with the migration"
         fi
     done
+
+    if kubectl get pods -n kube-system -l name=weave-net 2>/dev/null | grep -q .; then
+        bail "Weave pods still exist. Unable to proceed with the migration."
+    fi
 
     logSuccess "Weave has been successfully removed."
 }
 
 function flannel_kubeadm() {
+    logStep "Updating kubeadm to use Flannel"
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
@@ -316,6 +504,7 @@ function flannel_kubeadm() {
 
     kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
     kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
+    logSuccess "Kubeadm updated successfully"
 }
 
 function flannel_already_applied() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -41,8 +41,22 @@ function flannel_pre_init() {
             bail "Not migrating from Weave to Flannel"
         fi
         flannel_check_nodes_connectivity
+        flannel_check_rook_ceph_status
     fi
 }
+
+function flannel_check_rook_ceph_status() {
+    if kubectl get namespace/rook-ceph ; then
+       logStep "Checking Rook Status prior migrate from Weave to Flannel"
+       if ! "$DIR"/bin/kurl rook wait-for-health 300 ; then
+           kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+           bail "Failed to verify Rook, Ceph is not healthy. The migration from Weave to Flannel can not be performed"
+           bail "Please, ensure that Rook Ceph is healthy."
+       fi
+       logSuccess "Rook Ceph is healthy"
+    fi
+}
+
 
 # flannel_check_nodes_connectivity verifies that all nodes in the cluster can reach each other through
 # port 8472/UDP (this communication is a flannel requirement).
@@ -141,11 +155,12 @@ function flannel_health_check() {
 }
 
 function flannel_ready_spinner() {
-    echo "Waiting up to 5 minutes for Flannel to become healthy"
+    logSubstep "Waiting up to 5 minutes for Flannel to become healthy"
     if ! spinner_until 300 flannel_health_check; then
         kubectl logs -n kube-flannel -l app=flannel --all-containers --tail 10 || true
         bail "The Flannel add-on failed to deploy successfully."
     fi
+    logSuccess "Flannel is healthy"
 }
 
 function flannel_weave_conflict() {
@@ -156,17 +171,143 @@ function flannel_antrea_conflict() {
     ls /etc/cni/net.d/*antrea* >/dev/null 2>&1
 }
 
+function flannel_scale_down_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    if [ "$(kubectl -n kurl get deployments ekc-operator -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+    logSubstep "Scaling down Ekco Operator"
+    kubectl -n kurl scale deployment ekc-operator --replicas=0
+
+    log "Waiting for ekco pods to be removed"
+    if ! spinner_until 300 ekco_pods_gone; then
+        bail "Unable to scale down ekco operator"
+    fi
+    logSuccess "Ecko Operator is scaled down"
+}
+
+# rook_scale_up_ekco will scale up ekco to 1 replica
+function flannel_scale_up_ekco() {
+    if ! kubernetes_resource_exists kurl deployment ekc-operator ; then
+        return
+    fi
+
+    logSubstep "Scaling up Ecko Operator"
+    if ! timeout 120 kubectl -n kurl scale deployment ekc-operator --replicas=1 1>/dev/null; then
+        logWarn "Failed to scale down Ecko Operator within the timeout period."
+        return
+    fi
+
+    logSuccess "Ecko is scaled up"
+}
+
+
+# rook_scale_down_prometheus will scale down prometheus to 0 replicas
+function flannel_scale_down_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    if [ "$(kubectl -n monitoring get prometheus k8s -o jsonpath='{.spec.replicas}')" = "0" ]; then
+        return
+    fi
+
+    logSubstep "Scaling down Prometheus"
+
+    log "Patching prometheus to scale down"
+    if ! timeout 120 kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]' 1>/dev/null; then
+        logWarn "Failed to patch Prometheus to scale down within the timeout period."
+    fi
+
+    log "Waiting 30 seconds to let Prometheus scale down"
+    sleep 30
+
+    log "Waiting for prometheus pods to be removed"
+    if ! spinner_until 300 prometheus_pods_gone; then
+        logWarn "Prometheus pods still running. Trying once more"
+        kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 0}]'
+        if ! spinner_until 300 prometheus_pods_gone; then
+            bail "Unable to scale down prometheus"
+        fi
+    fi
+    logSuccess "Prometheus is scaled down"
+}
+
+# flannel_scale_up_prometheus will scale up prometheus replicas to 2
+function flannel_scale_up_prometheus() {
+    if ! kubernetes_resource_exists monitoring prometheus k8s ; then
+        return
+    fi
+
+    logSubstep "Scaling up Prometheus"
+    if ! timeout 120 kubectl -n monitoring patch prometheus k8s --type='json' --patch '[{"op": "replace", "path": "/spec/replicas", value: 2}]' 1>/dev/null; then
+        logWarn "Failed to patch Prometheus to scale up within the timeout period."
+    fi
+
+    log "Awaiting Prometheus pods to transition to Running"
+    if ! spinner_until 300 check_for_running_pods "monitoring"; then
+        logWarn "Prometheus scale up did not complete within the allotted time"
+        return
+    fi
+
+    logSuccess "Prometheus is scaled up"
+}
+
+function flannel_scale_down_rook() {
+    if ! kubernetes_resource_exists rook-ceph deployment rook-ceph-operator; then
+        return
+    fi
+
+    logSubstep "Scaling down Rook Ceph for the migration from Weave to Flannel"
+    log "Scaling down Rook Operator"
+    if ! timeout 300 kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=0 1>/dev/null; then
+        kubectl logs -n rook-ceph -l app=rook-ceph-operator --all-containers --tail 10 || true
+        bail "The Rook Ceph operator failed to scale down within the timeout period."
+    fi
+
+    logSuccess "Rook Ceph is scaled down"
+}
+
+function flannel_scale_up_rook() {
+    if ! kubernetes_resource_exists rook-ceph deployment rook-ceph-operator; then
+        return
+    fi
+
+    logSubstep "Scaling up Rook Ceph"
+    if ! timeout 120 kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=1 1>/dev/null; then
+        logWarn "Failed to scale up Rook Operator within the timeout period."
+    fi
+
+    log "Waiting Ceph become healthy"
+    if ! "$DIR"/bin/kurl rook wait-for-health 1200 ; then
+        kubectl logs -n rook-ceph -l app=rook-ceph-operator --all-containers --tail 10 || true
+        kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
+        logWarn "RookCeph is not healthy. Migration from Weave to Flannel does not seems to be completed successfully"
+        return
+    fi
+
+    logSuccess "Rook Ceph is scale up"
+}
+
 function weave_to_flannel() {
     local dst="$DIR/kustomize/flannel"
 
-    logStep "Removing Weave to install Flannel"
-    remove_weave
+    logStep "Scale down services prior remove Weave"
+    flannel_scale_down_ekco
+    flannel_scale_down_rook
+    flannel_scale_down_prometheus
+    logSuccess "Services scaled down successfully"
 
-    logStep "Updating kubeadm to use Flannel"
+    remove_weave
     flannel_kubeadm
 
     logStep "Applying Flannel"
     kubectl -n kube-flannel apply -k "$dst/"
+    logSuccess "Flannel applied successfully"
+
 
     # if there is more than one node, prompt to run on each primary/master node, and then on each worker/secondary node
     local master_node_count=
@@ -174,6 +315,8 @@ function weave_to_flannel() {
     local master_node_names=
     master_node_names=$(kubectl get nodes --no-headers --selector='node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$master_node_count" -gt 1 ]; then
+        logStep "Required to remove Weave from Primary Nodes"
+
         local other_master_nodes=
         other_master_nodes=$(echo "$master_node_names" | grep -v "$(get_local_node_name)")
         printf "${YELLOW}Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
@@ -196,6 +339,9 @@ function weave_to_flannel() {
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"
         prompt
+
+        logSuccess "User confirmation about nodes execution."
+        log "Deleting Pods from kube-flannel"
         kubectl -n kube-flannel delete pods --all
     fi
 
@@ -204,6 +350,8 @@ function weave_to_flannel() {
     local worker_node_names=
     worker_node_names=$(kubectl get nodes --no-headers --selector='!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name)
     if [ "$worker_node_count" -gt 0 ]; then
+        logStep "Required to remove Weave from Nodes"
+
         printf "${YELLOW}Moving from Weave to Flannel requires removing certain weave files and restarting kubelet.${NC}\n"
         printf "${YELLOW}Please run the following command on each of the listed secondary nodes:${NC}\n\n"
         printf "${worker_node_names}\n"
@@ -221,19 +369,26 @@ function weave_to_flannel() {
         kubectl -n kube-flannel delete pods --all
     fi
 
-    echo "waiting for kube-flannel-ds to become healthy in kube-flannel"
-    spinner_until 240 daemonset_fully_updated "kube-flannel" "kube-flannel-ds"
+    log "Waiting for kube-flannel-ds to become healthy in kube-flannel"
+    if ! spinner_until 240 daemonset_fully_updated "kube-flannel" "kube-flannel-ds"; then
+       logWarn "Unable to fully update Kube Flannel daemonset"
+    fi
 
     logStep "Restarting kubelet"
+    log "Stopping Kubelet"
     systemctl stop kubelet
+    log "Flushing IP Tables"
     iptables -t nat -F && iptables -t mangle -F && iptables -F && iptables -X
-    echo "waiting for containerd to restart"
+    log "Waiting for containerd to restart"
     restart_systemd_and_wait containerd
-    echo "waiting for kubelet to restart"
+    log "Waiting for kubelet to restart"
     restart_systemd_and_wait kubelet
 
     logStep "Restarting pods in kube-system"
+    log "it may take several minutes to delete all pods"
     kubectl -n kube-system delete pods --all
+
+    logStep "Restarting pods in kube-flannel"
     kubectl -n kube-flannel delete pods --all
     flannel_ready_spinner
 
@@ -251,10 +406,18 @@ function weave_to_flannel() {
     done
 
     sleep 60
-    logSuccess "Migrated from Weave to Flannel"
+
+    logStep "Scale up services"
+    flannel_scale_up_ekco
+    flannel_scale_up_prometheus
+    flannel_scale_up_rook
+    logSuccess "Services scaled up successfully"
+
+    logSuccess "Migration from Weave to Flannel finished"
 }
 
 function remove_weave() {
+    logStep "Removing Weave to install Flannel"
     local resources=("daemonset.apps/weave-net"
                      "rolebinding.rbac.authorization.k8s.io/weave-net"
                      "role.rbac.authorization.k8s.io/weave-net"
@@ -262,6 +425,12 @@ function remove_weave() {
                      "clusterrole.rbac.authorization.k8s.io/weave-net"
                      "serviceaccount/weave-net"
                      "secret/weave-passwd")
+
+    # Seems that we need to delete first the daemonset
+    log "Remove weave resources"
+    if ! timeout 60 kubectl delete daemonset.apps/weave-net -n kube-system --ignore-not-found 1>/dev/null; then
+         logWarn "Timeout occurred while delete  daemonset.apps/weave-net"
+    fi
 
     # Check if resource exists before deleting it
     for resource in "${resources[@]}"; do
@@ -272,7 +441,14 @@ function remove_weave() {
         fi
     done
 
-    # Delete the weave network interface, if it exists
+    if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --ignore-not-found &> /dev/null; then
+        logWarn "Timeout occurred while deleting weave Pods. Attempting force deletion."
+        if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --force --grace-period=0 1>/dev/null; then
+             logWarn "Timeout occurred while force Weave Pods deletion"
+        fi
+    fi
+
+    log "Delete the weave network interface, if it exists"
     if ip link show weave > /dev/null 2>&1; then
         ip link delete weave
     fi
@@ -282,7 +458,6 @@ function remove_weave() {
     rm -rf /opt/cni/bin/weave*
 
     logStep "Verifying Weave removal"
-
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
             logWarn "Resource: $resource still exists. Attempting force deletion."
@@ -294,17 +469,30 @@ function remove_weave() {
         fi
     done
 
+    if kubectl get pods -n kube-system -l name=weave-net 2>/dev/null | grep -q .; then
+        logWarn "Forcing deletion of Weave Pods"
+        if ! timeout 60 kubectl delete pods -n kube-system -l name=weave-net --force 1>/dev/null; then
+             logWarn "Timeout occurred while force Weave Pods deletion"
+        fi
+        echo "waiting 30 seconds to check removal"
+        sleep 30
+    fi
+
     for resource in "${resources[@]}"; do
         if kubectl -n kube-system get "$resource" &> /dev/null; then
-            logWarn "Unable to remove resource: $resource"
-            return
+            bail "Unable to remove Weave resources to move with the migration"
         fi
     done
+
+    if kubectl get pods -n kube-system -l name=weave-net 2>/dev/null | grep -q .; then
+        bail "Weave pods still exist. Unable to proceed with the migration."
+    fi
 
     logSuccess "Weave has been successfully removed."
 }
 
 function flannel_kubeadm() {
+    logStep "Updating kubeadm to use Flannel"
     # search for 'serviceSubnet', add podSubnet above it
     local pod_cidr_range_line=
     pod_cidr_range_line="  podSubnet: ${POD_CIDR}"
@@ -316,6 +504,7 @@ function flannel_kubeadm() {
 
     kubeadm init phase upload-config kubeadm --config="$KUBEADM_CONF_FILE"
     kubeadm init phase control-plane controller-manager --config="$KUBEADM_CONF_FILE"
+    logSuccess "Kubeadm updated successfully"
 }
 
 function flannel_already_applied() {

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -113,7 +113,7 @@
       localPVStorageClassName: "local"
 - name: "weave to flannel single node with addons and rook"
   flags: "yes"
-  cpu: 6
+  cpu: 8
   installerSpec:
     kubernetes:
       version: "1.26.x"

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -887,15 +887,16 @@ function restart_systemd_and_wait() {
 
     local pid="$(systemctl show --property MainPID $serviceName | cut -d = -f2)"
 
-    echo "Restarting $serviceName..."
+    logSubstep "Restarting $serviceName..."
     systemctl restart $serviceName
 
+    log "Checking if $serviceName was restarted successfully"
     if ! spinner_until 120 systemd_restart_succeeded $pid $serviceName; then
         journalctl -xe
         bail "Could not successfully restart systemd service $serviceName"
     fi
 
-    echo "Service $serviceName restarted."
+    logSuccess "Service $serviceName restarted."
 }
 
 # returns true when a job has completed


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently if the Rook Addon be in the installer spec the migration from Weave to Flannel will get stuck when we try to delete the Pods from kube-system. 

#### Which issue(s) this PR fixes:

Fixes # [sc-77764]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce

To check the error you can:

Install: curl https://kurl.sh/f070e69 | sudo bash -s ha
Create 2 work nodes: 
Update curl https://staging.kurl.sh/f0a3e1c | sudo bash -s ha

OR

Install: curl https://staging.kurl.sh/40458f7  | sudo bash -s ha
Create 2 work nodes: 
Update  curl https://staging.kurl.sh/01f0f67  | sudo bash -s ha

(with single node you will either face the issue)
Example: https://testgrid.kurl.sh/run/pr-4584-e8a9015-flannel-0.21.5-k8s-ctrd-2023-06-02T06:49:50Z?kurlLogsInstanceId=bpriyglsdisqmwur&nodeId=bpriyglsdisqmwur-initialprimary

Now, you can check the fix:

**Single Node**
Check the new e2e tests added in the testgrid to verify the migration from Weave to Flannel with Rook into the spec.

![Screenshot 2023-06-08 at 07 08 39](https://github.com/replicatedhq/kURL/assets/7708031/5fce6a41-13b4-4933-9f89-11c1742eabf8)

Note that prior this PR it fails ALWAYS. You can check it via testgrid.

**MultiNode**
Install: curl https://staging.kurl.sh/40458f7 | sudo bash -s yes ha
Create: 2 work nodes with the installer
Then Update: curl https://staging.kurl.sh/94f1517 | sudo bash -s ha yes

Following the relevant part of the logs and some final checks to ensure that the connection is OK. 

```
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
✔ Cluster Initialized
Applying resources
service/registry unchanged
secret/kurl-troubleshoot-spec configured
customresourcedefinition.apiextensions.k8s.io/installers.cluster.kurl.sh unchanged
installer.cluster.kurl.sh/94f1517 created
installer.cluster.kurl.sh/94f1517 labeled
configmap "kurl-last-config" deleted
configmap/kurl-last-config created
configmap "kurl-current-config" deleted
configmap/kurl-current-config created
configmap/kurl-current-config patched
⚙  Addon flannel 0.21.5
⚙  Scale down services prior remove Weave
	- Scaling down Ekco Operator
deployment.apps/ekc-operator scaled
Waiting for ekco pods to be removed
✔ Ecko Operator is scaled down
	- Scaling down Rook Ceph for the migration from Weave to Flannel
Scaling down Rook Operator
✔ Rook Ceph is scaled down
	- Scaling down Prometheus
Patching prometheus to scale down
Waiting 30 seconds to let Prometheus scale down
Waiting for prometheus pods to be removed
✔ Prometheus is scaled down
✔ Services scaled down successfully
⚙  Removing Weave to install Flannel
Remove weave resources
Delete the weave network interface, if it exists
⚙  Verifying Weave removal
✔ Weave has been successfully removed.
⚙  Updating kubeadm to use Flannel
[upload-config] Storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
[control-plane] Creating static Pod manifest for "kube-controller-manager"
✔ Kubeadm updated successfully
⚙  Applying Flannel
namespace/kube-flannel created
serviceaccount/flannel created
clusterrole.rbac.authorization.k8s.io/flannel created
clusterrolebinding.rbac.authorization.k8s.io/flannel created
configmap/kube-flannel-cfg created
secret/flannel-troubleshoot-spec created
daemonset.apps/kube-flannel-ds created
✔ Flannel applied successfully
⚙  Required to remove Weave from Primary Nodes
Moving primary nodes from Weave to Flannel requires removing certain weave files and restarting kubelet.
Please run the following command on each of the listed primary nodes:

camila-ubuntu-2004-pr-node-a
camila-ubuntu-2004-pr-node-b

	curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-f7050036/94f1517/tasks.sh | sudo bash -s weave-to-flannel-primary cert-key=d57eac52e0f9ec76ca023a983787c7b02e888112054dbdbbc10d21f16076691e

Once this has been run on all nodes, press enter to continue.
✔ User confirmation about nodes execution.
Deleting Pods from kube-flannel
pod "kube-flannel-ds-7dzvb" deleted
pod "kube-flannel-ds-q6jbv" deleted
pod "kube-flannel-ds-sh8lh" deleted
No resources found
Waiting for kube-flannel-ds to become healthy in kube-flannel
⚙  Restarting kubelet
Stopping Kubelet
Flushing IP Tables
Waiting for containerd to restart
Restarting containerd...
Service containerd restarted.
Waiting for kubelet to restart
Restarting kubelet...
Service kubelet restarted.
⚙  Restarting pods in kube-system
it may take several minutes to delete all pods
pod "coredns-787d4945fb-hkf8j" deleted
pod "coredns-787d4945fb-v4k5c" deleted
pod "etcd-camila-ubuntu-2004-pr-master" deleted
pod "etcd-camila-ubuntu-2004-pr-node-a" deleted
pod "etcd-camila-ubuntu-2004-pr-node-b" deleted
pod "haproxy-camila-ubuntu-2004-pr-master" deleted
pod "haproxy-camila-ubuntu-2004-pr-node-a" deleted
pod "haproxy-camila-ubuntu-2004-pr-node-b" deleted
pod "kube-apiserver-camila-ubuntu-2004-pr-master" deleted
pod "kube-apiserver-camila-ubuntu-2004-pr-node-a" deleted
pod "kube-apiserver-camila-ubuntu-2004-pr-node-b" deleted
pod "kube-controller-manager-camila-ubuntu-2004-pr-master" deleted
pod "kube-controller-manager-camila-ubuntu-2004-pr-node-a" deleted
pod "kube-controller-manager-camila-ubuntu-2004-pr-node-b" deleted
pod "kube-proxy-gc9f8" deleted
pod "kube-proxy-wr9b9" deleted
pod "kube-proxy-zfxtn" deleted
pod "kube-scheduler-camila-ubuntu-2004-pr-master" deleted
pod "kube-scheduler-camila-ubuntu-2004-pr-node-a" deleted
pod "kube-scheduler-camila-ubuntu-2004-pr-node-b" deleted
⚙  Restarting pods in kube-flannel
pod "kube-flannel-ds-6627r" deleted
pod "kube-flannel-ds-bm948" deleted
pod "kube-flannel-ds-zbtfq" deleted
	- Waiting up to 5 minutes for Flannel to become healthy
✔ Flannel is healthy
⚙  Restarting CSI pods
No resources found
pod "ceph-object-controller-detect-version-nlsvw" deleted
pod "csi-cephfsplugin-cv7qh" deleted
pod "csi-cephfsplugin-j98hw" deleted
pod "csi-cephfsplugin-jm4mv" deleted
pod "csi-cephfsplugin-provisioner-75687d99f-hxp9r" deleted
pod "csi-cephfsplugin-provisioner-75687d99f-sjh57" deleted
pod "csi-rbdplugin-f7f66" deleted
pod "csi-rbdplugin-ldjfc" deleted
pod "csi-rbdplugin-provisioner-67b6847497-ml48p" deleted
pod "csi-rbdplugin-provisioner-67b6847497-qkbjz" deleted
pod "csi-rbdplugin-rzvkp" deleted
pod "rook-ceph-crashcollector-camila-ubuntu-2004-pr-master-6fc9ckzhf" deleted
pod "rook-ceph-crashcollector-camila-ubuntu-2004-pr-node-a-7454sdhm2" deleted
pod "rook-ceph-crashcollector-camila-ubuntu-2004-pr-node-b-5fd8s2vns" deleted
pod "rook-ceph-csi-detect-version-w5spt" deleted
pod "rook-ceph-detect-version-2svpv" deleted
pod "rook-ceph-mds-rook-shared-fs-a-689fbf678-5r5mm" deleted
pod "rook-ceph-mds-rook-shared-fs-b-66ccfcf969-sgzfh" deleted
pod "rook-ceph-mgr-a-68d4c8655b-cssrr" deleted
pod "rook-ceph-mgr-b-574c9d84cc-kwskl" deleted
pod "rook-ceph-mon-a-768b4d5684-lg877" deleted
pod "rook-ceph-mon-b-7969747846-zmlsc" deleted
pod "rook-ceph-mon-c-5454f6cfb-trvx7" deleted
pod "rook-ceph-osd-0-69f764464d-srhjz" deleted
pod "rook-ceph-osd-1-5449688875-r5nx6" deleted
pod "rook-ceph-osd-2-7bbfc6dd87-f7cwx" deleted
pod "rook-ceph-osd-prepare-camila-ubuntu-2004-pr-master-2ln8r" deleted
pod "rook-ceph-osd-prepare-camila-ubuntu-2004-pr-node-a-n8q9x" deleted
pod "rook-ceph-osd-prepare-camila-ubuntu-2004-pr-node-b-57hx7" deleted
pod "rook-ceph-rgw-rook-ceph-store-a-66bcc6dccb-qwjbq" deleted
pod "rook-ceph-tools-9b7967b5d-t8nq9" deleted
pod "rook-discover-558x5" deleted
pod "rook-discover-9g849" deleted
pod "rook-discover-vkrfz" deleted
No resources found
⚙  Restarting all other pods
this may take several minutes
No resources found
No resources found
No resources found
pod "registry-c57cb9596-d2wbb" deleted
pod "registry-c57cb9596-h2cql" deleted
pod "minio-dc5f75d9-7g5cg" deleted
pod "alertmanager-prometheus-alertmanager-0" deleted
pod "alertmanager-prometheus-alertmanager-1" deleted
pod "alertmanager-prometheus-alertmanager-2" deleted
pod "grafana-54d94857f-g5qww" deleted
pod "kube-state-metrics-6d6d746687-pz8k8" deleted
pod "prometheus-adapter-64f8bc699f-p4dhv" deleted
pod "prometheus-node-exporter-gwpxh" deleted
pod "prometheus-node-exporter-kgswl" deleted
pod "prometheus-node-exporter-tbz77" deleted
pod "prometheus-operator-8589c57845-xxth7" deleted
pod "contour-695c8fb98d-2h5hb" deleted
pod "contour-695c8fb98d-bkhs5" deleted
pod "contour-certgen-v1.25.0-k9cqf" deleted
pod "envoy-49nss" deleted
pod "envoy-f2ktn" deleted
pod "envoy-swdnn" deleted
⚙  Scale up services
	- Scaling up Ecko Operator
✔ Ecko is scaled up
	- Scaling up Prometheus
Awaiting Prometheus pods to transition to Running
✔ Prometheus is scaled up
	- Scaling up Rook Ceph
Waiting Ceph become healthy
Waiting for Rook-Ceph to be healthy
Rook is healthy
✔ Rook Ceph is scale up
✔ Services scaled up successfully
✔ Migration from Weave to Flannel finished
	- Waiting up to 5 minutes for Flannel to become healthy
✔ Flannel is healthy
⚙  Checking cluster networking
service/kurlnet created
pod/kurlnet-server created
pod/kurlnet-client created
Waiting for kurlnet-client pod to start
Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "kurlnet-client" force deleted
pod "kurlnet-server" force deleted
service "kurlnet" deleted
configmap/kurl-current-config patched
⚙  Addon rook 1.11.7
Scaling down EKCO deployment to 0 replicas
deployment.apps/ekc-operator scaled
Waiting for ekco pods to be removed
customresourcedefinition.apiextensions.k8s.io/objectbuckets.objectbucket.io replaced
customresourcedefinition.apiextensions.k8s.io/objectbucketclaims.objectbucket.io replaced
customresourcedefinition.apiextensions.k8s.io/cephrbdmirrors.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephobjectzones.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephobjectzonegroups.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephobjectstoreusers.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephobjectstores.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephobjectrealms.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephnfses.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephfilesystemsubvolumegroups.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephfilesystems.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephfilesystemmirrors.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephclusters.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephclients.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephbuckettopics.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephbucketnotifications.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephblockpools.ceph.rook.io replaced
customresourcedefinition.apiextensions.k8s.io/cephblockpoolradosnamespaces.ceph.rook.io replaced
namespace/rook-ceph unchanged
serviceaccount/rook-ceph-cmd-reporter unchanged
serviceaccount/rook-ceph-mgr unchanged
serviceaccount/rook-ceph-osd unchanged
serviceaccount/rook-ceph-purge-osd unchanged
serviceaccount/rook-ceph-rgw unchanged
serviceaccount/rook-ceph-system unchanged
serviceaccount/rook-csi-cephfs-plugin-sa unchanged
serviceaccount/rook-csi-cephfs-provisioner-sa unchanged
serviceaccount/rook-csi-rbd-plugin-sa unchanged
serviceaccount/rook-csi-rbd-provisioner-sa unchanged
role.rbac.authorization.k8s.io/cephfs-external-provisioner-cfg unchanged
role.rbac.authorization.k8s.io/rbd-external-provisioner-cfg unchanged
role.rbac.authorization.k8s.io/rook-ceph-cmd-reporter unchanged
role.rbac.authorization.k8s.io/rook-ceph-mgr unchanged
role.rbac.authorization.k8s.io/rook-ceph-osd unchanged
role.rbac.authorization.k8s.io/rook-ceph-purge-osd unchanged
role.rbac.authorization.k8s.io/rook-ceph-rgw unchanged
role.rbac.authorization.k8s.io/rook-ceph-system unchanged
clusterrole.rbac.authorization.k8s.io/cephfs-csi-nodeplugin unchanged
clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner unchanged
clusterrole.rbac.authorization.k8s.io/rbd-csi-nodeplugin unchanged
clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-global unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-cluster unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-system unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-object-bucket unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-osd unchanged
clusterrole.rbac.authorization.k8s.io/rook-ceph-system unchanged
rolebinding.rbac.authorization.k8s.io/cephfs-csi-provisioner-role-cfg unchanged
rolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role-cfg unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-cmd-reporter unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-mgr unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-mgr-system unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-osd unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-purge-osd unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-rgw unchanged
rolebinding.rbac.authorization.k8s.io/rook-ceph-system unchanged
clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-nodeplugin-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-provisioner-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-nodeplugin unchanged
clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-global unchanged
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-mgr-cluster unchanged
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-object-bucket unchanged
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-osd unchanged
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-system unchanged
configmap/rook-config-override unchanged
configmap/rook-ceph-operator-config unchanged
deployment.apps/rook-ceph-tools unchanged
deployment.apps/rook-ceph-operator configured
Awaiting rook-ceph pods
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Cluster rook-ceph already deployed
Cluster rook-ceph up to date
Patching allowance of insecure rook clients
Awaiting rook-ceph dashboard password
checking for attached secondary block device (awaiting rook-ceph RGW pod)
cephobjectstoreuser.ceph.rook.io/kurl unchanged
Awaiting rook-ceph object store health
Awaiting Rook rollout in rook-ceph namespace
Awaiting CephCluster CR to report Ready
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is Progressing: Configuring Ceph OSDs
  Current CephCluster status is Progressing: Configuring Ceph OSDs
  Current CephCluster status is Progressing: Processing OSD 0 on node "camila-ubuntu-2004-pr-master"
  Current CephCluster status is Progressing: Processing OSD 0 on node "camila-ubuntu-2004-pr-master"
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is Progressing: Processing OSD 2 on node "camila-ubuntu-2004-pr-node-b"
  Current CephCluster status is Progressing: Processing OSD 1 on node "camila-ubuntu-2004-pr-node-a"
  Current CephCluster status is Progressing: Detecting Ceph version
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is Progressing: Configuring Ceph Mons
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
  Current CephCluster status is: Ready
CephCluster is ready
Awaiting Rook pods to transition to Running
Error from server (NotFound): pods "rook-ceph-osd-prepare-camila-ubuntu-2004-pr-master-g2m4j" not found
Error from server (NotFound): pods "rook-ceph-osd-prepare-camila-ubuntu-2004-pr-master-g2m4j" not found
configmap/kurl-current-config patched
⚙  Addon ekco 0.27.1
namespace/kurl unchanged
serviceaccount/ekco unchanged
role.rbac.authorization.k8s.io/ekco-rotate-certs unchanged
clusterrole.rbac.authorization.k8s.io/ekco-cluster unchanged
clusterrole.rbac.authorization.k8s.io/ekco-kube-system unchanged
clusterrole.rbac.authorization.k8s.io/ekco-kurl unchanged
clusterrole.rbac.authorization.k8s.io/ekco-minio unchanged
clusterrole.rbac.authorization.k8s.io/ekco-pvmigrate unchanged
clusterrole.rbac.authorization.k8s.io/ekco-rook-ceph unchanged
clusterrole.rbac.authorization.k8s.io/ekco-velero unchanged
rolebinding.rbac.authorization.k8s.io/ekco-rotate-certs unchanged
clusterrolebinding.rbac.authorization.k8s.io/ekco-cluster unchanged
configmap/ekco-config unchanged
deployment.apps/ekc-operator configured
rolebinding.rbac.authorization.k8s.io/ekco-kube-system unchanged
clusterrolebinding.rbac.authorization.k8s.io/ekco-pvmigrate unchanged
clusterrolebinding.rbac.authorization.k8s.io/ekco-kurl unchanged
clusterrolebinding.rbac.authorization.k8s.io/ekco-velero unchanged
rolebinding.rbac.authorization.k8s.io/ekco-rook-ceph unchanged
rolebinding.rbac.authorization.k8s.io/ekco-minio unchanged
pod "ekc-operator-76b8cf944-5q6wp" deleted
⚙  Installing ekco reboot service
✔ ekco reboot service installed
⚙  Installing ekco purge node command
✔ ekco purge node command installed
label "rook-priority.kurl.sh" not found.
namespace/rook-ceph not labeled
configmap/kurl-current-config patched
⚙  Addon minio 2023-05-18T00-05-36Z
Awaiting for minio deployment to rollout
Getting Minio storage format
namespace/minio unchanged
secret/minio-credentials configured
service/ha-minio unchanged
service/minio unchanged
persistentvolumeclaim/minio-pv-claim unchanged
deployment.apps/minio unchanged
awaiting minio deployment
awaiting minio readiness
awaiting minio endpoint
configmap/kurl-current-config patched
⚙  Addon contour 1.25.0
namespace/projectcontour unchanged
customresourcedefinition.apiextensions.k8s.io/contourconfigurations.projectcontour.io configured
customresourcedefinition.apiextensions.k8s.io/contourdeployments.projectcontour.io configured
customresourcedefinition.apiextensions.k8s.io/extensionservices.projectcontour.io configured
customresourcedefinition.apiextensions.k8s.io/httpproxies.projectcontour.io configured
customresourcedefinition.apiextensions.k8s.io/tlscertificatedelegations.projectcontour.io configured
serviceaccount/contour unchanged
serviceaccount/contour-certgen unchanged
serviceaccount/envoy unchanged
role.rbac.authorization.k8s.io/contour unchanged
role.rbac.authorization.k8s.io/contour-certgen unchanged
clusterrole.rbac.authorization.k8s.io/contour unchanged
rolebinding.rbac.authorization.k8s.io/contour unchanged
rolebinding.rbac.authorization.k8s.io/contour-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/contour unchanged
configmap/contour unchanged
service/contour unchanged
service/envoy unchanged
deployment.apps/contour unchanged
daemonset.apps/envoy configured
job.batch/contour-certgen-v1.25.0 unchanged
configmap/kurl-current-config patched
⚙  Addon registry 2.8.2
	- Installing Registry
Applying resources
Adding secret
Checking if PVC and Object Store exists
PVC and Object Store were found. Creating Registry Deployment with Object Store data
object store bucket docker-registry exists
Command "format-address" is deprecated, use 'kurl netutil format-ip-address' instead
Object Store IP: 10.96.2.81
Object Store Hostname: rook-ceph-rgw-rook-ceph-store.rook-ceph
Checking if PVC migration will be required
✔ Registry installed successfully
configmap/registry-config unchanged
configmap/registry-velero-config unchanged
secret/registry-s3-secret configured
service/registry unchanged
deployment.apps/registry unchanged
	- Configuring Registry
Checking if secrets exist
Secrets found. Patching kotsadm labels
secret/registry-htpasswd patched (no change)
secret/registry-creds patched (no change)
Checking Docker Registry: 10.96.0.175
/var/lib/kurl/addons/registry/2.8.2/tmp /var/lib/kurl /home/camila
Gathering CA from server
Generating a private key and a corresponding Certificate Signing Request (CSR) using OpenSSL
Generating a RSA private key
.......................................+++++
..............................................+++++
writing new private key to 'registry.key'
-----
Generating a self-signed X.509 certificate using OpenSSL
Signature ok
subject=CN = registry.kurl.svc.cluster.local
Getting CA Private Key
secret/registry-pki created
/var/lib/kurl /home/camila
✔ Registry configured successfully
	- Checking if registry is healthy
waiting for the registry to start
✔ Registry is healthy
configmap/kurl-current-config patched
⚙  Addon prometheus 0.65.1-46.6.0
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusagents.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/scrapeconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
deployment.apps "kube-state-metrics" deleted
Error from server (NotFound): daemonsets.apps "node-exporter" not found
deployment.apps "grafana" deleted
deployment.apps "prometheus-adapter" deleted
Error from server (NotFound): alertmanagers.monitoring.coreos.com "main" not found
service "kube-state-metrics" deleted
service "prometheus-operator" deleted
service "grafana" deleted
Error from server (NotFound): services "alertmanager-main" not found
service "prometheus-k8s" deleted
namespace/monitoring unchanged
serviceaccount/grafana unchanged
serviceaccount/k8s unchanged
serviceaccount/kube-state-metrics configured
serviceaccount/prometheus-adapter unchanged
serviceaccount/prometheus-alertmanager unchanged
serviceaccount/prometheus-node-exporter unchanged
serviceaccount/prometheus-operator unchanged
role.rbac.authorization.k8s.io/grafana configured
role.rbac.authorization.k8s.io/prometheus-k8s unchanged
clusterrole.rbac.authorization.k8s.io/grafana-clusterrole unchanged
clusterrole.rbac.authorization.k8s.io/k8s unchanged
clusterrole.rbac.authorization.k8s.io/kube-state-metrics unchanged
clusterrole.rbac.authorization.k8s.io/prometheus-adapter-resource-reader unchanged
clusterrole.rbac.authorization.k8s.io/prometheus-adapter-server-resources unchanged
clusterrole.rbac.authorization.k8s.io/prometheus-operator unchanged
rolebinding.rbac.authorization.k8s.io/prometheus-adapter-auth-reader unchanged
rolebinding.rbac.authorization.k8s.io/grafana unchanged
rolebinding.rbac.authorization.k8s.io/prometheus-k8s unchanged
clusterrolebinding.rbac.authorization.k8s.io/grafana-clusterrolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/k8s unchanged
clusterrolebinding.rbac.authorization.k8s.io/kube-state-metrics unchanged
clusterrolebinding.rbac.authorization.k8s.io/prometheus-adapter-hpa-controller unchanged
clusterrolebinding.rbac.authorization.k8s.io/prometheus-adapter-resource-reader unchanged
clusterrolebinding.rbac.authorization.k8s.io/prometheus-adapter-system-auth-delegator unchanged
clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator unchanged
configmap/grafana unchanged
configmap/grafana-config-dashboards unchanged
configmap/k8s unchanged
configmap/prometheus-adapter unchanged
configmap/prometheus-alertmanager-overview unchanged
configmap/prometheus-apiserver unchanged
configmap/prometheus-cluster-total unchanged
configmap/prometheus-controller-manager unchanged
configmap/prometheus-etcd unchanged
configmap/prometheus-grafana-datasource unchanged
configmap/prometheus-grafana-overview unchanged
configmap/prometheus-k8s-coredns unchanged
configmap/prometheus-k8s-resources-cluster unchanged
configmap/prometheus-k8s-resources-multicluster unchanged
configmap/prometheus-k8s-resources-namespace unchanged
configmap/prometheus-k8s-resources-node unchanged
configmap/prometheus-k8s-resources-pod unchanged
configmap/prometheus-k8s-resources-workload unchanged
configmap/prometheus-k8s-resources-workloads-namespace unchanged
configmap/prometheus-kubelet unchanged
configmap/prometheus-namespace-by-pod unchanged
configmap/prometheus-namespace-by-workload unchanged
configmap/prometheus-node-cluster-rsrc-use unchanged
configmap/prometheus-node-rsrc-use unchanged
configmap/prometheus-nodes unchanged
configmap/prometheus-nodes-darwin unchanged
configmap/prometheus-persistentvolumesusage unchanged
configmap/prometheus-pod-total unchanged
configmap/prometheus-proxy unchanged
configmap/prometheus-scheduler unchanged
configmap/prometheus-workload-total unchanged
secret/alertmanager-prometheus-alertmanager unchanged
service/prometheus-coredns unchanged
service/prometheus-kube-controller-manager unchanged
service/prometheus-kube-etcd unchanged
service/prometheus-kube-proxy unchanged
service/prometheus-kube-scheduler unchanged
service/grafana created
service/kube-state-metrics created
service/prometheus-adapter unchanged
service/prometheus-alertmanager unchanged
service/prometheus-k8s created
service/prometheus-node-exporter unchanged
service/prometheus-operator created
deployment.apps/grafana created
deployment.apps/kube-state-metrics created
deployment.apps/prometheus-adapter created
deployment.apps/prometheus-operator unchanged
apiservice.apiregistration.k8s.io/v1beta1.custom.metrics.k8s.io unchanged
daemonset.apps/prometheus-node-exporter configured
alertmanager.monitoring.coreos.com/prometheus-alertmanager unchanged
prometheus.monitoring.coreos.com/k8s unchanged
prometheusrule.monitoring.coreos.com/k8s unchanged
prometheusrule.monitoring.coreos.com/k8s-operator unchanged
prometheusrule.monitoring.coreos.com/prometheus-alertmanager.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-config-reloaders unchanged
prometheusrule.monitoring.coreos.com/prometheus-etcd unchanged
prometheusrule.monitoring.coreos.com/prometheus-general.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-k8s.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-apiserver-availability.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-apiserver-burnrate.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-apiserver-histogram.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-apiserver-slos unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-prometheus-general.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-prometheus-node-recording.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-scheduler.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kube-state-metrics unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubelet.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-apps unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-resources unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-storage unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system-apiserver unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system-controller-manager unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system-kube-proxy unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system-kubelet unchanged
prometheusrule.monitoring.coreos.com/prometheus-kubernetes-system-scheduler unchanged
prometheusrule.monitoring.coreos.com/prometheus-node-exporter unchanged
prometheusrule.monitoring.coreos.com/prometheus-node-exporter.rules unchanged
prometheusrule.monitoring.coreos.com/prometheus-node-network unchanged
prometheusrule.monitoring.coreos.com/prometheus-node.rules unchanged
servicemonitor.monitoring.coreos.com/grafana unchanged
servicemonitor.monitoring.coreos.com/k8s unchanged
servicemonitor.monitoring.coreos.com/kube-state-metrics unchanged
servicemonitor.monitoring.coreos.com/prometheus-alertmanager unchanged
servicemonitor.monitoring.coreos.com/prometheus-apiserver unchanged
servicemonitor.monitoring.coreos.com/prometheus-coredns unchanged
servicemonitor.monitoring.coreos.com/prometheus-kube-controller-manager unchanged
servicemonitor.monitoring.coreos.com/prometheus-kube-etcd unchanged
servicemonitor.monitoring.coreos.com/prometheus-kube-proxy unchanged
servicemonitor.monitoring.coreos.com/prometheus-kube-scheduler unchanged
servicemonitor.monitoring.coreos.com/prometheus-kubelet unchanged
servicemonitor.monitoring.coreos.com/prometheus-node-exporter unchanged
servicemonitor.monitoring.coreos.com/prometheus-operator unchanged
configmap/kurl-current-config patched
⚙  Addon sonobuoy 0.56.16
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 18.7M  100 18.7M    0     0  23.6M      0 --:--:-- --:--:-- --:--:-- 23.6M
configmap/kurl-current-config patched
⚙  Persisting the kurl installer spec
configmap "kurl-config" deleted
configmap/kurl-config created
✔ Kurl installer spec was successfully persisted in the kurl configmap
Rook Post-init: Installing Prometheus ServiceMonitor and Ceph Grafana Dashboard
configmap/ceph-cluster-dashboard unchanged
servicemonitor.monitoring.coreos.com/rook-ceph-servicemonitor unchanged
Scaling up EKCO deployment to 1 replica
deployment.apps/ekc-operator scaled
⚙  Checking proxy configuration with Containerd
Skipping test. No HTTP proxy configuration found.

No resources found

		Installation
		  Complete ✔
No resources found

Run this script on all remote nodes to apply changes

	curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-f7050036/94f1517/upgrade.sh | sudo bash -s docker-registry-ip=10.96.0.175 additional-no-proxy-addresses=10.96.0.0/22,10.32.16.0/20 primary-host=10.154.0.23 primary-host=10.154.0.24 primary-host=10.154.0.25

Press enter to proceed



The UIs of Prometheus, Grafana and Alertmanager have been exposed on NodePorts 30900, 30902 and 30903 respectively.



To access the cluster with kubectl:

    bash -l

Kurl uses /etc/kubernetes/admin.conf, you might want to copy kubeconfig to your home directory:

    cp /etc/kubernetes/admin.conf ~/.kube/config
    chown -R 1038 ~/.kube
    echo unset KUBECONFIG >> ~/.bash_profile
    bash -l

You will likely need to use sudo to copy and chown /etc/kubernetes/admin.conf.



Master node join commands expire after two hours, and worker node join commands expire after 24 hours.

To generate new node join commands, run curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-f7050036/94f1517/tasks.sh | sudo bash -s join_token ha on an existing master node.

To add worker nodes to this installation, run the following script on your other nodes:
    curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-f7050036/94f1517/join.sh | sudo bash -s kubernetes-master-address=localhost:6444 kubeadm-token=8j486w.yhy0hio4421675v3 kubeadm-token-ca-hash=sha256:96220cd09ab6a5c542d17bbeba5a0ac98acaa3ec88505656a176676c48062484 kubernetes-version=1.26.5 docker-registry-ip=10.96.0.175 additional-no-proxy-addresses=10.96.0.0/22,10.32.16.0/20 primary-host=10.154.0.23 primary-host=10.154.0.24 primary-host=10.154.0.25



To add MASTER nodes to this installation, run the following script on your other nodes:
    curl -fsSL https://staging.kurl.sh/version/v2023.05.30-0-f7050036/94f1517/join.sh | sudo bash -s kubernetes-master-address=localhost:6444 kubeadm-token=8j486w.yhy0hio4421675v3 kubeadm-token-ca-hash=sha256:96220cd09ab6a5c542d17bbeba5a0ac98acaa3ec88505656a176676c48062484 kubernetes-version=1.26.5 cert-key=c2e473810cfab16c72c731446e9d8bb50027b3309736a4bf017f6c188ab529ce control-plane docker-registry-ip=10.96.0.175 additional-no-proxy-addresses=10.96.0.0/22,10.32.16.0/20 primary-host=10.154.0.23 primary-host=10.154.0.24 primary-host=10.154.0.25
```


#### Does this PR introduce a user-facing change?
```release-note
Fixes migration from Weave to Flannel when Rook Addon is applied on the installer.  
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
