### PR TITLE
Add preflight to validate auto storage scaling

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -904,7 +904,7 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
 # bail if rook/openebs prereqs not met for minimumNodeCount param for automated storage scaling
 function bail_if_automated_storage_scaling_prereqs_not_met() {
     if [ -n "ROOK_MINIMUM_NODE_COUNT"]; then
-        semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.5" | sed 's/v//g')"
+        semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.7" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 1.11.5
             logFail "The current Rook version $ROOK_VERSION is less than 1.11.5 which is required to use automated storage scaling (minimumNodeCount Parameter)"
             bail "Please use a Rook version higher than 1.11.5 or remove minimumNodeCount Paramenter"

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -903,16 +903,20 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
 
 # bail if rook/openebs prereqs not met for minimumNodeCount param for automated storage scaling
 function bail_if_automated_storage_scaling_prereqs_not_met() {
-    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ]; then
+    if [ -n "$ROOK_VERSION" ] && [ -n "$OPENEBS_VERSION" ]; then
         semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.7" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 1.11.7
-            logFail "The current Rook version $ROOK_VERSION is less than 1.11.7 which is required to use automated storage scaling (minimumNodeCount Parameter)"
+            logFail "The current Rook version $ROOK_VERSION is less than 1.11.7 which is required to use automated storage scaling (minimumNodeCount parameter)"
             bail "Please use Rook version 1.11.7 or greater, or remove the minimumNodeCount parameter"
         fi
         semverCompare "$(echo "$OPENEBS_VERSION" | sed 's/v//g')" "$(echo "3.6.0" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 3.6.0
-            logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount Parameter)"
+            logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount parameter)"
             bail "Please use OpenEBS version 3.6.0 or greater, or remove the minimumNodeCount parameter"
+        fi
+
+        if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -lt "3" ]; then
+            bail "Rook minimumNodeCount parameter must be greater than or equal to 3."
         fi
     fi
 }

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -13,6 +13,7 @@ function preflights() {
     cri_preflights
     host_nameservers_reachable
     allow_remove_docker_new_install
+    bail_if_automated_storage_scaling_prereqs_not_met
     return 0
 }
 
@@ -899,3 +900,18 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
         log "and the current kURL version used is $KURL_VERSION"
     fi
 }
