### PR TITLE
bug: statically compile velero plugin

### DIFF
--- a/kurl_util/Makefile
+++ b/kurl_util/Makefile
@@ -77,7 +77,7 @@ bin/toml:
 	go build ${LDFLAGS} -o bin/toml cmd/toml/main.go
 
 bin/veleroplugin: cmd/veleroplugin/main.go
-	go build ${LDFLAGS} -o bin/veleroplugin cmd/veleroplugin/main.go
+	CGO_ENABLED=0 go build ${LDFLAGS} -o bin/veleroplugin cmd/veleroplugin/main.go
 
 bin/vendorflights:
 	go build ${LDFLAGS} -o bin/vendorflights cmd/vendorflights/main.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This is needed to ensure the Debian based `golang:1.20` velero plugin binary can run in `ubuntu:jammy` environment. See: https://github.com/replicatedhq/kURL/blob/main/kurl_util/deploy/Dockerfile

cf: https://github.com/replicatedhq/kURL-api/pull/268

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicated-collab/swaggerhub-kots/issues/188

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes issue where Velero deployment did not rollout successfully when using kURL version `v2023.06.20-0`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
