### PR TITLE
feat: support for amazon linux 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ addons/*/*/assets
 addons/*/*/images
 addons/*/*/rhel-*
 addons/*/*/ubuntu-*
+addons/*/*/amazon-*
 packages/*/*/assets
 packages/*/*/images
 packages/*/*/rhel-*

--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,21 @@ build/packages/kubernetes/%/rhel-9:
 	find build/packages/kubernetes/$*/rhel-9 | grep kubectl | grep -v kubectl-$* | xargs rm -vf
 	docker rm k8s-rhel9-$*
 
+build/packages/kubernetes/%/amazon-2023:
+	docker build \
+		--build-arg KUBERNETES_VERSION=$* \
+		--build-arg KUBERNETES_MINOR_VERSION=$(shell echo $* | sed 's/\.[0-9]*$$//') \
+		-t kurl/amazon-2023-k8s:$* \
+		-f bundles/k8s-amazon2023/Dockerfile \
+		bundles/k8s-amazon2023
+	-docker rm -f k8s-amazon2023-$* 2>/dev/null
+	docker create --name k8s-amazon2023-$* kurl/amazon-2023-k8s:$*
+	mkdir -p build/packages/kubernetes/$*/amazon-2023
+	docker cp k8s-amazon2023-$*:/packages/archives/. build/packages/kubernetes/$*/amazon-2023/
+	find build/packages/kubernetes/$*/amazon-2023 | grep kubelet | grep -v kubelet-$* | xargs rm -vf
+	find build/packages/kubernetes/$*/amazon-2023 | grep kubectl | grep -v kubectl-$* | xargs rm -vf
+	docker rm k8s-amazon2023-$*
+
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl
 
 .PHONY: build/bin ## Build kurl binary

--- a/addons/collectd/v5/Manifest
+++ b/addons/collectd/v5/Manifest
@@ -5,3 +5,6 @@ yum8 collectd-disk
 yum9 collectd
 yum9 collectd-rrdtool
 yum9 collectd-disk
+yum2023 collectd
+yum2023 collectd-rrdtool
+yum2023 collectd-disk

--- a/addons/collectd/v5/install.sh
+++ b/addons/collectd/v5/install.sh
@@ -13,7 +13,7 @@ function collectd() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if [ "$DIST_VERSION_MAJOR" = "8" ] || [ "$DIST_VERSION_MAJOR" = "9" ]; then
+                if [ "$DIST_VERSION_MAJOR" = "8" ] || [ "$DIST_VERSION_MAJOR" = "9" ] || [ "$DIST_VERSION_MAJOR" = "2023" ] ; then
                     yum_install_host_archives "$src" collectd collectd-rrdtool collectd-disk
                 else
                     yum_install_host_archives "$src" collectd collectd-rrdtool

--- a/addons/containerd/1.2.13/install.sh
+++ b/addons/containerd/1.2.13/install.sh
@@ -1,10 +1,4 @@
 
