### PR TITLE
bug: remove references to centos stream repos

### DIFF
--- a/addons/containerd/template/Dockerfile.centos8
+++ b/addons/containerd/template/Dockerfile.centos8
@@ -3,7 +3,6 @@ FROM rockylinux:8.5
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
 RUN yum install -y yum-utils epel-release createrepo
-RUN yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 RUN yum install -y modulemd-tools
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 RUN mkdir -p /packages/archives

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -109,7 +109,6 @@ function createrepo_rhel_8() {
             set -x
             echo -e \"fastestmirror=1\nmax_parallel_downloads=8\" >> /etc/dnf/dnf.conf && \
             yum install -y yum-utils createrepo && \
-            yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/ && \
             yum install -y modulemd-tools && \
             createrepo_c /packages/archives && \
             repo2module --module-name=kurl.local --module-stream=stable /packages/archives /tmp/modules.yaml && \

--- a/bundles/docker-rhel8/Dockerfile
+++ b/bundles/docker-rhel8/Dockerfile
@@ -3,7 +3,6 @@ FROM rockylinux:8
 RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
 RUN yum install -y yum-utils createrepo
-RUN yum-config-manager --add-repo http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 RUN yum install -y modulemd-tools
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 RUN mkdir -p /packages/archives


### PR DESCRIPTION
#### What this PR does / why we need it:

We can't rely on centos stream packages working on RHEL 8 releases. This PR removes all Centos Stream repo references.
