### PR TITLE
run the container-selinux installation on centos 7 as part of the 'install' step

### DIFF
--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -34,6 +34,7 @@ function containerd_install() {
 
     containerd_migrate_from_docker
 
+    containerd_install_container_selinux_if_missing
     install_host_packages "$src" containerd.io
 
     chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
@@ -109,7 +110,6 @@ function containerd_install() {
 function containerd_host_init() {
     require_centos8_containerd
     containerd_install_libzstd_if_missing
-    containerd_install_container_selinux_if_missing
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -34,6 +34,7 @@ function containerd_install() {
 
     containerd_migrate_from_docker
 
+    containerd_install_container_selinux_if_missing
     install_host_packages "$src" containerd.io
 
     chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
@@ -109,7 +110,6 @@ function containerd_install() {
 function containerd_host_init() {
     require_centos8_containerd
     containerd_install_libzstd_if_missing
-    containerd_install_container_selinux_if_missing
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -373,3 +373,17 @@
     validate_read_write_object_store postupgrade upgradefile.txt
     containerd --version
     containerd --version | grep "__testver__"
+
+- name: "flannel latest multinode"
+  installerSpec:
+    kubernetes:
+      version: "1.30.x"
+    flannel:
+      version: "latest"
+    containerd:
+      version: "__testver__"
+      s3Override: "__testdist__"
+    goldpinger:
+      version: "latest"
+  numPrimaryNodes: 1
+  numSecondaryNodes: 2


### PR DESCRIPTION

this allows it to be run on joins before the containerd.io package is installed

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