+
+# bail if rook/openebs prereqs not met for minimumNodeCount param for automated storage scaling
+function bail_if_automated_storage_scaling_prereqs_not_met() {
+    if [ -n "ROOK_MINIMUM_NODE_COUNT"]; then
+        semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.5" | sed 's/v//g')"
+        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 1.11.5
+            logFail "The current Rook version $ROOK_VERSION is less than 1.11.5 which is required to use automated storage scaling (minimumNodeCount Parameter)"
+            bail "Please use a Rook version higher than 1.11.5 or remove minimumNodeCount Paramenter"
+        fi
+        semverCompare "$(echo "$OPENEBS_VERSION" | sed 's/v//g')" "$(echo "3.6.0" | sed 's/v//g')"
+        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 3.6.0
+            logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount Parameter)"
+            bail "Please use an OpenEBS version higher than 3.6.0 or remove minimumNodeCount Paramenter"
+}
+

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -907,7 +907,7 @@ function bail_if_automated_storage_scaling_prereqs_not_met() {
         semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.7" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 1.11.5
             logFail "The current Rook version $ROOK_VERSION is less than 1.11.5 which is required to use automated storage scaling (minimumNodeCount Parameter)"
-            bail "Please use a Rook version higher than 1.11.5 or remove minimumNodeCount Paramenter"
+            bail "Please use Rook version 1.11.7 or greater, or remove the minimumNodeCount parameter"
         fi
         semverCompare "$(echo "$OPENEBS_VERSION" | sed 's/v//g')" "$(echo "3.6.0" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 3.6.0

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -912,7 +912,7 @@ function bail_if_automated_storage_scaling_prereqs_not_met() {
         semverCompare "$(echo "$OPENEBS_VERSION" | sed 's/v//g')" "$(echo "3.6.0" | sed 's/v//g')"
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 3.6.0
             logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount Parameter)"
-            bail "Please use an OpenEBS version higher than 3.6.0 or remove minimumNodeCount Paramenter"
+            bail "Please use OpenEBS version 3.6.0 or greater, or remove the minimumNodeCount parameter"
         fi
     fi
 }

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -903,14 +903,14 @@ function bail_if_kurl_version_is_lower_than_previous_config() {
 
 # bail if rook/openebs prereqs not met for minimumNodeCount param for automated storage scaling
 function bail_if_automated_storage_scaling_prereqs_not_met() {
-    if [ -n "ROOK_MINIMUM_NODE_COUNT"]; then
+    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ]; then
         semverCompare "$(echo "$ROOK_VERSION" | sed 's/v//g')" "$(echo "1.11.7" | sed 's/v//g')"
-        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 1.11.5
-            logFail "The current Rook version $ROOK_VERSION is less than 1.11.5 which is required to use automated storage scaling (minimumNodeCount Parameter)"
+        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 1.11.7
+            logFail "The current Rook version $ROOK_VERSION is less than 1.11.7 which is required to use automated storage scaling (minimumNodeCount Parameter)"
             bail "Please use Rook version 1.11.7 or greater, or remove the minimumNodeCount parameter"
         fi
         semverCompare "$(echo "$OPENEBS_VERSION" | sed 's/v//g')" "$(echo "3.6.0" | sed 's/v//g')"
-        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 3.6.0
+        if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # greater than or equal to 3.6.0
             logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount Parameter)"
             bail "Please use OpenEBS version 3.6.0 or greater, or remove the minimumNodeCount parameter"
         fi

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -913,5 +913,7 @@ function bail_if_automated_storage_scaling_prereqs_not_met() {
         if [ "$SEMVER_COMPARE_RESULT"  = "-1" ]; then # less than or equal to 3.6.0
             logFail "The current OpenEBS version $OPENEBS_VERSION is less than 3.6.0 which is required to use automated storage scaling (minimumNodeCount Parameter)"
             bail "Please use an OpenEBS version higher than 3.6.0 or remove minimumNodeCount Paramenter"
+        fi
+    fi
 }
 

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -530,7 +530,7 @@ function rook_maybe_migrate_from_openebs() {
     if [ -z "$ROOK_VERSION" ] || [ -z "$OPENEBS_VERSION" ]; then
         return 0
     fi
-    if [ -z "$ROOK_MINIMUM_NODE_COUNT" ] || [ "$ROOK_MINIMUM_NODE_COUNT" -le "1" ]; then
+    if [ -z "$ROOK_MINIMUM_NODE_COUNT" ] || [ "$ROOK_MINIMUM_NODE_COUNT" -lt "3" ]; then
         return 0
     fi
     rook_maybe_migrate_from_openebs_internal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Add preflight checks for auto storage scaling. Namely:
- ensure Rook add-on version >= 1.11.7
- ensure openebs add-on version >= 3.6.0
- ensure `minimumNodeCount` is >=3 when previous add-ons are present in the spec


When Rook version is < 1.11.7:
<img width="1049" alt="image" src="https://github.com/replicatedhq/kURL/assets/6497491/7f57deb5-ac0e-47f2-b0ff-8d2e9a5a8a02">

When OpenEBS version is < 3.6.0:
<img width="1064" alt="image" src="https://github.com/replicatedhq/kURL/assets/6497491/a1938d95-858a-4dc4-b073-dadb316419e2">

When minimumNode count is <3:
<img width="1064" alt="image" src="https://github.com/replicatedhq/kURL/assets/6497491/018b2167-88a6-40e5-af36-f1d341e4e262">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
