### PR TITLE
Goldpinger should listen on 8080 not 80

### DIFF
--- a/addons/goldpinger/template/values.yaml
+++ b/addons/goldpinger/template/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
   name: goldpinger # originally "" (replicated)
 
 goldpinger:
-  port: 80
+  port: 8080
 
 extraEnv:
   # added block from https://github.com/bloomberg/goldpinger/blob/4f8d872/extras/example-serviceaccounts.yml#L44-L48 (replicated)


### PR DESCRIPTION
As it is now non-root (see https://github.com/okgolove/helm-charts/pull/102) it can no longer listen on port 80

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
