### PR TITLE
move restic removal to normal install codepath

### DIFF
--- a/addons/velero/1.11.1/install.sh
+++ b/addons/velero/1.11.1/install.sh
@@ -85,6 +85,8 @@ function velero() {
         velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
         kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
     fi
+
+    spinner_until 120 deployment_fully_updated velero velero
 }
 
 function velero_join() {

--- a/addons/velero/1.11.1/install.sh
+++ b/addons/velero/1.11.1/install.sh
@@ -47,6 +47,11 @@ function velero() {
 
     velero_change_storageclass "$src" "$dst"
 
+    # Remove restic resources since they've been replaced by node agent
+    kubectl delete daemonset -n "$VELERO_NAMESPACE" restic --ignore-not-found
+    kubectl delete secret -n "$VELERO_NAMESPACE" velero-restic-credentials --ignore-not-found
+    kubectl delete crd resticrepositories.velero.io --ignore-not-found
+
     # If we already migrated, or we on a new install that has the disableS3 flag set, we need a PVC attached
     if kubernetes_resource_exists "$VELERO_NAMESPACE" pvc velero-internal-snapshots || [ "$KOTSADM_DISABLE_S3" == "1" ]; then
         velero_patch_internal_pvc_snapshots "$src" "$dst"
@@ -88,7 +93,7 @@ function velero_join() {
 }
 
 function velero_host_init() {
-    velero_install_nfs_utils_if_missing 
+    velero_install_nfs_utils_if_missing
 }
 
 function velero_install_nfs_utils_if_missing() {
@@ -159,7 +164,7 @@ function velero_install() {
         --namespace $VELERO_NAMESPACE \
         --plugins velero/velero-plugin-for-aws:v1.7.1,velero/velero-plugin-for-gcp:v1.7.1,velero/velero-plugin-for-microsoft-azure:v1.7.1,replicated/local-volume-provider:v0.5.4,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
-        --dry-run -o yaml > "$dst/velero.yaml" 
+        --dry-run -o yaml > "$dst/velero.yaml"
 
     rm -f velero-credentials
 }
@@ -169,7 +174,7 @@ function velero_already_applied() {
     local src="$DIR/addons/velero/$VELERO_VERSION"
     local dst="$DIR/kustomize/velero"
 
-    # If we need to migrate, we're going to need to basically reconstruct the original install 
+    # If we need to migrate, we're going to need to basically reconstruct the original install
     # underneath the migration
     if velero_should_migrate_from_object_store; then
 
@@ -177,7 +182,7 @@ function velero_already_applied() {
 
         determine_velero_pvc_size
 
-        velero_binary 
+        velero_binary
         velero_install "$src" "$dst"
         velero_patch_node_agent_privilege "$src" "$dst"
         velero_patch_args "$src" "$dst"
@@ -195,11 +200,6 @@ function velero_already_applied() {
     if [ -f "$dst/kustomization.yaml" ]; then
         kubectl apply -k "$dst"
     fi
-
-    # Remove restic resources since they've been replaced by node agent
-    kubectl delete daemonset -n "$VELERO_NAMESPACE" restic --ignore-not-found
-    kubectl delete secret -n "$VELERO_NAMESPACE" velero-restic-credentials --ignore-not-found
-    kubectl delete crd resticrepositories.velero.io --ignore-not-found
 
     # Bail if the migration fails, preventing the original object store from being deleted
     if velero_did_migrate_from_object_store; then

--- a/addons/velero/template/base/install.tmpl.sh
+++ b/addons/velero/template/base/install.tmpl.sh
@@ -85,6 +85,8 @@ function velero() {
         velero_pv_name=$(kubectl get pvc velero-internal-snapshots -n ${VELERO_NAMESPACE} -ojsonpath='{.spec.volumeName}')
         kubectl patch pv "$velero_pv_name" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
     fi
+
+    spinner_until 120 deployment_fully_updated velero velero
 }
 
 function velero_join() {

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,24 +1,24 @@
-- name: "Velero Minimal"
-  cpu: 6
-  installerSpec:
-    kubernetes:
-      version: "1.27.x"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
+#- name: "Velero Minimal"
+#  cpu: 6
+#  installerSpec:
+#    kubernetes:
+#      version: "1.27.x"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
 #- name: "Velero Minimal Airgap"
 #  cpu: 6
 #  airgap: true
@@ -134,48 +134,48 @@
 #    timeout 5m kubectl kots backup
 #    timeout 5m kubectl kots backup ls
 #
-#- name: "Velero remove restic"
-#  cpu: 8
-#  installerSpec:
-#    kubernetes:
-#      version: "1.27.x"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    velero:
-#      version: "1.9.x"
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.27.x"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    kubectl get pods -n velero
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#    # if restic pods are still running, fail the test
-#    if kubectl get pods -n velero | grep restic; then
-#      echo "Restic pods still running after upgrade"
-#      exit 1
-#    fi
-#
+- name: "Velero remove restic"
+  cpu: 8
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "1.9.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    kubectl get pods -n velero
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+    # if restic pods are still running, fail the test
+    if kubectl get pods -n velero | grep restic; then
+      echo "Restic pods still running after upgrade"
+      exit 1
+    fi
+

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,139 +1,139 @@
-#- name: "Velero Minimal"
-#  cpu: 6
-#  installerSpec:
-#    kubernetes:
-#      version: "1.27.x"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#- name: "Velero Minimal Airgap"
-#  cpu: 6
-#  airgap: true
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    registry:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#- name: "Velero DisableS3 - Rook"
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: "1.5.x"
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#      disableS3: true
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#- name: "Velero OpenEBS only"
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    containerd:
-#      version: "latest"
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    minio:
-#      version: "latest"
-#- name: "Velero Remove Object Storage"
-#  cpu: 8
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: latest
-#    velero:
-#      version: 1.9.x
-#    ekco:
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.24.x
-#    flannel:
-#      version: latest
-#    longhorn:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#      disableS3: true
-#    containerd:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    ekco:
-#      version: "latest"
-#  unsupportedOSIDs:
-#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
-#
+- name: "Velero Minimal"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero Minimal Airgap"
+  cpu: 6
+  airgap: true
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    registry:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero DisableS3 - Rook"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    rook:
+      version: "1.5.x"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+      disableS3: true
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero OpenEBS only"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    containerd:
+      version: "latest"
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+- name: "Velero Remove Object Storage"
+  cpu: 8
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: latest
+    velero:
+      version: 1.9.x
+    ekco:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: 1.24.x
+    flannel:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    ekco:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+
 - name: "Velero remove restic"
   cpu: 8
   installerSpec:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -5,7 +5,7 @@
     flannel:
       version: latest
     rook:
-      version: "1.10.x"
+      version: 1.12.x
     containerd:
       version: "latest"
     kotsadm:
@@ -26,7 +26,7 @@
     flannel:
       version: latest
     rook:
-      version: "1.10.x"
+      version: 1.12.x
     containerd:
       version: "latest"
     kotsadm:
@@ -90,7 +90,6 @@
     flannel:
       version: latest
     rook:
-      isBlockStorageEnabled: true
       version: 1.12.x
     registry:
       version: latest
@@ -140,7 +139,7 @@
     flannel:
       version: latest
     rook:
-      version: "1.10.x"
+      version: 1.12.x
     containerd:
       version: "latest"
     kotsadm:
@@ -153,7 +152,7 @@
     flannel:
       version: latest
     rook:
-      version: "1.10.x"
+      version: 1.12.x
     containerd:
       version: "latest"
     kotsadm:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,136 +1,138 @@
-#- name: "Velero Minimal"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.27.x"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    kubectl kots backup
-#    kubectl kots backup ls
-#- name: "Velero Minimal Airgap"
-#  airgap: true
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    registry:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    kubectl kots backup
-#    kubectl kots backup ls
-#- name: "Velero DisableS3 - Rook"
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: "1.5.x"
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#      disableS3: true
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    kubectl kots backup
-#    kubectl kots backup ls
-#- name: "Velero OpenEBS only"
-#  installerSpec:
-#    kubernetes:
-#      version: "latest"
-#    flannel:
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    containerd:
-#      version: "latest"
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    minio:
-#      version: "latest"
-#- name: "Velero Remove Object Storage"
-#  cpu: 8
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: latest
-#    velero:
-#      version: 1.9.x
-#    ekco:
-#      version: "latest"
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.24.x
-#    flannel:
-#      version: latest
-#    longhorn:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#      disableS3: true
-#    containerd:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    ekco:
-#      version: "latest"
-#  unsupportedOSIDs:
-#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    kubectl kots backup
-#    kubectl kots backup ls
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    kubectl kots backup
-#    kubectl kots backup ls
+- name: "Velero Minimal"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero Minimal Airgap"
+  cpu: 6
+  airgap: true
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    registry:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero DisableS3 - Rook"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    rook:
+      version: "1.5.x"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+      disableS3: true
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+- name: "Velero OpenEBS only"
+  installerSpec:
+    kubernetes:
+      version: "latest"
+    flannel:
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    containerd:
+      version: "latest"
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    minio:
+      version: "latest"
+- name: "Velero Remove Object Storage"
+  cpu: 8
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: latest
+    velero:
+      version: 1.9.x
+    ekco:
+      version: "latest"
+  upgradeSpec:
+    kubernetes:
+      version: 1.24.x
+    flannel:
+      version: latest
+    longhorn:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+      disableS3: true
+    containerd:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    ekco:
+      version: "latest"
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
 
 - name: "Velero remove restic"
   cpu: 8
@@ -166,12 +168,12 @@
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     install_and_customize_kurl_integration_test_application
-    kubectl kots backup
-    kubectl kots backup ls
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    kubectl kots backup
-    kubectl kots backup ls
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
     kubectl get pods -n velero
     # if restic pods are still running, fail the test
     if kubectl get pods -n velero | grep restic; then

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -5,7 +5,7 @@
     flannel:
       version: latest
     rook:
-      version: "latest"
+      version: "1.10.x"
     containerd:
       version: "latest"
     kotsadm:
@@ -26,7 +26,7 @@
     flannel:
       version: latest
     rook:
-      version: "latest"
+      version: "1.10.x"
     containerd:
       version: "latest"
     kotsadm:
@@ -140,7 +140,7 @@
     flannel:
       version: latest
     rook:
-      version: "latest"
+      version: "1.10.x"
     containerd:
       version: "latest"
     kotsadm:
@@ -153,7 +153,7 @@
     flannel:
       version: latest
     rook:
-      version: "latest"
+      version: "1.10.x"
     containerd:
       version: "latest"
     kotsadm:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -132,3 +132,48 @@
     source /opt/kurl-testgrid/testhelpers.sh
     kubectl kots backup
     kubectl kots backup ls
+
+- name: "Velero remove restic"
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: "latest"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "1.9.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: "latest"
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    kubectl kots backup
+    kubectl kots backup ls
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    kubectl kots backup
+    kubectl kots backup ls
+    kubectl get pods -n velero
+    # if restic pods are still running, fail the test
+    if kubectl get pods -n velero | grep restic; then
+      echo "Restic pods still running after upgrade"
+      exit 1
+    fi
+    

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -133,6 +133,7 @@
 #    kubectl kots backup ls
 
 - name: "Velero remove restic"
+  cpu: 8
   installerSpec:
     kubernetes:
       version: "1.27.x"

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,24 +1,24 @@
-#- name: "Velero Minimal"
-#  cpu: 6
-#  installerSpec:
-#    kubernetes:
-#      version: "1.27.x"
-#    flannel:
-#      version: latest
-#    rook:
-#      version: 1.12.x
-#    containerd:
-#      version: "latest"
-#    kotsadm:
-#      version: latest
-#    velero:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    install_and_customize_kurl_integration_test_application
-#    timeout 5m kubectl kots backup
-#    timeout 5m kubectl kots backup ls
+- name: "Velero Minimal"
+  cpu: 6
+  installerSpec:
+    kubernetes:
+      version: "1.27.x"
+    flannel:
+      version: latest
+    rook:
+      version: 1.12.x
+    containerd:
+      version: "latest"
+    kotsadm:
+      version: latest
+    velero:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    install_and_customize_kurl_integration_test_application
+    timeout 5m kubectl kots backup
+    timeout 5m kubectl kots backup ls
 #- name: "Velero Minimal Airgap"
 #  cpu: 6
 #  airgap: true
@@ -133,51 +133,49 @@
 #    source /opt/kurl-testgrid/testhelpers.sh
 #    timeout 5m kubectl kots backup
 #    timeout 5m kubectl kots backup ls
-
-- name: "Velero remove restic"
-  cpu: 8
-  installerSpec:
-    kubernetes:
-      version: "1.27.x"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    registry:
-      version: latest
-    velero:
-      version: "1.9.x"
-  upgradeSpec:
-    kubernetes:
-      version: "1.27.x"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    kubectl get pods -n velero
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-    # if restic pods are still running, fail the test
-    if kubectl get pods -n velero | grep restic; then
-      echo "Restic pods still running after upgrade"
-      exit 1
-    fi
-    
+#
+#- name: "Velero remove restic"
+#  cpu: 8
+#  installerSpec:
+#    kubernetes:
+#      version: "1.27.x"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    velero:
+#      version: "1.9.x"
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.27.x"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    kubectl get pods -n velero
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#    # if restic pods are still running, fail the test
+#    if kubectl get pods -n velero | grep restic; then
+#      echo "Restic pods still running after upgrade"
+#      exit 1
+#    fi
+#

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,138 +1,138 @@
-- name: "Velero Minimal"
-  cpu: 6
-  installerSpec:
-    kubernetes:
-      version: "1.27.x"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-- name: "Velero Minimal Airgap"
-  cpu: 6
-  airgap: true
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    registry:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-- name: "Velero DisableS3 - Rook"
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    rook:
-      version: "1.5.x"
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-      disableS3: true
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-- name: "Velero OpenEBS only"
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    containerd:
-      version: "latest"
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    minio:
-      version: "latest"
-- name: "Velero Remove Object Storage"
-  cpu: 8
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: latest
-    velero:
-      version: 1.9.x
-    ekco:
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: 1.24.x
-    flannel:
-      version: latest
-    longhorn:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-      disableS3: true
-    containerd:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    ekco:
-      version: "latest"
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    timeout 5m kubectl kots backup
-    timeout 5m kubectl kots backup ls
+#- name: "Velero Minimal"
+#  cpu: 6
+#  installerSpec:
+#    kubernetes:
+#      version: "1.27.x"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#- name: "Velero Minimal Airgap"
+#  cpu: 6
+#  airgap: true
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    registry:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#- name: "Velero DisableS3 - Rook"
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: "1.5.x"
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#      disableS3: true
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#- name: "Velero OpenEBS only"
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    containerd:
+#      version: "latest"
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    minio:
+#      version: "latest"
+#- name: "Velero Remove Object Storage"
+#  cpu: 8
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: latest
+#    velero:
+#      version: 1.9.x
+#    ekco:
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.24.x
+#    flannel:
+#      version: latest
+#    longhorn:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#      disableS3: true
+#    containerd:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    ekco:
+#      version: "latest"
+#  unsupportedOSIDs:
+#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    timeout 5m kubectl kots backup
+#    timeout 5m kubectl kots backup ls
 
 - name: "Velero remove restic"
   cpu: 8
@@ -172,9 +172,9 @@
     timeout 5m kubectl kots backup ls
   postUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
+    kubectl get pods -n velero
     timeout 5m kubectl kots backup
     timeout 5m kubectl kots backup ls
-    kubectl get pods -n velero
     # if restic pods are still running, fail the test
     if kubectl get pods -n velero | grep restic; then
       echo "Restic pods still running after upgrade"

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -1,136 +1,136 @@
-- name: "Velero Minimal"
-  installerSpec:
-    kubernetes:
-      version: "1.27.x"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    kubectl kots backup
-    kubectl kots backup ls
-- name: "Velero Minimal Airgap"
-  airgap: true
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-    registry:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    kubectl kots backup
-    kubectl kots backup ls
-- name: "Velero DisableS3 - Rook"
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    rook:
-      version: "1.5.x"
-    containerd:
-      version: "latest"
-    kotsadm:
-      version: latest
-      disableS3: true
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    kubectl kots backup
-    kubectl kots backup ls
-- name: "Velero OpenEBS only"
-  installerSpec:
-    kubernetes:
-      version: "latest"
-    flannel:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    containerd:
-      version: "latest"
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    minio:
-      version: "latest"
-- name: "Velero Remove Object Storage"
-  cpu: 8
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    flannel:
-      version: latest
-    rook:
-      version: 1.12.x
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: latest
-    velero:
-      version: 1.9.x
-    ekco:
-      version: "latest"
-  upgradeSpec:
-    kubernetes:
-      version: 1.24.x
-    flannel:
-      version: latest
-    longhorn:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-      disableS3: true
-    containerd:
-      version: latest
-    velero:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    ekco:
-      version: "latest"
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    install_and_customize_kurl_integration_test_application
-    kubectl kots backup
-    kubectl kots backup ls
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    kubectl kots backup
-    kubectl kots backup ls
+#- name: "Velero Minimal"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.27.x"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    kubectl kots backup
+#    kubectl kots backup ls
+#- name: "Velero Minimal Airgap"
+#  airgap: true
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#    registry:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    kubectl kots backup
+#    kubectl kots backup ls
+#- name: "Velero DisableS3 - Rook"
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    rook:
+#      version: "1.5.x"
+#    containerd:
+#      version: "latest"
+#    kotsadm:
+#      version: latest
+#      disableS3: true
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    kubectl kots backup
+#    kubectl kots backup ls
+#- name: "Velero OpenEBS only"
+#  installerSpec:
+#    kubernetes:
+#      version: "latest"
+#    flannel:
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    containerd:
+#      version: "latest"
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    minio:
+#      version: "latest"
+#- name: "Velero Remove Object Storage"
+#  cpu: 8
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    flannel:
+#      version: latest
+#    rook:
+#      version: 1.12.x
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: latest
+#    velero:
+#      version: 1.9.x
+#    ekco:
+#      version: "latest"
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.24.x
+#    flannel:
+#      version: latest
+#    longhorn:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#      disableS3: true
+#    containerd:
+#      version: latest
+#    velero:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    ekco:
+#      version: "latest"
+#  unsupportedOSIDs:
+#    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    install_and_customize_kurl_integration_test_application
+#    kubectl kots backup
+#    kubectl kots backup ls
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    kubectl kots backup
+#    kubectl kots backup ls
 
 - name: "Velero remove restic"
   installerSpec:
@@ -143,6 +143,8 @@
     containerd:
       version: "latest"
     kotsadm:
+      version: latest
+    registry:
       version: latest
     velero:
       version: "1.9.x"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Velero 1.11.1+ properly removes the legacy restic daemonset upon upgrade
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
