### PR TITLE
feat(rook): Don't deploy Ceph cluster if minimumNodeCount > 2 (instead of > 1)

### DIFF
--- a/addons/rook/1.11.7/install.sh
+++ b/addons/rook/1.11.7/install.sh
@@ -87,7 +87,7 @@ function rook() {
     rook_set_ceph_pool_replicas
     rook_ready_spinner # creating the cluster before the operator is ready fails
 
-    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
+    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "2" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
             log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -87,7 +87,7 @@ function rook() {
     rook_set_ceph_pool_replicas
     rook_ready_spinner # creating the cluster before the operator is ready fails
 
-    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
+    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "2" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
             log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -87,7 +87,7 @@ function rook() {
     rook_set_ceph_pool_replicas
     rook_ready_spinner # creating the cluster before the operator is ready fails
 
-    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
+    if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "2" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
             log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
When eligible for automatic storage scaling (local to distributed), the Rook add-on should not create a Ceph cluster if `minimumNodeCount` > 2. In such case, EKCO will create the Ceph Cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
