### PR TITLE
bug: make weave_to_flannel idempotent

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -30,10 +30,15 @@ function init_preflights() {
 # if kurl pods like ekco not be running then we should bail
 function bail_if_kurl_pods_are_unhealthy() {
     if commandExists kubectl; then
-      log "Awaiting 2 minutes to check kURL Pod(s) are Running"
-      if ! spinner_until 120 check_for_running_pods kurl; then
-          bail "Kurl has unhealthy Pod(s). Check the namespace kurl. Restarting the pod may fix the issue."
-      fi
+        # if host preflight are being ignored we just move forward.
+        if [ "${HOST_PREFLIGHT_IGNORE}" = "1" ]; then
+            logWarn "Host preflight checks being ignored, moving on without checking for unhealthy pods in kurl namespace."
+            return 0
+        fi
+        log "Awaiting 2 minutes to check kURL Pod(s) are Running"
+        if ! spinner_until 120 check_for_running_pods kurl; then
+            bail "Kurl has unhealthy Pod(s). Check the namespace kurl. Restarting the pod may fix the issue."
+        fi
     fi
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR contains some improvements on the `weave_to_flannel` migration function. We want to guarantee that if something goes wrong with the migration we will try it once more when the script runs again and that it will eventually finish its work correctly.

#### Notes

Depending where the Weave to Flannel migration fails we may end up with a cluster in a unhealthy state (no CNI running thus some pods may be failing). As the cluster may not be in a healthy state after the failure the user may need to provide the `-s host-preflight-ignore` flag to the script during a second attempt.

The second attempt to migrate from weave to flannel is dispatched directly from the flannel pre_init phase, this is done because we can't guarantee that all addons preflights will succeed in case of a cluster running without CNI. 

#### About testing

In order to test this code I had to randomly `ctrl+c` the installer during different stages of the weave to flannel migration and then re-run the install script passin gin `-s host-preflight-ignore` flag. I have tested this in both single and multi nodes scenarios.
