### PR TITLE
bug: systemd_restart_succeeded should fail if pid is zero

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -875,6 +875,10 @@ function systemd_restart_succeeded() {
         return 1
     fi
 
+    if [ "$newPid" = "0" ]; then
+        return 1
+    fi
+
     if ps -p $oldPid >/dev/null 2>&1; then
         return 1
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

As seen in our tests, in some cases `systemd` reports back the process pid as zero if the process failed to start. The function `systemd_restart_succeeded` was not taking that into account and returning a success on a failed systemd restart.

[sc-77628]