### PR TITLE
Update prometheus_crd_ready function to prevent service side apply issues during upgrade

### DIFF
--- a/addons/prometheus/0.68.0-51.0.0/install.sh
+++ b/addons/prometheus/0.68.0-51.0.0/install.sh
@@ -117,6 +117,9 @@ function prometheus_crd_ready() {
     if ! kubectl get customresourcedefinitions servicemonitors.monitoring.coreos.com &>/dev/null; then
         return 1
     fi
+    if ! kubectl get customresourcedefinitions servicemonitors.monitoring.coreos.com -o yaml | grep "enableHttp2" &>/dev/null; then
+        return 1
+    fi
     if ! kubectl get servicemonitors --all-namespaces &>/dev/null; then
         return 1
     fi

--- a/addons/prometheus/0.68.0-51.0.0/install.sh
+++ b/addons/prometheus/0.68.0-51.0.0/install.sh
@@ -126,6 +126,12 @@ function prometheus_crd_ready() {
     if ! kubectl get prometheuses --all-namespaces &>/dev/null; then
         return 1
     fi
+    if ! kubectl get customresourcedefinitions prometheusagents.monitoring.coreos.com &>/dev/null; then
+        return 1
+    fi
+    if ! kubectl get prometheusagents --all-namespaces &>/dev/null; then
+        return 1
+    fi
     return 0
 }
 

--- a/addons/prometheus/template/base/install.sh
+++ b/addons/prometheus/template/base/install.sh
@@ -117,6 +117,9 @@ function prometheus_crd_ready() {
     if ! kubectl get customresourcedefinitions servicemonitors.monitoring.coreos.com &>/dev/null; then
         return 1
     fi
+    if ! kubectl get customresourcedefinitions servicemonitors.monitoring.coreos.com -o yaml | grep "enableHttp2" &>/dev/null; then
+        return 1
+    fi
     if ! kubectl get servicemonitors --all-namespaces &>/dev/null; then
         return 1
     fi

--- a/addons/prometheus/template/base/install.sh
+++ b/addons/prometheus/template/base/install.sh
@@ -126,6 +126,12 @@ function prometheus_crd_ready() {
     if ! kubectl get prometheuses --all-namespaces &>/dev/null; then
         return 1
     fi
+    if ! kubectl get customresourcedefinitions prometheusagents.monitoring.coreos.com &>/dev/null; then
+        return 1
+    fi
+    if ! kubectl get prometheusagents --all-namespaces &>/dev/null; then
+        return 1
+    fi
     return 0
 }
 

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -43,9 +43,6 @@
       version: "__testver__"
       s3Override: "__testdist__"
 - name: "prometheus upgrade from 0.49.x"
-  cpu: 5
-  unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   installerSpec:
     kubernetes:
       version: "1.21.x"

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -42,6 +42,35 @@
     prometheus:
       version: "__testver__"
       s3Override: "__testdist__"
+- name: "prometheus upgrade from 0.49.x"
+  cpu: 5
+  unsupportedOSIDs:
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  installerSpec:
+    kubernetes:
+      version: "1.21.x"
+    flannel:
+      version: latest
+    rook:
+      version: "1.10.x"
+      isBlockStorageEnabled: true
+    containerd:
+      version: "latest"
+    prometheus:
+      version: "0.49.x"
+  upgradeSpec:
+    kubernetes:
+      version: "1.23.x"
+    flannel:
+      version: latest
+    rook:
+      version: "1.10.x"
+      isBlockStorageEnabled: true
+    containerd:
+      version: "latest"
+    prometheus:
+      version: "__testver__"
+      s3Override: "__testdist__"
 - name: "prometheus upgrade from latest"
   installerSpec:
     kubernetes:

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -51,9 +51,10 @@
       version: "1.21.x"
     flannel:
       version: latest
-    rook:
-      version: "1.10.x"
-      isBlockStorageEnabled: true
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: localpv
     containerd:
       version: "latest"
     prometheus:

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -61,9 +61,10 @@
       version: "1.23.x"
     flannel:
       version: latest
-    rook:
-      version: "1.10.x"
-      isBlockStorageEnabled: true
+    openebs:
+      version: "latest"
+      isLocalPVEnabled: true
+      localPVStorageClassName: localpv
     containerd:
       version: "latest"
     prometheus:


### PR DESCRIPTION
#### What this PR does / why we need it:

Due to the size of the Prometheus CRDs, we use server-side apply to implement them on the cluster. Our existing function doesn't account for updates in the latest versions of the Prometheus operator, potentially leading to a race condition where we apply Prometheus resources before the updated CRDs are ready.

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