-function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-}
-
 function containerd_install() {
     local src="$DIR/addons/containerd/1.2.13"
 

--- a/addons/containerd/1.2.13/install.sh
+++ b/addons/containerd/1.2.13/install.sh
@@ -1,4 +1,9 @@
 
+function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+}
 
 function containerd_install() {
     local src="$DIR/addons/containerd/1.2.13"

--- a/addons/containerd/1.3.7/host-preflight.yaml
+++ b/addons/containerd/1.3.7/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.3.7/install.sh
+++ b/addons/containerd/1.3.7/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.3.9/host-preflight.yaml
+++ b/addons/containerd/1.3.9/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.3.9/install.sh
+++ b/addons/containerd/1.3.9/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.10/host-preflight.yaml
+++ b/addons/containerd/1.4.10/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.10/install.sh
+++ b/addons/containerd/1.4.10/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.11/host-preflight.yaml
+++ b/addons/containerd/1.4.11/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.11/install.sh
+++ b/addons/containerd/1.4.11/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.12/host-preflight.yaml
+++ b/addons/containerd/1.4.12/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.12/install.sh
+++ b/addons/containerd/1.4.12/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.13/host-preflight.yaml
+++ b/addons/containerd/1.4.13/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.13/install.sh
+++ b/addons/containerd/1.4.13/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.3/host-preflight.yaml
+++ b/addons/containerd/1.4.3/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.3/install.sh
+++ b/addons/containerd/1.4.3/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.4/host-preflight.yaml
+++ b/addons/containerd/1.4.4/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.4/install.sh
+++ b/addons/containerd/1.4.4/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.6/host-preflight.yaml
+++ b/addons/containerd/1.4.6/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.6/install.sh
+++ b/addons/containerd/1.4.6/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.8/host-preflight.yaml
+++ b/addons/containerd/1.4.8/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.8/install.sh
+++ b/addons/containerd/1.4.8/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.9/host-preflight.yaml
+++ b/addons/containerd/1.4.9/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -3,6 +3,10 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
+    if is_amazon_2023 ; then
+        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.4.9/install.sh
+++ b/addons/containerd/1.4.9/install.sh
@@ -3,10 +3,6 @@ CONTAINERD_NEEDS_RESTART=0
 CONTAINERD_DID_MIGRATE_FROM_DOCKER=0
 
 function containerd_pre_init() {
-    if is_amazon_2023 ; then
-        bail "Containerd versions < 1.5.10 are not supported on Amazon Linux 2023"
-    fi
-
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     # Explicitly configure kubelet to use containerd instead of detecting dockershim socket

--- a/addons/containerd/1.5.10/host-preflight.yaml
+++ b/addons/containerd/1.5.10/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.5.11/host-preflight.yaml
+++ b/addons/containerd/1.5.11/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.10/host-preflight.yaml
+++ b/addons/containerd/1.6.10/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.10/install.sh
+++ b/addons/containerd/1.6.10/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.10/install.sh
+++ b/addons/containerd/1.6.10/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.10/install.sh
+++ b/addons/containerd/1.6.10/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.11/host-preflight.yaml
+++ b/addons/containerd/1.6.11/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.11/install.sh
+++ b/addons/containerd/1.6.11/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.11/install.sh
+++ b/addons/containerd/1.6.11/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.11/install.sh
+++ b/addons/containerd/1.6.11/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.12/host-preflight.yaml
+++ b/addons/containerd/1.6.12/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.12/install.sh
+++ b/addons/containerd/1.6.12/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.12/install.sh
+++ b/addons/containerd/1.6.12/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.12/install.sh
+++ b/addons/containerd/1.6.12/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.13/host-preflight.yaml
+++ b/addons/containerd/1.6.13/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.13/install.sh
+++ b/addons/containerd/1.6.13/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.13/install.sh
+++ b/addons/containerd/1.6.13/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.13/install.sh
+++ b/addons/containerd/1.6.13/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.14/host-preflight.yaml
+++ b/addons/containerd/1.6.14/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.14/install.sh
+++ b/addons/containerd/1.6.14/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.14/install.sh
+++ b/addons/containerd/1.6.14/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.14/install.sh
+++ b/addons/containerd/1.6.14/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.15/host-preflight.yaml
+++ b/addons/containerd/1.6.15/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.15/install.sh
+++ b/addons/containerd/1.6.15/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.16/host-preflight.yaml
+++ b/addons/containerd/1.6.16/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.16/install.sh
+++ b/addons/containerd/1.6.16/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.16/install.sh
+++ b/addons/containerd/1.6.16/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.16/install.sh
+++ b/addons/containerd/1.6.16/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.18/host-preflight.yaml
+++ b/addons/containerd/1.6.18/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.18/install.sh
+++ b/addons/containerd/1.6.18/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.18/install.sh
+++ b/addons/containerd/1.6.18/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.18/install.sh
+++ b/addons/containerd/1.6.18/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.19/host-preflight.yaml
+++ b/addons/containerd/1.6.19/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amzn = 2023"
+              message: "containerd addon supports amzn 2023"

--- a/addons/containerd/1.6.19/install.sh
+++ b/addons/containerd/1.6.19/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.19/install.sh
+++ b/addons/containerd/1.6.19/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.19/install.sh
+++ b/addons/containerd/1.6.19/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.20/host-preflight.yaml
+++ b/addons/containerd/1.6.20/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.20/install.sh
+++ b/addons/containerd/1.6.20/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.20/install.sh
+++ b/addons/containerd/1.6.20/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.20/install.sh
+++ b/addons/containerd/1.6.20/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.21/host-preflight.yaml
+++ b/addons/containerd/1.6.21/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.21/install.sh
+++ b/addons/containerd/1.6.21/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.21/install.sh
+++ b/addons/containerd/1.6.21/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.21/install.sh
+++ b/addons/containerd/1.6.21/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.22/host-preflight.yaml
+++ b/addons/containerd/1.6.22/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.22/install.sh
+++ b/addons/containerd/1.6.22/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.22/install.sh
+++ b/addons/containerd/1.6.22/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.22/install.sh
+++ b/addons/containerd/1.6.22/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.24/host-preflight.yaml
+++ b/addons/containerd/1.6.24/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.25/host-preflight.yaml
+++ b/addons/containerd/1.6.25/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.26/host-preflight.yaml
+++ b/addons/containerd/1.6.26/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.26/install.sh
+++ b/addons/containerd/1.6.26/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.26/install.sh
+++ b/addons/containerd/1.6.26/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.26/install.sh
+++ b/addons/containerd/1.6.26/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.27/host-preflight.yaml
+++ b/addons/containerd/1.6.27/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.27/install.sh
+++ b/addons/containerd/1.6.27/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.27/install.sh
+++ b/addons/containerd/1.6.27/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.27/install.sh
+++ b/addons/containerd/1.6.27/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.28/host-preflight.yaml
+++ b/addons/containerd/1.6.28/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.28/install.sh
+++ b/addons/containerd/1.6.28/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.28/install.sh
+++ b/addons/containerd/1.6.28/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.28/install.sh
+++ b/addons/containerd/1.6.28/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.31/host-preflight.yaml
+++ b/addons/containerd/1.6.31/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -412,11 +412,16 @@ function require_amazon2023_containerd() {
         return
     fi
 
-    if yum_is_host_package_installed containerd ; then
-        return
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
     fi
 
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
+    fi
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.32/host-preflight.yaml
+++ b/addons/containerd/1.6.32/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.32/install.sh
+++ b/addons/containerd/1.6.32/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.32/install.sh
+++ b/addons/containerd/1.6.32/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.32/install.sh
+++ b/addons/containerd/1.6.32/install.sh
@@ -412,11 +412,16 @@ function require_amazon2023_containerd() {
         return
     fi
 
-    if yum_is_host_package_installed containerd ; then
-        return
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
     fi
 
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
+    fi
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.33/host-preflight.yaml
+++ b/addons/containerd/1.6.33/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -29,7 +29,9 @@ function containerd_install() {
     if is_amazon_2023; then
         require_amazon2023_containerd
         log "Using containerd version provided by the Operating System."
-        systemctl restart containerd || true
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
     fi
 
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -412,11 +412,16 @@ function require_amazon2023_containerd() {
         return
     fi
 
-    if yum_is_host_package_installed containerd ; then
-        return
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
     fi
 
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
+    fi
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -42,10 +42,8 @@ function containerd_install() {
 
     if ! is_amazon_2023; then
         containerd_migrate_from_docker
-
         containerd_install_container_selinux_if_missing
         install_host_packages "$src" containerd.io
-
         chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
         # If the runc binary is executing the cp command will fail with "text file busy" error.
         # Containerd uses runc in detached mode so any runc processes should be short-lived and exit

--- a/addons/containerd/1.6.4/host-preflight.yaml
+++ b/addons/containerd/1.6.4/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.6/host-preflight.yaml
+++ b/addons/containerd/1.6.6/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.7/host-preflight.yaml
+++ b/addons/containerd/1.6.7/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.8/host-preflight.yaml
+++ b/addons/containerd/1.6.8/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amzn = 2023"
+              message: "containerd addon supports amzn 2023"

--- a/addons/containerd/1.6.8/install.sh
+++ b/addons/containerd/1.6.8/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.8/install.sh
+++ b/addons/containerd/1.6.8/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.8/install.sh
+++ b/addons/containerd/1.6.8/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/1.6.9/host-preflight.yaml
+++ b/addons/containerd/1.6.9/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - fail:
+              when: "amzn = 2023"
+              message: "containerd addon does not support amzn 2023"

--- a/addons/containerd/1.6.9/install.sh
+++ b/addons/containerd/1.6.9/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/1.6.9/install.sh
+++ b/addons/containerd/1.6.9/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,7 +117,22 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function containerd_install_libzstd_if_missing() {

--- a/addons/containerd/1.6.9/install.sh
+++ b/addons/containerd/1.6.9/install.sh
@@ -121,20 +121,6 @@ function containerd_host_init() {
     containerd_install_libzstd_if_missing
 }
 
-# require_amazon2023_containerd makes sure the OS version of containerd is
-# installed.
-function require_amazon2023_containerd() {
-    if ! is_amazon_2023 ; then
-        return
-    fi
-
-    if yum_is_host_package_installed containerd ; then
-        return
-    fi
-
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
-}
-
 function containerd_install_libzstd_if_missing() {
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
@@ -416,6 +402,25 @@ function containerd_kubernetes_pause_image() {
         cat "$DIR/packages/kubernetes/$KUBERNETES_VERSION/Manifest" | grep "pause" | awk '{ print $3 }'
     else
         echo ""
+    fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
+    fi
+
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
     fi
 }
 

--- a/addons/containerd/template/Dockerfile.amazon2023
+++ b/addons/containerd/template/Dockerfile.amazon2023
@@ -1,0 +1,2 @@
+FROM amazonlinux:2023
+RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -121,7 +121,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -412,11 +412,16 @@ function require_amazon2023_containerd() {
         return
     fi
 
-    if yum_is_host_package_installed containerd ; then
-        return
+    if ! yum_is_host_package_installed containerd ; then
+        bail "Containerd is not installed, please install it using the following command: yum install -y containerd-${CONTAINERD_VERSION}"
     fi
 
-    bail "Containerd is not installed, please install it using the following command: yum install -y containerd"
+    local installed_containerd_version=
+    installed_containerd_version=$(rpm -q --queryformat '%{VERSION}' containerd)
+    if [ "$installed_containerd_version" != "$CONTAINERD_VERSION" ]; then
+        logWarn "Containerd version $CONTAINERD_VERSION is required, but version $installed_containerd_version is installed."
+        bail "Please install containerd version ${CONTAINERD_VERSION} before proceeding."
+    fi
 }
 
 function require_centos8_containerd() {

--- a/addons/longhorn/1.1.0/install.sh
+++ b/addons/longhorn/1.1.0/install.sh
@@ -95,7 +95,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -123,7 +123,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/longhorn/1.1.1/install.sh
+++ b/addons/longhorn/1.1.1/install.sh
@@ -105,7 +105,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -133,7 +133,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/longhorn/1.1.2/install.sh
+++ b/addons/longhorn/1.1.2/install.sh
@@ -112,7 +112,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -140,7 +140,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/rook/1.0.4-14.2.21/install.sh
+++ b/addons/rook/1.0.4-14.2.21/install.sh
@@ -201,7 +201,7 @@ function rook_lvm2() {
         return
     fi
  
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.0.4/install.sh
+++ b/addons/rook/1.0.4/install.sh
@@ -191,7 +191,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -658,7 +658,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -657,7 +657,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -659,7 +659,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.2/install.sh
+++ b/addons/rook/1.11.2/install.sh
@@ -654,7 +654,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.3/install.sh
+++ b/addons/rook/1.11.3/install.sh
@@ -654,7 +654,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.4/install.sh
+++ b/addons/rook/1.11.4/install.sh
@@ -665,7 +665,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.5/install.sh
+++ b/addons/rook/1.11.5/install.sh
@@ -674,7 +674,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.6/install.sh
+++ b/addons/rook/1.11.6/install.sh
@@ -674,7 +674,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.7/install.sh
+++ b/addons/rook/1.11.7/install.sh
@@ -677,7 +677,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -677,7 +677,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.0/install.sh
+++ b/addons/rook/1.12.0/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.1/install.sh
+++ b/addons/rook/1.12.1/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.2/install.sh
+++ b/addons/rook/1.12.2/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.3/install.sh
+++ b/addons/rook/1.12.3/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.4/install.sh
+++ b/addons/rook/1.12.4/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.5/install.sh
+++ b/addons/rook/1.12.5/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.6/install.sh
+++ b/addons/rook/1.12.6/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.7/install.sh
+++ b/addons/rook/1.12.7/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.8/install.sh
+++ b/addons/rook/1.12.8/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -228,7 +228,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -379,7 +379,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.10/install.sh
+++ b/addons/rook/1.5.10/install.sh
@@ -373,7 +373,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -379,7 +379,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -395,7 +395,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -382,7 +382,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -456,7 +456,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -631,7 +631,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -664,7 +664,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -662,7 +662,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/velero/1.10.1/install.sh
+++ b/addons/velero/1.10.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.10.2/install.sh
+++ b/addons/velero/1.10.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.11.0/install.sh
+++ b/addons/velero/1.11.0/install.sh
@@ -102,7 +102,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.11.1/install.sh
+++ b/addons/velero/1.11.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.0/install.sh
+++ b/addons/velero/1.12.0/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.1/install.sh
+++ b/addons/velero/1.12.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.2/install.sh
+++ b/addons/velero/1.12.2/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.3/install.sh
+++ b/addons/velero/1.12.3/install.sh
@@ -108,7 +108,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.13.1/install.sh
+++ b/addons/velero/1.13.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.13.2/install.sh
+++ b/addons/velero/1.13.2/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.14.0/install.sh
+++ b/addons/velero/1.14.0/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.1/install.sh
+++ b/addons/velero/1.5.1/install.sh
@@ -79,7 +79,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.3/install.sh
+++ b/addons/velero/1.5.3/install.sh
@@ -54,7 +54,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.4/install.sh
+++ b/addons/velero/1.5.4/install.sh
@@ -54,7 +54,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.0/install.sh
+++ b/addons/velero/1.6.0/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.1/install.sh
+++ b/addons/velero/1.6.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.2/install.sh
+++ b/addons/velero/1.6.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.7.1/install.sh
+++ b/addons/velero/1.7.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.8.1/install.sh
+++ b/addons/velero/1.8.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.0/install.sh
+++ b/addons/velero/1.9.0/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.1/install.sh
+++ b/addons/velero/1.9.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.2/install.sh
+++ b/addons/velero/1.9.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.3/install.sh
+++ b/addons/velero/1.9.3/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.4/install.sh
+++ b/addons/velero/1.9.4/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.5/install.sh
+++ b/addons/velero/1.9.5/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/template/base/install.tmpl.sh
+++ b/addons/velero/template/base/install.tmpl.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/bin/containertools/Dockerfile.amazon2023
+++ b/bin/containertools/Dockerfile.amazon2023
@@ -1,0 +1,16 @@
+# amazonlinux does not have the modulemd-tools package so we use rockylinux
+# version instead, this is used only at build time.
+FROM rockylinux:9 as builder
+RUN yum install yum-utils -y
+RUN yumdownloader modulemd-tools
+
+FROM amazonlinux:2023
+COPY --from=builder /modulemd-tools-*.noarch.rpm /modulemd-tools.rpm
+RUN yum install -y /modulemd-tools.rpm
+
+ARG PACKAGES
+
+RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
+RUN yum install -y yum-utils createrepo findutils
+
+RUN [ -z "$PACKAGES" ] || yum install -y $PACKAGES

--- a/bundles/k8s-amazon2023/Dockerfile
+++ b/bundles/k8s-amazon2023/Dockerfile
@@ -1,0 +1,26 @@
+# amazonlinux does not have the modulemd-tools package so we use rockylinux
+# version instead, this is used only at build time.
+FROM rockylinux:9 as builder
+RUN yum install yum-utils -y
+RUN yumdownloader modulemd-tools
+
+FROM amazonlinux:2023
+COPY --from=builder /modulemd-tools-*.noarch.rpm /modulemd-tools.rpm
+RUN yum install -y /modulemd-tools.rpm
+
+ARG KUBERNETES_VERSION
+RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
+RUN yum install -y yum-utils createrepo findutils
+
+COPY ./containertools /opt/containertools
+COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+ARG KUBERNETES_MINOR_VERSION
+RUN sed -i "s/__KUBERNETES_MINOR_VERSION__/v${KUBERNETES_MINOR_VERSION}/g" /etc/yum.repos.d/kubernetes.repo
+RUN mkdir -p /packages/archives
+RUN /opt/containertools/yumdownloader.sh "kubelet-$KUBERNETES_VERSION kubectl-$KUBERNETES_VERSION kubernetes-cni"
+RUN /opt/containertools/createrepo.sh
+RUN /opt/containertools/builddeps.sh > /packages/archives/Deps \
+	&& sort /packages/archives/Deps | uniq | grep -v '^[[:space:]]*$' > /packages/archives/Deps.tmp \
+	&& mv /packages/archives/Deps.tmp /packages/archives/Deps
+RUN echo "git" >> /packages/archives/Deps
+CMD cp -r /packages/archives/* /out/

--- a/bundles/k8s-amazon2023/containertools/builddeps.sh
+++ b/bundles/k8s-amazon2023/containertools/builddeps.sh
@@ -17,16 +17,6 @@ available_packages="$(yum -q --disablerepo=* --enablerepo=kurl.local --releaseve
 depslist="$(echo "$available_packages" \
     | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --arch=noarch --resolve --requires \
     | awk 'NF{NF-=2}1' FS='-' OFS='-')" # strip last two fields
-
-# some packages may list both libcurl and libcurl-minimal, meaning one or the
-# other. on this case we want to prefer libcurl as its scope is broader and
-# there may be other packages on the system that depend on such broader scope.
-depslist="$(printf '%s\n' $depslist | sed 's/libcurl-minimal/libcurl/g')"
-
-# some packages may list both openssl-snapsafe-libs and openssl-libs, we are
-# going with openssl-libs.
-depslist="$(printf '%s\n' $depslist | sed 's/openssl-snapsafe-libs/openssl-libs/g')"
-
 for package in $available_packages ; do
     # remove packages that in the first level dependency provides
     depslist="$(echo "$depslist" | grep -v "^$package$")"

--- a/bundles/k8s-amazon2023/containertools/createrepo.sh
+++ b/bundles/k8s-amazon2023/containertools/createrepo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+createrepo_c /packages/archives
+repo2module --module-name=kurl.local --module-stream=stable /packages/archives /tmp/modules.yaml
+modifyrepo_c --mdtype=modules /tmp/modules.yaml /packages/archives/repodata

--- a/bundles/k8s-amazon2023/containertools/yumdownloader.sh
+++ b/bundles/k8s-amazon2023/containertools/yumdownloader.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <packages>"
+    exit 1
+fi
+
+mkdir -p /packages/archives
+#shellcheck disable=SC2086
+yumdownloader --releasever=/ --destdir=/packages/archives -y $1

--- a/bundles/k8s-amazon2023/kubernetes.repo
+++ b/bundles/k8s-amazon2023/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/__KUBERNETES_MINOR_VERSION__/rpm/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -441,6 +441,12 @@ function report_install_containerd() {
         return 0
     fi
 
+    # on amazon 2023 we are using the default containerd version that comes with the OS.
+    if is_amazon_2023 ; then
+        addon_install "containerd" "$CONTAINERD_VERSION"
+        return 0
+    fi
+
     # if we can't find containerd in the local filesystem then we can also install regardless
     # of version.
     if [ ! -f "/usr/bin/containerd" ]; then
@@ -728,7 +734,7 @@ function install_host_dependencies_openssl() {
         return
     fi
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package openssl
         return
     fi
@@ -746,7 +752,7 @@ function install_host_dependencies_fio() {
         return
     fi
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         if !  yum_ensure_host_package fio ; then
             logWarn "Failed to install fio, continuing anyways"
         fi

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -87,7 +87,8 @@ detectLsbDist() {
                 [ $1 -ge 6 ] && LSB_DIST=$_dist && DIST_VERSION=$_version && DIST_VERSION_MAJOR=$1 && DIST_VERSION_MINOR="${DIST_VERSION#$DIST_VERSION_MAJOR.}" && DIST_VERSION_MINOR="${DIST_VERSION_MINOR%%.*}"
                 ;;
             amzn)
-                _error_msg="$_error_msg\nHowever detected version $_version is not one of\n    2, 2.0, 2018.03, 2017.09, 2017.03, 2016.09, 2016.03, 2015.09, 2015.03, 2014.09, 2014.03."
+                _error_msg="$_error_msg\nHowever detected version $_version is not one of\n    2023, 2, 2.0, 2018.03, 2017.09, 2017.03, 2016.09, 2016.03, 2015.09, 2015.03, 2014.09, 2014.03."
+                [ "$_version" = "2023" ] || \
                 [ "$_version" = "2" ] || [ "$_version" = "2.0" ] || \
                 [ "$_version" = "2018.03" ] || \
                 [ "$_version" = "2017.03" ] || [ "$_version" = "2017.09" ] || \

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function kubernetes_pre_init() {
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         # git is packaged in the bundle and installed in other oses by
         # kubernetes_install_host_packages
         yum_ensure_host_package git
@@ -157,7 +157,7 @@ function kubernetes_install_host_packages() {
         kubernetes_cis_chmod_kubelet_service_file
 
         # less command is broken if libtinfo.so.5 is missing in amazon linux 2
-        if [ "$LSB_DIST" == "amzn" ] && [ "$AIRGAP" != "1" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
+        if [ "$LSB_DIST" == "amzn" ] && [ "$DIST_VERSION_MAJOR" != "2023" ] && [ "$AIRGAP" != "1" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
             if [ -d "$DIR/packages/kubernetes/${k8sVersion}/assets" ]; then
                 install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" ncurses-compat-libs
             fi
@@ -194,7 +194,7 @@ EOF
         ;;
     esac
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         # ensure git in kubernetes_pre_init
         install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}"
     else

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -15,7 +15,7 @@ function longhorn_install_iscsi_if_missing_common() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -43,7 +43,7 @@ function longhorn_install_nfs_utils_if_missing_common() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -93,7 +93,7 @@ function bailIfUnsupportedOS() {
             ;;
         centos8|centos8.0|centos8.1|centos8.2|centos8.3|centos8.4)
             ;;
-        amzn2)
+        amzn2|amzn2023)
             ;;
         ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7|ol8.8|ol8.9|ol8.10)
             ;;
@@ -333,8 +333,10 @@ function cri_preflights() {
 }
 
 function require_cri() {
-    if is_rhel_9_variant && [ -z "$CONTAINERD_VERSION" ]; then
-        bail "Containerd is required on RHEL 9 variants. Docker is not supported."
+    if is_rhel_9_variant || is_amazon_2023; then
+        if [ -z "$CONTAINERD_VERSION" ]; then
+            bail "Containerd is required on RHEL 9 variants and Amazon Linux 2023. Docker is not supported."
+        fi
     fi
 
     if commandExists docker ; then


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for Amazon Linux 2023.

#### Which issue(s) this PR fixes:
Fixes #106636

#### Special notes for your reviewer:

We have decided to stop installing Docker `containerd.io` packages on Amazon Linux 2023. We are installing the Containerd version provided by the underlying OS. On this case it does not matter the version the user has selected in the Kurl Installer, it is always going to install whatever the OS says is the last version.

As this impacts all versions of Containerd I had to backport the code to all versions. As the code gets changing while we keep going back in time I have opted to cut at `1.5.10`. If one attempts to install while selecting a version older than that the installer will report back an error as the code is not prepared to do so. This is far from ideal, if you can think in a better solution let me know.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Added support for Amazon Linux 2023.
```