### PR TITLE
skip build of Rook 1.4.3 and 1.4.9

### DIFF
--- a/bin/list-all-packages.sh
+++ b/bin/list-all-packages.sh
@@ -32,7 +32,7 @@ function pkgs() {
 }
 
 function list_all_addons() {
-    pkgs addons | sort | grep -v "rookupgrade"
+    pkgs addons | sort | grep -v "rookupgrade" | grep -v "rook-1.4"
 }
 
 function list_all_packages() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Rook 1.4.3 and 1.4.9 pull in k8scsi images (`quay.io/k8scsi/csi-attacher:v2.1.0`/`quay.io/k8scsi/csi-node-driver-registrar:v1.2.0` possibly more), that use a deprecated image format. This prevents rebuilding the package.

A future PR to kurl-api will need to be made to continue serving the last good version of this package in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
