### PR TITLE
Change how bash pattern so rhel and rocky are paired

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -77,9 +77,9 @@ function bailIfUnsupportedOS() {
             ;;
         ubuntu18.04|ubuntu20.04|ubuntu22.04)
             ;;
-        rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|rhel8.3|rhel8.4|rhel8.5|rhel8.6|rhel8.7|rhel8.8|rhel9.0|rhel9.1|rhel9.2)
+        rhel7.4|rhel7.5|rhel7.6|rhel7.7|rhel7.8|rhel7.9|rhel8.0|rhel8.1|rhel8.2|rhel8.3|rhel8.4|rhel8.5|rhel8.6|rhel8.7|rhel8.8)
             ;;
-        rocky9.0|rocky9.1|rocky9.2)
+        (rhel|rocky)(9.0|9.1|9.2))
             ;;
         centos7.4|centos7.5|centos7.6|centos7.7|centos7.8|centos7.9|centos8|centos8.0|centos8.1|centos8.2|centos8.3|centos8.4)
             ;;


### PR DESCRIPTION
#### What this PR does / why we need it:

Pairs rhel and rocky preflight pattern so when one is updated the other is as well.


#### Does this PR introduce a user-facing change?

NONE

```release-note
Improves the regex for Rhel and Rocky to ensure that they are paired when new versions are released
```

#### Does this PR require documentation?

NONE