### PR TITLE
Change ekco svc to node port type

### DIFF
--- a/addons/ekco/0.27.1/configmap.tmpl.yaml
+++ b/addons/ekco/0.27.1/configmap.tmpl.yaml
@@ -49,4 +49,4 @@ data:
     enable_ha_kotsadm: $EKCO_MAINTAIN_KOTSADM
     rook_minimum_node_count: ${ROOK_MINIMUM_NODE_COUNT:-0}
     rook_storage_class: "${STORAGE_CLASS:-distributed}"
-    storage_migration_auth_token: "$storage_migration_auth_token"
+    storage_migration_auth_token: "$EKCO_AUTH_TOKEN"

--- a/addons/ekco/0.27.1/service.tmpl.yaml
+++ b/addons/ekco/0.27.1/service.tmpl.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   name: ekc-operator
 spec:
+  type: NodePort
   selector:
     app: ekc-operator
   ports:
     - protocol: TCP
       port: 8080
+      nodePort: $EKCO_NODE_PORT

--- a/addons/ekco/template/base/configmap.tmpl.yaml
+++ b/addons/ekco/template/base/configmap.tmpl.yaml
@@ -49,4 +49,4 @@ data:
     enable_ha_kotsadm: $EKCO_MAINTAIN_KOTSADM
     rook_minimum_node_count: ${ROOK_MINIMUM_NODE_COUNT:-0}
     rook_storage_class: "${STORAGE_CLASS:-distributed}"
-    storage_migration_auth_token: "$storage_migration_auth_token"
+    storage_migration_auth_token: "$EKCO_AUTH_TOKEN"

--- a/addons/ekco/template/base/service.tmpl.yaml
+++ b/addons/ekco/template/base/service.tmpl.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   name: ekc-operator
 spec:
+  type: NodePort
   selector:
     app: ekc-operator
   ports:
     - protocol: TCP
       port: 8080
+      nodePort: $EKCO_NODE_PORT


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Change the `ekco` service to be of type `NodePort` so we can access it outside the cluster, namely during the join process.
Also, expose global vars `EKCO_AUTH_TOKEN` and `EKCO_ADDRESS` to be used as argument to `joins.sh`:
```bash
cat join.sh | sudo bash -s kubernetes-master-address=10.128.0.23:6443 kubeadm-token=ozlhkb.gzcs2bptis6itlxv kubeadm-token-ca-hash=sha256:e4af661f45c39c5f7a70e57718e23b745d466d947f0e1e1d749c4dd93a97076a kubernetes-version=1.27.2 ekco-address=10.128.0.23:31880 ekco-auth-token=8kt0lkjIQwoPsTdQozrxwrgy9VDIeqaqHSgUeTMCZoYMk6T34mhu2df9oLNrjfXy docker-registry-ip=10.96.0.118 additional-no-proxy-addresses=10.96.0.0/22,10.32.0.0/20 primary-host=10.128.0.23
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
