### PR TITLE
chore(Rook): Redirect stderr and update log message when checking for CephCluster CR

### DIFF
--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -91,8 +91,8 @@ function rook() {
 
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
-        if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
-            log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"
+        if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
+            log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi
     fi

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -91,8 +91,8 @@ function rook() {
 
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
-        if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
-            log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"
+        if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
+            log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This patch fixes the following output in Rook when `Rook.MinimumNodeCount` is set:
```
2023-07-07 12:39:25+00:00 Awaiting rook-ceph pods
2023-07-07 12:39:29+00:00  [|]   [/]  Error from server (NotFound): cephclusters.ceph.rook.io "rook-ceph" not found
2023-07-07 12:39:29+00:00 Not setting up a Ceph Cluster until there are at least 3 nodes
```
Resource not found error will be suppressed.
The message `Not setting up a Ceph Cluster until there are at least 3 nodes` will be changed to `Rook minimumNodeCount parameter set to 3. Ceph Cluster will be managed by EKCO.`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
