### PR TITLE
reenable centos/rhel/ol 7 + amazon linux 2 package builds

### DIFF
--- a/addons/containerd/1.6.32/Manifest
+++ b/addons/containerd/1.6.32/Manifest
@@ -1,5 +1,7 @@
 yum libzstd
 asset runc https://github.com/opencontainers/runc/releases/download/v1.1.13/runc.amd64
+dockerout rhel-7 addons/containerd/template/Dockerfile.centos7 1.6.32
+dockerout rhel-7-force addons/containerd/template/Dockerfile.centos7-force 1.6.32
 dockerout rhel-8 addons/containerd/template/Dockerfile.centos8 1.6.32
 dockerout rhel-9 addons/containerd/template/Dockerfile.rhel9 1.6.32
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.6.21

--- a/addons/containerd/template/Dockerfile.centos7
+++ b/addons/containerd/template/Dockerfile.centos7
@@ -1,0 +1,18 @@
+FROM centos:7.4.1708
+
+RUN yum-config-manager --disable main --disable base --disable extras --disable updates
+RUN yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/
+RUN curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key
+RUN rpm --import vault.gpg.key
+
+RUN yum install -y createrepo
+RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+RUN mkdir -p /packages/archives
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+CMD yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
+    containerd.io-$(yum list --showduplicates 'containerd.io' | grep ${VERSION} | tail -1 | awk '{ print $2 }' | sed 's/.\://') \
+  && createrepo /packages/archives \
+  && cp -r /packages/archives/* /out/

--- a/addons/containerd/template/Dockerfile.centos7-force
+++ b/addons/containerd/template/Dockerfile.centos7-force
@@ -1,0 +1,17 @@
+FROM centos:7.4.1708
+
+RUN yum-config-manager --disable main --disable base --disable extras --disable updates
+RUN yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/
+RUN curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key
+RUN rpm --import vault.gpg.key
+
+RUN yum install -y createrepo
+RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+RUN mkdir -p /packages/archives
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+CMD yumdownloader --resolve --destdir=/packages/archives -y \
+    containerd.io-$(yum list --showduplicates 'containerd.io' | grep ${VERSION} | tail -1 | awk '{ print $2 }' | sed 's/.\://') \
+  && cp -r /packages/archives/* /out/

--- a/addons/containerd/template/script.sh
+++ b/addons/containerd/template/script.sh
@@ -153,12 +153,16 @@ UNSUPPORTED_CONTAINERD_MINORS="01234"
 
 VERSIONS=()
 function find_common_versions() {
+    docker build --no-cache --pull -t centos8 -f Dockerfile.centos7 .
     docker build --no-cache --pull -t centos8 -f Dockerfile.centos8 .
     docker build --no-cache --pull -t rhel9 -f Dockerfile.rhel9 .
     docker build --no-cache --pull -t ubuntu16 -f Dockerfile.ubuntu16 .
     docker build --no-cache --pull -t ubuntu18 -f Dockerfile.ubuntu18 .
     docker build --no-cache --pull -t ubuntu20 -f Dockerfile.ubuntu20 .
     docker build --no-cache --pull -t ubuntu22 -f Dockerfile.ubuntu22 .
+
+    CENTOS7_VERSIONS=($(docker run --rm -i centos7 yum list --showduplicates containerd.io | grep -Eo '1\.[[:digit:]]+\.[[:digit:]]+' | grep -vE '1\.['"$UNSUPPORTED_CONTAINERD_MINORS"']\.' | sort -rV | uniq))
+    echo "Found ${#CENTOS7_VERSIONS[*]} containerd versions for CentOS 7: ${CENTOS7_VERSIONS[*]}"
 
     CENTOS8_VERSIONS=($(docker run --rm -i centos8 yum list --showduplicates containerd.io | grep -Eo '1\.[[:digit:]]+\.[[:digit:]]+' | grep -vE '1\.['"$UNSUPPORTED_CONTAINERD_MINORS"']\.' | sort -rV | uniq))
     echo "Found ${#CENTOS8_VERSIONS[*]} containerd versions for CentOS 8: ${CENTOS8_VERSIONS[*]}"
@@ -179,13 +183,28 @@ function find_common_versions() {
     echo "Found ${#UBUNTU22_VERSIONS[*]} containerd versions for Ubuntu 22: ${UBUNTU22_VERSIONS[*]}"
 
     # Get the union of versions available for all operating systems
-    local ALL_VERSIONS=("${CENTOS8_VERSIONS[@]}" "${RHEL9_VERSIONS[@]}" "${UBUNTU16_VERSIONS[@]}" "${UBUNTU18_VERSIONS[@]}" "${UBUNTU20_VERSIONS[@]}" "${UBUNTU22_VERSIONS[@]}")
+    local ALL_VERSIONS=("${CENTOS7_VERSIONS[@]}" "${CENTOS8_VERSIONS[@]}" "${RHEL9_VERSIONS[@]}" "${UBUNTU16_VERSIONS[@]}" "${UBUNTU18_VERSIONS[@]}" "${UBUNTU20_VERSIONS[@]}" "${UBUNTU22_VERSIONS[@]}")
     ALL_VERSIONS=($(echo "${ALL_VERSIONS[@]}" | tr ' ' '\n' | sort -rV | uniq -d | tr '\n' ' ')) # remove duplicates
     ALL_VERSIONS=($(echo "${ALL_VERSIONS[@]}" | tr ' ' '\n' | grep -vE '1\.7\.' | tr '\n' ' ')) # remove 7.x versions
 
     for version in ${ALL_VERSIONS[@]}; do
         init_preflight_file $version
         init_manifest_file $version
+
+        if ! contains "$version" ${CENTOS7_VERSIONS[*]}; then
+            echo "Centos 7 lacks version $version, using ${CENTOS7_VERSIONS[0]} instead"
+            add_override_os_to_preflight_file "$version" "${CENTOS7_VERSIONS[0]}" "centos" "7"
+            add_override_os_to_preflight_file "$version" "${CENTOS7_VERSIONS[0]}" "rhel" "7"
+            add_override_os_to_preflight_file "$version" "${CENTOS7_VERSIONS[0]}" "ol" "7"
+            add_override_os_to_manifest_file "$version" "${CENTOS7_VERSIONS[0]}" "rhel-7" "Dockerfile.centos7"
+            add_override_os_to_manifest_file "$version" "${CENTOS7_VERSIONS[0]}" "rhel-7-force" "Dockerfile.centos7-force"
+        else
+            add_supported_os_to_preflight_file "$version" "centos" "7"
+            add_supported_os_to_preflight_file "$version" "rhel" "7"
+            add_supported_os_to_preflight_file "$version" "ol" "7"
+            add_supported_os_to_manifest_file "$version" "rhel-7" "Dockerfile.centos7"
+            add_supported_os_to_manifest_file "$version" "rhel-7-force" "Dockerfile.centos7-force"
+        fi
 
         if ! contains "$version" ${CENTOS8_VERSIONS[*]}; then
             echo "Rocky 8 lacks version $version, using ${CENTOS8_VERSIONS[0]} instead"

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -27,6 +27,10 @@ function build_rhel_7() {
         centos:7.4.1708 \
         /bin/bash -c "\
             set -x
+            yum-config-manager --disable main --disable base --disable extras --disable updates && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
+            rpm --import vault.gpg.key
             yum update -y ca-certificates && \
             yum install -y epel-release && \
             mkdir -p /packages/archives && \
@@ -49,6 +53,10 @@ function build_rhel_7_force() {
         centos:7.4.1708 \
         /bin/bash -c "\
             set -x
+            yum-config-manager --disable main --disable base --disable extras --disable updates && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
+            rpm --import vault.gpg.key
             yum update -y ca-certificates && \
             yum install -y epel-release && \
             mkdir -p /packages/archives && \
@@ -68,6 +76,10 @@ function createrepo_rhel_7() {
         centos:7.4.1708 \
         /bin/bash -c "\
             set -x
+            yum-config-manager --disable main --disable base --disable extras --disable updates && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
+            rpm --import vault.gpg.key
             yum install -y createrepo && \
             createrepo /packages/archives"
     sudo docker cp "rhel-7-createrepo-$PACKAGE_NAME":/packages/archives "$outdir"
@@ -224,6 +236,10 @@ function build_ol_7() {
         centos:7.4.1708 \
         /bin/bash -c "\
             set -x && \
+            yum-config-manager --disable main --disable base --disable extras --disable updates && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
+            rpm --import vault.gpg.key && \
             yum-config-manager --add-repo=http://public-yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/ && \
             mkdir -p /packages/archives && \
             yumdownloader --disablerepo=* --enablerepo=public-yum.oracle.com_repo_OracleLinux_OL7_latest_x86_64_ --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y ${packages[*]}"
@@ -242,6 +258,10 @@ function createrepo_ol_7() {
         centos:7.4.1708 \
         /bin/bash -c "\
             set -x
+            yum-config-manager --disable main --disable base --disable extras --disable updates && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
+            rpm --import vault.gpg.key
             yum install -y createrepo && \
             createrepo /packages/archives"
     sudo docker cp "ol-7-createrepo-$PACKAGE_NAME":/packages/archives "$outdir"

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -32,7 +32,6 @@ function build_rhel_7() {
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \
-            yum install -y epel-release && \
             mkdir -p /packages/archives && \
             yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y ${packages[*]}"
     sudo docker cp "rhel-7-$PACKAGE_NAME":/packages/archives "$outdir"
@@ -58,7 +57,6 @@ function build_rhel_7_force() {
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \
-            yum install -y epel-release && \
             mkdir -p /packages/archives && \
             yumdownloader --resolve --destdir=/packages/archives -y ${packages[*]}"
     sudo docker cp "rhel-7-force-$PACKAGE_NAME":/packages/archives "$outdir"

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -29,9 +29,11 @@ function build_rhel_7() {
             set -x
             yum-config-manager --disable main --disable base --disable extras --disable updates && \
             yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \
+            yum install -y epel-release && \
             mkdir -p /packages/archives && \
             yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y ${packages[*]}"
     sudo docker cp "rhel-7-$PACKAGE_NAME":/packages/archives "$outdir"
@@ -54,9 +56,11 @@ function build_rhel_7_force() {
             set -x
             yum-config-manager --disable main --disable base --disable extras --disable updates && \
             yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \
+            yum install -y epel-release && \
             mkdir -p /packages/archives && \
             yumdownloader --resolve --destdir=/packages/archives -y ${packages[*]}"
     sudo docker cp "rhel-7-force-$PACKAGE_NAME":/packages/archives "$outdir"

--- a/bin/save-manifest-assets.sh
+++ b/bin/save-manifest-assets.sh
@@ -29,7 +29,7 @@ function build_rhel_7() {
             set -x
             yum-config-manager --disable main --disable base --disable extras --disable updates && \
             yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
-            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/extras/x86_64/ && \
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \
@@ -56,7 +56,7 @@ function build_rhel_7_force() {
             set -x
             yum-config-manager --disable main --disable base --disable extras --disable updates && \
             yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
-            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/ && \
+            yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/extras/x86_64/ && \
             curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key && \
             rpm --import vault.gpg.key
             yum update -y ca-certificates && \

--- a/bundles/k8s-rhel7-force/Dockerfile
+++ b/bundles/k8s-rhel7-force/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazonlinux:2
+ARG KUBERNETES_VERSION
+COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+ARG KUBERNETES_MINOR_VERSION
+RUN sed -i "s/__KUBERNETES_MINOR_VERSION__/v${KUBERNETES_MINOR_VERSION}/g" /etc/yum.repos.d/kubernetes.repo
+RUN mkdir -p /packages/archives
+
+RUN yum install yum-utils -y
+RUN yumdownloader --resolve --destdir=/packages/archives -y \
+	kubelet-${KUBERNETES_VERSION} \
+	kubectl-${KUBERNETES_VERSION} \
+	ncurses-compat-libs \
+	git
+
+CMD cp -r /packages/archives/* /out/

--- a/bundles/k8s-rhel7-force/kubernetes.repo
+++ b/bundles/k8s-rhel7-force/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/__KUBERNETES_MINOR_VERSION__/rpm/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key

--- a/bundles/k8s-rhel7/Dockerfile
+++ b/bundles/k8s-rhel7/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:7
+ARG KUBERNETES_VERSION
+COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+ARG KUBERNETES_MINOR_VERSION
+RUN sed -i "s/__KUBERNETES_MINOR_VERSION__/v${KUBERNETES_MINOR_VERSION}/g" /etc/yum.repos.d/kubernetes.repo
+RUN mkdir -p /packages/archives
+
+RUN yum-config-manager --disable main --disable base --disable extras --disable updates
+RUN yum-config-manager --add-repo https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/
+RUN curl https://archive.kernel.org/centos-vault/7.9.2009/os/x86_64/RPM-GPG-KEY-CentOS-7 > vault.gpg.key
+RUN rpm --import vault.gpg.key
+
+RUN yum install -y createrepo
+RUN yumdownloader --installroot=/tmp/empty-directory --releasever=/ --resolve --destdir=/packages/archives -y \
+	kubelet-${KUBERNETES_VERSION} \
+	kubectl-${KUBERNETES_VERSION} \
+	git
+RUN createrepo /packages/archives
+
+CMD cp -r /packages/archives/* /out/

--- a/bundles/k8s-rhel7/kubernetes.repo
+++ b/bundles/k8s-rhel7/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/__KUBERNETES_MINOR_VERSION__/rpm/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

this largely undoes https://github.com/replicatedhq/kURL/commit/aa084d421734387bf6e7d2d3d0d7bad981ed8189, but adds some changes to the dockerfiles to use the centos vault repo instead of the (now disabled) original upstreams.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
CentOS 7, RHEL 7, Oracle Linux 7 and Amazon Linux 2 packages are now sourced from the CentOS Vault. These packages will not receive security updates.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
