### PR TITLE
test on centos 8 stream. expect preinstalled containerd 1.6.31+ on centos 8.4

### DIFF
--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -374,7 +374,7 @@ function containerd_kubernetes_pause_image() {
 }
 
 function require_centos8_containerd() {
-    if [ "$LSB_DIST" == "centos" ] || [ "$DIST_VERSION_MAJOR" == "8" ]; then
+    if [ "$LSB_DIST" == "centos" ] && [ "$DIST_VERSION_MAJOR" == "8" ]; then
         # if this is not centos 8 Stream, require preinstallation of containerd on 1.6.31+
 
         if cat /etc/centos-release | grep -q "CentOS Stream"; then

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -374,7 +374,7 @@ function containerd_kubernetes_pause_image() {
 }
 
 function require_centos8_containerd() {
-    if [ "$LSB_DIST" == "centos" ] || [ "$DIST_VERSION_MAJOR" == "8" ]; then
+    if [ "$LSB_DIST" == "centos" ] && [ "$DIST_VERSION_MAJOR" == "8" ]; then
         # if this is not centos 8 Stream, require preinstallation of containerd on 1.6.31+
 
         if cat /etc/centos-release | grep -q "CentOS Stream"; then

--- a/testgrid/specs/os-customer-common.yaml
+++ b/testgrid/specs/os-customer-common.yaml
@@ -2,7 +2,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: "yum update -y && yum install -y traceroute"
+  preinit: "yum update -y && yum install -y traceroute iptables"
 - id: ubuntu-2204
   name: Ubuntu
   version: "22.04"

--- a/testgrid/specs/os-customer-common.yaml
+++ b/testgrid/specs/os-customer-common.yaml
@@ -2,7 +2,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: "yum update -y && yum install -y traceroute iptables"
+  preinit: "yum update -y && yum install -y traceroute iptables bind-utils"
 - id: ubuntu-2204
   name: Ubuntu
   version: "22.04"

--- a/testgrid/specs/os-customer-common.yaml
+++ b/testgrid/specs/os-customer-common.yaml
@@ -1,8 +1,8 @@
-- id: centos-84
+- id: centos-8-stream-2024-04
   name: CentOS
-  version: "8.4"
-  vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2
-  preinit: ""
+  version: "8.2024-04"
+  vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
+  preinit: "yum update -y && yum install -y traceroute"
 - id: ubuntu-2204
   name: Ubuntu
   version: "22.04"

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -18,10 +18,10 @@
   version: "8.1"
   vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
   preinit: ""
-- id: centos-84
+- id: centos-8-stream-2024-04
   name: CentOS
-  version: "8.4"
-  vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2
+  version: "8.2024-04"
+  vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
   preinit: ""
 - id: ol-79
   name: Oracle Linux

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -22,7 +22,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: "yum update -y && yum install -y traceroute iptables"
+  preinit: "yum update -y && yum install -y traceroute iptables bind-utils"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -22,7 +22,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: ""
+  preinit: "yum update -y && yum install -y traceroute iptables"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -42,7 +42,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: ""
+  preinit: "yum update -y && yum install -y traceroute iptables"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -38,6 +38,11 @@
   version: "8.4"
   vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2
   preinit: ""
+- id: centos-8-stream-2024-04
+  name: CentOS
+  version: "8.2024-04"
+  vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
+  preinit: ""
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -42,7 +42,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: "yum update -y && yum install -y traceroute iptables"
+  preinit: "yum update -y && yum install -y traceroute iptables bind-utils"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -17,7 +17,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: ""
+  preinit: "yum update -y && yum install -y traceroute iptables"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -8,11 +8,6 @@
   version: "7.9"
   vmimageuri: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2
   preinit: ""
-- id: centos-84
-  name: CentOS
-  version: "8.4"
-  vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2
-  preinit: ""
 - id: centos-8-stream-2024-04
   name: CentOS
   version: "8.2024-04"

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -17,7 +17,7 @@
   name: CentOS
   version: "8.2024-04"
   vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
-  preinit: "yum update -y && yum install -y traceroute iptables"
+  preinit: "yum update -y && yum install -y traceroute iptables bind-utils"
 - id: ol-79
   name: Oracle Linux
   version: "7.9"

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -13,6 +13,11 @@
   version: "8.4"
   vmimageuri: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2
   preinit: ""
+- id: centos-8-stream-2024-04
+  name: CentOS
+  version: "8.2024-04"
+  vmimageuri: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20240415.0.x86_64.qcow2
+  preinit: ""
 - id: ol-79
   name: Oracle Linux
   version: "7.9"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Centos 8.4 + ContainerD 1.6.31 results in an infinite hang. So, let's require the user install containerd manually, since that OS has been EOL for > 2 years.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Centos 8.4 and before now require the `containerd.io` package be preinstalled when installing `containerd` 1.6.31 and later.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
