### PR TITLE
create the ceph mgr blockpool before making the ceph cluster

### DIFF
--- a/addons/rook/1.11.5/install.sh
+++ b/addons/rook/1.11.5/install.sh
@@ -90,6 +90,7 @@ function rook() {
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
+            kubectl apply -f "$src/mgr-blockpool.yaml"
             log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi

--- a/addons/rook/1.11.5/mgr-blockpool.yaml
+++ b/addons/rook/1.11.5/mgr-blockpool.yaml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  # If the built-in Ceph pool used by the Ceph mgr needs to be configured with alternate
+  # settings, create this pool with any of the pool properties. Create this pool immediately
+  # with the cluster CR, or else some properties may not be applied when Ceph creates the
+  # pool by default.
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
+  # the pool name created in Ceph with this name property.
+  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
+  name: .mgr
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true
+  parameters:
+    compression_mode: none
+  mirroring:
+    enabled: false

--- a/addons/rook/1.11.6/install.sh
+++ b/addons/rook/1.11.6/install.sh
@@ -90,6 +90,7 @@ function rook() {
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph; then
+            kubectl apply -f "$src/mgr-blockpool.yaml"
             log "Not setting up a Ceph Cluster until there are at least ${ROOK_MINIMUM_NODE_COUNT} nodes"
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi

--- a/addons/rook/1.11.6/mgr-blockpool.yaml
+++ b/addons/rook/1.11.6/mgr-blockpool.yaml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  # If the built-in Ceph pool used by the Ceph mgr needs to be configured with alternate
+  # settings, create this pool with any of the pool properties. Create this pool immediately
+  # with the cluster CR, or else some properties may not be applied when Ceph creates the
+  # pool by default.
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
+  # the pool name created in Ceph with this name property.
+  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
+  name: .mgr
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true
+  parameters:
+    compression_mode: none
+  mirroring:
+    enabled: false

--- a/addons/rook/1.11.7/install.sh
+++ b/addons/rook/1.11.7/install.sh
@@ -92,6 +92,7 @@ function rook() {
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
+            kubectl apply -f "$src/mgr-blockpool.yaml"
             log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi

--- a/addons/rook/1.11.7/mgr-blockpool.yaml
+++ b/addons/rook/1.11.7/mgr-blockpool.yaml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  # If the built-in Ceph pool used by the Ceph mgr needs to be configured with alternate
+  # settings, create this pool with any of the pool properties. Create this pool immediately
+  # with the cluster CR, or else some properties may not be applied when Ceph creates the
+  # pool by default.
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
+  # the pool name created in Ceph with this name property.
+  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
+  name: .mgr
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true
+  parameters:
+    compression_mode: none
+  mirroring:
+    enabled: false

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -90,9 +90,9 @@ function rook() {
     rook_ready_spinner # creating the cluster before the operator is ready fails
 
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
-        kubectl apply -f "$src/mgr-blockpool.yaml"
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
+            kubectl apply -f "$src/mgr-blockpool.yaml"
             log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -90,6 +90,7 @@ function rook() {
     rook_ready_spinner # creating the cluster before the operator is ready fails
 
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
+        kubectl apply -f "$src/mgr-blockpool.yaml"
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
             log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."

--- a/addons/rook/1.11.8/mgr-blockpool.yaml
+++ b/addons/rook/1.11.8/mgr-blockpool.yaml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  # If the built-in Ceph pool used by the Ceph mgr needs to be configured with alternate
+  # settings, create this pool with any of the pool properties. Create this pool immediately
+  # with the cluster CR, or else some properties may not be applied when Ceph creates the
+  # pool by default.
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
+  # the pool name created in Ceph with this name property.
+  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
+  name: .mgr
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true
+  parameters:
+    compression_mode: none
+  mirroring:
+    enabled: false

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -92,6 +92,7 @@ function rook() {
     if [ -n "$ROOK_MINIMUM_NODE_COUNT" ] && [ "$ROOK_MINIMUM_NODE_COUNT" -gt "1" ]; then
         # check if there is already a CephCluster - if there is, this code should manage it
         if ! kubectl get cephcluster -n rook-ceph rook-ceph >/dev/null 2>&1; then
+            kubectl apply -f "$src/mgr-blockpool.yaml"
             log "Rook minimumNodeCount parameter set to ${ROOK_MINIMUM_NODE_COUNT}. Ceph Cluster will be managed by EKCO."
             return 0 # do not create a ceph cluster if it should instead be managed by ekco
         fi

--- a/addons/rook/template/base/mgr-blockpool.yaml
+++ b/addons/rook/template/base/mgr-blockpool.yaml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  # If the built-in Ceph pool used by the Ceph mgr needs to be configured with alternate
+  # settings, create this pool with any of the pool properties. Create this pool immediately
+  # with the cluster CR, or else some properties may not be applied when Ceph creates the
+  # pool by default.
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  # The required pool name with underscores cannot be specified as a K8s resource name, thus we override
+  # the pool name created in Ceph with this name property.
+  # The ".mgr" pool is called "device_health_metrics" in Ceph versions v16.x.y and below.
+  name: .mgr
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true
+  parameters:
+    compression_mode: none
+  mirroring:
+    enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When the ekco operator creates the cephcluster for automated storage migrations, it the `.mgr` pool is created with one replica. This should force it to use 3 replicas.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
