### PR TITLE
Revert "use patches _correctly_"

### DIFF
--- a/addons/flannel/0.22.0/yaml/kustomization.yaml
+++ b/addons/flannel/0.22.0/yaml/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - troubleshoot.yaml
 
 patches:
-  - path: kube-flannel-cfg.patch.yaml
+  - kube-flannel-cfg.patch.yaml

--- a/addons/flannel/template/base/yaml/kustomization.yaml
+++ b/addons/flannel/template/base/yaml/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
   - troubleshoot.yaml
 
 patches:
-  - path: kube-flannel-cfg.patch.yaml
+  - kube-flannel-cfg.patch.yaml

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -1,7 +1,7 @@
 - name: "flannel latest single node"
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     flannel:
@@ -52,14 +52,14 @@
 - name: "weave to flannel single node"
   installerSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     weave:
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     flannel:
@@ -70,7 +70,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     weave:
@@ -91,7 +91,7 @@
       localPVStorageClassName: "local"
   upgradeSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     flannel:
@@ -116,7 +116,7 @@
   cpu: 8
   installerSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     weave:
@@ -135,7 +135,7 @@
       version: "1.11.x"
   upgradeSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.27.x"
     containerd:
       version: "latest"
     flannel:

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -1,7 +1,7 @@
 - name: "flannel latest single node"
   installerSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.25.x"
     containerd:
       version: "latest"
     flannel:
@@ -52,14 +52,14 @@
 - name: "weave to flannel single node"
   installerSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     weave:
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     flannel:
@@ -70,7 +70,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     weave:
@@ -91,7 +91,7 @@
       localPVStorageClassName: "local"
   upgradeSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     flannel:
@@ -116,7 +116,7 @@
   cpu: 8
   installerSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     weave:
@@ -135,7 +135,7 @@
       version: "1.11.x"
   upgradeSpec:
     kubernetes:
-      version: "1.27.x"
+      version: "1.26.x"
     containerd:
       version: "latest"
     flannel:


### PR DESCRIPTION
Reverts replicatedhq/kURL#4632

see: https://testgrid.kurl.sh/run/pr-4638-07b56ca-velero-1.11.0-k8s-docker-2023-06-23T04:10:08Z, https://github.com/replicatedhq/kURL/pull/4638