### PR TITLE
feat: add EKCO K8s service and tweak EKCO rbac permissions

### DIFF
--- a/addons/ekco/0.27.1/install.sh
+++ b/addons/ekco/0.27.1/install.sh
@@ -429,6 +429,7 @@ function ekco_create_deployment() {
     cp "$src/rbac.yaml" "$dst/rbac.yaml"
     cp "$src/rolebinding.yaml" "$dst/rolebinding.yaml"
     cp "$src/rotate-certs-rbac.yaml" "$dst/rotate-certs-rbac.yaml"
+    cp "$src/service.yaml" "$dst/service.yaml"
 
     # is rook enabled
     if kubectl get ns rook-ceph >/dev/null 2>&1 ; then

--- a/addons/ekco/0.27.1/kustomization.yaml
+++ b/addons/ekco/0.27.1/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - configmap.yaml
 - deployment.yaml
 - rotate-certs-rbac.yaml
+- service.yaml

--- a/addons/ekco/0.27.1/rbac-rook.yaml
+++ b/addons/ekco/0.27.1/rbac-rook.yaml
@@ -36,6 +36,7 @@ rules:
       - cephfilesystems
       - cephobjectstores
     verbs:
+      - create
       - get
       - update
       - patch

--- a/addons/ekco/0.27.1/rbac.yaml
+++ b/addons/ekco/0.27.1/rbac.yaml
@@ -141,6 +141,7 @@ rules:
     resources:
       - storageclasses
     verbs:
+      - create
       - get
       - list
       - update

--- a/addons/ekco/0.27.1/service.yaml
+++ b/addons/ekco/0.27.1/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ekco
+spec:
+  selector:
+    app: ekc-operator
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/addons/ekco/0.27.1/service.yaml
+++ b/addons/ekco/0.27.1/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ekco
+  name: ekco-operator
 spec:
   selector:
     app: ekc-operator

--- a/addons/ekco/0.27.1/service.yaml
+++ b/addons/ekco/0.27.1/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ekco-operator
+  name: ekc-operator
 spec:
   selector:
     app: ekc-operator

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -429,6 +429,7 @@ function ekco_create_deployment() {
     cp "$src/rbac.yaml" "$dst/rbac.yaml"
     cp "$src/rolebinding.yaml" "$dst/rolebinding.yaml"
     cp "$src/rotate-certs-rbac.yaml" "$dst/rotate-certs-rbac.yaml"
+    cp "$src/service.yaml" "$dst/service.yaml"
 
     # is rook enabled
     if kubectl get ns rook-ceph >/dev/null 2>&1 ; then

--- a/addons/ekco/template/base/kustomization.yaml
+++ b/addons/ekco/template/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - configmap.yaml
 - deployment.yaml
 - rotate-certs-rbac.yaml
+- service.yaml

--- a/addons/ekco/template/base/rbac-rook.yaml
+++ b/addons/ekco/template/base/rbac-rook.yaml
@@ -36,6 +36,7 @@ rules:
       - cephfilesystems
       - cephobjectstores
     verbs:
+      - create
       - get
       - update
       - patch

--- a/addons/ekco/template/base/rbac.yaml
+++ b/addons/ekco/template/base/rbac.yaml
@@ -141,6 +141,7 @@ rules:
     resources:
       - storageclasses
     verbs:
+      - create
       - get
       - list
       - update

--- a/addons/ekco/template/base/service.yaml
+++ b/addons/ekco/template/base/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ekco
+spec:
+  selector:
+    app: ekc-operator
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/addons/ekco/template/base/service.yaml
+++ b/addons/ekco/template/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ekco
+  name: ekco-operator
 spec:
   selector:
     app: ekc-operator

--- a/addons/ekco/template/base/service.yaml
+++ b/addons/ekco/template/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ekco-operator
+  name: ekc-operator
 spec:
   selector:
     app: ekc-operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Add clusterIP service and give EKCO permission to create cephcluster and storage class resources so it can perform the automated storage migration from openebs to rook.

This change also allows the [`migrate-multinode-storage`](https://github.com/replicatedhq/kURL/pull/4550) command to discover the EKCO service.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-70768](https://app.shortcut.com/replicated/story/70768/automated-storage-migration-mvp)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
