### PR TITLE
bug: remove centos stream from rhel 8 repo list

### DIFF
--- a/bundles/k8s-rhel8/Dockerfile
+++ b/bundles/k8s-rhel8/Dockerfile
@@ -6,7 +6,6 @@ RUN mkdir -p /packages/archives
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
 RUN yum install -y yum-utils createrepo
-RUN yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 RUN yum install -y modulemd-tools
 RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
 	kubelet-${KUBERNETES_VERSION} \


### PR DESCRIPTION
Not all packages available for Centos Stream are compatible with RHEL 8 enterprise. By removing this Centos Stream repository all packages will be downloaded from Rocky Linux repositories or the download will fail and we gonna see the failure when releasing the staging version.

I have tested to fetch dependencies for `kubelet` and `kubectl` using the changed Dockeffile for the following versions:

- latest 1.27
- latest 1.26
- latest 1.25
- latest 1.24
- latest 1.23
- latest 1.22
- latest 1.21
