### PR TITLE
improve no-subnet-found messaging

### DIFF
--- a/kurl_util/cmd/subnet/main.go
+++ b/kurl_util/cmd/subnet/main.go
@@ -32,12 +32,14 @@ func main() {
 	debug := *debugFlag
 
 	if cidrRange < 1 || cidrRange > 32 {
-		panic(fmt.Sprintf("subnet-size %d invalid", cidrRange))
+		fmt.Printf("cidr-range %d invalid, must be between 1 and 32\n", cidrRange)
+		os.Exit(1)
 	}
 
 	_, subnetAllocRange, err := net.ParseCIDR(*subnetAllocRangeFlag)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to parse subnet-alloc-range cidr"))
+		fmt.Printf("failed to parse subnet-alloc-range cidr: %s\n", err.Error())
+		os.Exit(1)
 	}
 
 	var excludeSubnets []*net.IPNet
@@ -53,7 +55,8 @@ func main() {
 
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to list routes"))
+		fmt.Printf("failed to list routes: %s", err.Error())
+		os.Exit(1)
 	}
 	if debug {
 		for _, route := range routes {
@@ -74,7 +77,8 @@ func main() {
 
 	subnet, err := FindAvailableSubnet(cidrRange, subnetAllocRange, routes, debug)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to find available subnet"))
+		fmt.Printf("failed to find available subnet: %s\n", err.Error())
+		os.Exit(1)
 	}
 
 	fmt.Print(subnet)
@@ -97,7 +101,7 @@ func FindAvailableSubnet(cidrRange int, subnetRange *net.IPNet, routes []netlink
 	for {
 		firstIP, lastIP := cidr.AddressRange(subnet)
 		if !subnetRange.Contains(firstIP) || !subnetRange.Contains(lastIP) {
-			return nil, errors.New("no available subnet found")
+			return nil, fmt.Errorf("no available subnet found within %s", subnet.String())
 		}
 
 		route := findFirstOverlappingRoute(subnet, routes)

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -570,7 +570,11 @@ function discover_pod_subnet() {
         return 0
     fi
 
-    bail "Failed to find available subnet for pod network. Use the pod-cidr flag to set a pod network"
+    if [ -n "$WEAVE_VERSION" ] ; then
+        bail "Failed to find an available /${size} subnet for the pod network within either 10.32.0.0/16 or 10.0.0.0/8. \n  Use Weave's podCIDR parameter to set a pod network that is not already in use. \n  https://kurl.sh/docs/add-ons/weave#advanced-install-options"
+    else
+        bail "Failed to find an available /${size} subnet for the pod network within either 10.32.0.0/16 or 10.0.0.0/8. \n  Use Flannel's podCIDR parameter to set a pod network that is not already in use. \n  https://kurl.sh/docs/add-ons/flannel#advanced-install-options"
+    fi
 }
 
 # This must run after discover_pod_subnet since it excludes the pod cidr
@@ -641,7 +645,7 @@ function discover_service_subnet() {
         return 0
     fi
 
-    bail "Failed to find available subnet for service network. Use the service-cidr flag to set a service network"
+    bail "Failed to find an available /${size} subnet for the service network within either 10.32.0.0/16 or 10.0.0.0/8. \n  Use Kubernetes's serviceCIDR parameter to set a pod network that is not already in use. \n  https://kurl.sh/docs/add-ons/kubernetes#advanced-install-options"
 }
 
 function kubernetes_node_images() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

remove panics from subnet discovery binary

report subnet ranges that were searched

fix 'how to set range manually' messaging, and link to docs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
