### PR TITLE
improve 'is k8s already installed' check in flannel addon

### DIFF
--- a/addons/flannel/0.25.5/install.sh
+++ b/addons/flannel/0.25.5/install.sh
@@ -197,7 +197,7 @@ function flannel_init_pod_subnet() {
 
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
-    if commandExists kubectl; then
+    if commandExists kubectl && kubectl get pods 2>/dev/null >/dev/null; then
         EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -197,7 +197,7 @@ function flannel_init_pod_subnet() {
 
     cp "$src/kubeadm.yaml" "$DIR/kustomize/kubeadm/init-patches/flannel.yaml"
 
-    if commandExists kubectl; then
+    if commandExists kubectl && kubectl get pods 2>/dev/null >/dev/null; then
         EXISTING_POD_CIDR=$(awk -F '=' '/--cluster-cidr/{print $2}' /etc/kubernetes/manifests/kube-controller-manager.yaml 2>/dev/null)
     fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This makes it so flannel will only attempt to get the pod subnet from the cluster if it can actually run a kubectl command. Previously, it only checked whether the kubectl command existed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
