### PR TITLE
bug: allow ekco service account to list velero resources

### DIFF
--- a/addons/ekco/template/base/rbac.yaml
+++ b/addons/ekco/template/base/rbac.yaml
@@ -190,5 +190,6 @@ rules:
       - backuprepositories
     verbs:
       - get
+      - list
       - update
 ---


### PR DESCRIPTION

#### What this PR does / why we need it:

Allow ekco to list velero resources.

