### PR TITLE
make failing to install fio not a fatal error

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -720,7 +720,7 @@ function path_add() {
 
 function install_host_dependencies() {
     install_host_dependencies_openssl
-    install_host_dependencies_fio
+    install_host_dependencies_fio || true # fio is not a hard requirement, just a nice-to-have
 }
 
 function install_host_dependencies_openssl() {
@@ -747,7 +747,9 @@ function install_host_dependencies_fio() {
     fi
 
     if is_rhel_9_variant ; then
-        yum_ensure_host_package fio
+        if !  yum_ensure_host_package fio ; then
+            logWarn "Failed to install fio, continuing anyways"
+        fi
         return
     fi
 
@@ -763,7 +765,9 @@ function install_host_dependencies_fio() {
         package_download "${package}"
         tar xf "$(package_filepath "${package}")" --no-same-owner
     fi
-    install_host_archives "${DIR}/packages/host/fio" fio
+    if ! install_host_archives "${DIR}/packages/host/fio" fio; then
+        logWarn "Failed to install fio, continuing anyways"
+    fi
 }
 
 function maybe_read_kurl_config_from_cluster() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
If the `fio` host package cannot be installed, installation will continue without host filesystem performance metrics.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
