### PR TITLE
chore: migrate testgrid to kubernetes v1.31

### DIFF
--- a/addons/cert-manager/template/testgrid/k8s-docker.yaml
+++ b/addons/cert-manager/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
 - name: fresh install
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:
@@ -57,7 +57,7 @@
 - name: upgrade from latest
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:
@@ -66,7 +66,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:
@@ -88,7 +88,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -1,8 +1,8 @@
-- name: basic containerd and flannel, internal LB, airgap, 1.30
+- name: basic containerd and flannel, internal LB, airgap, 1.31
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     containerd:
@@ -379,7 +379,7 @@
 - name: "flannel latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:

--- a/addons/contour/template/testgrid/k8s-docker.yaml
+++ b/addons/contour/template/testgrid/k8s-docker.yaml
@@ -2,7 +2,7 @@
   installerApiEndpoint: https://kurl.sh
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     containerd:
@@ -11,7 +11,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     containerd:
@@ -82,10 +82,10 @@
 
     curl -v "http://$private_address:80"
 
-- name: "k8s 1.30"
+- name: "k8s 1.31"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     containerd:

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -1,7 +1,7 @@
 - name: "flannel latest single node"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: "latest"
     flannel:

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
-- name: "prometheus minimal k8s 1.30"
+- name: "prometheus minimal k8s 1.31"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     openebs:
@@ -80,7 +80,7 @@
   installerApiEndpoint: https://kurl.sh
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     openebs:
@@ -93,7 +93,7 @@
       version: "latest"
   upgradeSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     openebs:
@@ -121,7 +121,7 @@
 - name: "prometheus minimal airgap"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -1,7 +1,7 @@
 - name: registry_latest_rook
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -2,7 +2,7 @@
   cpu: 6
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:
@@ -31,7 +31,7 @@
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:
@@ -145,7 +145,7 @@
   cpu: 8
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:
@@ -158,7 +158,7 @@
       version: "1.9.x"
   upgradeSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: latest
     rook:

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -39,7 +39,7 @@
     - rocky-9 # docker is not supported on rhel 9 variants
     - centos-9 # docker is not supported on rhel 9 variants
     - amazon-2023 # docker is not supported on amazon 2023
-- name: "Upgrade to 1.25 to 1.30, Migrate from Rook 1.12.x to OpenEBS + Minio"
+- name: "Upgrade to 1.25 to 1.31, Migrate from Rook 1.12.x to OpenEBS + Minio"
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -58,7 +58,7 @@
       version: 1.12.x
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: 1.6.x
     flannel:
@@ -157,7 +157,7 @@
     fi
   unsupportedOSIDs:
     - centos-9 # centos 9 was not supported on kurl v2024.07.02-0
-- name: "Upgrade from k8s 1.27 to 1.30 - Airgap"
+- name: "Upgrade from k8s 1.27 to 1.31 - Airgap"
   airgap: true
   installerSpec:
     kubernetes:
@@ -180,7 +180,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     kurl:
       installerVersion: ""
     flannel:
@@ -205,10 +205,10 @@
   preUpgradeScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-- name: k8s130x_cis_benchmarks_checks
+- name: k8s131x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
       cisCompliance: true
     containerd:
       version: "latest"
@@ -224,10 +224,10 @@
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
-- name: "k8s_130x with kurl in-cluster support bundle spec"
+- name: "k8s_131x with kurl in-cluster support bundle spec"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: latest
     flannel:
@@ -240,10 +240,10 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
-- name: "k8s_130x with rook"
+- name: "k8s_131x with rook"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: latest
     flannel:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -443,7 +443,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     weave:
       version: 2.8.1
     rook:
@@ -580,7 +580,7 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.30 airgap"
+- name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.31 airgap"
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
   installerSpec:
@@ -606,7 +606,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     weave: # flannel has errors with dns and docker
       version: latest
     openebs:
@@ -674,11 +674,11 @@
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
-- name: "K8s 1.30x Rook, disableS3"
+- name: "K8s 1.31x Rook, disableS3"
   cpu: 6
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -772,7 +772,7 @@
   - rocky-9 # docker is not supported on rhel 9 variants
   - centos-9 # docker is not supported on rhel 9 variants
   - amazon-2023 # docker is not supported on amazon 2023
-- name: "Upgrade to 1.30 minimal airgap"
+- name: "Upgrade to 1.31 minimal airgap"
   installerSpec:
     kubernetes:
       version: 1.26.x
@@ -794,7 +794,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     flannel:
       version: latest
     openebs:
@@ -819,10 +819,10 @@
     ( cd /var/lib/kurl/assets && curl -fLO "$(kubernetes_upgrade_bundle_url "$KURL_URL" "$KURL_UPGRADE_URL")" )
   unsupportedOSIDs:
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: k8s130-all-the-flags
+- name: k8s131-all-the-flags
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -848,7 +848,7 @@
 - name: ekco-podimageoverrides
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: "latest"
     flannel:
@@ -906,10 +906,10 @@
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: k8s130x_reserved_resources
+- name: k8s131x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
@@ -937,7 +937,7 @@
 - name: less_command
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: latest
     flannel:
@@ -954,7 +954,7 @@
 - name: "weave latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     weave:
       version: "latest"
     containerd:
@@ -968,7 +968,7 @@
 - name: "flannel latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     containerd:
