### PR TITLE
use the internal ekco service address to trigger storage migrations

### DIFF
--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -1597,7 +1597,7 @@ function node_is_using_docker() {
     kubectl get node "$node" -ojsonpath='{.metadata.annotations.kubeadm\.alpha\.kubernetes\.io/cri-socket}' | grep -q "dockershim.sock"
 }
 
-# get_ekco_addr prints the host address (including port) for reaching the EKCO service to stdout
+# get_ekco_addr prints the service address (including port) for reaching the EKCO service to stdout
 function get_ekco_addr() {
     if [ -n "$EKCO_ADDRESS" ]; then
         echo "$EKCO_ADDRESS"
@@ -1606,14 +1606,10 @@ function get_ekco_addr() {
 
     local ekco_addr=
     local ekco_port=
-    local current_node_ip=
-    current_node_ip=$(kubectl get nodes -o wide | grep "$(get_local_node_name)" | awk '{print $6}')
-    ekco_port="${EKCO_NODE_PORT}"
-
-    if [ -z "${ekco_port}" ]; then
-        ekco_port=$(kubectl get svc ekc-operator -n kurl -o jsonpath='{.spec.ports[?(@.nodePort)].nodePort}')
-    fi
-    ekco_addr="${current_node_ip}:${ekco_port}"
+    local ekco_service_ip=
+    ekco_service_ip=$(kubectl get svc ekc-operator -n kurl -o jsonpath='{.spec.clusterIP}')
+    ekco_port=$(kubectl get svc ekc-operator -n kurl -o jsonpath='{.spec.ports[?(@.nodePort)].port}')
+    ekco_addr="${ekco_service_ip}:${ekco_port}"
     echo "$ekco_addr"
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The within-cluster service address is available to nodes joining the cluster at the point the storage migration will be run. We should use it to avoid requiring an additional port to be opened between nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the 'minimum-node-count' parameter for rook storage would require port 31880 to be opened between the node joining the cluster and a primary node.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
