### PR TITLE
wait for the openebs deployment to be ready when installing

### DIFF
--- a/addons/openebs/3.8.0/install.sh
+++ b/addons/openebs/3.8.0/install.sh
@@ -185,6 +185,9 @@ function openebs_apply_operator() {
     logStep "Waiting for OpenEBS CustomResourceDefinitions to be ready"
     spinner_until 120 kubernetes_resource_exists default crd blockdevices.openebs.io
 
+    logStep "Waiting for the OpenEBS Operator to be ready"
+    spinner_until 300 deployment_fully_updated openebs openebs-localpv-provisioner
+
     openebs_cleanup_kubesystem
     logSuccess "OpenEBS CustomResourceDefinitions are ready"
 }

--- a/addons/openebs/3.9.0/install.sh
+++ b/addons/openebs/3.9.0/install.sh
@@ -185,6 +185,9 @@ function openebs_apply_operator() {
     logStep "Waiting for OpenEBS CustomResourceDefinitions to be ready"
     spinner_until 120 kubernetes_resource_exists default crd blockdevices.openebs.io
 
+    logStep "Waiting for the OpenEBS Operator to be ready"
+    spinner_until 300 deployment_fully_updated openebs openebs-localpv-provisioner
+
     openebs_cleanup_kubesystem
     logSuccess "OpenEBS CustomResourceDefinitions are ready"
 }

--- a/addons/openebs/template/base/install.sh
+++ b/addons/openebs/template/base/install.sh
@@ -185,6 +185,9 @@ function openebs_apply_operator() {
     logStep "Waiting for OpenEBS CustomResourceDefinitions to be ready"
     spinner_until 120 kubernetes_resource_exists default crd blockdevices.openebs.io
 
+    logStep "Waiting for the OpenEBS Operator to be ready"
+    spinner_until 300 deployment_fully_updated openebs openebs-localpv-provisioner
+
     openebs_cleanup_kubesystem
     logSuccess "OpenEBS CustomResourceDefinitions are ready"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
OpenEBS 3.8.0+ will wait for the operator deployment to be fully updated and healthy before continuing the installation.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
