### PR TITLE
do not log http requests made with retryClient

### DIFF
--- a/pkg/cli/cluster_migrate_multinode_storage.go
+++ b/pkg/cli/cluster_migrate_multinode_storage.go
@@ -130,7 +130,10 @@ func isClusterReadyForStorageMigration(opts migrateOpts) (*ClusterReadyStatus, e
 
 func isEkcoReadyForStorageMigration(opts migrateOpts) (*MigrationReadyStatus, error) {
 	url := fmt.Sprintf("http://%s/storagemigration/ready", opts.ekcoAddress)
-	resp, err := retryablehttp.Get(url)
+	retryClient := retryablehttp.NewClient()
+	retryClient.Logger = nil
+	retryClient.RetryMax = 5
+	resp, err := retryClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ekco status: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Currently, the logs waiting to run a storage migration look like this:
```

2023-08-15 14:03:54+00:00 2023/08/15 14:03:54 cluster reporting ready for migration: ceph cluster was Progressing, not ready
2023-08-15 14:03:59+00:00 2023/08/15 14:03:59 [DEBUG] GET http://172.18.0.17:31880/storagemigration/ready
2023-08-15 14:03:59+00:00 2023/08/15 14:03:59 cluster reporting ready for migration: ceph cluster was Progressing, not ready
2023-08-15 14:04:04+00:00 2023/08/15 14:04:04 [DEBUG] GET http://172.18.0.17:31880/storagemigration/ready
2023-08-15 14:04:04+00:00 2023/08/15 14:04:04 cluster reporting ready for migration: ceph cluster was Progressing, not ready
2023-08-15 14:04:09+00:00 2023/08/15 14:04:09 [DEBUG] GET http://172.18.0.17:31880/storagemigration/ready
```

The 'DEBUG' lines should not be present.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
