### PR TITLE
Update local-volume-provider to v0.5.6

### DIFF
--- a/addons/velero/1.12.1/Manifest
+++ b/addons/velero/1.12.1/Manifest
@@ -4,7 +4,7 @@ image velero-restore-helper-gcr gcr.io/velero-gcp/velero-restore-helper:v1.12.1
 image velero-aws velero/velero-plugin-for-aws:v1.8.1
 image velero-gcp velero/velero-plugin-for-gcp:v1.8.1
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.8.1
-image local-volume-provider replicated/local-volume-provider:v0.5.5
+image local-volume-provider replicated/local-volume-provider:v0.5.6
 image s3cmd kurlsh/s3cmd:20230406-9a6d89f
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.12.1/velero-v1.12.1-linux-amd64.tar.gz

--- a/addons/velero/1.12.1/install.sh
+++ b/addons/velero/1.12.1/install.sh
@@ -165,7 +165,7 @@ function velero_install() {
         $bslArgs \
         $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --plugins velero/velero-plugin-for-aws:v1.8.1,velero/velero-plugin-for-gcp:v1.8.1,velero/velero-plugin-for-microsoft-azure:v1.8.1,replicated/local-volume-provider:v0.5.5,"$KURL_UTIL_IMAGE" \
+        --plugins velero/velero-plugin-for-aws:v1.8.1,velero/velero-plugin-for-gcp:v1.8.1,velero/velero-plugin-for-microsoft-azure:v1.8.1,replicated/local-volume-provider:v0.5.6,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
         --dry-run -o yaml > "$dst/velero.yaml"
 

--- a/addons/velero/1.12.2/Manifest
+++ b/addons/velero/1.12.2/Manifest
@@ -4,7 +4,7 @@ image velero-restore-helper-gcr gcr.io/velero-gcp/velero-restore-helper:v1.12.2
 image velero-aws velero/velero-plugin-for-aws:v1.8.2
 image velero-gcp velero/velero-plugin-for-gcp:v1.8.2
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.8.2
-image local-volume-provider replicated/local-volume-provider:v0.5.5
+image local-volume-provider replicated/local-volume-provider:v0.5.6
 image s3cmd kurlsh/s3cmd:20230406-9a6d89f
 
 asset velero.tar.gz https://github.com/vmware-tanzu/velero/releases/download/v1.12.2/velero-v1.12.2-linux-amd64.tar.gz

--- a/addons/velero/1.12.2/install.sh
+++ b/addons/velero/1.12.2/install.sh
@@ -165,7 +165,7 @@ function velero_install() {
         $bslArgs \
         $secretArgs \
         --namespace $VELERO_NAMESPACE \
-        --plugins velero/velero-plugin-for-aws:v1.8.2,velero/velero-plugin-for-gcp:v1.8.2,velero/velero-plugin-for-microsoft-azure:v1.8.2,replicated/local-volume-provider:v0.5.5,"$KURL_UTIL_IMAGE" \
+        --plugins velero/velero-plugin-for-aws:v1.8.2,velero/velero-plugin-for-gcp:v1.8.2,velero/velero-plugin-for-microsoft-azure:v1.8.2,replicated/local-volume-provider:v0.5.6,"$KURL_UTIL_IMAGE" \
         --use-volume-snapshots=false \
         --dry-run -o yaml > "$dst/velero.yaml"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Updates the local-volume-provider image to version v0.5.6.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Updates the local-volume-provider image to v0.5.6 in the [Velero add-on](https://kurl.sh/docs/add-ons/velero) to resolve CVE-2019-8457 and CVE-2023-45853 with critical severity; and CVE-2022-3715, CVE-2021-33560, CVE-2022-4899, CVE-2022-1304, CVE-2020-16156, CVE-2023-31484, CVE-2023-47038 with high severity; and CVE-2023-4806, CVE-2023-4813, CVE-2023-5981, CVE-2023-5678, CVE-2023-4039, CVE-2023-50495, CVE-2023-4641 with medium severity; and TEMP-0841856-B18BAF, CVE-2016-2781, CVE-2017-18018, CVE-2022-3219, CVE-2011-3374, CVE-2010-4756, CVE-2018-20796, CVE-2019-1010022, CVE-2019-1010023, CVE-2019-1010024, CVE-2019-1010025, CVE-2019-9192, CVE-2018-6829, CVE-2011-3389, CVE-2018-5709, CVE-2022-41409, CVE-2017-11164, CVE-2017-16231, CVE-2017-7245, CVE-2017-7246, CVE-2019-20838, CVE-2021-36084, CVE-2021-36085, CVE-2021-36086, CVE-2021-36087, CVE-2007-6755, CVE-2010-0928, CVE-2013-4392, CVE-2020-13529, CVE-2023-31437, CVE-2023-31438, CVE-2023-31439, CVE-2007-5686, CVE-2013-4235, CVE-2019-19882, CVE-2023-29383, TEMP-0628843-DBAD28, CVE-2011-4116, CVE-2023-31486, TEMP-0517018-A83CE6, CVE-2005-2541, CVE-2022-48303, CVE-2023-39804, TEMP-0290435-0B57B5, CVE-2022-0563 with low severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
