### PR TITLE
feat: add support for amazon linux 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ addons/*/*/assets
 addons/*/*/images
 addons/*/*/rhel-*
 addons/*/*/ubuntu-*
+addons/*/*/amazon-*
 packages/*/*/assets
 packages/*/*/images
 packages/*/*/rhel-*

--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,21 @@ build/packages/kubernetes/%/rhel-9:
 	find build/packages/kubernetes/$*/rhel-9 | grep kubectl | grep -v kubectl-$* | xargs rm -vf
 	docker rm k8s-rhel9-$*
 
+build/packages/kubernetes/%/amazon-2023:
+	docker build \
+		--build-arg KUBERNETES_VERSION=$* \
+		--build-arg KUBERNETES_MINOR_VERSION=$(shell echo $* | sed 's/\.[0-9]*$$//') \
+		-t kurl/amazon-2023-k8s:$* \
+		-f bundles/k8s-amazon2023/Dockerfile \
+		bundles/k8s-amazon2023
+	-docker rm -f k8s-amazon2023-$* 2>/dev/null
+	docker create --name k8s-amazon2023-$* kurl/amazon-2023-k8s:$*
+	mkdir -p build/packages/kubernetes/$*/amazon-2023
+	docker cp k8s-amazon2023-$*:/packages/archives/. build/packages/kubernetes/$*/amazon-2023/
+	find build/packages/kubernetes/$*/amazon-2023 | grep kubelet | grep -v kubelet-$* | xargs rm -vf
+	find build/packages/kubernetes/$*/amazon-2023 | grep kubectl | grep -v kubectl-$* | xargs rm -vf
+	docker rm k8s-amazon2023-$*
+
 build/templates: build/templates/install.tmpl build/templates/join.tmpl build/templates/upgrade.tmpl build/templates/tasks.tmpl
 
 .PHONY: build/bin ## Build kurl binary

--- a/addons/collectd/v5/install.sh
+++ b/addons/collectd/v5/install.sh
@@ -13,7 +13,7 @@ function collectd() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if [ "$DIST_VERSION_MAJOR" = "8" ] || [ "$DIST_VERSION_MAJOR" = "9" ]; then
+                if [ "$DIST_VERSION_MAJOR" = "8" ] || [ "$DIST_VERSION_MAJOR" = "9" ] || [ "$DIST_VERSION_MAJOR" = "2023" ] ; then
                     yum_install_host_archives "$src" collectd collectd-rrdtool collectd-disk
                 else
                     yum_install_host_archives "$src" collectd collectd-rrdtool

--- a/addons/containerd/1.3.7/host-preflight.yaml
+++ b/addons/containerd/1.3.7/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.3.9/host-preflight.yaml
+++ b/addons/containerd/1.3.9/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.10/host-preflight.yaml
+++ b/addons/containerd/1.4.10/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.11/host-preflight.yaml
+++ b/addons/containerd/1.4.11/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.12/host-preflight.yaml
+++ b/addons/containerd/1.4.12/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.13/host-preflight.yaml
+++ b/addons/containerd/1.4.13/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.3/host-preflight.yaml
+++ b/addons/containerd/1.4.3/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.4/host-preflight.yaml
+++ b/addons/containerd/1.4.4/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.6/host-preflight.yaml
+++ b/addons/containerd/1.4.6/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.8/host-preflight.yaml
+++ b/addons/containerd/1.4.8/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.4.9/host-preflight.yaml
+++ b/addons/containerd/1.4.9/host-preflight.yaml
@@ -26,3 +26,6 @@ spec:
           - fail:
               when: "ubuntu = 22.04"
               message: "containerd addon does not support ubuntu 22.04"
+          - fail:
+              when: "amazon >= 2023"
+              message: "containerd addon does not support amazon 2023"

