### PR TITLE
load the kubernetes pause image when installing containerd

### DIFF
--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -146,6 +146,8 @@ EOF
         sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
 
         echo "Set containerd sandbox_image to $pause_image"
+        ctr -n=k8s.io images import "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz"
+        echo "Loaded Kubernetes $KUBERNETES_VERSION pause image"
     fi
 
     if [ -n "$CONTAINERD_TOML_CONFIG" ]; then

--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -150,7 +150,7 @@ EOF
         # if containerd is running, this is an upgrade and we can load the pause image
         if systemctl is-active --quiet containerd; then
             log "Loading Kubernetes $KUBERNETES_VERSION pause image"
-            ctr -n=k8s.io images import "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz"
+            cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz" | gunzip | ctr -n=k8s.io images import -
             log "Loaded Kubernetes $KUBERNETES_VERSION pause image"
         fi
     fi

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -146,6 +146,8 @@ EOF
         sed -i "/sandbox_image/c\\    sandbox_image = \"$pause_image\"" /etc/containerd/config.toml
 
         echo "Set containerd sandbox_image to $pause_image"
+        ctr -n=k8s.io images import "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz"
+        echo "Loaded Kubernetes $KUBERNETES_VERSION pause image"
     fi
 
     if [ -n "$CONTAINERD_TOML_CONFIG" ]; then

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -150,7 +150,7 @@ EOF
         # if containerd is running, this is an upgrade and we can load the pause image
         if systemctl is-active --quiet containerd; then
             log "Loading Kubernetes $KUBERNETES_VERSION pause image"
-            ctr -n=k8s.io images import "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz"
+            cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/images/pause.tar.gz" | gunzip | ctr -n=k8s.io images import -
             log "Loaded Kubernetes $KUBERNETES_VERSION pause image"
         fi
     fi

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -30,11 +30,11 @@
     cat /var/lib/kubelet/kubeadm-flags.env | grep pause # should be 3.9, this is for debugging
     cat /var/lib/kubelet/kubeadm-flags.env | grep pause:3.9
 
-- name: basic containerd and flannel, internal LB, airgap, 1.26 to 1.27, airgap
+- name: basic containerd and flannel, internal LB, airgap, 1.23 to 1.27, airgap
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.26.x"
+      version: "1.23.x"
     flannel:
       version: latest
     containerd:
@@ -73,6 +73,8 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+    mkdir -p /var/lib/kurl/assets
+    ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   postInstallScript: |
     echo "checking /etc/containerd/config.toml"
     cat /etc/containerd/config.toml | grep pause # should be 3.6, this is for debugging


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

As demostrated by https://testgrid.kurl.sh/run/laverya-dec12-containerd-k8supgrade, upgrades of kubernetes to 1.27+ fail in airgap when coming more than a few versions. This is because the pause image has not yet been loaded by 1.23, and will not be loaded by the 1.24 upgrade process - because it is a 1.25 (or later) image.

This PR loads the image when it sets that as the pause image in the containerd configuration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
