### PR TITLE
fix: Add /etc/kubernetes/audit.yaml to remote primary nodes if not present on Kubernetes upgrades

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -37,6 +37,14 @@ maybe_upgrade() {
     local kubeletMajor="$major"
     local kubeletMinor="$minor"
     local kubeletPatch="$patch"
+    local kustomize_kubeadm_init="$DIR/kustomize/kubeadm/init"
+
+    # ensure that /etc/kubernetes/audit.yaml exists
+    if [ -f "$kustomize_kubeadm_init/audit.yaml" ] && [ ! -f /etc/kubernetes/audit.yaml ]; then
+        cp $kustomize_kubeadm_init/audit.yaml /etc/kubernetes/audit.yaml
+    fi
+    # ensure audit log directory exists
+    mkdir -p /var/log/apiserver
 
     if [ -n "$HOSTNAME_CHECK" ]; then
         if [ "$HOSTNAME_CHECK" != "$(get_local_node_name)" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

When performing a Kubernetes upgrade using a kURL version after [v2022.03.23-0](https://github.com/replicatedhq/kURL/releases/tag/v2022.03.23-0), which introduced a [change](https://github.com/replicatedhq/kURL/pull/2757/files#diff-b01438ad103068260412ebc5ec8b9fcba3c55ba2be041cb963565f2d212e85eb) to the destination of audit logs, the upgrade on remote primary nodes will fail if /etc/kubernetes/audit.yaml does not exist:

```sh
⚙  Kubernetes version v1.20.15 detected, upgrading node to version v1.21.14
+ kubeadm upgrade node
[upgrade] Reading configuration from the cluster...
[upgrade] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
[preflight] Running pre-flight checks
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[upgrade] Upgrading your Static Pod-hosted control plane instance to version "v1.20.15"...
Static pod: kube-apiserver-rafael-swimlane-audit-yaml-bug-repro-3b hash: 7fb2325f2a1542c8b0bc1f1c92bb99df
Static pod: kube-controller-manager-rafael-swimlane-audit-yaml-bug-repro-3b hash: 61f973905d90a5dc3adda42429669ba1
Static pod: kube-scheduler-rafael-swimlane-audit-yaml-bug-repro-3b hash: e8f872f9a07112e96e684366d7248982
[upgrade/etcd] Upgrading to TLS for etcd
Static pod: etcd-rafael-swimlane-audit-yaml-bug-repro-3b hash: dde454c197ce79fd9955bc9136f4a275
[upgrade/staticpods] Preparing for "etcd" upgrade
[upgrade/staticpods] Current and new manifests of etcd are equal, skipping upgrade
[upgrade/etcd] Waiting for etcd to become available
[upgrade/staticpods] Writing new Static Pod manifests to "/etc/kubernetes/tmp/kubeadm-upgraded-manifests224700499"
[upgrade/staticpods] Preparing for "kube-apiserver" upgrade
[upgrade/staticpods] Renewing apiserver certificate
[upgrade/staticpods] Renewing apiserver-kubelet-client certificate
[upgrade/staticpods] Renewing front-proxy-client certificate
[upgrade/staticpods] Renewing apiserver-etcd-client certificate
[upgrade/staticpods] Moved new manifest to "/etc/kubernetes/manifests/kube-apiserver.yaml" and backed up old manifest to "/etc/kubernetes/tmp/kubeadm-backup-manifests-2023-08-08-06-02-43/kube-apiserver.yaml"
[upgrade/staticpods] Waiting for the kubelet to restart the component
[upgrade/staticpods] This might take a minute or longer depending on the component/version gap (timeout 5m0s)
[apiclient] Found 2 Pods for label selector component=kube-apiserver
error execution phase control-plane: couldn't complete the static pod upgrade: couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: timed out waiting for the condition
To see the stack trace of this error execute with --v=5 or higher
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
See story [comment](https://app.shortcut.com/replicated/story/83964/audit-logs-don-t-exist-for-old-clusters-that-are-being-upgraded#activity-85101)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the control plane would not get upgraded on remote primary nodes due to /etc/kubernetes/audit.yaml file missing
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
