### PR TITLE
include 'fio' for filesystem performance benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,12 @@ dist/host-openssl.tar.gz:
 	mkdir -p dist
 	tar cf - -C build packages/host/openssl | gzip > dist/host-openssl.tar.gz
 
+dist/host-fio.tar.gz:
+	mkdir -p build/packages/host/fio
+	bin/save-manifest-assets.sh "host-fio" packages/host/fio/Manifest $(CURDIR)/build/packages/host/fio
+	mkdir -p dist
+	tar cf - -C build packages/host/fio | gzip > dist/host-fio.tar.gz
+
 dist/host-longhorn.tar.gz:
 	mkdir -p build/packages/host/longhorn
 	bin/save-manifest-assets.sh "host-longhorn" packages/host/longhorn/Manifest $(CURDIR)/build/packages/host/longhorn

--- a/packages/host/fio/Manifest
+++ b/packages/host/fio/Manifest
@@ -1,2 +1,4 @@
 yum fio
+yum8 fio
+yumol fio
 apt fio

--- a/packages/host/fio/Manifest
+++ b/packages/host/fio/Manifest
@@ -1,0 +1,2 @@
+yum fio
+apt fio

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -720,6 +720,7 @@ function path_add() {
 
 function install_host_dependencies() {
     install_host_dependencies_openssl
+    install_host_dependencies_fio
 }
 
 function install_host_dependencies_openssl() {
@@ -738,6 +739,24 @@ function install_host_dependencies_openssl() {
         tar xf "$(package_filepath "${package}")" --no-same-owner
     fi
     install_host_archives "${DIR}/packages/host/openssl" openssl
+}
+
+function install_host_dependencies_fio() {
+    if commandExists "fio"; then
+        return
+    fi
+
+    if is_rhel_9_variant ; then
+        yum_ensure_host_package fio
+        return
+    fi
+
+    if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
+        local package="host-fio.tar.gz"
+        package_download "${package}"
+        tar xf "$(package_filepath "${package}")" --no-same-owner
+    fi
+    install_host_archives "${DIR}/packages/host/fio" fio
 }
 
 function maybe_read_kurl_config_from_cluster() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The `fio` is now included for filesystem benchmarking.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
