### PR TITLE
use k8s 1.27 style patches based on current k8s version not target version

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -29,9 +29,15 @@ function insert_patches_strategic_merge() {
     local kustomization_file="$1"
     local patch_file="$2"
 
+    # we care about the current kubernetes version here, not the target version - this function can be called from pre-init addons
+    local kubeletVersion=
+    kubeletVersion="$(kubelet_version)"
+    semverParse "$kubeletVersion"
+    local kubeletMinor="$minor"
+
     # Kubernetes 1.27 uses kustomize v5 which dropped support for old, legacy style patches
     # See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1270
-    if [ "$KUBERNETES_TARGET_VERSION_MINOR" -ge "27" ]; then
+    if [ "$kubeletMinor" -ge "27" ]; then
         if [[ $kustomization_file =~ "prometheus" ]] || [[ $kustomization_file =~ "rook" ]]; then
             # TODO: multi-doc patches is not currently supported in kustomize v5
             # continue using the deprecated 'patchesStrategicMerge' field until this is fixed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

If you migrate from longhorn or rook on old k8s (found in 1.19) to openebs + minio on k8s 1.27+, minio install fails due to bad patches because it's being installed onto k8s 1.19 and not 1.27 like this code expects

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
