### PR TITLE
Use cluster-cidr from kube-controller-manager.yaml

### DIFF
--- a/addons/flannel/0.20.0/install.sh
+++ b/addons/flannel/0.20.0/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.20.1/install.sh
+++ b/addons/flannel/0.20.1/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.20.2/install.sh
+++ b/addons/flannel/0.20.2/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.0/install.sh
+++ b/addons/flannel/0.21.0/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.1/install.sh
+++ b/addons/flannel/0.21.1/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.2/install.sh
+++ b/addons/flannel/0.21.2/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.3/install.sh
+++ b/addons/flannel/0.21.3/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.4/install.sh
+++ b/addons/flannel/0.21.4/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.21.5/install.sh
+++ b/addons/flannel/0.21.5/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.22.0/install.sh
+++ b/addons/flannel/0.22.0/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.22.1/install.sh
+++ b/addons/flannel/0.22.1/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.22.2/install.sh
+++ b/addons/flannel/0.22.2/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.22.3/install.sh
+++ b/addons/flannel/0.22.3/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.23.0/install.sh
+++ b/addons/flannel/0.23.0/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.24.0/install.sh
+++ b/addons/flannel/0.24.0/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.24.1/install.sh
+++ b/addons/flannel/0.24.1/install.sh
@@ -162,7 +162,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.24.2/install.sh
+++ b/addons/flannel/0.24.2/install.sh
@@ -195,7 +195,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.24.4/install.sh
+++ b/addons/flannel/0.24.4/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.25.1/install.sh
+++ b/addons/flannel/0.25.1/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.25.2/install.sh
+++ b/addons/flannel/0.25.2/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.25.3/install.sh
+++ b/addons/flannel/0.25.3/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/0.25.4/install.sh
+++ b/addons/flannel/0.25.4/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -194,7 +194,7 @@ function flannel_init_pod_subnet() {
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
     if commandExists kubectl; then
-        EXISTING_POD_CIDR=$(kubectl -n kube-system get cm kubeadm-config -oyaml 2>/dev/null | grep podSubnet | awk '{ print $NF }')
+        EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
Instead of using the in-cluster kubeadm config which sometimes? loses the configured podSubnet, instead pull the podSubnet from the kube-controller-manager static manifest. this should prevent an issue where kurl sometimes resets the podSubnet on upgrade.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
