### PR TITLE
feat: Increase default goldpinger timeouts and add goldpinger troubleshoot spec

### DIFF
--- a/addons/goldpinger/3.2.0-4.1.1/goldpinger.yaml
+++ b/addons/goldpinger/3.2.0-4.1.1/goldpinger.yaml
@@ -86,7 +86,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
       - name: goldpinger-daemon
@@ -107,6 +107,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PING_TIMEOUT_MS
+            value: 2000
+          - name: CHECK_TIMEOUT_MS
+            value: 3000
+          - name: CHECK_ALL_TIMEOUT_MS
+            value: 10000
         ports:
         - name: http
           containerPort: 80

--- a/addons/goldpinger/3.2.0-4.2.1/goldpinger.yaml
+++ b/addons/goldpinger/3.2.0-4.2.1/goldpinger.yaml
@@ -86,7 +86,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
       - name: goldpinger-daemon
@@ -107,6 +107,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PING_TIMEOUT_MS
+            value: 2000
+          - name: CHECK_TIMEOUT_MS
+            value: 3000
+          - name: CHECK_ALL_TIMEOUT_MS
+            value: 10000
         ports:
         - name: http
           containerPort: 80

--- a/addons/goldpinger/3.2.0-5.0.0/goldpinger.yaml
+++ b/addons/goldpinger/3.2.0-5.0.0/goldpinger.yaml
@@ -91,7 +91,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
       - name: goldpinger-daemon
@@ -112,6 +112,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PING_TIMEOUT_MS
+            value: 2000
+          - name: CHECK_TIMEOUT_MS
+            value: 3000
+          - name: CHECK_ALL_TIMEOUT_MS
+            value: 10000
         ports:
         - name: http
           containerPort: 80

--- a/addons/goldpinger/3.3.0-5.1.0/goldpinger.yaml
+++ b/addons/goldpinger/3.3.0-5.1.0/goldpinger.yaml
@@ -91,7 +91,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
       - name: goldpinger-daemon
@@ -112,6 +112,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PING_TIMEOUT_MS
+            value: 2000
+          - name: CHECK_TIMEOUT_MS
+            value: 3000
+          - name: CHECK_ALL_TIMEOUT_MS
+            value: 10000
         ports:
         - name: http
           containerPort: 80

--- a/addons/goldpinger/3.5.1-5.2.0/goldpinger.yaml
+++ b/addons/goldpinger/3.5.1-5.2.0/goldpinger.yaml
@@ -91,7 +91,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
       - name: goldpinger-daemon
@@ -112,6 +112,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: PING_TIMEOUT_MS
+            value: 2000
+          - name: CHECK_TIMEOUT_MS
+            value: 3000
+          - name: CHECK_ALL_TIMEOUT_MS
+            value: 10000
         ports:
         - name: http
           containerPort: 80

--- a/addons/goldpinger/3.6.1-5.4.2/goldpinger.yaml
+++ b/addons/goldpinger/3.6.1-5.4.2/goldpinger.yaml
@@ -91,7 +91,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
         - name: goldpinger-daemon
@@ -112,6 +112,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PING_TIMEOUT
+              value: 2s
+            - name: CHECK_TIMEOUT
+              value: 3s
+            - name: CHECK_ALL_TIMEOUT
+              value: 10s
           ports:
             - name: http
               containerPort: 80

--- a/addons/goldpinger/3.7.0-5.5.0/goldpinger.yaml
+++ b/addons/goldpinger/3.7.0-5.5.0/goldpinger.yaml
@@ -105,7 +105,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
         - name: goldpinger-daemon
@@ -125,11 +125,17 @@ spec:
               value: "80"
             - name: LABEL_SELECTOR
               value: "app.kubernetes.io/name=goldpinger"
-            
+
             - name: POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PING_TIMEOUT
+              value: 2s
+            - name: CHECK_TIMEOUT
+              value: 3s
+            - name: CHECK_ALL_TIMEOUT
+              value: 10s
           ports:
             - name: http
               containerPort: 80

--- a/addons/goldpinger/3.7.0-5.6.0/goldpinger.yaml
+++ b/addons/goldpinger/3.7.0-5.6.0/goldpinger.yaml
@@ -105,7 +105,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
         - name: goldpinger-daemon
@@ -125,11 +125,17 @@ spec:
               value: "80"
             - name: LABEL_SELECTOR
               value: "app.kubernetes.io/name=goldpinger"
