### PR TITLE
chore: adding test for hostpreflight installer merge

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2744,6 +2744,7 @@
                 - warn:
                     message: \"Unexpected response\"" > /opt/kurl-testgrid/patchfile.yaml
   postInstallScript: |
+    kubectl get installer -A -o yaml | grep replicated.app
     mkdir -p /opt/kurl-testgrid/
     echo "apiVersion: cluster.kurl.sh/v1beta1
     kind: Installer
@@ -2781,3 +2782,5 @@
                       message: Port 8888 is available
                   - warn:
                       message: Unexpected port status" > /opt/kurl-testgrid/patchfile.yaml
+  postUpgradeScript: |
+    kubectl get installer -A -o yaml | grep 8888

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -2698,3 +2698,86 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
+- name: merge-installer-hostpreflight-and-upgrade
+  installerSpec:
+    kubernetes:
+      version: 1.28.x
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.28.x
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+  preInstallScript: |
+    mkdir -p /opt/kurl-testgrid/
+    echo "apiVersion: cluster.kurl.sh/v1beta1
+    kind: Installer
+    metadata:
+      name: installer
+    spec:
+      kurl:
+        hostPreflights:
+          apiVersion: troubleshoot.sh/v1beta2
+          kind: HostPreflight
+          spec:
+            collectors:
+            - http:
+                collectorName: Can Access Replicated API
+                get:
+                  url: https://replicated.app
+            analyzers:
+            - http:
+                checkName: Can Access Replicated API
+                collectorName: Can Access Replicated API
+                outcomes:
+                - warn:
+                    when: \"error\"
+                    message: Error connecting to https://replicated.app
+                - pass:
+                    when: \"statusCode == 200\"
+                    message: Connected to https://replicated.app
+                - warn:
+                    message: \"Unexpected response\"" > /opt/kurl-testgrid/patchfile.yaml
+  postInstallScript: |
+    mkdir -p /opt/kurl-testgrid/
+    echo "apiVersion: cluster.kurl.sh/v1beta1
+    kind: Installer
+    metadata:
+      name: installer
+    spec:
+      kurl:
+        hostPreflights:
+          apiVersion: troubleshoot.sh/v1beta2
+          kind: HostPreflight
+          spec:
+            collectors:
+            - tcpPortStatus:
+                collectorName: \"Checks port 8888 is available\"
+                port: 8888
+            analyzers:
+            - tcpPortStatus:
+                checkName: \"Checks port 8888 is available\"
+                collectorName: \"Checks port 8888 is available\"
+                outcomes:
+                  - fail:
+                      when: \"connection-refused\"
+                      message: Connection to port 8888 was refused.
+                  - warn:
+                      when: \"address-in-use\"
+                      message: Another process was already listening on port 8888.
+                  - fail:
+                      when: \"connection-timeout\"
+                      message: Timed out connecting to port 8888.
+                  - fail:
+                      when: \"error\"
+                      message: Unexpected port status
+                  - pass:
+                      when: \"connected\"
+                      message: Port 8888 is available
+                  - warn:
+                      message: Unexpected port status" > /opt/kurl-testgrid/patchfile.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:

current stable kurl version does not work when we attempt to install and patch the installer providing a custom hostpreflight. this is what happens when we have attempt to patch the installer `installer-spec-file` flag:

```
$ cat patch.yaml
apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: installer
spec:
  kurl:
    hostPreflights:
      apiVersion: troubleshoot.sh/v1beta2
      kind: HostPreflight
      spec:
        collectors:
        - http:
            collectorName: Can Access Replicated API
            get:
              url: https://replicated.app
        analyzers:
        - http:
            checkName: Can Access Replicated API
            collectorName: Can Access Replicated API
            outcomes:
            - warn:
                when: "error"
                message: Error connecting to https://replicated.app
            - pass:
                when: "statusCode == 200"
                message: Connected to https://replicated.app
            - warn:
                message: "Unexpected response"
$ curl https://kurl.sh/29035ee | sudo bash -s installer-spec-file=./patch.yaml
<redacted>
✔ Cluster Initialized
secret/kurl-troubleshoot-spec created
customresourcedefinition.apiextensions.k8s.io/installers.cluster.kurl.sh created
installer.cluster.kurl.sh/29035ee created

Error from server (BadRequest): error when creating "/tmp/kurl-bin-utils/specs/merged.yaml": Installer in version "v1beta1" cannot be handled as a Installer: strict decoding error: unknown field "spec.kurl.hostPreflights.metadata.creationTimestamp"
spent 1m attempting to run "kubectl apply -f /tmp/kurl-bin-utils/specs/merged.yaml" without success
```

this problem has been fixed by https://github.com/replicatedhq/kURL/pull/4792 and this pr adds some tests to validate that:

1) we can install providing a custom host preflight.
2) once the cluster has been installed we can upgrade using a custom host preflight.