### PR TITLE
update the curl k8s api health check code

### DIFF
--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -194,7 +194,13 @@ EOF
 }
 
 function kubeadm_api_is_healthy() {
-    curl --globoff --noproxy "*" --fail --silent --insecure "https://$(kubernetes_api_address)/healthz" >/dev/null
+    curl --globoff --noproxy "*" --fail --silent --insecure "https://$(kubernetes_api_address)/healthz" > /tmp/k8s-healthz.out || true
+    if grep -q "ok" /tmp/k8s-healthz.out; then
+        rm /tmp/k8s-healthz.out
+        return 0
+    fi
+    rm /tmp/k8s-healthz.out
+    return 1
 }
 
 function kubeadm_conf_api_version() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

```
laverya@laverya-ubuntu18:~$ curl -k https://34.132.114.199:6443/healthz && echo "curl worked" || echo "curl failed"
curl: (16) Error in the HTTP2 framing layer
okcurl failed
```

the curl returns 'ok', and yet it fails because the curl also has an error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
