### PR TITLE
chore: disable test on amazon 2023

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -157,6 +157,7 @@
     fi
   unsupportedOSIDs:
     - centos-9 # centos 9 was not supported on kurl v2024.07.02-0
+    - amazon-2023 # amazon 2023 isn't supported on installer version v2024.07.02-0.
 - name: "Upgrade from k8s 1.27 to 1.31 - Airgap"
   airgap: true
   installerSpec:


### PR DESCRIPTION
this test is using a static installer version (v2024.07.02-0). on such version amazon 2023 isn't supported.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
