### PR TITLE
chore: disable amazon 2023 tests for k8s < 1.24

### DIFF
--- a/addons/antrea/template/testgrid/tests.yaml
+++ b/addons/antrea/template/testgrid/tests.yaml
@@ -11,6 +11,8 @@
     antrea:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: openebs and kotsadm airgap
   airgap: true
@@ -33,6 +35,8 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: openebs and kotsadm upgrade
   installerSpec:
@@ -64,3 +68,5 @@
     antrea:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/cert-manager/template/testgrid/k8s-docker.yaml
+++ b/addons/cert-manager/template/testgrid/k8s-docker.yaml
@@ -53,6 +53,8 @@
     # todo validate that cert-manager is actually working (TBD how)
     kubectl get pods -n cert-manager
     kubectl get issuers letsencrypt-staging
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: upgrade from latest
   installerSpec:

--- a/addons/collectd/template/testgrid/k8s-docker.yaml
+++ b/addons/collectd/template/testgrid/k8s-docker.yaml
@@ -8,3 +8,5 @@
     collectd:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -89,6 +89,8 @@
     echo "checking /var/lib/kubelet/kubeadm-flags.env"
     cat /var/lib/kubelet/kubeadm-flags.env | grep pause # should be 3.9, this is for debugging
     cat /var/lib/kubelet/kubeadm-flags.env | grep pause:3.9
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 
 
@@ -281,6 +283,7 @@
     - ubuntu-2204
     - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
     - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+    - amazon-2023 # installer version v2024.07.02-0 does not know amazon 2023
 
 - name: Upgrade Containerd from 1.5.x to __testver__
   installerApiEndpoint: https://kurl.sh
@@ -327,6 +330,7 @@
   unsupportedOSIDs:
     - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
     - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+    - amazon-2023 # installer version v2024.07.02-0 does not know amazon 2023
 
 - name: "Upgrade Containerd from current to __testver__"
   installerSpec:

--- a/addons/contour/template/testgrid/k8s-docker.yaml
+++ b/addons/contour/template/testgrid/k8s-docker.yaml
@@ -81,6 +81,8 @@
     echo "Discovered private address: $private_address"
 
     curl -v "http://$private_address:80"
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: "k8s 1.31"
   installerSpec:
@@ -127,3 +129,5 @@
     echo "Discovered private address: $private_address"
 
     curl -v "http://$private_address:80"
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.

--- a/addons/ekco/template/testgrid/k8s-docker.yaml
+++ b/addons/ekco/template/testgrid/k8s-docker.yaml
@@ -126,6 +126,8 @@
       s3Override: "__testdist__"
       enableInternalLoadBalancer: true
   flags: "ha"
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: HA minio initial installation
   installerSpec:
     kubernetes:

--- a/addons/flannel/template/testgrid/k8s-ctrd.yaml
+++ b/addons/flannel/template/testgrid/k8s-ctrd.yaml
@@ -241,3 +241,5 @@
     flannel:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.

--- a/addons/fluentd/template/testgrid/k8s-docker.yaml
+++ b/addons/fluentd/template/testgrid/k8s-docker.yaml
@@ -10,3 +10,5 @@
     fluentd:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/goldpinger/template/testgrid/tests.yaml
+++ b/addons/goldpinger/template/testgrid/tests.yaml
@@ -25,6 +25,8 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: upgrade from latest
   installerSpec:
@@ -53,6 +55,8 @@
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: upgrade from oldest
   installerSpec:
@@ -81,6 +85,8 @@
     # print goldpinger output (and fail if unable to connect to the service)
     curl $GP_ENDPOINT/check_all
     curl $GP_ENDPOINT/metrics
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: airgap fresh install
   airgap: true
@@ -113,3 +119,5 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-goldpinger-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/longhorn/template/testgrid/k8s-ctrd.yaml
+++ b/addons/longhorn/template/testgrid/k8s-ctrd.yaml
@@ -94,6 +94,8 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: upgrade-from-rook-1.5
   cpu: 6
@@ -172,6 +174,8 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: upgrade-from-oldest-longhorn-1.2.x
   installerSpec:

