### PR TITLE
Allow nightly versions of kots to install with any k8s version

### DIFF
--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -558,7 +558,7 @@ spec:
         checkName: "Kots and Kubernetes Compatibility"
         # Kubernetes 1.29+ requires kots 1.96.2+, so we exclude this check if kots/kubernetes are not installed, if kots is nightly, if kots > 1.96.2, or if kubernetes < 1.29
         # if the check runs, it will always fail - excluding it is the only way to pass
-        exclude: '{{kurl or (not .Installer.Spec.Kotsadm.Version) (not .Installer.Spec.Kubernetes.Version) (.Installer.Spec.Kotsadm.Version | strings.Contains "nightly") (semverCompare "> v1.96.2" .Installer.Spec.Kotsadm.Version) (semverCompare "< 1.29.0" .Installer.Spec.Kubernetes.Version) }}'
+        exclude: '{{kurl or (not .Installer.Spec.Kotsadm.Version) (not .Installer.Spec.Kubernetes.Version) (.Installer.Spec.Kotsadm.Version | contains "nightly") (semverCompare "> v1.96.2" .Installer.Spec.Kotsadm.Version) (semverCompare "< 1.29.0" .Installer.Spec.Kubernetes.Version) }}'
         outcomes:
           - fail:
               message: "Kots < 1.96.2 is not compatible with Kubernetes >= 1.29.0"

--- a/pkg/preflight/assets/host-preflights.yaml
+++ b/pkg/preflight/assets/host-preflights.yaml
@@ -556,9 +556,9 @@ spec:
     # hijack hostOS analyzer in order to analyze the kURL Installer spec
     - hostOS:
         checkName: "Kots and Kubernetes Compatibility"
-        # Kubernetes 1.29+ requires kots 1.96.2+, so we exclude this check if kots/kubernetes are not installed, if kots > 1.96.2, or if kubernetes < 1.29
+        # Kubernetes 1.29+ requires kots 1.96.2+, so we exclude this check if kots/kubernetes are not installed, if kots is nightly, if kots > 1.96.2, or if kubernetes < 1.29
         # if the check runs, it will always fail - excluding it is the only way to pass
-        exclude: '{{kurl or (not .Installer.Spec.Kotsadm.Version) (not .Installer.Spec.Kubernetes.Version) (semverCompare "> v1.96.2" .Installer.Spec.Kotsadm.Version) (semverCompare "< 1.29.0" .Installer.Spec.Kubernetes.Version) }}'
+        exclude: '{{kurl or (not .Installer.Spec.Kotsadm.Version) (not .Installer.Spec.Kubernetes.Version) (.Installer.Spec.Kotsadm.Version | strings.Contains "nightly") (semverCompare "> v1.96.2" .Installer.Spec.Kotsadm.Version) (semverCompare "< 1.29.0" .Installer.Spec.Kubernetes.Version) }}'
         outcomes:
           - fail:
               message: "Kots < 1.96.2 is not compatible with Kubernetes >= 1.29.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Nightly versions of kots are not (per semver) greater than 1.96.1, and so fail when paired with k8s 1.29. This exempts nightly kots versions from the check.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
