### PR TITLE
chore: Unable to migrate from OpenEBS to Rook msg should not be an error

### DIFF
--- a/scripts/common/rook.sh
+++ b/scripts/common/rook.sh
@@ -552,7 +552,7 @@ function rook_maybe_migrate_from_openebs_internal() {
     fi
 
     # check if OpenEBS to Rook multi-node migration is available - if it is, prompt the user to start it
-    if "${DIR}"/bin/kurl cluster migrate-multinode-storage --ekco-address "$EKCO_ADDRESS" --ekco-auth-token "$EKCO_AUTH_TOKEN" --check-status; then
+    if cluster_status_msg=$("${DIR}"/bin/kurl cluster migrate-multinode-storage --ekco-address "$EKCO_ADDRESS" --ekco-auth-token "$EKCO_AUTH_TOKEN" --check-status 2>&1); then
         printf "    The installer detected both OpenEBS and Rook installations in your cluster. Migration from OpenEBS to Rook\n"
         printf "    is possible now, but it requires scaling down applications using OpenEBS volumes, causing downtime. You can\n"
         printf "    choose to run the migration later if preferred.\n"
@@ -563,7 +563,7 @@ function rook_maybe_migrate_from_openebs_internal() {
         fi
     else
         # migration is not available, so exit
-        printf "Migration from OpenEBS to Rook is not available\n"
+        printf "Migration from OpenEBS to Rook is not available: %s\n" "$(echo $cluster_status_msg | sed s/'Error: '//)"
         return 0
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
If kURL detects an OpenEBS to Rook migration but the migration requirements are not meant it shouldn't be an error message.

Change the previous message: `Error: cannot begin multi-node storage migration: required number of cluster nodes (3) are not met` to
`Migration from OpenEBS to Rook is not available: cannot begin multi-node storage migration: required number of cluster nodes (3) are not met`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