--- a/addons/metrics-server/template/testgrid/k8s-docker.yaml
+++ b/addons/metrics-server/template/testgrid/k8s-docker.yaml
@@ -14,6 +14,8 @@
   postInstallScript: |
     kubectl top pods -A
     kubectl top nodes
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: "upgrade from latest"
   installerSpec:
     kubernetes:
@@ -41,3 +43,5 @@
   postUpgradeScript: |
     kubectl top pods -A
     kubectl top nodes
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/minio/template/testgrid/k8s-docker.yaml
+++ b/addons/minio/template/testgrid/k8s-docker.yaml
@@ -19,6 +19,8 @@
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 # migration from rook-ceph object store to minio
 - name: migrate from rook-ceph object store to minio
@@ -79,6 +81,8 @@
     else
        echo "Namespace rook-ceph was removed"
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 # installation with specified PVC size
 - name: install with 20Gi volume (openebs)
@@ -122,6 +126,8 @@
     source /opt/kurl-testgrid/testhelpers.sh
     minio_object_store_info
     validate_read_write_object_store rwtest testfile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 # upgrade that changes PVC size
 - name: upgrade minio from latest while increasing PVC claim size (longhorn)
@@ -198,6 +204,8 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 # upgrade from 2020-01-25T02-50-51Z using openebs
 - name: upgrade minio from 2020-01-25T02-50-51Z (openebs)
@@ -238,6 +246,8 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 
 - name: upgrade minio from 2020-01-25T02-50-51Z while increasing PVC claim size (openebs)
   flags: "yes"
@@ -281,3 +291,5 @@
     echo "PVC size should be 20Gi:"
     kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}'
     kubectl get pvc -n minio minio-pv-claim -o jsonpath='{.spec.resources.requests.storage}' | grep 20Gi
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
+++ b/addons/openebs/template/testgrid/k8s-docker-localpv.yaml
@@ -73,6 +73,8 @@
     minio_object_store_info
     validate_testfile rwtest testfile.txt
     validate_read_write_object_store postupgrade upgradefile.txt
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: airgap localpv
   airgap: true
@@ -202,6 +204,8 @@
     else
        echo "Namespace rook-ceph was removed"
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: localpv migrate from rook 1.10.x and from k8s 1.24.x
   flags: "yes"

--- a/addons/prometheus/template/testgrid/k8s-docker.yaml
+++ b/addons/prometheus/template/testgrid/k8s-docker.yaml
@@ -17,6 +17,7 @@
   cpu: 5
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
   installerApiEndpoint: https://kurl.sh
   installerSpec:
     kurl:
@@ -76,6 +77,8 @@
     prometheus:
       version: "__testver__"
       s3Override: "__testdist__"
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "prometheus upgrade from latest"
   installerApiEndpoint: https://kurl.sh
   installerSpec:

--- a/addons/registry/template/testgrid/k8s-docker.yaml
+++ b/addons/registry/template/testgrid/k8s-docker.yaml
@@ -197,6 +197,8 @@
 
     # pull it from the registry
     ctr -n k8s.io images pull --tlscacert /etc/kubernetes/pki/ca.crt --user "$(echo $DOCKER_AUTH | base64 -d)" $DOCKER_REGISTRY_IP/registry:testtag
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: registry_publish_port
   installerSpec:

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -131,6 +131,7 @@
       version: "latest"
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
   postInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     install_and_customize_kurl_integration_test_application

--- a/addons/velero/template/testgrid/k8s-docker.yaml
+++ b/addons/velero/template/testgrid/k8s-docker.yaml
@@ -74,6 +74,8 @@
     install_and_customize_kurl_integration_test_application
     timeout 5m kubectl kots backup
     timeout 5m kubectl kots backup ls
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: "Velero OpenEBS only"
   installerSpec:
     kubernetes:
@@ -91,6 +93,8 @@
       s3Override: "__testdist__"
     minio:
       version: "latest"
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: "Velero Remove Object Storage"
   cpu: 8
   installerSpec:

