### PR TITLE
do not attempt to test contour 1.29+ with k8s < 1.21

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -220,7 +220,7 @@
     weave:
       version: 2.8.1
     contour:
-      version: latest
+      version: 1.28.0
   unsupportedOSIDs:
   - ubuntu-2204 # docker 20.10.5 is not available on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants4
@@ -241,7 +241,7 @@
     weave:
       version: 2.6.5
     contour:
-      version: latest
+      version: 1.28.0
     containerd:
       version: 1.6.x
   unsupportedOSIDs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The staging daily test is failing to run because a spec is invalid, specifically:

>Error: generate versioned url from upgrade url {"error":{"message":"Contour versions greater than or equal to 1.29.0 require Kubernetes 1.21+"}}: unable to parse url "{\"error\":{\"message\":\"Contour versions greater than or equal to 1.29.0 require Kubernetes 1.21+\"}}"


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
