### PR TITLE
Update preflights.sh - RHEL 9.2 Support

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -77,7 +77,7 @@ function bailIfUnsupportedOS() {
             ;;
         ubuntu18.04|ubuntu20.04|ubuntu22.04)
             ;;
-        rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|rhel8.3|rhel8.4|rhel8.5|rhel8.6|rhel8.7|rhel8.8|rhel9.0|rhel9.1)
+        rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|rhel8.3|rhel8.4|rhel8.5|rhel8.6|rhel8.7|rhel8.8|rhel9.0|rhel9.1|rhel9.2)
             ;;
         rocky9.0|rocky9.1|rocky9.2)
             ;;


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds RHEL 9.2 to the supported OS list in preflights.

It's listed as supported here: https://kurl.sh/docs/install-with-kurl/system-requirements

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

## Steps to reproduce

- Spin up a RHEL 9.2 VM
- `curl https://kurl.sh/latest | sudo bash`

#### Does this PR introduce a user-facing change?

N/A

#### Does this PR require documentation?

Docs already state RHEL 9.2 is supported.