### PR TITLE
additional fixes to old k8s builds

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -53,7 +53,7 @@ jobs:
         OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
         echo "matrix=$OUTPUT" >> $GITHUB_OUTPUT
 
-  build-upload-packages:
+  b-u-p: # shortened to allow reading what job is being run within github's UI
     runs-on: ubuntu-20.04
     needs:
     - build-go-bins-matrix
@@ -290,7 +290,7 @@ jobs:
   set-current-version:
     runs-on: ubuntu-20.04
     needs:
-    - build-upload-packages
+    - b-u-p
     - copy-stage-packages-to-prod
     steps:
     - name: Set VERSION file in s3

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -53,7 +53,7 @@ jobs:
         OUTPUT=`bin/list-all-packages-actions-matrix.sh "${{ github.event.inputs.index }}"`
         echo "matrix=$OUTPUT" >> $GITHUB_OUTPUT
 
-  b-u-p: # shortened to allow reading what job is being run within github's UI
+  bup: # shortened to allow reading what job is being run within github's UI
     runs-on: ubuntu-20.04
     needs:
     - build-go-bins-matrix
@@ -290,7 +290,7 @@ jobs:
   set-current-version:
     runs-on: ubuntu-20.04
     needs:
-    - b-u-p
+    - bup
     - copy-stage-packages-to-prod
     steps:
     - name: Set VERSION file in s3

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -66,7 +66,7 @@ jobs:
       env:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
-  build-upload-packages:
+  b-u-p: # shortened to allow reading what job is being run within github's UI
     runs-on: ubuntu-20.04
     needs:
     - get-tag
@@ -145,7 +145,7 @@ jobs:
     needs:
     - get-tag
     - build-addons
-    - build-upload-packages
+    - b-u-p
     steps:
     - name: Set VERSION file in s3
       run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -66,7 +66,7 @@ jobs:
       env:
         VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
 
-  b-u-p: # shortened to allow reading what job is being run within github's UI
+  bup: # shortened to allow reading what job is being run within github's UI
     runs-on: ubuntu-20.04
     needs:
     - get-tag
@@ -145,7 +145,7 @@ jobs:
     needs:
     - get-tag
     - build-addons
-    - b-u-p
+    - bup
     steps:
     - name: Set VERSION file in s3
       run: |

--- a/bin/upload-dist-versioned.sh
+++ b/bin/upload-dist-versioned.sh
@@ -161,11 +161,16 @@ function deploy() {
             copy_package_staging "${package}"
         fi
     else
-        if package_has_changes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" "${path}" || ! is_old_kubernetes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" ; then
+        if package_has_changes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" "${path}" ; then
             echo "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${package} no changes in package"
             copy_package_dist "${package}"
         else
-            echo "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${package} no changes in versioned package"
+            if is_old_kubernetes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" ; then
+                echo "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${package} old kubernetes package"
+                copy_package_dist "${package}"
+            else
+                echo "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${package} no changes in versioned package"
+            fi
         fi
     fi
 }

--- a/bin/upload-dist-versioned.sh
+++ b/bin/upload-dist-versioned.sh
@@ -161,7 +161,7 @@ function deploy() {
             copy_package_staging "${package}"
         fi
     else
-        if package_has_changes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" "${path}" ; then
+        if package_has_changes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" "${path}" || ! is_old_kubernetes "${PACKAGE_PREFIX}/${VERSION_TAG}/${package}" ; then
             echo "s3://${S3_BUCKET}/${PACKAGE_PREFIX}/${package} no changes in package"
             copy_package_dist "${package}"
         else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Currently, when deploying to staging [we see logs ](https://github.com/replicatedhq/kURL/actions/runs/7761423487/job/21169957531#step:6:16) like the following:
```
Old kubernetes package kubernetes-1.20.4.tar.gz
Old kubernetes package kubernetes-1.20.4.tar.gz
s3://kurl-sh/staging/kubernetes-1.20.4.tar.gz no changes in versioned package
```

And the old kubernetes packages are not uploaded. This aims to fix that by always uploading old k8s versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
