### PR TITLE
fix testgrid for flannel, see that docker is not support in rock 9.2

### DIFF
--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -196,7 +196,7 @@
       version: "__testver__"
       s3Override: "__testdist__"
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
   - centos-81 # docker 20.10.17 is not supported on centos 8.1.
   - centos-84 # docker 20.10.17 is not supported on centos 8.4.
   - ol-8x # docker 20.10.17 is not supported on ol 8.7.


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix test. See that we forgot to update the skip for rock-92 when we added it.
Then, the test will fail with:

```
2023-06-20 16:43:15+00:00 Failed to get unit file state for firewalld.service: No such file or directory
2023-06-20 16:43:15+00:00 ✔ Firewalld is either not enabled or not active.
2023-06-20 16:43:15+00:00 Containerd is required
+ KURL_EXIT_STATUS=1
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
