### PR TITLE
chore: Retry Ekco Api Calls for migrate-multinode-storage cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/itchyny/gojq v0.12.13
 	github.com/longhorn/longhorn-manager v1.4.1
 	github.com/mattn/go-isatty v0.0.19
@@ -140,7 +141,6 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.9 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,8 @@ github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
-github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
-github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=

--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ func NewClusterMigrateMultinodeStorageCmd(cli CLI) *cobra.Command {
 // getEkcoMigrationLogs returns the logs of the migration as reported back by ekco.
 func getEkcoMigrationLogs(opts migrateOpts) (string, error) {
 	url := fmt.Sprintf("http://%s/storagemigration/logs", opts.ekcoAddress)
-	resp, err := http.Get(url)
+	resp, err := retryablehttp.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to get migration logs: %w", err)
 	}
@@ -77,7 +78,7 @@ func getEkcoMigrationLogs(opts migrateOpts) (string, error) {
 // getEkcoMigrationStatus returns the status of the storage migration as reported back by ekco.
 func getEkcoMigrationStatus(opts migrateOpts) (string, error) {
 	url := fmt.Sprintf("http://%s/storagemigration/status", opts.ekcoAddress)
-	resp, err := http.Get(url)
+	resp, err := retryablehttp.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to get migration status: %w", err)
 	}
@@ -107,7 +108,7 @@ type MigrationReadyStatus struct {
 
 func isClusterReadyForStorageMigration(opts migrateOpts) (*ClusterReadyStatus, error) {
 	url := fmt.Sprintf("http://%s/storagemigration/cluster-ready", opts.ekcoAddress)
-	resp, err := http.Get(url)
+	resp, err := retryablehttp.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ekco cluster ready status: %w", err)
 	}
@@ -129,7 +130,7 @@ func isClusterReadyForStorageMigration(opts migrateOpts) (*ClusterReadyStatus, e
 
 func isEkcoReadyForStorageMigration(opts migrateOpts) (*MigrationReadyStatus, error) {
 	url := fmt.Sprintf("http://%s/storagemigration/ready", opts.ekcoAddress)
-	resp, err := http.Get(url)
+	resp, err := retryablehttp.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ekco status: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Make Ekco api calls resilient to transient network failures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Default retry configuration: https://github.com/hashicorp/go-retryablehttp/blob/v0.7.4/client.go#L50-L53

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
