### PR TITLE
chore: Update containerd add-on tests to exclude Rock 9.2

### DIFF
--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -74,7 +74,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerSpec:
@@ -135,7 +135,7 @@
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
-  - rocky-91 # docker is not supported on rhel 9 variants
+  - rocky-92 # docker is not supported on rhel 9 variants
 
 - name: Upgrade Containerd from 1.4.x to __testver__
   installerSpec:
@@ -192,7 +192,7 @@
   - centos-79
   - ol-79
   - ubuntu-2204
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 
 - name: Upgrade Containerd from 1.5.x to __testver__
   installerSpec:
@@ -233,7 +233,7 @@
   postUpgradeScript: |
     containerd --version | grep "__testver__"
   unsupportedOSIDs:
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 
 - name: "Upgrade Containerd from current to __testver__"
   installerSpec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Containerd+Docker tests were _explicitly_ failing because of outdated unsupported info. These tests should be excluded for latest Rocky 9.2 release.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
