### PR TITLE
do not install fio on Ubuntu 18.04

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -751,6 +751,13 @@ function install_host_dependencies_fio() {
         return
     fi
 
+    # if this is Ubuntu 18.04, do not install fio - there are python issues
+    if [ "$LSB_DIST$DIST_VERSION" = "ubuntu18.04" ]; then
+        logWarn "Skipping fio install on Ubuntu 18.04"
+        return
+    fi
+
+
     if [ "$AIRGAP" != "1" ] && [ -n "$DIST_URL" ]; then
         local package="host-fio.tar.gz"
         package_download "${package}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The install of fio on Ubuntu 18.04 appears to fail in our testing, so we will skip it for now and accept not having fs performance metrics on that operating system.

...It's getting close to EOL anyways, after all.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
