### PR TITLE
chore: add storage-migration-ready-timeout bash flag

### DIFF
--- a/kurl_util/cmd/bashmerge/main.go
+++ b/kurl_util/cmd/bashmerge/main.go
@@ -265,6 +265,8 @@ func parseBashFlags(installer *kurlv1beta1.Installer, bashFlags string) error {
 				installer.Spec.Kurl = &kurlv1beta1.Kurl{}
 			}
 			installer.Spec.Kurl.SkipSystemPackageInstall = true
+		case "storage-migration-ready-timeout":
+			continue
 		case "exclude-builtin-host-preflights", "exclude-builtin-preflights":
 			if installer.Spec.Kurl == nil {
 				installer.Spec.Kurl = &kurlv1beta1.Kurl{}

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1569,3 +1569,11 @@ function get_ekco_storage_migration_auth_token() {
 
     echo "$auth_token"
 }
+
+# determine storage migration ready timeout
+function storage_migration_ready_timeout() {
+    if [ -z "$STORAGE_MIGRATION_READY_TIMEOUT" ]; then
+        STORAGE_MIGRATION_READY_TIMEOUT="10m0s"
+    fi
+    echo "$STORAGE_MIGRATION_READY_TIMEOUT"
+}

--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -568,7 +568,7 @@ function rook_maybe_migrate_from_openebs_internal() {
     fi
 
     # Initiate OpenEBS to Rook multi-node migration
-    if ! "${DIR}"/bin/kurl cluster migrate-multinode-storage --ekco-address "$EKCO_ADDRESS" --ekco-auth-token "$EKCO_AUTH_TOKEN" --assume-yes; then
+    if ! "${DIR}"/bin/kurl cluster migrate-multinode-storage --ekco-address "$EKCO_ADDRESS" --ekco-auth-token "$EKCO_AUTH_TOKEN" --ready-timeout "$(storage_migration_ready_timeout)" --assume-yes; then
         logFail "Failed to migrate from OpenEBS to Rook. The installation will move on."
         logFail "If you would like to run the migration later, run the following command:"
         logFail "    $DIR/bin/kurl cluster migrate-multinode-storage --ekco-address $EKCO_ADDRESS --ekco-auth-token $EKCO_AUTH_TOKEN"

--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -146,6 +146,9 @@ function get_patch_yaml() {
                 ;;
             load-balancer-address)
                 ;;
+            storage-migration-ready-timeout)
+                STORAGE_MIGRATION_READY_TIMEOUT="${_value}"
+                ;;
             # Legacy Command
             preflight-ignore)
                 ;;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Indirectly set the `--ready-timeout` flag for `kurl cluster migrate-multinode-storage` command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
