### PR TITLE
all docker-on-rhel-8 installs should receive an 'unsupported' warning

### DIFF
--- a/scripts/common/docker.sh
+++ b/scripts/common/docker.sh
@@ -63,8 +63,11 @@ function docker_install() {
     case "$LSB_DIST" in
     centos|rhel|ol)
         if [ "${DIST_VERSION_MAJOR}" = "8" ] && ! is_docker_version_supported ; then
-            rpm_force_install_host_packages "${DIR}/packages/docker/${DOCKER_VERSION}" "docker-ce-${DOCKER_VERSION}" "docker-ce-cli-${DOCKER_VERSION}"
-            export DID_INSTALL_DOCKER=1
+            # only forcibly install docker before 19.03.15 on centos/rhel 8 - other versions can use the normal install path
+            if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
+                rpm_force_install_host_packages "${DIR}/packages/docker/${DOCKER_VERSION}" "docker-ce-${DOCKER_VERSION}" "docker-ce-cli-${DOCKER_VERSION}"
+                export DID_INSTALL_DOCKER=1
+            fi
         fi
         ;;
     esac
@@ -81,9 +84,7 @@ function is_docker_version_supported() {
     case "$LSB_DIST" in
     centos|rhel|ol)
         if [ "${DIST_VERSION_MAJOR}" = "8" ] && [ -n "$DOCKER_VERSION" ]; then
-            if [ "$DOCKER_VERSION" = "18.09.8" ] || [ "$DOCKER_VERSION" = "19.03.4" ] || [ "$DOCKER_VERSION" = "19.03.10" ]; then
-                return 1
-            fi
+            return 1
         fi
         ;;
     esac


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The `is_docker_version_supported` function is also, funnily enough, used to determine whether we should print a 'docker is unsupported here' message, which we want to keep on all rhel 8 docker installs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
