### PR TITLE
make the reset script more resilient

### DIFF
--- a/scripts/tasks.sh
+++ b/scripts/tasks.sh
@@ -43,7 +43,7 @@ function tasks() {
             generate_admin_user
             ;;
         reset)
-            reset
+            reset $@
             ;;
         kotsadm-accept-tls-uploads|kotsadm_accept_tls_uploads)
             kotsadm_accept_tls_uploads
@@ -182,8 +182,18 @@ function generate_admin_user() {
     printf "\n"
 }
 
-# TODO kube-proxy ipvs cleanup
 function reset() {
+    if ! reset_impl "$@"; then
+        printf "\n"
+        printf "${RED}Failed to reset this system. Please correct any errors manually and try again.${NC}\n"
+        printf "\n"
+        return
+    fi
+    printf "${GREEN}Successfully reset this system.${NC}\n"
+}
+
+# TODO kube-proxy ipvs cleanup
+function reset_impl() {
     set +e
 
     shift # the first param is reset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

make the reset script print a nice, big, red warning if it fails, and also make it less likely to fail by retrying removing directories (and also continuing anyways if it still can't remove them after 10 tries)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improves the reliability of the reset task by adding directory removal retry logic
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
