### PR TITLE
supply 'yes' flag to remote node commands

### DIFF
--- a/scripts/common/addon.sh
+++ b/scripts/common/addon.sh
@@ -309,7 +309,7 @@ function addon_outro() {
         if [ "$AIRGAP" = "1" ]; then
             local command=
             command=$(printf "cat ./upgrade.sh | sudo bash -s airgap${common_flags}")
-            echo "$command" > "$DIR/remotes/allnodes"
+            echo "$command yes" > "$DIR/remotes/allnodes"
 
             printf "\n\t${GREEN}%s${NC}\n\n" "$command"
         else
@@ -318,7 +318,7 @@ function addon_outro() {
 
             local command=
             command=$(printf "${prefix}upgrade.sh | sudo bash -s${common_flags}")
-            echo "$command" > "$DIR/remotes/allnodes"
+            echo "$command yes" > "$DIR/remotes/allnodes"
 
             printf "\n\t${GREEN}%s${NC}\n\n" "$command"
         fi

--- a/scripts/common/upgrade.sh
+++ b/scripts/common/upgrade.sh
@@ -522,7 +522,7 @@ function upgrade_kubernetes_remote_node() {
     if [ "$AIRGAP" = "1" ]; then
         local command=
         command=$(printf "cat ./upgrade.sh | sudo bash -s airgap kubernetes-version=%s%s" "$targetK8sVersion" "$common_flags")
-        echo "$command" > "$DIR/remotes/$nodeName"
+        echo "$command yes" > "$DIR/remotes/$nodeName"
         printf "\t%b%s%b\n\n" "$GREEN" "$command" "$NC"
     else
         local prefix=
@@ -530,7 +530,7 @@ function upgrade_kubernetes_remote_node() {
 
         local command=
         command=$(printf "%supgrade.sh | sudo bash -s kubernetes-version=%s%s" "$prefix" "$targetK8sVersion" "$common_flags")
-        echo "$command" > "$DIR/remotes/$nodeName"
+        echo "$command yes" > "$DIR/remotes/$nodeName"
 
         printf "\t%b %s%b\n\n" "$GREEN" "$command" "$NC"
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Not all upgrade commands (ex: weave to flannel) can take the 'yes' flag, so we need to supply it when required instead of having it supplied everywhere

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
