### PR TITLE
feat: Add kurl in-cluster support bundle spec

### DIFF
--- a/scripts/common/kurl.sh
+++ b/scripts/common/kurl.sh
@@ -22,6 +22,31 @@ function kurl_set_current_version() {
     kubectl patch configmaps -n kurl kurl-current-config --type merge -p "{\"data\":{\"kurl-version\":\"${KURL_VERSION}\"}}"
 }
 
+function kurl_install_support_bundle_configmap() {
+    cat <<EOF | kubectl apply -n kurl kurl-current-config -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kurl-supportbundle-spec
+  labels:
+    troubleshoot.io/kind: support-bundle
+stringData:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: kurl
+    spec:
+      collectors:
+        - copyFromHost:
+            collectorName: "copy kURL logs"
+            image: alpine
+            hostPath: "/var/log/kurl/"
+            name: "logs"
+            extractArchive: true
+EOF
+}
+
 function kurl_get_current_version() {
     kubectl get configmap -n kurl kurl-current-config -o jsonpath="{.data.kurl-version}"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -595,6 +595,7 @@ function main() {
     export SUPPORT_BUNDLE_READY=1 # allow ctrl+c and ERR traps to collect support bundles now that k8s is installed
     kurl_init_config
     maybe_set_kurl_cluster_uuid
+    kurl_install_support_bundle_configmap
     ${K8S_DISTRO}_addon_for_each addon_install
     maybe_cleanup_rook
     maybe_cleanup_longhorn

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -211,3 +211,19 @@
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
+- name: "k8s_127x with kurl in-cluster support bundle spec"
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+  postInstallScript: |
+    echo "test whether the kurl support bundle spec was installed"
+    supportBundle=$(kubectl get secrets -n kurl kurl-supportbundle-spec -ojsonpath='{.data.support-bundle-spec}')
+    echo "$supportBundle"
+    echo "test if the content of the secret is a support bundle spec"
+    echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
+    echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
+    kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2645,3 +2645,19 @@
       version: "1.11.x"
   unsupportedOSIDs:
     - centos-74 # Rook 1.11.6 will not be installed due to failed preflight checks.
+- name: "k8s_127x with kurl in-cluster support bundle spec"
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+  postInstallScript: |
+    echo "test whether the kurl support bundle spec was installed"
+    supportBundle=$(kubectl get secrets -n kurl kurl-supportbundle-spec -ojsonpath='{.data.support-bundle-spec}')
+    echo "$supportBundle"
+    echo "test if the content of the secret is a support bundle spec"
+    echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
+    echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
+    kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->
#### What this PR does / why we need it:

This PR adds a change to install an in-cluster support bundle during installation and upgrade of kURL clusters. The support bundle spec is installed in `kurl-supportbundle-spec` secret in the `kurl` namespace. It will be discovered by the `support-bundle` binary whenever the `--load-cluster-specs` option is used

The purpose of having this support bundle spec here is to ensure that we always (assuming `--load-cluster-specs` is passed) get kURL specific collectors and analysers run even if a vendor does not have them specified in their specs, or even if they do not exist in specs provided by Replicated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [79290](https://app.shortcut.com/replicated/story/79290/collect-kurl-installer-logs-from-embedded-clusters-in-the-support-bundle)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
