### PR TITLE
fix: quote the repl so preflight can run standalone

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -32,7 +32,7 @@ spec:
     - tcpLoadBalancer:
         collectorName: "Kubernetes API Server Load Balancer"
         port: 6443
-        address: {{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}
+        address: '{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}'
         timeout: 3m
         # ha and is first master (primary and not join) and not is upgrade
         exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary (not .IsJoin) (not .IsUpgrade) | not }}'


### PR DESCRIPTION
#### What this PR does / why we need it:

This simply adds single quotes around the address value in `pkg/preflight/assets/host-preflights.yaml` so it can be run in standalone mode as described here: https://community.replicated.com/t/kurl-how-to-do-a-standalone-run-of-host-preflights/782

*setup*
```
$ curl -sL https://github.com/replicatedhq/troubleshoot/releases/latest/download/preflight_linux_amd64.tar.gz | tar xzvf -
LICENSE
README.md
key.pub
troubleshoot-sbom.tgz
troubleshoot-sbom.tgz.sig
preflight
```

*before*
```
$ curl -sO https://raw.githubusercontent.com/replicatedhq/kURL/main/pkg/preflight/assets/host-preflights.yaml
$ md5sum host-preflights.yaml
f055284b83bd0fe513fbaa02819b305f  host-preflights.yaml
$ sudo ./preflight host-preflights.yaml
Warning: no preflight or host preflight spec was found
```

*after*
```
$ curl -s -O https://raw.githubusercontent.com/nate-credoai/kURL/fix/host-preflights-asset/pkg/preflight/assets/host-preflights.yaml
$ md5sum host-preflights.yaml
6584ab719a5eb9cc9a3e58a974826499  host-preflights.yaml
$ sudo ./preflight host-preflights.yaml
 * [TCP Port Status] Running collector...
 * [CPU Info] Running collector...
 * [Amount of Memory] Running collector...
 * [Block Devices] Running collector...
 * [Host OS Info] Running collector...
 [...]
```

*diff*
```
$ diff -u host-preflights.yaml.old host-preflights.yaml.new
--- host-preflights.yaml.old	2023-12-29 04:16:43.943708099 +0000
+++ host-preflights.yaml.new	2023-12-29 04:16:53.119712945 +0000
@@ -32,7 +32,7 @@
     - tcpLoadBalancer:
         collectorName: "Kubernetes API Server Load Balancer"
         port: 6443
-        address: {{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}
+        address: '{{kurl .Installer.Spec.Kubernetes.LoadBalancerAddress }}'
         timeout: 3m
         # ha and is first master (primary and not join) and not is upgrade
         exclude: '{{kurl and .Installer.Spec.Kubernetes.Version .Installer.Spec.Kubernetes.LoadBalancerAddress .IsPrimary (not .IsJoin) (not .IsUpgrade) | not }}'
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- I'm assuming this should be possible and that `address` should be a string which seems obvious.
- I'm not sure if this asset originates from another repo that might need updating.
- My understanding is that this is the minimum host preflights that kurl will run if they are not overridden.

## Steps to reproduce

```
$ curl -sL https://github.com/replicatedhq/troubleshoot/releases/latest/download/preflight_linux_amd64.tar.gz | tar xzvf -
LICENSE
README.md
key.pub
troubleshoot-sbom.tgz
troubleshoot-sbom.tgz.sig
preflight
$ curl -sO https://raw.githubusercontent.com/replicatedhq/kURL/main/pkg/preflight/assets/host-preflights.yaml
$ md5sum host-preflights.yaml
f055284b83bd0fe513fbaa02819b305f  host-preflights.yaml
$ sudo ./preflight host-preflights.yaml
Warning: no preflight or host preflight spec was found
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE