### PR TITLE
chore: inform users that 15% of the root disk is reserved

### DIFF
--- a/pkg/cluster/space/openebs_disk_space_validator.go
+++ b/pkg/cluster/space/openebs_disk_space_validator.go
@@ -56,7 +56,7 @@ func (o *OpenEBSDiskSpaceValidator) NodesWithoutSpace(ctx context.Context) ([]st
 
 		var reservedMsg string
 		if vol.RootVolume {
-			reservedMsg = "(15% of the root disk is reserved for the OS)"
+			reservedMsg = "(15% of the root disk is reserved to prevent diskpressure evictions)"
 		}
 
 		faultyNodes[node] = true

--- a/pkg/cluster/space/openebs_disk_space_validator.go
+++ b/pkg/cluster/space/openebs_disk_space_validator.go
@@ -56,7 +56,7 @@ func (o *OpenEBSDiskSpaceValidator) NodesWithoutSpace(ctx context.Context) ([]st
 
 		var reservedMsg string
 		if vol.RootVolume {
-			reservedMsg = "(15% of the root disk is reserved to prevent diskpressure evictions)"
+			reservedMsg = "(15% of the root disk is reserved to prevent DiskPressure evictions)"
 		}
 
 		faultyNodes[node] = true

--- a/pkg/cluster/space/openebs_disk_space_validator.go
+++ b/pkg/cluster/space/openebs_disk_space_validator.go
@@ -54,13 +54,19 @@ func (o *OpenEBSDiskSpaceValidator) NodesWithoutSpace(ctx context.Context) ([]st
 			continue
 		}
 
+		var reservedMsg string
+		if vol.RootVolume {
+			reservedMsg = "(15% of the root disk is reserved for the OS)"
+		}
+
 		faultyNodes[node] = true
 		o.log.Printf(
-			"Node %q has %s available, which is less than the %s that would be migrated from the %q storage class",
+			"Node %q has %s available, which is less than the %s that would be migrated from the %q storage class %s",
 			node,
 			bytefmt.ByteSize(uint64(free)),
 			bytefmt.ByteSize(uint64(reservedPerNode[node])),
 			o.srcSC,
+			reservedMsg,
 		)
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When evaluating the amount of free disk space to migrate to OpenEBS we reserve 15% of the disk for the operating system (avoid Kubernetes triggering of its clean up unused images routine). We haven't been informing users of that causing confusion on why the available + used amounts did not add up to the full root disk size.