--- a/addons/containerd/1.5.10/host-preflight.yaml
+++ b/addons/containerd/1.5.10/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.5.10/install.sh
+++ b/addons/containerd/1.5.10/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.5.11/host-preflight.yaml
+++ b/addons/containerd/1.5.11/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.5.11/install.sh
+++ b/addons/containerd/1.5.11/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.10/host-preflight.yaml
+++ b/addons/containerd/1.6.10/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.10/install.sh
+++ b/addons/containerd/1.6.10/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.11/host-preflight.yaml
+++ b/addons/containerd/1.6.11/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.11/install.sh
+++ b/addons/containerd/1.6.11/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.12/host-preflight.yaml
+++ b/addons/containerd/1.6.12/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.12/install.sh
+++ b/addons/containerd/1.6.12/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.13/host-preflight.yaml
+++ b/addons/containerd/1.6.13/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.13/install.sh
+++ b/addons/containerd/1.6.13/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.14/host-preflight.yaml
+++ b/addons/containerd/1.6.14/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.14/install.sh
+++ b/addons/containerd/1.6.14/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.15/host-preflight.yaml
+++ b/addons/containerd/1.6.15/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.15/install.sh
+++ b/addons/containerd/1.6.15/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.16/host-preflight.yaml
+++ b/addons/containerd/1.6.16/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.16/install.sh
+++ b/addons/containerd/1.6.16/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.18/host-preflight.yaml
+++ b/addons/containerd/1.6.18/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.18/install.sh
+++ b/addons/containerd/1.6.18/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.19/host-preflight.yaml
+++ b/addons/containerd/1.6.19/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.19/install.sh
+++ b/addons/containerd/1.6.19/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.20/host-preflight.yaml
+++ b/addons/containerd/1.6.20/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.20/install.sh
+++ b/addons/containerd/1.6.20/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.21/host-preflight.yaml
+++ b/addons/containerd/1.6.21/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.21/install.sh
+++ b/addons/containerd/1.6.21/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.22/host-preflight.yaml
+++ b/addons/containerd/1.6.22/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.22/install.sh
+++ b/addons/containerd/1.6.22/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.24/host-preflight.yaml
+++ b/addons/containerd/1.6.24/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.24/install.sh
+++ b/addons/containerd/1.6.24/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.25/host-preflight.yaml
+++ b/addons/containerd/1.6.25/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.25/install.sh
+++ b/addons/containerd/1.6.25/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.26/host-preflight.yaml
+++ b/addons/containerd/1.6.26/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.26/install.sh
+++ b/addons/containerd/1.6.26/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.27/host-preflight.yaml
+++ b/addons/containerd/1.6.27/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.27/install.sh
+++ b/addons/containerd/1.6.27/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.28/host-preflight.yaml
+++ b/addons/containerd/1.6.28/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.28/install.sh
+++ b/addons/containerd/1.6.28/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.31/host-preflight.yaml
+++ b/addons/containerd/1.6.31/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.32/host-preflight.yaml
+++ b/addons/containerd/1.6.32/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.32/install.sh
+++ b/addons/containerd/1.6.32/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.33/host-preflight.yaml
+++ b/addons/containerd/1.6.33/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.4/host-preflight.yaml
+++ b/addons/containerd/1.6.4/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.4/install.sh
+++ b/addons/containerd/1.6.4/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.6/host-preflight.yaml
+++ b/addons/containerd/1.6.6/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.6/install.sh
+++ b/addons/containerd/1.6.6/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.7/host-preflight.yaml
+++ b/addons/containerd/1.6.7/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.7/install.sh
+++ b/addons/containerd/1.6.7/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.8/host-preflight.yaml
+++ b/addons/containerd/1.6.8/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.8/install.sh
+++ b/addons/containerd/1.6.8/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/1.6.9/host-preflight.yaml
+++ b/addons/containerd/1.6.9/host-preflight.yaml
@@ -50,3 +50,6 @@ spec:
           - pass:
               when: "ubuntu = 22.04"
               message: "containerd addon supports ubuntu 22.04"
+          - pass:
+              when: "amazon >= 2023"
+              message: "containerd addon supports amazon 2023"

