### PR TITLE
migrate from longhorn to openebs, then upgrade k8s past 1.24

### DIFF
--- a/addons/openebs/3.7.0/install.sh
+++ b/addons/openebs/3.7.0/install.sh
@@ -410,11 +410,19 @@ function openebs_prompt_migrate_from_longhorn() {
 
     semverParse "$KUBERNETES_VERSION"
     if [ "$minor" -gt 24 ] ; then
-        logFail "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
-        logFail "    on your cluster. As a result, it is not possible to migrate data from Longhorn to OpenEBS. To successfully migrate data, please choose a Kubernetes"
-        logFail "    version that is compatible with the version of Longhorn running on your cluster (note: Longhorn is compatible with Kubernetes versions up to and"
-        logFail "    including 1.24)."
-        bail "Not migrating"
+        logWarn ""
+        logWarn "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
+        logWarn "    on your cluster. Because of this, we will install OpenEBS and migrate your data from Longhorn before upgrading Kubernetes."
+
+        log "Would you like to continue? "
+        if ! confirmN; then
+            bail "Not migrating"
+        fi
+
+        longhorn_prepare_for_migration
+        addon_install "openebs" "$OPENEBS_VERSION"
+        maybe_cleanup_longhorn
+        return
     fi
 
     log "Would you like to continue? "

--- a/addons/openebs/3.7.0/install.sh
+++ b/addons/openebs/3.7.0/install.sh
@@ -420,7 +420,9 @@ function openebs_prompt_migrate_from_longhorn() {
         fi
 
         longhorn_prepare_for_migration
+        report_addon_start "openebs-preinstall" "$OPENEBS_VERSION"
         addon_install "openebs" "$OPENEBS_VERSION"
+        report_addon_success "openebs-preinstall" "$OPENEBS_VERSION"
         maybe_cleanup_longhorn
         return
     fi

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -410,11 +410,19 @@ function openebs_prompt_migrate_from_longhorn() {
 
     semverParse "$KUBERNETES_VERSION"
     if [ "$minor" -gt 24 ] ; then
-        logFail "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
-        logFail "    on your cluster. As a result, it is not possible to migrate data from Longhorn to OpenEBS. To successfully migrate data, please choose a Kubernetes"
-        logFail "    version that is compatible with the version of Longhorn running on your cluster (note: Longhorn is compatible with Kubernetes versions up to and"
-        logFail "    including 1.24)."
-        bail "Not migrating"
+        logWarn ""
+        logWarn "    It appears that the Kubernetes version you are attempting to install ($KUBERNETES_VERSION) is incompatible with the version of Longhorn currently installed"
+        logWarn "    on your cluster. Because of this, we will install OpenEBS and migrate your data from Longhorn before upgrading Kubernetes."
+
+        log "Would you like to continue? "
+        if ! confirmN; then
+            bail "Not migrating"
+        fi
+
+        longhorn_prepare_for_migration
+        addon_install "openebs" "$OPENEBS_VERSION"
+        maybe_cleanup_longhorn
+        return
     fi
 
     log "Would you like to continue? "

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -420,7 +420,9 @@ function openebs_prompt_migrate_from_longhorn() {
         fi
 
         longhorn_prepare_for_migration
+        report_addon_start "openebs-preinstall" "$OPENEBS_VERSION"
         addon_install "openebs" "$OPENEBS_VERSION"
+        report_addon_success "openebs-preinstall" "$OPENEBS_VERSION"
         maybe_cleanup_longhorn
         return
     fi

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -290,6 +290,12 @@
     pvc_uses_provisioner "migration-test" "default" "openebs"
     # pulls the image we pushed before the migration.
     test_pull_image_from_registry
+    
+    # ensure that longhorn has been removed
+    if kubectl get ns | grep -q longhorn-system; then
+      echo "longhorn-system namespace still exists"
+      exit 1
+    fi
 
 - name: localpv upgrade from latest
   flags: "yes"
@@ -333,3 +339,73 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+
+
+- name: localpv migrate from longhorn with kubernetes upgrade
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.9"
+    flannel:
+      version: "latest"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    prometheus:
+      version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
+    registry:
+      version: "2.8.1"
+    longhorn:
+      version: "1.3.1"
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: "latest"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    prometheus:
+      version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
+    registry:
+      version: "2.8.1"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    # create a deployment using the longhorn storage class ("default" namespace).
+    create_deployment_with_mounted_volume "migration-test" "default" "/data"
+    # generate a random file and copies it to the pod deployed by the previously created deployment.
+    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    # pushes an image to the internal registry.
+    test_push_image_to_registry
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    # sleep for a while to guarantee that the pod has been scaled up.
+    sleep 120
+    # downloads the previously stored file and compares, expecting to see the same content.
+    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+    # makes sure that the new pvc is being provisioned by openebs.
+    pvc_uses_provisioner "migration-test" "default" "openebs"
+    # pulls the image we pushed before the migration.
+    test_pull_image_from_registry
+    
+    # ensure that kubernetes has upgraded
+    k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
+    echo $k8sVersion | grep 1.25
+    
+    # ensure that longhorn has been removed
+    if kubectl get ns | grep -q longhorn-system; then
+      echo "longhorn-system namespace still exists"
+      exit 1
+    fi

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -389,6 +389,9 @@
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     # pushes an image to the internal registry.
     test_push_image_to_registry
+    
+    sleep 60
+    kubectl get pods -A
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     # sleep for a while to guarantee that the pod has been scaled up.

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -1,344 +1,344 @@
-#- name: basic localpv
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: openebs
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#
-#- name: localpv upgrade from 2.6.0
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.21.x" # this is the latest version of k8s that supports openebs 2.6
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "2020-01-25T02-50-51Z"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "2.6.0"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.22.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#
-#- name: airgap localpv
-#  airgap: true
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: openebs
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#
-#- name: localpv upgrade from 1.12.0
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
-#    weave:
-#      version: latest
-#    docker:
-#      version: "latest"
-#    minio:
-#      version: "2020-01-25T02-50-51Z"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "1.12.0"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.21.x"
-#    weave:
-#      version: latest
-#    docker:
-#      version: "latest"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#  unsupportedOSIDs:
-#  - rocky-91 # docker is not supported on rhel 9 variants
-#
-#- name: localpv migrate from Rook 1.0.4 with old versions
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.19.x" # this is the latest version of k8s that supports rook 1.0.4
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    rook:
-#      version: "1.0.x"
-#    kotsadm:
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.21.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: openebs
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rook_ceph_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    echo "Verify if rook-ceph namespace was removed after upgrade"
-#    if kubectl get namespace/rook-ceph ; then
-#       echo "Namespace rook-ceph was not removed"
-#       exit 1
-#    else
-#       echo "Namespace rook-ceph was removed"
-#    fi
-#
-#- name: localpv migrate from rook 1.10.x and from k8s 1.24.x
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.24.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    rook:
-#      version: "1.10.x"
-#    kotsadm:
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.26.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: openebs
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#  unsupportedOSIDs:
-#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rook_ceph_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    echo "Verify if rook-ceph namespace was removed after upgrade"
-#    if kubectl get namespace/rook-ceph ; then
-#       echo "Namespace rook-ceph was not removed"
-#       exit 1
-#    else
-#       echo "Namespace rook-ceph was removed"
-#    fi
-#
-#- name: localpv migrate from longhorn
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.24.9"
-#    flannel:
-#      version: "latest"
-#    containerd:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    prometheus:
-#      version: "0.60.1-41.7.3"
-#    minio:
-#      version: "latest"
-#    registry:
-#      version: "2.8.1"
-#    longhorn:
-#      version: "1.3.1"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.24.9"
-#    flannel:
-#      version: "latest"
-#    containerd:
-#      version: "latest"
-#    ekco:
-#      version: "latest"
-#    prometheus:
-#      version: "0.60.1-41.7.3"
-#    minio:
-#      version: "latest"
-#    registry:
-#      version: "2.8.1"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: openebs
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    # create a deployment using the longhorn storage class ("default" namespace).
-#    create_deployment_with_mounted_volume "migration-test" "default" "/data"
-#    # generate a random file and copies it to the pod deployed by the previously created deployment.
-#    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-#    # pushes an image to the internal registry.
-#    test_push_image_to_registry
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    # sleep for a while to guarantee that the pod has been scaled up.
-#    sleep 120
-#    # downloads the previously stored file and compares, expecting to see the same content.
-#    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
-#    # makes sure that the new pvc is being provisioned by openebs.
-#    pvc_uses_provisioner "migration-test" "default" "openebs"
-#    # pulls the image we pushed before the migration.
-#    test_pull_image_from_registry
-#
-#    # ensure that longhorn has been removed
-#    if kubectl get ns | grep -q longhorn-system; then
-#      echo "longhorn-system namespace still exists"
-#      exit 1
-#    fi
-#
-#- name: localpv upgrade from latest
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "2020-01-25T02-50-51Z"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "latest"
-#    minio:
-#      version: "latest"
-#    kotsadm:
-#      version: "latest"
-#    openebs:
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#      namespace: openebs
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
+- name: basic localpv
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+- name: localpv upgrade from 2.6.0
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.21.x" # this is the latest version of k8s that supports openebs 2.6
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "2020-01-25T02-50-51Z"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "2.6.0"
+  upgradeSpec:
+    kubernetes:
+      version: "1.22.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+
+- name: airgap localpv
+  airgap: true
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+
+- name: localpv upgrade from 1.12.0
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
+    weave:
+      version: latest
+    docker:
+      version: "latest"
+    minio:
+      version: "2020-01-25T02-50-51Z"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "1.12.0"
+  upgradeSpec:
+    kubernetes:
+      version: "1.21.x"
+    weave:
+      version: latest
+    docker:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - rocky-91 # docker is not supported on rhel 9 variants
+
+- name: localpv migrate from Rook 1.0.4 with old versions
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.19.x" # this is the latest version of k8s that supports rook 1.0.4
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    rook:
+      version: "1.0.x"
+    kotsadm:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.21.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    echo "Verify if rook-ceph namespace was removed after upgrade"
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1
+    else
+       echo "Namespace rook-ceph was removed"
+    fi
+
+- name: localpv migrate from rook 1.10.x and from k8s 1.24.x
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    rook:
+      version: "1.10.x"
+    kotsadm:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.26.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rook_ceph_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    echo "Verify if rook-ceph namespace was removed after upgrade"
+    if kubectl get namespace/rook-ceph ; then
+       echo "Namespace rook-ceph was not removed"
+       exit 1
+    else
+       echo "Namespace rook-ceph was removed"
+    fi
+
+- name: localpv migrate from longhorn
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.24.9"
+    flannel:
+      version: "latest"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    prometheus:
+      version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
+    registry:
+      version: "2.8.1"
+    longhorn:
+      version: "1.3.1"
+  upgradeSpec:
+    kubernetes:
+      version: "1.24.9"
+    flannel:
+      version: "latest"
+    containerd:
+      version: "latest"
+    ekco:
+      version: "latest"
+    prometheus:
+      version: "0.60.1-41.7.3"
+    minio:
+      version: "latest"
+    registry:
+      version: "2.8.1"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: openebs
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    # create a deployment using the longhorn storage class ("default" namespace).
+    create_deployment_with_mounted_volume "migration-test" "default" "/data"
+    # generate a random file and copies it to the pod deployed by the previously created deployment.
+    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+    # pushes an image to the internal registry.
+    test_push_image_to_registry
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    # sleep for a while to guarantee that the pod has been scaled up.
+    sleep 120
+    # downloads the previously stored file and compares, expecting to see the same content.
+    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+    # makes sure that the new pvc is being provisioned by openebs.
+    pvc_uses_provisioner "migration-test" "default" "openebs"
+    # pulls the image we pushed before the migration.
+    test_pull_image_from_registry
+
+    # ensure that longhorn has been removed
+    if kubectl get ns | grep -q longhorn-system; then
+      echo "longhorn-system namespace still exists"
+      exit 1
+    fi
+
+- name: localpv upgrade from latest
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "2020-01-25T02-50-51Z"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "latest"
+    minio:
+      version: "latest"
+    kotsadm:
+      version: "latest"
+    openebs:
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+      namespace: openebs
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
 
 
 - name: localpv migrate from longhorn with kubernetes upgrade

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -1,344 +1,344 @@
-- name: basic localpv
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: openebs
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-
-- name: localpv upgrade from 2.6.0
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.21.x" # this is the latest version of k8s that supports openebs 2.6
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "2020-01-25T02-50-51Z"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "2.6.0"
-  upgradeSpec:
-    kubernetes:
-      version: "1.22.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-
-- name: airgap localpv
-  airgap: true
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: openebs
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-
-- name: localpv upgrade from 1.12.0
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
-    weave:
-      version: latest
-    docker:
-      version: "latest"
-    minio:
-      version: "2020-01-25T02-50-51Z"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "1.12.0"
-  upgradeSpec:
-    kubernetes:
-      version: "1.21.x"
-    weave:
-      version: latest
-    docker:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
-
-- name: localpv migrate from Rook 1.0.4 with old versions
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.19.x" # this is the latest version of k8s that supports rook 1.0.4
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    rook:
-      version: "1.0.x"
-    kotsadm:
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: "1.21.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: openebs
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rook_ceph_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-    echo "Verify if rook-ceph namespace was removed after upgrade"
-    if kubectl get namespace/rook-ceph ; then
-       echo "Namespace rook-ceph was not removed"
-       exit 1 
-    else
-       echo "Namespace rook-ceph was removed"
-    fi
-
-- name: localpv migrate from rook 1.10.x and from k8s 1.24.x
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.24.x" 
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    rook:
-      version: "1.10.x"
-    kotsadm:
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: "1.26.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: openebs
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rook_ceph_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt    
-    echo "Verify if rook-ceph namespace was removed after upgrade"
-    if kubectl get namespace/rook-ceph ; then
-       echo "Namespace rook-ceph was not removed"
-       exit 1 
-    else
-       echo "Namespace rook-ceph was removed"
-    fi
-
-- name: localpv migrate from longhorn
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.24.9"
-    flannel:
-      version: "latest"
-    containerd:
-      version: "latest"
-    ekco:
-      version: "latest"
-    prometheus:
-      version: "0.60.1-41.7.3"
-    minio:
-      version: "latest"
-    registry:
-      version: "2.8.1"
-    longhorn:
-      version: "1.3.1"
-  upgradeSpec:
-    kubernetes:
-      version: "1.24.9"
-    flannel:
-      version: "latest"
-    containerd:
-      version: "latest"
-    ekco:
-      version: "latest"
-    prometheus:
-      version: "0.60.1-41.7.3"
-    minio:
-      version: "latest"
-    registry:
-      version: "2.8.1"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: openebs
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    # create a deployment using the longhorn storage class ("default" namespace).
-    create_deployment_with_mounted_volume "migration-test" "default" "/data"
-    # generate a random file and copies it to the pod deployed by the previously created deployment.
-    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
-    # pushes an image to the internal registry.
-    test_push_image_to_registry
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    # sleep for a while to guarantee that the pod has been scaled up.
-    sleep 120
-    # downloads the previously stored file and compares, expecting to see the same content.
-    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
-    # makes sure that the new pvc is being provisioned by openebs.
-    pvc_uses_provisioner "migration-test" "default" "openebs"
-    # pulls the image we pushed before the migration.
-    test_pull_image_from_registry
-    
-    # ensure that longhorn has been removed
-    if kubectl get ns | grep -q longhorn-system; then
-      echo "longhorn-system namespace still exists"
-      exit 1
-    fi
-
-- name: localpv upgrade from latest
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "2020-01-25T02-50-51Z"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "latest"
-    minio:
-      version: "latest"
-    kotsadm:
-      version: "latest"
-    openebs:
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-      namespace: openebs
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
+#- name: basic localpv
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: openebs
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#
+#- name: localpv upgrade from 2.6.0
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.21.x" # this is the latest version of k8s that supports openebs 2.6
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "2020-01-25T02-50-51Z"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "2.6.0"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.22.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#
+#- name: airgap localpv
+#  airgap: true
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: openebs
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#
+#- name: localpv upgrade from 1.12.0
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.21.x" # this is the latest version of k8s that supports openebs 1.12
+#    weave:
+#      version: latest
+#    docker:
+#      version: "latest"
+#    minio:
+#      version: "2020-01-25T02-50-51Z"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "1.12.0"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.21.x"
+#    weave:
+#      version: latest
+#    docker:
+#      version: "latest"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#  unsupportedOSIDs:
+#  - rocky-91 # docker is not supported on rhel 9 variants
+#
+#- name: localpv migrate from Rook 1.0.4 with old versions
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.19.x" # this is the latest version of k8s that supports rook 1.0.4
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    rook:
+#      version: "1.0.x"
+#    kotsadm:
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.21.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: openebs
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rook_ceph_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    echo "Verify if rook-ceph namespace was removed after upgrade"
+#    if kubectl get namespace/rook-ceph ; then
+#       echo "Namespace rook-ceph was not removed"
+#       exit 1
+#    else
+#       echo "Namespace rook-ceph was removed"
+#    fi
+#
+#- name: localpv migrate from rook 1.10.x and from k8s 1.24.x
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.24.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    rook:
+#      version: "1.10.x"
+#    kotsadm:
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.26.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: openebs
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#  unsupportedOSIDs:
+#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rook_ceph_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    echo "Verify if rook-ceph namespace was removed after upgrade"
+#    if kubectl get namespace/rook-ceph ; then
+#       echo "Namespace rook-ceph was not removed"
+#       exit 1
+#    else
+#       echo "Namespace rook-ceph was removed"
+#    fi
+#
+#- name: localpv migrate from longhorn
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.24.9"
+#    flannel:
+#      version: "latest"
+#    containerd:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    prometheus:
+#      version: "0.60.1-41.7.3"
+#    minio:
+#      version: "latest"
+#    registry:
+#      version: "2.8.1"
+#    longhorn:
+#      version: "1.3.1"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.24.9"
+#    flannel:
+#      version: "latest"
+#    containerd:
+#      version: "latest"
+#    ekco:
+#      version: "latest"
+#    prometheus:
+#      version: "0.60.1-41.7.3"
+#    minio:
+#      version: "latest"
+#    registry:
+#      version: "2.8.1"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: openebs
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    # create a deployment using the longhorn storage class ("default" namespace).
+#    create_deployment_with_mounted_volume "migration-test" "default" "/data"
+#    # generate a random file and copies it to the pod deployed by the previously created deployment.
+#    create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
+#    # pushes an image to the internal registry.
+#    test_push_image_to_registry
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    # sleep for a while to guarantee that the pod has been scaled up.
+#    sleep 120
+#    # downloads the previously stored file and compares, expecting to see the same content.
+#    download_file_from_deployment_and_compare "migration-test" "default" "./test.data" "/data/test.data"
+#    # makes sure that the new pvc is being provisioned by openebs.
+#    pvc_uses_provisioner "migration-test" "default" "openebs"
+#    # pulls the image we pushed before the migration.
+#    test_pull_image_from_registry
+#
+#    # ensure that longhorn has been removed
+#    if kubectl get ns | grep -q longhorn-system; then
+#      echo "longhorn-system namespace still exists"
+#      exit 1
+#    fi
+#
+#- name: localpv upgrade from latest
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "2020-01-25T02-50-51Z"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "latest"
+#    minio:
+#      version: "latest"
+#    kotsadm:
+#      version: "latest"
+#    openebs:
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#      namespace: openebs
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
 
 
 - name: localpv migrate from longhorn with kubernetes upgrade
@@ -392,6 +392,7 @@
     
     sleep 60
     kubectl get pods -A
+    kubectl get pod -n kurl -o jsonpath='{.status.reason}'
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     # sleep for a while to guarantee that the pod has been scaled up.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This would install openebs, migrate from longhorn, delete longhorn, and only then upgrade k8s past what longhorn supported

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix an issue where storage could not be moved from Longhorn to OpenEBS at the same time as Kubernetes was upgraded to 1.25.x+
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
