### PR TITLE
chore: Update storage migration test to support Rook 1.12

### DIFF
--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -662,6 +662,8 @@
     minio:
       version: latest
   postInstallScript: |
+    # wait for ekco to scale up the Ceph cluster
+    while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -55,7 +55,7 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: Migrate from Rook 1.11.x to OpenEBS + Minio
+- name: Migrate from Rook 1.12.x to OpenEBS + Minio
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -71,7 +71,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -261,7 +261,7 @@
       echo Rook namespace should NOT be removed after the upgrade. MinIO is NOT selected
       exit 1
     fi
-- name: Migrate from Rook 1.11.x to OpenEBS (S3 disabled)
+- name: Migrate from Rook 1.12.x to OpenEBS (S3 disabled)
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -275,7 +275,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -513,7 +513,7 @@
     #    echo  Rook Data directory not removed.
     #    exit 1
     # fi
-- name: Migrate from Rook 1.8.x to Rook 1.11.x
+- name: Migrate from Rook 1.8.x to Rook 1.12.x
   flags: "yes"
   cpu: 4
   numPrimaryNodes: 1
@@ -547,7 +547,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
   postInstallScript: |
     # wait for ekco to scale up the Ceph cluster
     while [ "$(kubectl -n rook-ceph get pod --no-headers -l app=rook-ceph-osd | wc -l)" != "3" ]; do sleep 10 ; done
@@ -568,7 +568,7 @@
     #    echo  Rook Data directory not removed.
     #    exit 1
     # fi
-- name: Migrate from Longhorn + Minio to Rook 1.11.x
+- name: Migrate from Longhorn + Minio to Rook 1.12.x
   flags: "yes"
   cpu: 4
   numPrimaryNodes: 1
@@ -604,7 +604,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
@@ -682,7 +682,7 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
-- name: Migrate from Rook 1.11.x to OpenEBS + Minio (multi-node)
+- name: Migrate from Rook 1.12.x to OpenEBS + Minio (multi-node)
   flags: "yes"
   cpu: 4
   numPrimaryNodes: 1
@@ -701,7 +701,7 @@
     ekco:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
   upgradeSpec:
     kubernetes:
       version: 1.26.x
@@ -800,7 +800,7 @@
       echo Longhorn namespace found after the upgrade.
       exit 1
     fi
-- name: Migrate from Rook 1.11.x to OpenEBS 3.4.0 with localpv migrate
+- name: Migrate from Rook 1.12.x to OpenEBS 3.4.0 with localpv migrate
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -810,7 +810,7 @@
     containerd:
       version: latest
     rook:
-      version: 1.11.x
+      version: 1.12.x
     kotsadm:
       version: latest
   upgradeSpec:
@@ -1444,7 +1444,7 @@
     minio:
       version: latest
     rook:
-      version: 1.11.8
+      version: 1.12.0
       minimumNodeCount: 3
     goldpinger:
       version: latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Update storage migration testsuite to use newest version of Rook, `1.12.0`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
