### PR TITLE
systemd drop-in to set checksum offloading off on flannel iface

### DIFF
--- a/addons/flannel/template/base/flannel-ethtool.service
+++ b/addons/flannel/template/base/flannel-ethtool.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable vxlan checksum offloading for flannel.1
+After=sys-devices-virtual-net-flannel.1.device
+Requires=sys-devices-virtual-net-flannel.1.device
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -K flannel.1 tx-checksum-ip-generic off
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sys-devices-virtual-net-flannel.1.device

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -176,8 +176,6 @@ function flannel_install_ethtool_service() {
     # the kernel.
     local src="$1"
 
-    logStep "
-
     logStep "Installing flannel ethtool service"
 
     cp "$src/flannel-ethtool.service" /etc/systemd/system/flannel-ethtool.service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Add a systemd service file that turns tcp checksum offloading OFF when it sees that the vmware VMXNET3 driver is in use

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

https://app.shortcut.com/replicated/story/91846/hostpreflight-detect-if-host-nic-uses-vmxnet3-driver-from-vmware-and-if-so-warn-about-vxlan-checksum-offloading

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

Users of VMWare clusters using the VMXNET3 NIC driver will see a new systemd .service file included that disables tcp checksum offloading on the flannel interface.  This fixes an issue we have seen with dropped packets under certain combinations of VMWare NIC and cluster configurations. 

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->

NONE
