### PR TITLE
bug: validate if received data is an uuid

### DIFF
--- a/pkg/cli/nodes_connectivity.go
+++ b/pkg/cli/nodes_connectivity.go
@@ -78,11 +78,11 @@ func newNetutilNodesConnectivity(_ CLI) *cobra.Command {
 		Example: usageExamples,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.port == 0 {
-				return fmt.Errorf("--port flag is required.")
+				return fmt.Errorf("--port flag is required")
 			}
 			opts.proto = strings.ToUpper(opts.proto)
 			if proto := corev1.Protocol(opts.proto); proto != corev1.ProtocolTCP && proto != corev1.ProtocolUDP {
-				return fmt.Errorf("--protocol must be either tcp or udp.")
+				return fmt.Errorf("--protocol must be either tcp or udp")
 			}
 			// now that all input args have been validated we can silence the usage print upon error.
 			cmd.SilenceUsage = true
@@ -256,7 +256,13 @@ func attachToListenersPods(ctx context.Context, opts nodeConnectivityOptions, po
 			for scanner.Scan() {
 				txt := scanner.Text()
 				opts.debugf("Pod %s log: %s\n", pod.Name, txt)
-				out <- logLine{message: scanner.Text()}
+				if _, err := uuid.Parse(txt); err != nil {
+					opts.debugf("Pod line is not an UUID\n")
+					out <- logLine{err: fmt.Errorf("invalid output found: %s", txt)}
+					continue
+				}
+				opts.debugf("Pod line is an UUID\n")
+				out <- logLine{message: txt}
 			}
 			if err := scanner.Err(); err != nil {
 				opts.debugf("Error closing scanner on pod %s: %v\n", pod.Name, err)

--- a/pkg/cli/nodes_connectivity.go
+++ b/pkg/cli/nodes_connectivity.go
@@ -257,11 +257,11 @@ func attachToListenersPods(ctx context.Context, opts nodeConnectivityOptions, po
 				txt := scanner.Text()
 				opts.debugf("Pod %s log: %s\n", pod.Name, txt)
 				if _, err := uuid.Parse(txt); err != nil {
-					opts.debugf("Pod line is not an UUID\n")
+					opts.debugf("Pod line is not a UUID\n")
 					out <- logLine{err: fmt.Errorf("invalid output found: %s", txt)}
 					continue
 				}
-				opts.debugf("Pod line is an UUID\n")
+				opts.debugf("Pod line is a UUID\n")
 				out <- logLine{message: txt}
 			}
 			if err := scanner.Err(); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

When validating nodes can talk to each other we send uuid from one point to another but we are not validating if the output matches the expected uuid. in some scenarios the pod may log some error and if we don't and on these cases the log is not an uuid and we should retur an error instead.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improve error reporting capabilities during weave to flannel migration.
```