### PR TITLE
fix post-completion/failure longhorn prometheus scale code

### DIFF
--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -157,7 +157,9 @@ function longhorn_to_sc_migration() {
         kubectl annotate storageclass "$longhornStorageClass" storageclass.kubernetes.io/is-default-class-
     done
 
-    longhorn_restore_migration_replicas
+    if ! longhorn_restore_migration_replicas; then
+        log "Failed to restore the scale of Longhorn volumes and replicas. All data was successfully migrated to $destStorageClass and no action needs to be taken."
+    fi
 
     # reset ekco scale
     if [ "$ekcoScaledDown" = "1" ] ; then

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -162,6 +162,7 @@
     fi
 - name: Migrate from Longhorn + Minio to OpenEBS + Minio
   flags: "yes"
+  cpu: 6
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -179,6 +180,8 @@
       version: 1.3.x
     minio:
       version: latest
+    prometheus:
+      version: latest
   upgradeSpec:
     kubernetes:
       version: 1.24.x
@@ -193,10 +196,12 @@
     ekco:
       version: latest
     openebs:
-      version: 3.4.x
+      version: latest
       isLocalPVEnabled: true
       localPVStorageClassName: local
     minio:
+      version: latest
+    prometheus:
       version: latest
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The longhorn pre-pvmigrate code was recently changed to not scale down prometheus and instead scale down the prometheus operator deployment to allow pvmigrate to know what nodes to create PVCs on. The 'revert scales after from-longhorn migration failed'/completed code was not, and was attempting to scale the prometheus object back to its previous state. This object was missing an annotation, causing a failure.

This PR makes the rescale behavior unconditionally set the prometheus-operator scale to 1, and removes the prometheus type imports from the code.

Further, this PR catches errors in the longhorn rescale code following successful migration. In that scenario, longhorn is no longer used by any cluster data, and failing to reset scales is not a fatal error. (We're going to delete longhorn as part of the script!)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
