### PR TITLE
bug: retry creating installer for 1m

### DIFF
--- a/scripts/common/yaml.sh
+++ b/scripts/common/yaml.sh
@@ -219,7 +219,7 @@ function apply_installer_crd() {
         cat > $ORIGINAL_INSTALLER_SPEC <<EOL
 ${INSTALLER_YAML}
 EOL
-        kubectl apply -f "$ORIGINAL_INSTALLER_SPEC"
+        try_1m kubectl apply -f "$ORIGINAL_INSTALLER_SPEC"
     fi
 
     try_1m kubectl apply -f "$MERGED_YAML_SPEC"


### PR DESCRIPTION
we have seen cases in our tests where the crd is created but as soon as we try to create an object it fails. as this happens sometimes and not all times and judging that we are already using retry for 1m a couple of lines below let's add the retry here as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
