### PR TITLE
bug: weave to flannel migration wrong task command flag

### DIFF
--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.4/install.sh
+++ b/addons/flannel/0.21.4/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.22.0/install.sh
+++ b/addons/flannel/0.22.0/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.22.1/install.sh
+++ b/addons/flannel/0.22.1/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.22.2/install.sh
+++ b/addons/flannel/0.22.2/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/0.22.3/install.sh
+++ b/addons/flannel/0.22.3/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -414,11 +414,11 @@ function weave_to_flannel() {
         printf "${worker_node_names}\n"
 
         if [ "$AIRGAP" = "1" ]; then
-            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
+            printf "\n\t${GREEN}cat ./tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
         else
             local prefix=
             prefix="$(build_installer_prefix "${INSTALLER_ID}" "${KURL_VERSION}" "${KURL_URL}" "${PROXY_ADDRESS}" "${PROXY_HTTPS_ADDRESS}")"
-            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary airgap${NC}\n\n"
+            printf "\n\t${GREEN}${prefix}tasks.sh | sudo bash -s weave-to-flannel-secondary${NC}\n\n"
         fi
 
         printf "${YELLOW}Once this has been run on all nodes, press enter to continue.${NC}"


### PR DESCRIPTION
#### What this PR does / why we need it:
when migrating from weave to flannel the flannel add-on was asking users to run a `task.sh` command with the `airgap` flag set in an environment with internet access.

this commit fixes it by inverting the logic: only ask for `airgap` when in a disconnected enfironment.


#### Does this PR introduce a user-facing change?
```release-note
Fixes wrong airgap flag usage on weave to flannel migration on connected environment.
```