### PR TITLE
don't use removed 'kubectl version --short' command

### DIFF
--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.2/install.sh
+++ b/addons/rook/1.11.2/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.3/install.sh
+++ b/addons/rook/1.11.3/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.4/install.sh
+++ b/addons/rook/1.11.4/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.5/install.sh
+++ b/addons/rook/1.11.5/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.6/install.sh
+++ b/addons/rook/1.11.6/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.7/install.sh
+++ b/addons/rook/1.11.7/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.12.0/install.sh
+++ b/addons/rook/1.12.0/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.12.1/install.sh
+++ b/addons/rook/1.12.1/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -7,7 +7,7 @@ function rook_pre_init() {
         export SKIP_ROOK_INSTALL='true'
         if [ "$version" = "1.0.4" ] && [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
             KUBERNETES_UPGRADE="0"
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -26,7 +26,7 @@ function rook_pre_init() {
                 SKIP_ROOK_INSTALL=1
                 if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
                     KUBERNETES_UPGRADE="0"
-                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
                     parse_kubernetes_target_version
                     # There's no guarantee the packages from this version of Kubernetes are still available
                     SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.5.10/install.sh
+++ b/addons/rook/1.5.10/install.sh
@@ -26,7 +26,7 @@ function rook_pre_init() {
                 SKIP_ROOK_INSTALL=1
                 if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
                     KUBERNETES_UPGRADE="0"
-                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
                     parse_kubernetes_target_version
                     # There's no guarantee the packages from this version of Kubernetes are still available
                     SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -26,7 +26,7 @@ function rook_pre_init() {
                 SKIP_ROOK_INSTALL=1
                 if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
                     KUBERNETES_UPGRADE="0"
-                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
                     parse_kubernetes_target_version
                     # There's no guarantee the packages from this version of Kubernetes are still available
                     SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -26,7 +26,7 @@ function rook_pre_init() {
                 SKIP_ROOK_INSTALL=1
                 if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
                     KUBERNETES_UPGRADE="0"
-                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
                     parse_kubernetes_target_version
                     # There's no guarantee the packages from this version of Kubernetes are still available
                     SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -26,7 +26,7 @@ function rook_pre_init() {
                 SKIP_ROOK_INSTALL=1
                 if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ]; then
                     KUBERNETES_UPGRADE="0"
-                    KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+                    KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
                     parse_kubernetes_target_version
                     # There's no guarantee the packages from this version of Kubernetes are still available
                     SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -12,7 +12,7 @@ function rook_pre_init() {
         if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge 20 ] && [ "$current_version" = "1.0.4" ]; then
             export KUBERNETES_UPGRADE=0
             export KUBERNETES_VERSION
-            KUBERNETES_VERSION=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+            KUBERNETES_VERSION=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
             parse_kubernetes_target_version
             # There's no guarantee the packages from this version of Kubernetes are still available
             export SKIP_KUBERNETES_HOST=1

--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -365,7 +365,7 @@ function join_token() {
     fi
 
     # get the kubernetes version
-    local kubernetes_version=$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')
+    local kubernetes_version=$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')
 
     local service_cidr=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.service_cidr }')
     local pod_cidr=$(kubectl -n kube-system get cm kurl-config -ojsonpath='{ .data.pod_cidr }')

--- a/testgrid/specs/customer-migration-specs.yaml
+++ b/testgrid/specs/customer-migration-specs.yaml
@@ -69,7 +69,7 @@
     fi
 
     # ensure kubernetes was upgraded
-    if [[ ! "$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')" =~ "1.27" ]]; then
+    if [[ ! "$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')" =~ "1.27" ]]; then
       echo "Kubernetes was not upgraded to 1.27.x"
       exit 1
     fi
@@ -149,7 +149,7 @@
     fi
 
     # ensure kubernetes was upgraded
-    if [[ ! "$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')" =~ "1.27" ]]; then
+    if [[ ! "$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')" =~ "1.27" ]]; then
       echo "Kubernetes was not upgraded to 1.27.x"
       exit 1
     fi
@@ -231,7 +231,7 @@
     fi
 
     # ensure kubernetes was upgraded
-    if [[ ! "$(kubectl version --short | grep -i server | awk '{ print $3 }' | sed 's/^v*//')" =~ "1.27" ]]; then
+    if [[ ! "$(kubectl get nodes --sort-by='{.status.nodeInfo.kubeletVersion}' -o=jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' | sed 's/^v*//')" =~ "1.27" ]]; then
       echo "Kubernetes was not upgraded to 1.27.x"
       exit 1
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Kubernetes 1.28 removed the '--short' flag from kubectl version, so we need a replacement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
