### PR TITLE
Fix MinIO PVC resize race condition

### DIFF
--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -75,6 +75,9 @@
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
+    echo "PVC size should be 20Gi:"
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
 
 # installation with hostPath
 - name: install using /opt/minio hostpath
@@ -99,7 +102,7 @@
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.25.x"
     flannel:
       version: latest
     longhorn:
@@ -110,7 +113,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "latest"
+      version: "1.25.x"
     flannel:
       version: latest
     longhorn:
@@ -130,6 +133,9 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+    echo "PVC size should be 20Gi:"
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
 
 # upgrade from 2020-01-25T02-50-51Z
 - name: upgrade minio from 2020-01-25T02-50-51Z
@@ -246,3 +252,6 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+    echo "PVC size should be 20Gi:"
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -78,8 +78,8 @@
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
     echo "PVC size should be 20Gi:"
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
 
 # installation with hostPath
 - name: install using /opt/minio hostpath
@@ -136,8 +136,8 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
     echo "PVC size should be 20Gi:"
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
 
 # upgrade from 2020-01-25T02-50-51Z
 - name: upgrade minio from 2020-01-25T02-50-51Z (longhorn)
@@ -255,5 +255,5 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
     echo "PVC size should be 20Gi:"
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
-    kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
+    kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -1,5 +1,5 @@
 # basic test
-- name: fresh minio install
+- name: fresh minio install (openebs)
   installerSpec:
     kubernetes:
       version: "latest"
@@ -57,14 +57,16 @@
 
 
 # installation with specified PVC size
-- name: install with 20Gi volume
+- name: install with 20Gi volume (openebs)
   installerSpec:
     kubernetes:
-      version: "latest"
+      version: "1.27.x"
     flannel:
       version: latest
-    longhorn:
+    openebs:
       version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: "default"
     containerd:
       version: "latest"
     minio:
@@ -98,11 +100,11 @@
     validate_read_write_object_store rwtest testfile.txt
 
 # upgrade that changes PVC size
-- name: upgrade minio from latest while increasing PVC claim size
+- name: upgrade minio from latest while increasing PVC claim size (longhorn)
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.24.x"
     flannel:
       version: latest
     longhorn:
@@ -113,7 +115,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.24.x"
     flannel:
       version: latest
     longhorn:
@@ -138,7 +140,7 @@
     kubectl get pvc -n kurl minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
 
 # upgrade from 2020-01-25T02-50-51Z
-- name: upgrade minio from 2020-01-25T02-50-51Z
+- name: upgrade minio from 2020-01-25T02-50-51Z (longhorn)
   flags: "yes"
   installerSpec:
     kubernetes:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Resizing the MinIO PVC is dependent on scaling down the existing pod, which we don't wait for. This PR adds an additional spinner for the pod to scale down before waiting for the size to change.

It also adds checks to testgrid to make sure we don't break this in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