-            
+
             - name: POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PING_TIMEOUT
+              value: 2s
+            - name: CHECK_TIMEOUT
+              value: 3s
+            - name: CHECK_ALL_TIMEOUT
+              value: 10s
           ports:
             - name: http
               containerPort: 80

--- a/addons/goldpinger/3.7.0-6.0.1/goldpinger.yaml
+++ b/addons/goldpinger/3.7.0-6.0.1/goldpinger.yaml
@@ -105,7 +105,7 @@ spec:
         app.kubernetes.io/name: goldpinger
         app.kubernetes.io/instance: goldpinger
     spec:
-      priorityClassName: 
+      priorityClassName:
       serviceAccountName: goldpinger
       containers:
         - name: goldpinger-daemon
@@ -129,6 +129,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PING_TIMEOUT
+              value: 2s
+            - name: CHECK_TIMEOUT
+              value: 3s
+            - name: CHECK_ALL_TIMEOUT
+              value: 10s
           ports:
             - name: http
               containerPort: 80

--- a/addons/goldpinger/template/testgrid/tests.yaml
+++ b/addons/goldpinger/template/testgrid/tests.yaml
@@ -12,10 +12,19 @@
   postInstallScript: |
     # find the goldpinger endpoint
     export GP_ENDPOINT=$(kubectl get endpoints -n kurl goldpinger | grep -v NAME | awk '{ print $2 }')
-    
+
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
+
+    # Check if the support bundle spec was installed
+    echo "test whether the goldpinger support bundle spec was installed"
+    supportBundle=$(kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -ojsonpath='{.data.support-bundle-spec}')
+    echo "$supportBundle"
+    echo "test if the content of the secret is a support bundle spec"
+    echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
+    echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
+    kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
 
 - name: upgrade from latest
   installerSpec:
@@ -40,7 +49,7 @@
   postUpgradeScript: |
     # find the goldpinger endpoint
     export GP_ENDPOINT=$(kubectl get endpoints -n kurl goldpinger | grep -v NAME | awk '{ print $2 }')
-    
+
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
@@ -68,7 +77,7 @@
   postUpgradeScript: |
     # find the goldpinger endpoint
     export GP_ENDPOINT=$(kubectl get endpoints -n kurl goldpinger | grep -v NAME | awk '{ print $2 }')
-    
+
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
@@ -91,7 +100,16 @@
   postInstallScript: |
     # find the goldpinger endpoint
     export GP_ENDPOINT=$(kubectl get endpoints -n kurl goldpinger | grep -v NAME | awk '{ print $2 }')
-    
+
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
+
+    # Check if the support bundle spec was installed
+    echo "test whether the goldpinger support bundle spec was installed"
+    supportBundle=$(kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -ojsonpath='{.data.support-bundle-spec}')
+    echo "$supportBundle"
+    echo "test if the content of the secret is a support bundle spec"
+    echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
+    echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
+    kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'

--- a/addons/goldpinger/template/values.yaml
+++ b/addons/goldpinger/template/values.yaml
@@ -31,6 +31,12 @@ extraEnv:
     valueFrom:
       fieldRef:
         fieldPath: status.podIP
+  - name: PING_TIMEOUT
+    value: 2s
+  - name: CHECK_TIMEOUT
+    value: 3s
+  - name: CHECK_ALL_TIMEOUT
+    value: 10s
 
 service:
   type: ClusterIP # originally "LoadBalancer" (replicated)

--- a/addons/goldpinger/template/yaml/troubleshoot.yaml
+++ b/addons/goldpinger/template/yaml/troubleshoot.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kurl-goldpinger-supportbundle-spec
+  labels:
+    troubleshoot.io/kind: support-bundle
+stringData:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: goldpinger
+    spec:
+      collectors:
+        - goldpinger:
+            collectorName: kurl-goldpinger
+            namespace: kurl
+      analyzers:
+        - goldpinger: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

- Increases goldpinger addon timeouts. In slowish networks, pings tend to fail unnecessarily. The default ping timeout is `300ms`.
- Add a support bundle spec whenever goldpinger addon is added to a kurl spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#sc-91987](https://app.shortcut.com/replicated/story/91987/analyzer-goldpinger-pingmap)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
- Create a kURL cluster
- Run `support-bundle --load-cluster-specs` and notice goldpinger analysis in the results. This bit is dependant on https://github.com/replicatedhq/troubleshoot/pull/1398 changes being released

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
