### PR TITLE
bug: completed should be considered an ok state

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1169,7 +1169,7 @@ function check_for_running_pods() {
             continue
         fi
 
-        if [ "$status" != "Running" ] && [ "$status" != "Succeeded" ]; then
+        if [ "$status" != "Running" ] && [ "$status" != "Succeeded" ] && [ "$status" != "Completed" ]; then
             unhealthy_podnames="$unhealthy_podnames $pod"
             continue
         fi


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

when verifying if all pods in the kurl namespace are in good shape we were considering pods in completed state as pods not healthy. this commit addresses this.