--- a/addons/containerd/1.6.9/install.sh
+++ b/addons/containerd/1.6.9/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -26,22 +26,30 @@ function containerd_join() {
 }
 
 function containerd_install() {
+    if is_amazon_2023; then
+        require_amazon2023_containerd
+        log "Using containerd version provided by the Operating System."
+        if ! systemctl is-active --quiet containerd; then
+            systemctl start containerd
+        fi
+    fi
+
     local src="$DIR/addons/containerd/$CONTAINERD_VERSION"
 
     if ! containerd_xfs_ftype_enabled; then
         bail "The filesystem mounted at /var/lib/containerd does not have ftype enabled"
     fi
 
-    containerd_migrate_from_docker
-
-    containerd_install_container_selinux_if_missing
-    install_host_packages "$src" containerd.io
-
-    chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
-    # If the runc binary is executing the cp command will fail with "text file busy" error.
-    # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
-    # as soon as the container starts
-    try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    if ! is_amazon_2023; then
+        containerd_migrate_from_docker
+        containerd_install_container_selinux_if_missing
+        install_host_packages "$src" containerd.io
+        chmod +x ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc
+        # If the runc binary is executing the cp command will fail with "text file busy" error.
+        # Containerd uses runc in detached mode so any runc processes should be short-lived and exit
+        # as soon as the container starts
+        try_1m_stderr cp ${DIR}/addons/containerd/${CONTAINERD_VERSION}/assets/runc $(which runc)
+    fi
 
     logStep "Containerd configuration"
     containerd_configure
@@ -109,6 +117,7 @@ function containerd_install() {
 
 function containerd_host_init() {
     require_centos8_containerd
+    require_amazon2023_containerd
     containerd_install_libzstd_if_missing
 }
 
@@ -121,7 +130,7 @@ function containerd_install_libzstd_if_missing() {
                 return
             fi
 
-            if is_rhel_9_variant ; then
+            if ! host_packages_shipped ; then
                 yum_ensure_host_package libzstd
             else
                 yum_install_host_archives "$src" libzstd
@@ -394,6 +403,20 @@ function containerd_kubernetes_pause_image() {
     else
         echo ""
     fi
+}
+
+# require_amazon2023_containerd makes sure the OS version of containerd is
+# installed.
+function require_amazon2023_containerd() {
+    if ! is_amazon_2023 ; then
+        return
+    fi
+
+    if yum_is_host_package_installed containerd ; then
+        return
+    fi
+
+    bail "Containerd is not installed, please install it using the following command: dnf install -y containerd"
 }
 
 function require_centos8_containerd() {

--- a/addons/containerd/template/script.sh
+++ b/addons/containerd/template/script.sh
@@ -95,12 +95,13 @@ EOT
 function add_unsupported_os_to_preflight_file() {
     local version=$1
     local os_distro=$2
-    local os_version=$3
+    local operator=$3
+    local os_version=$4
 
     local file=/tmp/containerd/$version/host-preflight.yaml
     cat <<EOT >> $file
           - fail:
-              when: "$os_distro = $os_version"
+              when: "$os_distro $operator $os_version"
               message: "containerd addon does not support $os_distro $os_version"
 EOT
 }
@@ -108,12 +109,13 @@ EOT
 function add_supported_os_to_preflight_file() {
     local version=$1
     local os_distro=$2
-    local os_version=$3
+    local operator=$3
+    local os_version=$4
 
     local file=/tmp/containerd/$version/host-preflight.yaml
     cat <<EOT >> $file
           - pass:
-              when: "$os_distro = $os_version"
+              when: "$os_distro $operator $os_version"
               message: "containerd addon supports $os_distro $os_version"
 EOT
 }
@@ -200,9 +202,9 @@ function find_common_versions() {
             add_override_os_to_manifest_file "$version" "${CENTOS7_VERSIONS[0]}" "rhel-7" "Dockerfile.centos7"
             add_override_os_to_manifest_file "$version" "${CENTOS7_VERSIONS[0]}" "rhel-7-force" "Dockerfile.centos7-force"
         else
-            add_supported_os_to_preflight_file "$version" "centos" "7"
-            add_supported_os_to_preflight_file "$version" "rhel" "7"
-            add_supported_os_to_preflight_file "$version" "ol" "7"
+            add_supported_os_to_preflight_file "$version" "centos" "=" "7"
+            add_supported_os_to_preflight_file "$version" "rhel" "=" "7"
+            add_supported_os_to_preflight_file "$version" "ol" "=" "7"
             add_supported_os_to_manifest_file "$version" "rhel-7" "Dockerfile.centos7"
             add_supported_os_to_manifest_file "$version" "rhel-7-force" "Dockerfile.centos7-force"
         fi
@@ -214,33 +216,33 @@ function find_common_versions() {
             add_override_os_to_preflight_file "$version" "${CENTOS8_VERSIONS[0]}" "ol" "8"
             add_override_os_to_manifest_file "$version" "${CENTOS8_VERSIONS[0]}" "rhel-8" "Dockerfile.centos8"
         else
-            add_supported_os_to_preflight_file "$version" "centos" "8"
-            add_supported_os_to_preflight_file "$version" "rhel" "8"
-            add_supported_os_to_preflight_file "$version" "ol" "8"
+            add_supported_os_to_preflight_file "$version" "centos" "=" "8"
+            add_supported_os_to_preflight_file "$version" "rhel" "=" "8"
+            add_supported_os_to_preflight_file "$version" "ol" "=" "8"
             add_supported_os_to_manifest_file "$version" "rhel-8" "Dockerfile.centos8"
         fi
 
         if ! contains "$version" ${RHEL9_VERSIONS[*]}; then
             echo "RHEL 9 lacks version $version"
-            add_unsupported_os_to_preflight_file "$version" "centos" "9"
-            add_unsupported_os_to_preflight_file "$version" "rhel" "9"
-            add_unsupported_os_to_preflight_file "$version" "ol" "9"
-            add_unsupported_os_to_preflight_file "$version" "rocky" "9"
+            add_unsupported_os_to_preflight_file "$version" "centos" "=" "9"
+            add_unsupported_os_to_preflight_file "$version" "rhel" "=" "9"
+            add_unsupported_os_to_preflight_file "$version" "ol" "=" "9"
+            add_unsupported_os_to_preflight_file "$version" "rocky" "=" "9"
         else
-            add_supported_os_to_preflight_file "$version" "centos" "9"
-            add_supported_os_to_preflight_file "$version" "rhel" "9"
-            add_supported_os_to_preflight_file "$version" "rocky" "9"
+            add_supported_os_to_preflight_file "$version" "centos" "=" "9"
+            add_supported_os_to_preflight_file "$version" "rhel" "=" "9"
+            add_supported_os_to_preflight_file "$version" "rocky" "=" "9"
             add_supported_os_to_manifest_file "$version" "rhel-9" "Dockerfile.rhel9"
 
             # exclude Oracle Linux 9 (OL 9) until we officially support it
-            add_unsupported_os_to_preflight_file "$version" "ol" "9"
+            add_unsupported_os_to_preflight_file "$version" "ol" "=" "9"
         fi
 
         if ! contains "$version" ${UBUNTU16_VERSIONS[*]}; then
             echo "Ubuntu 16 lacks version $version"
-            add_unsupported_os_to_preflight_file "$version" "ubuntu" "16.04"
+            add_unsupported_os_to_preflight_file "$version" "ubuntu" "=" "16.04"
         else
-            add_supported_os_to_preflight_file "$version" "ubuntu" "16.04"
+            add_supported_os_to_preflight_file "$version" "ubuntu" "=" "16.04"
             add_supported_os_to_manifest_file "$version" "ubuntu-16.04" "Dockerfile.ubuntu16"
         fi
 
@@ -249,25 +251,30 @@ function find_common_versions() {
             add_override_os_to_preflight_file "$version" "${UBUNTU18_VERSIONS[0]}" "ubuntu" "18.04"
             add_override_os_to_manifest_file "$version" "${UBUNTU18_VERSIONS[0]}" "ubuntu-18.04" "Dockerfile.ubuntu18"
         else
-            add_supported_os_to_preflight_file "$version" "ubuntu" "18.04"
+            add_supported_os_to_preflight_file "$version" "ubuntu" "=" "18.04"
             add_supported_os_to_manifest_file "$version" "ubuntu-18.04" "Dockerfile.ubuntu18"
         fi
 
         if ! contains "$version" ${UBUNTU20_VERSIONS[*]}; then
             echo "Ubuntu 20 lacks version $version"
-            add_unsupported_os_to_preflight_file "$version" "ubuntu" "20.04"
+            add_unsupported_os_to_preflight_file "$version" "ubuntu" "=" "20.04"
         else
-            add_supported_os_to_preflight_file "$version" "ubuntu" "20.04"
+            add_supported_os_to_preflight_file "$version" "ubuntu" "=" "20.04"
             add_supported_os_to_manifest_file "$version" "ubuntu-20.04" "Dockerfile.ubuntu20"
         fi
 
         if ! contains "$version" ${UBUNTU22_VERSIONS[*]}; then
             echo "Ubuntu 22 lacks version $version"
-            add_unsupported_os_to_preflight_file "$version" "ubuntu" "22.04"
+            add_unsupported_os_to_preflight_file "$version" "ubuntu" "=" "22.04"
         else
-            add_supported_os_to_preflight_file "$version" "ubuntu" "22.04"
+            add_supported_os_to_preflight_file "$version" "ubuntu" "=" "22.04"
             add_supported_os_to_manifest_file "$version" "ubuntu-22.04" "Dockerfile.ubuntu22"
         fi
+
+        # for amazon 2023 we use the containerd version provided by the
+        # operating system. on this case we just set all found versions as
+        # supported.
+        add_supported_os_to_preflight_file "$version" "amazon" ">=" "2023"
 
         VERSIONS+=("$version")
     done

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -152,6 +152,7 @@
   unsupportedOSIDs:
     - rocky-91 # docker is not supported on rhel 9 variants
     - rocky-9 # docker is not supported on rhel 9 variants
+    - amazon-2023 # docker is not supported on amazon 2023
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.25 airgap"
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -217,6 +218,7 @@
   unsupportedOSIDs:
     - rocky-91 # docker is not supported on rhel 9 variants
     - rocky-9 # docker is not supported on rhel 9 variants
+    - amazon-2023 # docker is not supported on amazon 2023
 
 - name: Upgrade Containerd from 1.4.x to __testver__
   installerApiEndpoint: https://kurl.sh

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -91,6 +91,7 @@
     - centos-81 # docker 20.10.17 is not supported on centos 8.1.
     - centos-84 # docker 20.10.17 is not supported on centos 8.4.
     - ol-8x # docker 20.10.17 is not supported on ol 8.7.
+    - amazon-2023 # docker is not supported on amazon 2023
 - name: "weave to flannel single node with addons and openebs"
   flags: "yes"
   cpu: 6
@@ -230,6 +231,7 @@
   - centos-81 # docker 20.10.17 is not supported on centos 8.1.
   - centos-84 # docker 20.10.17 is not supported on centos 8.4.
   - ol-8x # docker 20.10.17 is not supported on ol 8.7.
+  - amazon-2023 # docker is not supported on amazon 2023
 - name: "flannel 1.19 single node"
   installerSpec:
     kubernetes:

--- a/addons/longhorn/1.1.0/install.sh
+++ b/addons/longhorn/1.1.0/install.sh
@@ -95,7 +95,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -123,7 +123,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/longhorn/1.1.1/install.sh
+++ b/addons/longhorn/1.1.1/install.sh
@@ -105,7 +105,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -133,7 +133,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/longhorn/1.1.2/install.sh
+++ b/addons/longhorn/1.1.2/install.sh
@@ -112,7 +112,7 @@ function longhorn_install_iscsi_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -140,7 +140,7 @@ function longhorn_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -148,6 +148,7 @@
     validate_read_write_object_store postupgrade upgradefile.txt
   unsupportedOSIDs:
   - rocky-91 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
 
 - name: localpv migrate from Rook 1.0.4 with old versions
   flags: "yes"

--- a/addons/rook/1.0.4-14.2.21/install.sh
+++ b/addons/rook/1.0.4-14.2.21/install.sh
@@ -201,7 +201,7 @@ function rook_lvm2() {
         return
     fi
  
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.0.4/install.sh
+++ b/addons/rook/1.0.4/install.sh
@@ -191,7 +191,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.11/install.sh
+++ b/addons/rook/1.10.11/install.sh
@@ -658,7 +658,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.6/install.sh
+++ b/addons/rook/1.10.6/install.sh
@@ -657,7 +657,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.10.8/install.sh
+++ b/addons/rook/1.10.8/install.sh
@@ -659,7 +659,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.2/install.sh
+++ b/addons/rook/1.11.2/install.sh
@@ -654,7 +654,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.3/install.sh
+++ b/addons/rook/1.11.3/install.sh
@@ -654,7 +654,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.4/install.sh
+++ b/addons/rook/1.11.4/install.sh
@@ -665,7 +665,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.5/install.sh
+++ b/addons/rook/1.11.5/install.sh
@@ -674,7 +674,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.6/install.sh
+++ b/addons/rook/1.11.6/install.sh
@@ -674,7 +674,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.7/install.sh
+++ b/addons/rook/1.11.7/install.sh
@@ -677,7 +677,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.11.8/install.sh
+++ b/addons/rook/1.11.8/install.sh
@@ -677,7 +677,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.0/install.sh
+++ b/addons/rook/1.12.0/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.1/install.sh
+++ b/addons/rook/1.12.1/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.2/install.sh
+++ b/addons/rook/1.12.2/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.3/install.sh
+++ b/addons/rook/1.12.3/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.4/install.sh
+++ b/addons/rook/1.12.4/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.5/install.sh
+++ b/addons/rook/1.12.5/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.6/install.sh
+++ b/addons/rook/1.12.6/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.7/install.sh
+++ b/addons/rook/1.12.7/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.12.8/install.sh
+++ b/addons/rook/1.12.8/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.4.3/install.sh
+++ b/addons/rook/1.4.3/install.sh
@@ -228,7 +228,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.4.9/install.sh
+++ b/addons/rook/1.4.9/install.sh
@@ -379,7 +379,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.10/install.sh
+++ b/addons/rook/1.5.10/install.sh
@@ -373,7 +373,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.11/install.sh
+++ b/addons/rook/1.5.11/install.sh
@@ -379,7 +379,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.12/install.sh
+++ b/addons/rook/1.5.12/install.sh
@@ -395,7 +395,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.5.9/install.sh
+++ b/addons/rook/1.5.9/install.sh
@@ -382,7 +382,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.6.11/install.sh
+++ b/addons/rook/1.6.11/install.sh
@@ -456,7 +456,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.7.11/install.sh
+++ b/addons/rook/1.7.11/install.sh
@@ -631,7 +631,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.8.10/install.sh
+++ b/addons/rook/1.8.10/install.sh
@@ -664,7 +664,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/1.9.12/install.sh
+++ b/addons/rook/1.9.12/install.sh
@@ -662,7 +662,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/rook/template/base/install.sh
+++ b/addons/rook/template/base/install.sh
@@ -691,7 +691,7 @@ function rook_lvm2() {
         return
     fi
 
-    if is_rhel_9_variant; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package lvm2
     else
         install_host_archives "$src" lvm2

--- a/addons/velero/1.10.1/install.sh
+++ b/addons/velero/1.10.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.10.2/install.sh
+++ b/addons/velero/1.10.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.11.0/install.sh
+++ b/addons/velero/1.11.0/install.sh
@@ -102,7 +102,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.11.1/install.sh
+++ b/addons/velero/1.11.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.0/install.sh
+++ b/addons/velero/1.12.0/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.1/install.sh
+++ b/addons/velero/1.12.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.2/install.sh
+++ b/addons/velero/1.12.2/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.12.3/install.sh
+++ b/addons/velero/1.12.3/install.sh
@@ -108,7 +108,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.13.1/install.sh
+++ b/addons/velero/1.13.1/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.13.2/install.sh
+++ b/addons/velero/1.13.2/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.14.0/install.sh
+++ b/addons/velero/1.14.0/install.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.1/install.sh
+++ b/addons/velero/1.5.1/install.sh
@@ -79,7 +79,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.3/install.sh
+++ b/addons/velero/1.5.3/install.sh
@@ -54,7 +54,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.5.4/install.sh
+++ b/addons/velero/1.5.4/install.sh
@@ -54,7 +54,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.0/install.sh
+++ b/addons/velero/1.6.0/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.1/install.sh
+++ b/addons/velero/1.6.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.6.2/install.sh
+++ b/addons/velero/1.6.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.7.1/install.sh
+++ b/addons/velero/1.7.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.8.1/install.sh
+++ b/addons/velero/1.8.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.0/install.sh
+++ b/addons/velero/1.9.0/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.1/install.sh
+++ b/addons/velero/1.9.1/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.2/install.sh
+++ b/addons/velero/1.9.2/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.3/install.sh
+++ b/addons/velero/1.9.3/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.4/install.sh
+++ b/addons/velero/1.9.4/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/1.9.5/install.sh
+++ b/addons/velero/1.9.5/install.sh
@@ -98,7 +98,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/addons/velero/template/base/install.tmpl.sh
+++ b/addons/velero/template/base/install.tmpl.sh
@@ -109,7 +109,7 @@ function velero_install_nfs_utils_if_missing() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/bin/containertools/Dockerfile.amazon2023
+++ b/bin/containertools/Dockerfile.amazon2023
@@ -1,0 +1,16 @@
+# amazonlinux does not have the modulemd-tools package so we use rockylinux
+# version instead, this is used only at build time.
+FROM rockylinux:9 as builder
+RUN yum install yum-utils -y
+RUN yumdownloader modulemd-tools
+
+FROM amazonlinux:2023
+COPY --from=builder /modulemd-tools-*.noarch.rpm /modulemd-tools.rpm
+RUN yum install -y /modulemd-tools.rpm
+
+ARG PACKAGES
+
+RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
+RUN yum install -y yum-utils createrepo findutils
+
+RUN [ -z "$PACKAGES" ] || yum install -y $PACKAGES

--- a/bin/containertools/builddeps.sh
+++ b/bin/containertools/builddeps.sh
@@ -17,6 +17,16 @@ available_packages="$(yum -q --disablerepo=* --enablerepo=kurl.local --releaseve
 depslist="$(echo "$available_packages" \
     | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --arch=noarch --resolve --requires \
     | awk 'NF{NF-=2}1' FS='-' OFS='-')" # strip last two fields
+
+# some packages may list both libcurl and libcurl-minimal, meaning one or the
+# other. on this case we want to prefer libcurl as its scope is broader and
+# there may be other packages on the system that depend on such broader scope.
+depslist="$(printf '%s\n' $depslist | sed 's/libcurl-minimal/libcurl/g')"
+
+# some packages may list both openssl-snapsafe-libs and openssl-libs, we are
+# going with openssl-libs.
+depslist="$(printf '%s\n' $depslist | sed 's/openssl-snapsafe-libs/openssl-libs/g')"
+
 for package in $available_packages ; do
     # remove packages that in the first level dependency provides
     depslist="$(echo "$depslist" | grep -v "^$package$")"

--- a/bundles/k8s-amazon2023/Dockerfile
+++ b/bundles/k8s-amazon2023/Dockerfile
@@ -1,0 +1,26 @@
+# amazonlinux does not have the modulemd-tools package so we use rockylinux
+# version instead, this is used only at build time.
+FROM rockylinux:9 as builder
+RUN yum install yum-utils -y
+RUN yumdownloader modulemd-tools
+
+FROM amazonlinux:2023
+COPY --from=builder /modulemd-tools-*.noarch.rpm /modulemd-tools.rpm
+RUN yum install -y /modulemd-tools.rpm
+
+ARG KUBERNETES_VERSION
+RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
+RUN yum install -y yum-utils createrepo findutils
+
+COPY ./containertools /opt/containertools
+COPY ./kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+ARG KUBERNETES_MINOR_VERSION
+RUN sed -i "s/__KUBERNETES_MINOR_VERSION__/v${KUBERNETES_MINOR_VERSION}/g" /etc/yum.repos.d/kubernetes.repo
+RUN mkdir -p /packages/archives
+RUN /opt/containertools/yumdownloader.sh "kubelet-$KUBERNETES_VERSION kubectl-$KUBERNETES_VERSION kubernetes-cni"
+RUN /opt/containertools/createrepo.sh
+RUN /opt/containertools/builddeps.sh > /packages/archives/Deps \
+	&& sort /packages/archives/Deps | uniq | grep -v '^[[:space:]]*$' > /packages/archives/Deps.tmp \
+	&& mv /packages/archives/Deps.tmp /packages/archives/Deps
+RUN echo "git" >> /packages/archives/Deps
+CMD cp -r /packages/archives/* /out/

--- a/bundles/k8s-amazon2023/containertools/builddeps.sh
+++ b/bundles/k8s-amazon2023/containertools/builddeps.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+cat > /etc/yum.repos.d/kurl.local.repo <<EOF
+[kurl.local]
+name=kURL Local Repo
+baseurl=file:///packages/archives
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+
+# list first level dependency provides
+available_packages="$(yum -q --disablerepo=* --enablerepo=kurl.local --releasever=/ --installroot=/tmp/empty-directory list available \
+    | grep -v "Available Packages" | awk '{ print $1 }' | sed 's/\.x86_64//')"
+depslist="$(echo "$available_packages" \
+    | xargs -L1 yum -q --enablerepo=kurl.local deplist --arch=x86_64 --arch=noarch --resolve --requires \
+    | awk 'NF{NF-=2}1' FS='-' OFS='-')" # strip last two fields
+for package in $available_packages ; do
+    # remove packages that in the first level dependency provides
+    depslist="$(echo "$depslist" | grep -v "^$package$")"
+done
+echo "$depslist"

--- a/bundles/k8s-amazon2023/containertools/createrepo.sh
+++ b/bundles/k8s-amazon2023/containertools/createrepo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+createrepo_c /packages/archives
+repo2module --module-name=kurl.local --module-stream=stable /packages/archives /tmp/modules.yaml
+modifyrepo_c --mdtype=modules /tmp/modules.yaml /packages/archives/repodata

--- a/bundles/k8s-amazon2023/containertools/yumdownloader.sh
+++ b/bundles/k8s-amazon2023/containertools/yumdownloader.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <packages>"
+    exit 1
+fi
+
+mkdir -p /packages/archives
+#shellcheck disable=SC2086
+yumdownloader --releasever=/ --destdir=/packages/archives -y $1

--- a/bundles/k8s-amazon2023/kubernetes.repo
+++ b/bundles/k8s-amazon2023/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/__KUBERNETES_MINOR_VERSION__/rpm/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key

--- a/scripts/common/common.sh
+++ b/scripts/common/common.sh
@@ -441,6 +441,12 @@ function report_install_containerd() {
         return 0
     fi
 
+    # on amazon 2023 we are using the default containerd version that comes with the OS.
+    if is_amazon_2023 ; then
+        addon_install "containerd" "$CONTAINERD_VERSION"
+        return 0
+    fi
+
     # if we can't find containerd in the local filesystem then we can also install regardless
     # of version.
     if [ ! -f "/usr/bin/containerd" ]; then
@@ -728,7 +734,7 @@ function install_host_dependencies_openssl() {
         return
     fi
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         yum_ensure_host_package openssl
         return
     fi
@@ -746,7 +752,7 @@ function install_host_dependencies_fio() {
         return
     fi
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         if !  yum_ensure_host_package fio ; then
             logWarn "Failed to install fio, continuing anyways"
         fi

--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -87,7 +87,8 @@ detectLsbDist() {
                 [ $1 -ge 6 ] && LSB_DIST=$_dist && DIST_VERSION=$_version && DIST_VERSION_MAJOR=$1 && DIST_VERSION_MINOR="${DIST_VERSION#$DIST_VERSION_MAJOR.}" && DIST_VERSION_MINOR="${DIST_VERSION_MINOR%%.*}"
                 ;;
             amzn)
-                _error_msg="$_error_msg\nHowever detected version $_version is not one of\n    2, 2.0, 2018.03, 2017.09, 2017.03, 2016.09, 2016.03, 2015.09, 2015.03, 2014.09, 2014.03."
+                _error_msg="$_error_msg\nHowever detected version $_version is not one of\n    2023, 2, 2.0, 2018.03, 2017.09, 2017.03, 2016.09, 2016.03, 2015.09, 2015.03, 2014.09, 2014.03."
+                [ "$_version" = "2023" ] || \
                 [ "$_version" = "2" ] || [ "$_version" = "2.0" ] || \
                 [ "$_version" = "2018.03" ] || \
                 [ "$_version" = "2017.03" ] || [ "$_version" = "2017.09" ] || \

--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -47,12 +47,16 @@ function _install_host_packages() {
             ;;
 
         amzn)
-            local fullpath=
-            fullpath="$(realpath "${dir}")/rhel-7-force${dir_prefix}"
-            if test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
-                _rpm_force_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
+            if is_amazon_2023; then
+                _yum_install_host_packages_el9 "$dir" "$dir_prefix" "${packages[@]}"
             else
-                _yum_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
+                local fullpath=
+                fullpath="$(realpath "${dir}")/rhel-7-force${dir_prefix}"
+                if test -n "$(shopt -s nullglob; echo "${fullpath}"/*.rpm)" ; then
+                    _rpm_force_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
+                else
+                    _yum_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
+                fi
             fi
             ;;
 
@@ -149,7 +153,7 @@ function yum_install_host_archives() {
     local dir="$1"
     local dir_prefix="/archives"
     local packages=("${@:2}")
-    if [ "$DIST_VERSION_MAJOR" = "9" ]; then
+    if [ "$DIST_VERSION_MAJOR" = "9" ] || [ "$DIST_VERSION_MAJOR" = "2023" ]; then
         _yum_install_host_packages_el9 "$dir" "$dir_prefix" "${packages[@]}"
     else
         _yum_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
@@ -160,7 +164,7 @@ function yum_install_host_packages() {
     local dir="$1"
     local dir_prefix=""
     local packages=("${@:2}")
-    if [ "$DIST_VERSION_MAJOR" = "9" ]; then
+    if [ "$DIST_VERSION_MAJOR" = "9" ] || [ "$DIST_VERSION_MAJOR" = "2023" ]; then
         _yum_install_host_packages_el9 "$dir" "$dir_prefix" "${packages[@]}"
     else
         _yum_install_host_packages "$dir" "$dir_prefix" "${packages[@]}"
@@ -309,6 +313,8 @@ function _yum_get_host_packages_path() {
 
     if [ "$DIST_VERSION_MAJOR" = "9" ]; then
         echo "$(realpath "${dir}")/rhel-9${dir_prefix}"
+    elif [ "$DIST_VERSION_MAJOR" = "2023" ]; then
+        echo "$(realpath "${dir}")/amazon-2023${dir_prefix}"
     elif [ "$DIST_VERSION_MAJOR" = "8" ]; then
         echo "$(realpath "${dir}")/rhel-8${dir_prefix}"
     else
@@ -322,6 +328,15 @@ function _yum_get_host_packages_path() {
 # because it cannot resolve modular dependencies.
 function reset_dnf_module_kurl_local() {
     yum module reset -y kurl.local 2>/dev/null || true
+}
+
+# host_packages_shipped returns true if we do ship host packages for the distro
+# we are running the installation on.
+function host_packages_shipped() {
+    if ! is_rhel_9_variant && ! is_amazon_2023; then
+        return 0
+    fi
+    return 1
 }
 
 # is_rhel_9_variant returns 0 if the current distro is RHEL 9 or a derivative
@@ -338,6 +353,17 @@ function is_rhel_9_variant() {
             return 1
             ;;
     esac
+}
+
+# is_amazon_2023 returns 0 if the current distro is Amazon 2023.
+function is_amazon_2023() {
+    if [ "$DIST_VERSION_MAJOR" != "2023" ]; then
+        return 1
+    fi
+    if [ "$LSB_DIST" != "amzn" ]; then
+        return 1
+    fi
+    return 0
 }
 
 # yum_ensure_host_package ensures that a package is installed on the host
@@ -357,18 +383,35 @@ function yum_ensure_host_package() {
 
 # preflights_require_host_packages ensures that all required host packages are installed.
 function preflights_require_host_packages() {
-    if ! is_rhel_9_variant ; then
-        return # only rhel 9 requires this
+    if host_packages_shipped ; then
+        return
     fi
 
     logStep "Checking required host packages"
 
+    local seen=()
     local fail=0
+    local skip=0
     # shellcheck disable=SC2044
     for deps_file in $(find . -name Deps); do
         while read -r dep ; do
-            if ! echo "$deps_file" | grep -q "rhel-9"; then
+
+            skip=0
+            for seen_item in "${seen[@]}"; do
+                if [ "$dep" = "$seen_item" ]; then
+                    skip=1
+                    break
+                fi
+            done
+            if [ "$skip" = "1" ]; then
                 continue
+            fi
+            seen+=("$dep")
+
+            if ! echo "$deps_file" | grep -q "rhel-9"; then
+                if ! echo "$deps_file" | grep -q "amazon-2023"; then
+                    continue
+                fi
             fi
             if rpm -q "$dep" >/dev/null 2>&1 ; then
                 continue

--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function kubernetes_pre_init() {
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         # git is packaged in the bundle and installed in other oses by
         # kubernetes_install_host_packages
         yum_ensure_host_package git
@@ -157,7 +157,7 @@ function kubernetes_install_host_packages() {
         kubernetes_cis_chmod_kubelet_service_file
 
         # less command is broken if libtinfo.so.5 is missing in amazon linux 2
-        if [ "$LSB_DIST" == "amzn" ] && [ "$AIRGAP" != "1" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
+        if [ "$LSB_DIST" == "amzn" ] && [ "$DIST_VERSION_MAJOR" != "2023" ] && [ "$AIRGAP" != "1" ] && ! file_exists "/usr/lib64/libtinfo.so.5"; then
             if [ -d "$DIR/packages/kubernetes/${k8sVersion}/assets" ]; then
                 install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" ncurses-compat-libs
             fi
@@ -194,7 +194,7 @@ EOF
         ;;
     esac
 
-    if is_rhel_9_variant ; then
+    if ! host_packages_shipped ; then
         # ensure git in kubernetes_pre_init
         install_host_packages "${DIR}/packages/kubernetes/${k8sVersion}" "kubelet-${k8sVersion}" "kubectl-${k8sVersion}"
     else

--- a/scripts/common/longhorn.sh
+++ b/scripts/common/longhorn.sh
@@ -15,7 +15,7 @@ function longhorn_install_iscsi_if_missing_common() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package iscsi-initiator-utils
                 else
                     yum_install_host_archives "$src" iscsi-initiator-utils
@@ -43,7 +43,7 @@ function longhorn_install_nfs_utils_if_missing_common() {
                 ;;
 
             centos|rhel|ol|rocky|amzn)
-                if is_rhel_9_variant ; then
+                if ! host_packages_shipped ; then
                     yum_ensure_host_package nfs-utils
                 else
                     yum_install_host_archives "$src" nfs-utils

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -93,7 +93,7 @@ function bailIfUnsupportedOS() {
             ;;
         centos8|centos8.0|centos8.1|centos8.2|centos8.3|centos8.4|centos9)
             ;;
-        amzn2)
+        amzn2|amzn2023)
             ;;
         ol8.0|ol8.1|ol8.2|ol8.3|ol8.4|ol8.5|ol8.6|ol8.7|ol8.8|ol8.9|ol8.10)
             ;;
@@ -333,8 +333,10 @@ function cri_preflights() {
 }
 
 function require_cri() {
-    if is_rhel_9_variant && [ -z "$CONTAINERD_VERSION" ]; then
-        bail "Containerd is required on RHEL 9 variants. Docker is not supported."
+    if is_rhel_9_variant || is_amazon_2023; then
+        if [ -z "$CONTAINERD_VERSION" ]; then
+            bail "Containerd is required on RHEL 9 variants and Amazon Linux 2023. Docker is not supported."
+        fi
     fi
 
     if commandExists docker ; then

--- a/testgrid/specs/customer-migration-specs.yaml
+++ b/testgrid/specs/customer-migration-specs.yaml
@@ -211,6 +211,7 @@
       nodeUnreachableToleration: "1m"
   unsupportedOSIDs:
     - ubuntu-2204 # this version of docker is too old for 22.04
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh
@@ -348,6 +349,7 @@
     - rocky-91
     - rocky-9
     - ol-8x
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh
@@ -467,6 +469,7 @@
     - rocky-91
     - rocky-9
     - ol-8x
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh
@@ -580,6 +583,7 @@
     - rocky-91
     - rocky-9
     - ol-8x
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh
@@ -711,6 +715,7 @@
     - rocky-91
     - rocky-9
     - ol-8x
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh
@@ -796,6 +801,7 @@
     - rocky-91
     - rocky-9
     - ol-8x
+    - amazon-2023 # docker is not supported on amazon 2023
   postInstallScript: |
     # source helper functions
     source /opt/kurl-testgrid/testhelpers.sh

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -38,6 +38,7 @@
     - rocky-91 # docker is not supported on rhel 9 variants
     - rocky-9 # docker is not supported on rhel 9 variants
     - centos-9 # docker is not supported on rhel 9 variants
+    - amazon-2023 # docker is not supported on amazon 2023
 - name: "Upgrade to 1.25 to 1.30, Migrate from Rook 1.12.x to OpenEBS + Minio"
   flags: "yes"
   installerSpec:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -645,6 +645,7 @@
   - rocky-91 # doc:
   - rocky-9 # docker is not supported on rhel 9 variants
   - centos-9 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
 - name: "K8s 1.24x Rook"
   cpu: 6
   installerSpec:
@@ -770,6 +771,7 @@
   - rocky-91 # docker is not supported on rhel 9 variantsl
   - rocky-9 # docker is not supported on rhel 9 variants
   - centos-9 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
 - name: "Upgrade to 1.30 minimal airgap"
   installerSpec:
     kubernetes:
@@ -2108,6 +2110,7 @@
     - rocky-91 # docker is not supported on rhel 9 variants
     - rocky-9 # docker is not supported on rhel 9 variants
     - centos-9 # docker is not supported on rhel 9 variants
+    - amazon-2023 # docker is not supported on amazon 2023
 - name: "weave to flannel single node with addons and openebs"
   flags: "yes"
   cpu: 8

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -56,3 +56,9 @@
   version: "22.04"
   vmimageuri: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
   preinit: ""
+- id: amazon-2023
+  name: Amazon Linux
+  version: "2023"
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  preinit: |
+    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -67,3 +67,9 @@
   version: "22.04"
   vmimageuri: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
   preinit: ""
+- id: amazon-2023
+  name: Amazon Linux
+  version: "2023"
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  preinit: |
+    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -46,4 +46,9 @@
   version: "22.04"
   vmimageuri: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
   preinit: ""
-
+- id: amazon-2023
+  name: Amazon Linux
+  version: "2023"
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  preinit: |
+    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -985,6 +985,7 @@
   - rocky-91 # docker is not supported on rhel 9 variants
   - rocky-9 # docker is not supported on rhel 9 variants
   - ubuntu-2204 # Docker versions < 20.10.17 not supported on ubuntu 22.04
+  - amazon-2023 # docker is not supported on amazon 2023
 - name: Migrate from OpenEBS (S3 disabled) to OpenEBS + Minio
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -1144,6 +1145,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
   - rocky-9 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets
@@ -1267,6 +1269,7 @@
   - ubuntu-2204 # docker 19.03.4 is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
   - rocky-9 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets
@@ -1380,6 +1383,7 @@
   - ubuntu-2204 # docker 19.03.10 is not supported on ubuntu 22.04
   - rocky-91 # docker is not supported on rhel 9 variants
   - rocky-9 # docker is not supported on rhel 9 variants
+  - amazon-2023 # docker is not supported on amazon 2023
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets


### PR DESCRIPTION
#### What this PR does / why we need it:

adds support for amazon linux 2023. one thing is different in comparison with other operating system's, we do not install containerd.io package, we go with the default containerd provided by amazon.

#### Which issue(s) this PR fixes:
Fixes #106636

#### Does this PR introduce a user-facing change?
```release-note
Added Amazon Linux 2023 support.
```