--- a/addons/weave/template/testgrid/k8s-docker.yaml
+++ b/addons/weave/template/testgrid/k8s-docker.yaml
@@ -19,6 +19,8 @@
 
     echo "weave iptables list"
     kubectl exec -n kube-system daemonset/weave-net -c weave -- iptables -L
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: "weave latest multi node"
   installerSpec:
     kubernetes:
@@ -30,6 +32,8 @@
       s3Override: "__testdist__"
   numPrimaryNodes: 1
   numSecondaryNodes: 2
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: "weave airgap latest multi node"
   installerSpec:
     kubernetes:
@@ -45,3 +49,5 @@
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/scripts/common/preflights.sh
+++ b/scripts/common/preflights.sh
@@ -3,6 +3,7 @@
 function preflights() {
     require64Bit
     bailIfUnsupportedOS
+    bailIfUnsupportedKubernetesVersion
     mustSwapoff
     prompt_if_docker_unsupported_os
     check_docker_k8s_version
@@ -102,7 +103,17 @@ function bailIfUnsupportedOS() {
             ;;
     esac
 }
- 
+
+# bailIfUnsupportedKubernetesVersion bails out if the Kubernetes version we are
+# about to install isn't supported by the underlying Operating System.
+function bailIfUnsupportedKubernetesVersion() {
+    if is_amazon_2023 ; then
+        if [ "$KUBERNETES_TARGET_VERSION_MINOR" -lt "24" ]; then
+            bail "Kubernetes versions < 1.24 are not supported on Amazon Linux 2023."
+        fi
+    fi
+}
+
 function mustSwapoff() {
     if swap_is_on || swap_is_enabled; then
         printf "\n${YELLOW}This application is incompatible with memory swapping enabled. Disable swap to continue?${NC} "

--- a/testgrid/specs/customer-migration-specs.yaml
+++ b/testgrid/specs/customer-migration-specs.yaml
@@ -159,6 +159,8 @@
       echo "Kubernetes was not upgraded to 1.27.x"
       exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 
 - name: "Cust sha1:f78c1e8cfec1cace37d9c96e0f35481f75ffdc26: k8s 1.19 -> 1.27, docker -> containerd, weave -> flannel, rook 1.0.4 -> openebs 3.7.x"
   flags: "yes"

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -341,6 +341,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: k8s120_minimal_containerd1411
   installerSpec:
     kubernetes:

--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -24,6 +24,7 @@
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s121x_containerd
   installerSpec:
     kubernetes:
@@ -54,6 +55,7 @@
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s1184_1202_containerd
   installerSpec:
     kubernetes:
@@ -77,6 +79,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119x_containerd148
   installerSpec:
     kubernetes:
@@ -103,6 +106,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119x_containerd139
   installerSpec:
     kubernetes:
@@ -129,6 +133,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_containerd1412
   installerSpec:
     kubernetes:
@@ -155,6 +160,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_containerd146-airgap
   installerSpec:
     kubernetes:
@@ -182,6 +188,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_containerd_rook_block
   cpu: 6
   installerSpec:
@@ -211,6 +218,7 @@
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_ctrd_longhorn
   installerSpec:
     kubernetes:
@@ -242,6 +250,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_ctrd_longhorn-airgap
   installerSpec:
     kubernetes:
@@ -274,6 +283,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s119_helm
   installerSpec:
     kubernetes:
@@ -347,6 +357,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s129_selinux
   flags: "yes"
   installerSpec:
@@ -395,6 +406,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s120-airgap
   installerSpec:
     kubernetes:
@@ -424,6 +436,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s24x_rook_upgrade_17x_110x
   flags: "yes"
   cpu: 6
@@ -498,6 +511,7 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "K8s 1.22x Rook"
   cpu: 6
   installerSpec:
@@ -524,6 +538,7 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "K8s 1.22x Rook, disableS3"
   cpu: 6
   installerSpec:
@@ -550,6 +565,7 @@
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "K8s 1.22x Airgap"
   cpu: 6
   installerSpec:
@@ -580,6 +596,7 @@
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "Migrate from Docker to Containerd and Kubernetes from 1.23 to 1.31 airgap"
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -906,6 +923,7 @@
     ./kube-bench --config-dir=`pwd`/cfg --config=`pwd`/cfg/config.yaml --exit-code=1
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s131x_reserved_resources
   installerSpec:
     kubernetes:
@@ -1011,6 +1029,7 @@
       version: "0.4.x"
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: rook-upgrade-to-1.5
   flags: "yes"
   installerSpec:
@@ -1075,6 +1094,7 @@
     kubectl get namespaces
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: rook-upgrade-to-1.5-airgap
   flags: "yes"
   airgap: true
@@ -1152,6 +1172,7 @@
     kubectl get namespaces
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "k8s_125x containerd 1.5.x upgrade to latest"
   installerSpec:
     kubernetes:
@@ -1402,6 +1423,7 @@
     echo $k8sVersion | grep 1.31
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "Upgrade Kubernetes from 1.19 to 1.24, Rook from 1.0.4 to 1.5.12"
   flags: "yes"
   installerSpec:
@@ -1443,6 +1465,7 @@
     echo $operatorVersion | grep 1.5.12
   unsupportedOSIDs:
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: "Preserve CoreDNS config, kubeadm upgrade --ignore-preflight-errors=CoreDNSUnsupportedPlugins"
   flags: "yes kubernetes-upgrade-ignore-preflight-errors=CoreDNSUnsupportedPlugins"
   installerSpec:
@@ -1781,6 +1804,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: k8s122-airgap
   installerSpec:
     kubernetes:
@@ -1808,6 +1832,7 @@
   unsupportedOSIDs:
     - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
     - centos-81 # containerd 1.6.31+ not supported on non-stream centos 8
+    - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git

--- a/testgrid/specs/k8s-upgrade.yaml
+++ b/testgrid/specs/k8s-upgrade.yaml
@@ -22,3 +22,5 @@
   postUpgradeScript: |
     kubectl get nodes
     kubectl get nodes | grep 1.31
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.

--- a/testgrid/specs/latest.yaml
+++ b/testgrid/specs/latest.yaml
@@ -18,6 +18,8 @@
       version: latest
     kotsadm:
       version: latest
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
 - name: openebs
   installerSpec:
     contour:
@@ -42,3 +44,5 @@
       version: latest
     kotsadm:
       version: latest
+  unsupportedOSIDs:
+  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -66,4 +66,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd
+    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -77,4 +77,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd
+    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -56,4 +56,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd
+    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/storage-migration.yaml
+++ b/testgrid/specs/storage-migration.yaml
@@ -58,6 +58,8 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.12.x to OpenEBS + Minio
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -281,6 +283,8 @@
       echo Rook namespace should NOT be removed after the upgrade. MinIO is NOT selected
       exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.12.x to OpenEBS (S3 disabled)
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -548,6 +552,8 @@
     #    echo  Rook Data directory not removed.
     #    exit 1
     # fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.8.x to Rook 1.12.x
   flags: "yes"
   cpu: 4
@@ -606,6 +612,8 @@
     #    echo  Rook Data directory not removed.
     #    exit 1
     # fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Longhorn + Minio to Rook 1.12.x
   flags: "yes"
   cpu: 4
@@ -663,6 +671,8 @@
       echo Longhorn namespace found after the upgrade.
       exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.0.4 to OpenEBS + Minio (multi-node)
   flags: "yes"
   cpu: 4
@@ -728,6 +738,8 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.12.x to OpenEBS + Minio (multi-node)
   flags: "yes"
   cpu: 4
@@ -852,6 +864,8 @@
       echo Longhorn namespace found after the upgrade.
       exit 1
     fi
+  unsupportedOSIDs:
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
 - name: Migrate from Rook 1.12.x to OpenEBS 3.4.0 with localpv migrate
   flags: "yes"
   installerApiEndpoint: https://kurl.sh
@@ -1479,6 +1493,7 @@
   unsupportedOSIDs:
   - rocky-91 # rocky 9.1 is unsupported on kurl version v2023.02.23-0
   - rocky-9 # rocky 9.1 is unsupported on kurl version v2023.02.23-0
+  - amazon-2023 # Kubernetes < 1.24 are not supported on Amazon Linux.
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     mkdir -p /var/lib/kurl/assets


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

kubernetes <= 1.24 isn't supported by amazon linux 2023.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
