### PR TITLE
print the kurl pods, and list the unhealthy ones, when failing the ns preflight

### DIFF
--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -39,7 +39,8 @@ function bail_if_kurl_pods_are_unhealthy() {
         fi
         log "Awaiting 2 minutes to check kURL Pod(s) are Running"
         if ! spinner_until 120 check_for_running_pods kurl; then
-            bail "Kurl has unhealthy Pod(s). Check the namespace kurl. Restarting the pod may fix the issue."
+            kubectl get pods -n kurl
+            bail "Kurl has unhealthy Pod(s) $UNHEALTHY_PODS. Restarting the pod may fix the issue."
         fi
     fi
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
