### PR TITLE
attempt overriding containerd pause image on containerd side

### DIFF
--- a/addons/containerd/1.6.24/Manifest
+++ b/addons/containerd/1.6.24/Manifest
@@ -7,4 +7,3 @@ dockerout rhel-9 addons/containerd/template/Dockerfile.rhel9 1.6.24
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.6.21
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.6.24
 dockerout ubuntu-22.04 addons/containerd/template/Dockerfile.ubuntu22 1.6.24
-image pause registry.k8s.io/pause:3.6

--- a/addons/containerd/1.6.24/Manifest
+++ b/addons/containerd/1.6.24/Manifest
@@ -7,3 +7,4 @@ dockerout rhel-9 addons/containerd/template/Dockerfile.rhel9 1.6.24
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.6.21
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.6.24
 dockerout ubuntu-22.04 addons/containerd/template/Dockerfile.ubuntu22 1.6.24
+image pause registry.k8s.io/pause:3.6

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -75,9 +75,9 @@ function containerd_install() {
         systemctl restart containerd || true
         sleep 120
         log "containerd status"
-        systemctl status containerd.service
+        systemctl status containerd.service || true
         log "containerd logs"
-        journalctl -u containerd.service
+        journalctl -xeu containerd.service
         bail "Failed to restart containerd"
         CONTAINERD_NEEDS_RESTART=0
     fi

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -72,13 +72,13 @@ function containerd_install() {
     if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
         log "Re-starting containerd"
         systemctl daemon-reload
-        if ! restart_systemd_and_wait containerd; then
-            log "containerd status"
-            systemctl status containerd.service
-            log "containerd logs"
-            journalctl -u containerd.service
-            bail "Failed to restart containerd"
-        fi
+        systemctl restart containerd
+        sleep 120
+        log "containerd status"
+        systemctl status containerd.service
+        log "containerd logs"
+        journalctl -u containerd.service
+        bail "Failed to restart containerd"
         CONTAINERD_NEEDS_RESTART=0
     fi
 

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -140,7 +140,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
     local pause_image=
-    pause_image="$(containerd_kubernetes_pause_image "$KUBERNETES_VERSION_MINOR")"
+    pause_image="$(containerd_kubernetes_pause_image "$KUBERNETES_VERSION")"
     if [ -n "$pause_image" ]; then
         cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri"]
@@ -358,10 +358,8 @@ function _containerd_migrate_images_from_docker() {
 # versions 1.26 and earlier return the empty string as they can be overridden to use a different image
 function containerd_kubernetes_pause_image() {
     version="$1"
-    echo "kubernetes_version = $version"
     local minor_version=
     minor_version="$(kubernetes_version_minor "$version")"
-    echo "minor_version = $minor_version"
 
     if [ "$minor_version" -gt "27" ]; then
         echo "registry.k8s.io/pause:3.9"

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -142,8 +142,8 @@ EOF
     local pause_image=
     pause_image="$(containerd_kubernetes_pause_image "$KUBERNETES_VERSION")"
     if [ -n "$pause_image" ]; then
-        # replace the line 'sandbox_image = ""' with 'sandbox_image = "$pause_image"' in /etc/containerd/config.toml
-        sed -i "/sandbox_image/c\\  sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
+        # replace the line 'sandbox_image = "whatever the image previously was"' with 'sandbox_image = "$pause_image"' in /etc/containerd/config.toml
+        sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
 
         echo "Set containerd sandbox_image to $pause_image"
         cat /etc/containerd/config.toml

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -72,7 +72,7 @@ function containerd_install() {
     if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
         log "Re-starting containerd"
         systemctl daemon-reload
-        systemctl restart containerd
+        systemctl restart containerd || true
         sleep 120
         log "containerd status"
         systemctl status containerd.service

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -72,7 +72,13 @@ function containerd_install() {
     if [ "$CONTAINERD_NEEDS_RESTART" = "1" ]; then
         log "Re-starting containerd"
         systemctl daemon-reload
-        restart_systemd_and_wait containerd
+        if ! restart_systemd_and_wait containerd; then
+            log "containerd status"
+            systemctl status containerd.service
+            log "containerd logs"
+            journalctl -u containerd.service
+            bail "Failed to restart containerd"
+        fi
         CONTAINERD_NEEDS_RESTART=0
     fi
 

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -140,7 +140,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
     local pause_image=
-    pause_image="$(containerd_kubernetes_pause_image "$KUBERNETES_VERSION")"
+    pause_image="$(containerd_kubernetes_pause_image)"
     if [ -n "$pause_image" ]; then
         # replace the line 'sandbox_image = "whatever the image previously was"' with 'sandbox_image = "$pause_image"' in /etc/containerd/config.toml
         sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
@@ -352,15 +352,14 @@ function _containerd_migrate_images_from_docker() {
     done
 }
 
-# return the pause image for the specified minor version of kubernetes
+# return the pause image for the current version of kubernetes
 # versions 1.26 and earlier return the empty string as they can be overridden to use a different image
 function containerd_kubernetes_pause_image() {
-    version="$1"
     local minor_version=
-    minor_version="$(kubernetes_version_minor "$version")"
+    minor_version="$(kubernetes_version_minor "$KUBERNETES_VERSION")"
 
-    if [ "$minor_version" -gt "27" ]; then
-        echo "registry.k8s.io/pause:3.9"
+    if [ "$minor_version" -ge "27" ]; then
+        cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
     fi

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -358,8 +358,10 @@ function _containerd_migrate_images_from_docker() {
 # versions 1.26 and earlier return the empty string as they can be overridden to use a different image
 function containerd_kubernetes_pause_image() {
     version="$1"
+    echo "kubernetes_version = $version"
     local minor_version=
     minor_version="$(kubernetes_version_minor "$version")"
+    echo "minor_version = $minor_version"
 
     if [ "$minor_version" -gt "27" ]; then
         echo "registry.k8s.io/pause:3.9"

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -146,7 +146,6 @@ EOF
         sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
 
         echo "Set containerd sandbox_image to $pause_image"
-        cat /etc/containerd/config.toml
     fi
 
     if [ -n "$CONTAINERD_TOML_CONFIG" ]; then

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -140,7 +140,7 @@ function containerd_configure() {
   SystemdCgroup = true
 EOF
     local pause_image=
-    pause_image="$(containerd_kubernetes_pause_image "$KUBERNETES_VERSION")"
+    pause_image="$(containerd_kubernetes_pause_image)"
     if [ -n "$pause_image" ]; then
         # replace the line 'sandbox_image = "whatever the image previously was"' with 'sandbox_image = "$pause_image"' in /etc/containerd/config.toml
         sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
@@ -352,15 +352,14 @@ function _containerd_migrate_images_from_docker() {
     done
 }
 
-# return the pause image for the specified minor version of kubernetes
+# return the pause image for the current version of kubernetes
 # versions 1.26 and earlier return the empty string as they can be overridden to use a different image
 function containerd_kubernetes_pause_image() {
-    version="$1"
     local minor_version=
-    minor_version="$(kubernetes_version_minor "$version")"
+    minor_version="$(kubernetes_version_minor "$KUBERNETES_VERSION")"
 
-    if [ "$minor_version" -gt "27" ]; then
-        echo "registry.k8s.io/pause:3.9"
+    if [ "$minor_version" -ge "27" ]; then
+        cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
     fi

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -1,4 +1,27 @@
-- name: basic containerd and flannel, internal LB
+- name: basic containerd and flannel, internal LB, airgap, 1.28
+  airgap: true
+  installerSpec:
+    kubernetes:
+      version: "1.28.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+      enableInternalLoadBalancer: true
+    kotsadm:
+      version: latest
+
+- name: basic containerd and flannel, internal LB, airgap, 1.26
+  airgap: true
   installerSpec:
     kubernetes:
       version: "1.26.x"

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -90,265 +90,265 @@
 
 
 
-#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    docker:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.25.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#  unsupportedOSIDs:
-#  - rocky-92 # docker is not supported on rhel 9 variants
-#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    docker:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.25.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  airgap: true
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    mkdir -p /var/lib/kurl/assets
-#    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#  unsupportedOSIDs:
-#  - rocky-92 # docker is not supported on rhel 9 variants
-#
-#- name: Upgrade Containerd from 1.4.x to __testver__
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "1.4.x"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    containerd --version | grep "__testver__"
-#  unsupportedOSIDs:
-#  - centos-74
-#  - centos-79
-#  - ol-79
-#  - ubuntu-2204
-#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-#
-#- name: Upgrade Containerd from 1.5.x to __testver__
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "1.5.11"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postUpgradeScript: |
-#    containerd --version | grep "__testver__"
-#  unsupportedOSIDs:
-#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-#
-#- name: "Upgrade Containerd from current to __testver__"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    containerd --version | grep "__testver__"
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - rocky-92 # docker is not supported on rhel 9 variants
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - rocky-92 # docker is not supported on rhel 9 variants
+
+- name: Upgrade Containerd from 1.4.x to __testver__
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "1.4.x"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    containerd --version | grep "__testver__"
+  unsupportedOSIDs:
+  - centos-74
+  - centos-79
+  - ol-79
+  - ubuntu-2204
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+
+- name: Upgrade Containerd from 1.5.x to __testver__
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "1.5.11"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postUpgradeScript: |
+    containerd --version | grep "__testver__"
+  unsupportedOSIDs:
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+
+- name: "Upgrade Containerd from current to __testver__"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    containerd --version | grep "__testver__"

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -19,6 +19,9 @@
       enableInternalLoadBalancer: true
     kotsadm:
       version: latest
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 
 - name: basic containerd and flannel, internal LB, airgap, 1.26
   airgap: true
@@ -41,266 +44,269 @@
       enableInternalLoadBalancer: true
     kotsadm:
       version: latest
-#
-#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    docker:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.25.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#  unsupportedOSIDs:
-#  - rocky-92 # docker is not supported on rhel 9 variants
-#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
-#  flags: "yes"
-#  installerSpec:
-#    kubernetes:
-#      version: 1.23.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    docker:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: 1.25.x
-#    weave: # flannel has errors with dns and docker
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    registry:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#  airgap: true
-#  preInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    mkdir -p /var/lib/kurl/assets
-#    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#  unsupportedOSIDs:
-#  - rocky-92 # docker is not supported on rhel 9 variants
-#
-#- name: Upgrade Containerd from 1.4.x to __testver__
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "1.4.x"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#    echo "Checking kubectl with kube/config"
-#    echo "Kubeconfig was $KUBECONFIG"
-#    unset KUBECONFIG
-#    kubectl get namespaces
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    containerd --version | grep "__testver__"
-#  unsupportedOSIDs:
-#  - centos-74
-#  - centos-79
-#  - ol-79
-#  - ubuntu-2204
-#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-#
-#- name: Upgrade Containerd from 1.5.x to __testver__
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "1.5.11"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postUpgradeScript: |
-#    containerd --version | grep "__testver__"
-#  unsupportedOSIDs:
-#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-#
-#- name: "Upgrade Containerd from current to __testver__"
-#  installerSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: latest
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  upgradeSpec:
-#    kubernetes:
-#      version: "1.25.x"
-#    flannel:
-#      version: latest
-#    containerd:
-#      version: "__testver__"
-#      s3Override: "__testdist__"
-#    openebs:
-#      version: latest
-#      isLocalPVEnabled: true
-#      localPVStorageClassName: default
-#    minio:
-#      version: latest
-#    ekco:
-#      version: latest
-#    kotsadm:
-#      version: latest
-#  postInstallScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_read_write_object_store rwtest testfile.txt
-#  postUpgradeScript: |
-#    source /opt/kurl-testgrid/testhelpers.sh
-#    minio_object_store_info
-#    validate_testfile rwtest testfile.txt
-#    validate_read_write_object_store postupgrade upgradefile.txt
-#    containerd --version | grep "__testver__"
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - rocky-92 # docker is not supported on rhel 9 variants
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+  flags: "yes"
+  installerSpec:
+    kubernetes:
+      version: 1.23.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    docker:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: 1.25.x
+    weave: # flannel has errors with dns and docker
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    registry:
+      version: latest
+    kotsadm:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+  airgap: true
+  preInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - rocky-92 # docker is not supported on rhel 9 variants
+
+- name: Upgrade Containerd from 1.4.x to __testver__
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "1.4.x"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+    echo "Checking kubectl with kube/config"
+    echo "Kubeconfig was $KUBECONFIG"
+    unset KUBECONFIG
+    kubectl get namespaces
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    containerd --version | grep "__testver__"
+  unsupportedOSIDs:
+  - centos-74
+  - centos-79
+  - ol-79
+  - ubuntu-2204
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+
+- name: Upgrade Containerd from 1.5.x to __testver__
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "1.5.11"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postUpgradeScript: |
+    containerd --version | grep "__testver__"
+  unsupportedOSIDs:
+  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+
+- name: "Upgrade Containerd from current to __testver__"
+  installerSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: latest
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.25.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+    kotsadm:
+      version: latest
+  postInstallScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_read_write_object_store rwtest testfile.txt
+  postUpgradeScript: |
+    source /opt/kurl-testgrid/testhelpers.sh
+    minio_object_store_info
+    validate_testfile rwtest testfile.txt
+    validate_read_write_object_store postupgrade upgradefile.txt
+    containerd --version | grep "__testver__"

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -41,266 +41,266 @@
       enableInternalLoadBalancer: true
     kotsadm:
       version: latest
-
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    docker:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: 1.25.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-  - rocky-92 # docker is not supported on rhel 9 variants
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    docker:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: 1.25.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  airgap: true
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    mkdir -p /var/lib/kurl/assets
-    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-  - rocky-92 # docker is not supported on rhel 9 variants
-
-- name: Upgrade Containerd from 1.4.x to __testver__
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "1.4.x"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-    containerd --version | grep "__testver__"
-  unsupportedOSIDs:
-  - centos-74
-  - centos-79
-  - ol-79
-  - ubuntu-2204
-  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-
-- name: Upgrade Containerd from 1.5.x to __testver__
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "1.5.11"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postUpgradeScript: |
-    containerd --version | grep "__testver__"
-  unsupportedOSIDs:
-  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
-
-- name: "Upgrade Containerd from current to __testver__"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-    containerd --version | grep "__testver__"
+#
+#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    docker:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.25.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#  unsupportedOSIDs:
+#  - rocky-92 # docker is not supported on rhel 9 variants
+#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    docker:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.25.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  airgap: true
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    mkdir -p /var/lib/kurl/assets
+#    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#  unsupportedOSIDs:
+#  - rocky-92 # docker is not supported on rhel 9 variants
+#
+#- name: Upgrade Containerd from 1.4.x to __testver__
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "1.4.x"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    containerd --version | grep "__testver__"
+#  unsupportedOSIDs:
+#  - centos-74
+#  - centos-79
+#  - ol-79
+#  - ubuntu-2204
+#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+#
+#- name: Upgrade Containerd from 1.5.x to __testver__
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "1.5.11"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postUpgradeScript: |
+#    containerd --version | grep "__testver__"
+#  unsupportedOSIDs:
+#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+#
+#- name: "Upgrade Containerd from current to __testver__"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    containerd --version | grep "__testver__"

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -23,7 +23,7 @@
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 
-- name: basic containerd and flannel, internal LB, airgap, 1.26 to 1.28, airgap
+- name: basic containerd and flannel, internal LB, airgap, 1.26 to 1.27, airgap
   airgap: true
   installerSpec:
     kubernetes:
@@ -46,7 +46,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: "1.28.x"
+      version: "1.27.x"
     flannel:
       version: latest
     containerd:

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -22,6 +22,13 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  postInstallScript: |
+    echo "checking /etc/containerd/config.toml"
+    cat /etc/containerd/config.toml | grep pause # should be 3.9, this is for debugging
+    cat /etc/containerd/config.toml | grep pause:3.9
+    echo "checking /var/lib/kubelet/kubeadm-flags.env"
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause # should be 3.9, this is for debugging
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause:3.9
 
 - name: basic containerd and flannel, internal LB, airgap, 1.26 to 1.27, airgap
   airgap: true
@@ -66,266 +73,282 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    docker:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: 1.25.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
   postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
+    echo "checking /etc/containerd/config.toml"
+    cat /etc/containerd/config.toml | grep pause # should be 3.6, this is for debugging
+    cat /etc/containerd/config.toml | grep pause:3.6 
+    echo "checking /var/lib/kubelet/kubeadm-flags.env"
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause # should be 3.6, this is for debugging
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause:3.6
   postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-  - rocky-92 # docker is not supported on rhel 9 variants
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
-  flags: "yes"
-  installerSpec:
-    kubernetes:
-      version: 1.23.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    docker:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: 1.25.x
-    weave: # flannel has errors with dns and docker
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    registry:
-      version: latest
-    kotsadm:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-  airgap: true
-  preInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    mkdir -p /var/lib/kurl/assets
-    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-  unsupportedOSIDs:
-  - rocky-92 # docker is not supported on rhel 9 variants
+    echo "checking /etc/containerd/config.toml"
+    cat /etc/containerd/config.toml | grep pause # should be 3.9, this is for debugging
+    cat /etc/containerd/config.toml | grep pause:3.9 
+    echo "checking /var/lib/kubelet/kubeadm-flags.env"
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause # should be 3.9, this is for debugging
+    cat /var/lib/kubelet/kubeadm-flags.env | grep pause:3.9
 
-- name: Upgrade Containerd from 1.4.x to __testver__
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "1.4.x"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-    echo "Checking kubectl with kube/config"
-    echo "Kubeconfig was $KUBECONFIG"
-    unset KUBECONFIG
-    kubectl get namespaces
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-    containerd --version | grep "__testver__"
-  unsupportedOSIDs:
-  - centos-74
-  - centos-79
-  - ol-79
-  - ubuntu-2204
-  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 
-- name: Upgrade Containerd from 1.5.x to __testver__
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "1.5.11"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postUpgradeScript: |
-    containerd --version | grep "__testver__"
-  unsupportedOSIDs:
-  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
 
-- name: "Upgrade Containerd from current to __testver__"
-  installerSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: latest
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  upgradeSpec:
-    kubernetes:
-      version: "1.25.x"
-    flannel:
-      version: latest
-    containerd:
-      version: "__testver__"
-      s3Override: "__testdist__"
-    openebs:
-      version: latest
-      isLocalPVEnabled: true
-      localPVStorageClassName: default
-    minio:
-      version: latest
-    ekco:
-      version: latest
-    kotsadm:
-      version: latest
-  postInstallScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_read_write_object_store rwtest testfile.txt
-  postUpgradeScript: |
-    source /opt/kurl-testgrid/testhelpers.sh
-    minio_object_store_info
-    validate_testfile rwtest testfile.txt
-    validate_read_write_object_store postupgrade upgradefile.txt
-    containerd --version | grep "__testver__"
+#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25"
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    docker:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.25.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#  unsupportedOSIDs:
+#  - rocky-92 # docker is not supported on rhel 9 variants
+#- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
+#  flags: "yes"
+#  installerSpec:
+#    kubernetes:
+#      version: 1.23.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    docker:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: 1.25.x
+#    weave: # flannel has errors with dns and docker
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    registry:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#  airgap: true
+#  preInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    mkdir -p /var/lib/kurl/assets
+#    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#  unsupportedOSIDs:
+#  - rocky-92 # docker is not supported on rhel 9 variants
+#
+#- name: Upgrade Containerd from 1.4.x to __testver__
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "1.4.x"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#    echo "Checking kubectl with kube/config"
+#    echo "Kubeconfig was $KUBECONFIG"
+#    unset KUBECONFIG
+#    kubectl get namespaces
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    containerd --version | grep "__testver__"
+#  unsupportedOSIDs:
+#  - centos-74
+#  - centos-79
+#  - ol-79
+#  - ubuntu-2204
+#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+#
+#- name: Upgrade Containerd from 1.5.x to __testver__
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "1.5.11"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postUpgradeScript: |
+#    containerd --version | grep "__testver__"
+#  unsupportedOSIDs:
+#  - rocky-92 # containerd < 1.6 is not supported on rhel 9 variants
+#
+#- name: "Upgrade Containerd from current to __testver__"
+#  installerSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: latest
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  upgradeSpec:
+#    kubernetes:
+#      version: "1.25.x"
+#    flannel:
+#      version: latest
+#    containerd:
+#      version: "__testver__"
+#      s3Override: "__testdist__"
+#    openebs:
+#      version: latest
+#      isLocalPVEnabled: true
+#      localPVStorageClassName: default
+#    minio:
+#      version: latest
+#    ekco:
+#      version: latest
+#    kotsadm:
+#      version: latest
+#  postInstallScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_read_write_object_store rwtest testfile.txt
+#  postUpgradeScript: |
+#    source /opt/kurl-testgrid/testhelpers.sh
+#    minio_object_store_info
+#    validate_testfile rwtest testfile.txt
+#    validate_read_write_object_store postupgrade upgradefile.txt
+#    containerd --version | grep "__testver__"

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -23,11 +23,30 @@
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
 
-- name: basic containerd and flannel, internal LB, airgap, 1.26
+- name: basic containerd and flannel, internal LB, airgap, 1.26 to 1.28, airgap
   airgap: true
   installerSpec:
     kubernetes:
       version: "1.26.x"
+    flannel:
+      version: latest
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    openebs:
+      version: latest
+      isLocalPVEnabled: true
+      localPVStorageClassName: default
+    minio:
+      version: latest
+    ekco:
+      version: latest
+      enableInternalLoadBalancer: true
+    kotsadm:
+      version: latest
+  upgradeSpec:
+    kubernetes:
+      version: "1.28.x"
     flannel:
       version: latest
     containerd:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Fixes an issue where k8s 1.27+ could have the pause image pruned under disk pressure

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
