### PR TITLE
use the already-pulled 'registry:2.8.3' image in on-merge tests, not 'registry:2.8.1'

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -75,7 +75,7 @@
       version: latest
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.3"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     test_push_image_to_registry
     install_and_customize_kurl_integration_test_application
@@ -138,7 +138,7 @@
       version: latest
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.3"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     test_push_image_to_registry
     install_and_customize_kurl_integration_test_application
@@ -252,6 +252,7 @@
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
-    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.1"
+    create_deployment_with_mounted_volume "migration-test" "default" "/data" "registry:2.8.3"
     create_random_file_and_upload_to_deployment "migration-test" "default" "./test.data" "/data/test.data"
     test_push_image_to_registry
+    test_pull_image_from_registry


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
