### PR TITLE
update flannel v0.24.2

### DIFF
--- a/addons/flannel/0.24.2/flannel-ethtool.service
+++ b/addons/flannel/0.24.2/flannel-ethtool.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable vxlan checksum offloading for flannel.1
+After=sys-devices-virtual-net-flannel.1.device
+Requires=sys-devices-virtual-net-flannel.1.device
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -K flannel.1 tx-checksum-ip-generic off
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sys-devices-virtual-net-flannel.1.device

--- a/addons/flannel/0.24.2/install.sh
+++ b/addons/flannel/0.24.2/install.sh
@@ -174,6 +174,7 @@ function flannel_install_ethtool_service() {
     local src="$1"
 
     logStep "Installing flannel ethtool service"
+    logStep "Disabling TCP checksum offloading on flannel interface for VMWare VMXNET3 NICs"
 
     cp "$src/flannel-ethtool.service" /etc/systemd/system/flannel-ethtool.service
 

--- a/addons/flannel/0.24.2/install.sh
+++ b/addons/flannel/0.24.2/install.sh
@@ -160,13 +160,10 @@ function flannel() {
 }
 
 function flannel_detect_vmware_nic() {
-    local vmxnet3=false
-
     if lspci -v | grep Ethernet | grep -q "VMware VMXNET3"; then
-        vmxnet3=true
+        true
     fi
-
-    return $vmxnet3
+    false
 }
 
 

--- a/addons/flannel/0.24.2/install.sh
+++ b/addons/flannel/0.24.2/install.sh
@@ -151,8 +151,43 @@ function flannel() {
        kubectl rollout restart --namespace=kube-flannel daemonset/kube-flannel-ds
     fi
 
+    if flannel_detect_vmware_nic; then
+        flannel_install_ethtool_service "$src"
+    fi
+
     flannel_ready_spinner
     check_network
+}
+
+function flannel_detect_vmware_nic() {
+    local vmxnet3=false
+
+    if lspci -v | grep Ethernet | grep -q "VMware VMXNET3"; then
+        vmxnet3=true
+    fi
+
+    return $vmxnet3
+}
+
+
+function flannel_install_ethtool_service() {
+    # this disables the tcp checksum offloading on flannel interface - this is a workaround for
+    # certain VMWare NICs that use NSX and have a conflict with the way the checksum is handled by
+    # the kernel.
+    local src="$1"
+
+    logStep "Installing flannel ethtool service"
+
+    cp "$src/flannel-ethtool.service" /etc/systemd/system/flannel-ethtool.service
+
+    systemctl daemon-reload
+    systemctl enable flannel-ethtool.service
+    if ! timeout 30s systemctl start flannel-ethtool.service; then
+        log "Failed to start flannel-ethtool.service within 30s, restarting it"
+        systemctl restart flannel-ethtool.service
+    fi
+
+    logSuccess "Flannel ethtool service installed"
 }
 
 function flannel_init_pod_subnet() {

--- a/addons/flannel/0.24.2/install.sh
+++ b/addons/flannel/0.24.2/install.sh
@@ -161,9 +161,9 @@ function flannel() {
 
 function flannel_detect_vmware_nic() {
     if lspci -v | grep Ethernet | grep -q "VMware VMXNET3"; then
-        true
+        return 0
     fi
-    false
+    return 1
 }
 
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -161,9 +161,9 @@ function flannel() {
 
 function flannel_detect_vmware_nic() {
     if lspci -v | grep Ethernet | grep -q "VMware VMXNET3"; then
-        true
+        return 0
     fi
-    false
+    return 1
 }
 
 function flannel_install_ethtool_service() {

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -160,15 +160,11 @@ function flannel() {
 }
 
 function flannel_detect_vmware_nic() {
-    local vmxnet3=false
-
     if lspci -v | grep Ethernet | grep -q "VMware VMXNET3"; then
-        vmxnet3=true
+        true
     fi
-
-    return $vmxnet3
+    false
 }
-
 
 function flannel_install_ethtool_service() {
     # this disables the tcp checksum offloading on flannel interface - this is a workaround for

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -173,6 +173,7 @@ function flannel_install_ethtool_service() {
     local src="$1"
 
     logStep "Installing flannel ethtool service"
+    logStep "Disabling TCP checksum offloading on flannel interface for VMWare VMXNET3 NICs"
 
     cp "$src/flannel-ethtool.service" /etc/systemd/system/flannel-ethtool.service
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Adds a systemd drop-in to disable TCP checksum offloading for VMware VMXNET3 NIC drivers - this is defaulted to ON in modern Linux kernels, but in certain VMWare deployments, the checksum offloading is handled incorrectly leading to dropped packets on the interface.  Detecting it is difficult because it only manifests in multi-node configurations once additional nodes have been added, but host networking works just fine so kURL does not detect a problem at installation time.  Disabling this for all VMXNET3 driver users seems like a safe assumption and disabling TCP checksum offloading incurs very little performance penalty.

The `ethtool` command can be used to fix the problem in-situ but changes made with that tool are not persistent, so this systemd unit hooks into the flannel device unit file and disables the offloading option whenever the flannel interface is configured.

Researching the issue 

See also 
- https://github.com/projectcalico/calico/issues/4727
- https://t.du9l.com/2020/03/kubernetes-flannel-udp-packets-dropped-for-wrong-checksum-workaround/





#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://app.shortcut.com/replicated/story/91846/hostpreflight-detect-if-host-nic-uses-vmxnet3-driver-from-vmware-and-if-so-warn-about-vxlan-checksum-offloading

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Install a VMWare ESXi cluster with NSX networking enabled for software-defined-networking at the VMWare cluster level 
2. configure >2 VMs with the VMXNet3 NIC driver 
3. install kurl on primary
4. add secondary
5. observe that pod-pod traffic between nodes fails silently

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE