### PR TITLE
do not require registry IP when joining non-docker nodes

### DIFF
--- a/addons/registry/2.7.1/install.sh
+++ b/addons/registry/2.7.1/install.sh
@@ -179,11 +179,12 @@ function registry_cred_secrets() {
 }
 
 function registry_docker_ca() {
-    if [ -z "$DOCKER_REGISTRY_IP" ]; then
-        bail "Docker registry address required"
-    fi
-
     if [ -n "$DOCKER_VERSION" ]; then
+        if [ -z "$DOCKER_REGISTRY_IP" ]; then
+            bail "Docker registry address required"
+        fi
+
+        log "Gathering CA from server to configure Docker"
         local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
 
         mkdir -p /etc/docker/certs.d/$DOCKER_REGISTRY_IP

--- a/addons/registry/2.8.1/install.sh
+++ b/addons/registry/2.8.1/install.sh
@@ -178,11 +178,12 @@ function registry_cred_secrets() {
 }
 
 function registry_docker_ca() {
-    if [ -z "$DOCKER_REGISTRY_IP" ]; then
-        bail "Docker registry address required"
-    fi
-
     if [ -n "$DOCKER_VERSION" ]; then
+        if [ -z "$DOCKER_REGISTRY_IP" ]; then
+            bail "Docker registry address required"
+        fi
+
+        log "Gathering CA from server to configure Docker"
         local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
 
         mkdir -p /etc/docker/certs.d/$DOCKER_REGISTRY_IP

--- a/addons/registry/2.8.2/install.sh
+++ b/addons/registry/2.8.2/install.sh
@@ -198,11 +198,11 @@ function registry_cred_secrets() {
 }
 
 function registry_docker_ca() {
-    if [ -z "$DOCKER_REGISTRY_IP" ]; then
-        bail "Docker registry address required"
-    fi
-
     if [ -n "$DOCKER_VERSION" ]; then
+        if [ -z "$DOCKER_REGISTRY_IP" ]; then
+            bail "Docker registry address required"
+        fi
+
         log "Gathering CA from server to configure Docker"
         local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
 

--- a/addons/registry/template/base/install.sh
+++ b/addons/registry/template/base/install.sh
@@ -198,11 +198,11 @@ function registry_cred_secrets() {
 }
 
 function registry_docker_ca() {
-    if [ -z "$DOCKER_REGISTRY_IP" ]; then
-        bail "Docker registry address required"
-    fi
-
     if [ -n "$DOCKER_VERSION" ]; then
+        if [ -z "$DOCKER_REGISTRY_IP" ]; then
+            bail "Docker registry address required"
+        fi
+
         log "Gathering CA from server to configure Docker"
         local ca_crt="$(${K8S_DISTRO}_get_server_ca)"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This will allow upgrading k8s and adding docker registry at the same time on clusters using containerd, as the IP was only required for docker clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
