### PR TITLE
feat(ekco): Disable Rook storage node reconciliation in EKCO if Rook min. node count is set

### DIFF
--- a/addons/ekco/0.27.1/install.sh
+++ b/addons/ekco/0.27.1/install.sh
@@ -14,7 +14,7 @@ function ekco_pre_init() {
         EKCO_MIN_READY_WORKER_NODE_COUNT=0
     fi
     EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=true
-    if [ -z "$ROOK_VERSION" ] || [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ]; then
+    if [ -z "$ROOK_VERSION" ] || [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ] || [ -n "$ROOK_MINIMUM_NODE_COUNT" ]; then
         EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
     fi
     EKCO_RECONCILE_ROOK_MDS_PLACEMENT=true

--- a/addons/ekco/template/base/install.sh
+++ b/addons/ekco/template/base/install.sh
@@ -14,7 +14,7 @@ function ekco_pre_init() {
         EKCO_MIN_READY_WORKER_NODE_COUNT=0
     fi
     EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=true
-    if [ -z "$ROOK_VERSION" ] || [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ]; then
+    if [ -z "$ROOK_VERSION" ] || [ "$EKCO_ROOK_SHOULD_USE_ALL_NODES" = "1" ] || [ -n "$ROOK_MINIMUM_NODE_COUNT" ]; then
         EKCO_SHOULD_MAINTAIN_ROOK_STORAGE_NODES=false
     fi
     EKCO_RECONCILE_ROOK_MDS_PLACEMENT=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
When Rook and OpenEBS are installed and `Rook.minimumNodeCount` is set, disable ekco from [reconciling the Ceph cluster pool replication levels](https://github.com/replicatedhq/ekco/blob/main/pkg/ekcoops/operator.go#L155-L179). When `Rook.minimumNodeCount` cluster nodes is met, the EKCO operator will create the CephCluster via a Helm chart apply. This change will prevent EKCO from changing the default CephCluster created.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