@@ -1315,7 +1315,7 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
-- name: "containerd upgrade from 1.4.x to 1.6.x (kubernetes 1.24.x to 1.30.x)"
+- name: "containerd upgrade from 1.4.x to 1.6.x (kubernetes 1.24.x to 1.31.x)"
   installerSpec:
     kubernetes:
       version: 1.24.x
@@ -1331,7 +1331,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     flannel:
       version: latest
     containerd:
@@ -1358,7 +1358,7 @@
 - name: custom-kurl-install-directory
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1375,7 +1375,7 @@
   preInstallScript: |
     touch /var/lib/kurl
     mkdir -p /custom
-- name: "Upgrade Kubernetes from 1.19 to 1.30"
+- name: "Upgrade Kubernetes from 1.19 to 1.31"
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -1388,7 +1388,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1399,7 +1399,7 @@
     source /opt/kurl-testgrid/testhelpers.sh
 
     k8sVersion=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}')
-    echo $k8sVersion | grep 1.30
+    echo $k8sVersion | grep 1.31
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
 - name: "Upgrade Kubernetes from 1.19 to 1.24, Rook from 1.0.4 to 1.5.12"
@@ -1456,7 +1456,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1489,7 +1489,7 @@
       nameserver: 8.8.8.8
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1502,10 +1502,10 @@
     kubectl -n kube-system get configmap coredns -o yaml | grep -F 'forward . 8.8.8.8'
   postUpgradeScript: |
     kubectl -n kube-system get configmap coredns -o yaml | grep -F 'forward . 8.8.8.8'
-- name: k8s130-rook-override-node-storage
+- name: k8s131-rook-override-node-storage
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1543,11 +1543,11 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: "1.30 with all metrics and kots"
+- name: "1.31 with all metrics and kots"
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     contour:
@@ -1576,11 +1576,11 @@
       version: "latest"
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: (k8s 1.30) install addons not deprecated less prometheus, goldpinger
+- name: (k8s 1.31) install addons not deprecated less prometheus, goldpinger
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     rook:
@@ -1615,11 +1615,11 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.11.6 will not be installed due to failed preflight checks.
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: (k8s 1.30) install addons not deprecated less prometheus, goldpinger with symbolic links
+- name: (k8s 1.31) install addons not deprecated less prometheus, goldpinger with symbolic links
   flags: "yes"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     flannel:
       version: "latest"
     rook:
@@ -1692,7 +1692,7 @@
     ln -s $FOLDER/var/lib/rook /var/lib/rook
     
     cd /testsymbolic
-- name: "K8s 1.30x Airgap with invalid proxyAddress"
+- name: "K8s 1.31x Airgap with invalid proxyAddress"
   cpu: 6
   airgap: true
   numPrimaryNodes: 1
@@ -1704,7 +1704,7 @@
         - .corporate.internal
       noProxy: false
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -1910,6 +1910,21 @@
       enableInternalLoadBalancer: true
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+- name: minimal-131
+  installerSpec:
+    containerd:
+      version: latest
+    kurl:
+      installerVersion: ""
+    kubernetes:
+      version: 1.31.x
+    flannel:
+      version: latest
+    ekco:
+      version: latest
+      enableInternalLoadBalancer: true
+  unsupportedOSIDs:
+    - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
 - name: k8s124x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
@@ -1933,10 +1948,10 @@
     kubectl get namespaces
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: k8s130x_reserved_resources
+- name: k8s131x_reserved_resources
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
       kubeReserved: true
       evictionThresholdResources: '{"memory.available":  "234Mi", "nodefs.available": "11%", "nodefs.inodesFree": "6%"}'
       systemReservedResources: '{ "cpu": "123m", "memory": "123Mi", "ephemeral-storage": "1.23Gi" }'
@@ -1963,10 +1978,10 @@
     kubectl get namespaces
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: k8s130-openebs
+- name: k8s131-openebs
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     kurl:
       installerVersion: ""
     containerd:
@@ -2021,11 +2036,11 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
-- name: "k8s_130x airgap"
+- name: "k8s_131x airgap"
   airgap: true
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     kurl:
       installerVersion: ""
     flannel:
@@ -2163,10 +2178,10 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.11.6 will not be installed due to failed preflight checks.
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
-- name: "k8s_130x with kurl in-cluster support bundle spec"
+- name: "k8s_131x with kurl in-cluster support bundle spec"
   installerSpec:
     kubernetes:
-      version: "1.30.x"
+      version: "1.31.x"
     containerd:
       version: latest
     flannel:
@@ -2184,14 +2199,14 @@
 - name: merge-installer-hostpreflight-and-upgrade
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:
@@ -2273,7 +2288,7 @@
 - name: reset and reinstall
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: latest
     flannel:

--- a/testgrid/specs/k8s-upgrade.yaml
+++ b/testgrid/specs/k8s-upgrade.yaml
@@ -1,4 +1,4 @@
-- name: 119 to 130
+- name: 119 to 131
   numPrimaryNodes: 1
   numSecondaryNodes: 2
   cpu: 3
@@ -12,7 +12,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     containerd:
       version: 1.6.x
     flannel:
@@ -21,4 +21,4 @@
     kubectl get nodes
   postUpgradeScript: |
     kubectl get nodes
-    kubectl get nodes | grep 1.30
+    kubectl get nodes | grep 1.31


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:
move tests to the new kubernetes version.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
