### PR TITLE
Don't scale down Longhorn pods before pvmigrate runs

### DIFF
--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -189,9 +189,6 @@ func NewLonghornPrepareForMigration(cli CLI) *cobra.Command {
 			}
 			logger.Print("All Longhorn volumes and nodes are healthy.")
 
-			if err := scaleDownPodsUsingLonghorn(cmd.Context(), logger, cli); err != nil {
-				return fmt.Errorf("error scaling down pods using longhorn volumes: %w", err)
-			}
 			logger.Print("Environment is ready for the Longhorn migration.")
 			return nil
 		},
@@ -250,28 +247,6 @@ func scaleUpPodsUsingLonghorn(ctx context.Context, logger *log.Logger, cli clien
 	}
 
 	logger.Print("Pods using Longhorn volumes have been scaled up.")
-	return nil
-}
-
-// scaleDownPodsUsingLonghorn scales down all pods using Longhorn volumes.
-func scaleDownPodsUsingLonghorn(ctx context.Context, logger *log.Logger, cli client.Client) error {
-	logger.Print("Scaling down pods using Longhorn volumes.")
-	if err := scaleEkco(ctx, logger, cli, 0); err != nil {
-		return fmt.Errorf("error scaling down ekco operator: %w", err)
-	}
-	if err := scaleDownPrometheus(ctx, logger, cli); err != nil {
-		return fmt.Errorf("error scaling down prometheus: %w", err)
-	}
-	objects, err := getObjectsUsingLonghorn(ctx, cli)
-	if err != nil {
-		return fmt.Errorf("error getting objects using longhorn: %w", err)
-	}
-	for _, obj := range objects {
-		if err := scaleDownObject(ctx, logger, cli, obj); err != nil {
-			return err
-		}
-	}
-	logger.Print("Pods using Longhorn volumes have been scaled down.")
 	return nil
 }
 

--- a/pkg/cli/longhorn.go
+++ b/pkg/cli/longhorn.go
@@ -6,14 +6,11 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -25,8 +22,6 @@ import (
 	lhv1b1 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/spf13/cobra"
-
-	"github.com/replicatedhq/kurl/pkg/k8sutil"
 )
 
 var scaleDownReplicasWaitTime = 5 * time.Minute
@@ -189,6 +184,9 @@ func NewLonghornPrepareForMigration(cli CLI) *cobra.Command {
 			}
 			logger.Print("All Longhorn volumes and nodes are healthy.")
 
+			if err := scaleDownPodsUsingLonghorn(cmd.Context(), logger, cli); err != nil {
+				return fmt.Errorf("error scaling down pods using longhorn volumes: %w", err)
+			}
 			logger.Print("Environment is ready for the Longhorn migration.")
 			return nil
 		},
@@ -247,6 +245,20 @@ func scaleUpPodsUsingLonghorn(ctx context.Context, logger *log.Logger, cli clien
 	}
 
 	logger.Print("Pods using Longhorn volumes have been scaled up.")
+	return nil
+}
+
+// scaleDownPodsUsingLonghorn scales down all pods using Longhorn volumes.
+func scaleDownPodsUsingLonghorn(ctx context.Context, logger *log.Logger, cli client.Client) error {
+	logger.Print("Scaling down kURL components using Longhorn volumes.")
+	if err := scaleEkco(ctx, logger, cli, 0); err != nil {
+		return fmt.Errorf("error scaling down ekco operator: %w", err)
+	}
+	if err := scaleDownPrometheus(ctx, logger, cli); err != nil {
+		return fmt.Errorf("error scaling down prometheus: %w", err)
+	}
+
+	logger.Print("kURL components using Longhorn volumes have been scaled down.")
 	return nil
 }
 
@@ -410,195 +422,6 @@ func waitForPodsToBeScaledDown(ctx context.Context, logger *log.Logger, cli clie
 		}
 		return true, nil
 	})
