### PR TITLE
publish 'fio' in the addon versions list to allow it to be included in airgap bundles dynamically

### DIFF
--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -617,4 +617,7 @@ module.exports.InstallerVersions = {
   aws: [
     "0.1.0",
   ],
+  fio: [ // used as a signal that fio should be included in airgap bundles
+    "host",
+  ],
 };


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

kurl-api needs a signal to include fio in airgap bundles. It shouldn't be included in old kurl version bundles, because the file would not exist there.

Adding it to the existing addon versions file provides that signal.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