-}
-
-// scaleDownObject scales down a deployment or a statefulset to 0 replicas.
-func scaleDownObject(ctx context.Context, logger *log.Logger, cli client.Client, obj client.Object) error {
-	kind := strings.ToLower(fmt.Sprintf("%T", obj))
-	logger.Printf("Scaling down %s %s/%s", kind, obj.GetNamespace(), obj.GetName())
-
-	var selector labels.Selector
-	var replicas *int32
-	switch concrete := obj.(type) {
-	case *appsv1.Deployment:
-		replicas = concrete.Spec.Replicas
-		concrete.Spec.Replicas = ptr.To(int32(0))
-		selector = labels.SelectorFromSet(concrete.Spec.Selector.MatchLabels)
-	case *appsv1.StatefulSet:
-		replicas = concrete.Spec.Replicas
-		concrete.Spec.Replicas = ptr.To(int32(0))
-		selector = labels.SelectorFromSet(concrete.Spec.Selector.MatchLabels)
-	default:
-		return fmt.Errorf("unsupported object type %T", obj)
-	}
-
-	if replicas == nil {
-		replicas = ptr.To(int32(0))
-	}
-
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	if _, ok := annotations[pvmigrateScaleDownAnnotation]; !ok {
-		annotations[pvmigrateScaleDownAnnotation] = fmt.Sprintf("%d", *replicas)
-		obj.SetAnnotations(annotations)
-	}
-
-	if err := cli.Update(ctx, obj); err != nil {
-		return fmt.Errorf("error scaling down %s %s/%s: %w", kind, obj.GetNamespace(), obj.GetName(), err)
-	}
-	if err := waitForPodsToBeScaledDown(ctx, logger, cli, obj.GetNamespace(), selector); err != nil {
-		return fmt.Errorf("error waiting for %s %s/%s to scale down: %w", kind, obj.GetNamespace(), obj.GetName(), err)
-	}
-	return nil
-}
-
-// getObjectsUsingLonghorn returns all objects that use Longhorn volumes. Only deployments, statefulsets,
-// and replicasets are supported (as those are the only types supported by pvmigrate).
-func getObjectsUsingLonghorn(ctx context.Context, cli client.Client) ([]client.Object, error) {
-	pods, err := getPodsUsingLonghorn(ctx, cli)
-	if err != nil {
-		return nil, fmt.Errorf("error getting pods using longhorn: %w", err)
-	}
-	var objects []client.Object
-	controllers := make(map[string]client.Object)
-	for _, pod := range pods {
-		ctrl := metav1.GetControllerOf(&pod)
-		if ctrl == nil {
-			return nil, fmt.Errorf("pod %s/%s has no owners and can't be migrated", pod.Name, pod.Namespace)
-		}
-		uid, obj, err := getOwnerObject(ctx, cli, pod.Namespace, *ctrl)
-		if err != nil {
-			return nil, fmt.Errorf("error getting owner object for pod %s/%s: %w", pod.Namespace, pod.Name, err)
-		}
-		controllers[*uid] = obj
-	}
-
-	// convert map to slice
-	for _, obj := range controllers {
-		objects = append(objects, obj)
-	}
-
-	return objects, nil
-}
-
-// getOwnerObject returns the object referred by the provided owner reference. Only deployments, statefulsets,
-// and replicasets are supported (as those are the only types supported by pvmigrate).
-func getOwnerObject(ctx context.Context, cli client.Client, namespace string, owner metav1.OwnerReference) (*string, client.Object, error) {
-	switch owner.Kind {
-	case "StatefulSet":
-		nsn := types.NamespacedName{Namespace: namespace, Name: owner.Name}
-		var sset appsv1.StatefulSet
-		if err := cli.Get(ctx, nsn, &sset); err != nil {
-			return nil, nil, fmt.Errorf("error getting statefulset %s: %w", nsn, err)
-		}
-		return (*string)(&sset.UID), &sset, nil
-	case "ReplicaSet":
-		nsn := types.NamespacedName{Namespace: namespace, Name: owner.Name}
-		var rset appsv1.ReplicaSet
-		if err := cli.Get(ctx, nsn, &rset); err != nil {
-			return nil, nil, fmt.Errorf("error getting replicaset %s: %w", nsn, err)
-		}
-		ctrl := metav1.GetControllerOf(&rset)
-		if ctrl == nil {
-			return nil, nil, fmt.Errorf("no owner found for replicaset %s/%s", owner.Name, namespace)
-		} else if ctrl.Kind != "Deployment" {
-			return nil, nil, fmt.Errorf(
-				"expected replicaset %s in %s to have a deployment as owner, found %s instead",
-				owner.Name, namespace, ctrl.Kind,
-			)
-		}
-		nsn = types.NamespacedName{Namespace: namespace, Name: ctrl.Name}
-		var deployment appsv1.Deployment
-		if err := cli.Get(ctx, nsn, &deployment); err != nil {
-			return nil, nil, fmt.Errorf("error getting deployment %s: %w", nsn, err)
-		}
-		return (*string)(&deployment.UID), &deployment, nil
-	default:
-		return nil, nil, fmt.Errorf(
-			"scaling pods controlled by a %s is not supported, please delete the pods controlled by "+
-				"%s in %s before retrying", owner.Kind, owner.Kind, namespace,
-		)
-	}
-}
-
-// getPodsUsingLonghorn returns all pods that mount Longhorn volumes.
-func getPodsUsingLonghorn(ctx context.Context, cli client.Client) ([]corev1.Pod, error) {
-	pvcs, err := getLonghornPersistenVolumeClaims(ctx, cli)
-	if err != nil {
-		return nil, fmt.Errorf("error getting longhorn persistent volume claims: %w", err)
-	}
-	var pods corev1.PodList
-	if err := cli.List(ctx, &pods); err != nil {
-		return nil, fmt.Errorf("error listing pods: %w", err)
-	}
-	var podsUsingLonghorn []corev1.Pod
-	for _, pvc := range pvcs {
-		for _, pod := range pods.Items {
-			if k8sutil.PodHasPVC(pod, pvc.Namespace, pvc.Name) {
-				podsUsingLonghorn = append(podsUsingLonghorn, pod)
-			}
-		}
-	}
-	return podsUsingLonghorn, nil
-}
-
-// getLonghornPersistenVolumeClaims returns all persistent volume claims that are claiming Longhorn volumes.
-func getLonghornPersistenVolumeClaims(ctx context.Context, cli client.Client) ([]corev1.PersistentVolumeClaim, error) {
-	pvs, err := getLonghornPersistenVolumes(ctx, cli)
-	if err != nil {
-		return nil, fmt.Errorf("error getting longhorn persistent volumes: %w", err)
-	}
-	var pvcs []corev1.PersistentVolumeClaim
-	for _, pv := range pvs {
-		if pv.Spec.ClaimRef == nil {
-			return nil, fmt.Errorf("pv %s does not have an associated pvc, resolve this before rerunning", pv.Name)
-		}
-		nsn := types.NamespacedName{Namespace: pv.Spec.ClaimRef.Namespace, Name: pv.Spec.ClaimRef.Name}
-		var pvc corev1.PersistentVolumeClaim
-		if err := cli.Get(ctx, nsn, &pvc); err != nil {
-			return nil, fmt.Errorf("error getting persistent volume claim %s: %w", nsn, err)
-		}
-		pvcs = append(pvcs, pvc)
-	}
-	return pvcs, nil
-}
-
-// getLonghornPersistenVolumes returns all persistent volumes that are backed by Longhorn.
-func getLonghornPersistenVolumes(ctx context.Context, cli client.Client) ([]corev1.PersistentVolume, error) {
-	storageClasses, err := getLonghornStorageClasses(ctx, cli)
-	if err != nil {
-		return nil, fmt.Errorf("error getting longhorn storage classes: %w", err)
-	}
-	var allPVs corev1.PersistentVolumeList
-	if err := cli.List(ctx, &allPVs); err != nil {
-		return nil, fmt.Errorf("error listing persistent volumes: %w", err)
-	}
-	var longhornPVs []corev1.PersistentVolume
-	for _, pv := range allPVs.Items {
-		for _, storageClass := range storageClasses {
-			if pv.Spec.StorageClassName == storageClass.Name {
-				longhornPVs = append(longhornPVs, pv)
-			}
-		}
-	}
-	return longhornPVs, nil
-}
-
-// getLonghornStorageClasses returns all storage classes that use the Longhorn provisioner.
-func getLonghornStorageClasses(ctx context.Context, cli client.Client) ([]storagev1.StorageClass, error) {
-	var storageClasses storagev1.StorageClassList
-	if err := cli.List(ctx, &storageClasses); err != nil {
-		return nil, fmt.Errorf("error listing storage classes: %w", err)
-	}
-	var longhornStorageClasses []storagev1.StorageClass
-	for _, storageClass := range storageClasses.Items {
-		if strings.Contains(storageClass.Provisioner, "longhorn") {
-			longhornStorageClasses = append(longhornStorageClasses, storageClass)
-		}
-	}
-	return longhornStorageClasses, nil
 }
 
 // scaleDownReplicas scales down the number of replicas for all volumes to 1. Returns a bool indicating if any


### PR DESCRIPTION
#### What this PR does / why we need it:

Today both kURL and Pvmigrate have code to scale down pods using Longhorn before a migration starts. Pvmigrate however contains additional code to determine where it should schedule a volume based on its attached workload which is relevant for migrations to OpenEBS LocalPV where the volumes can't be mounted to multiple nodes. This change leaves pod scale down operations to Pvmigrate so that it can also make determinations based on where existing workloads were running when scheduling the migration pod that creates new volumes. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
