### PR TITLE
bug: bail out if no policycoreutils-python-utils

### DIFF
--- a/scripts/common/utilbinaries.sh
+++ b/scripts/common/utilbinaries.sh
@@ -301,6 +301,12 @@ function apply_selinux_config() {
         return
     fi
 
+    if is_amazon_2023 ; then
+        if ! yum_is_host_package_installed "policycoreutils-python-utils" ; then
+            bail "Package policycoreutils-python-utils is required to manage SELinux policies"
+        fi
+    fi
+
     CONFIGURE_SELINUX_SCRIPT=$CONFIGURE_SELINUX_SCRIPT $BIN_SYSTEM_CONFIG -c selinux -g -y $MERGED_YAML_SPEC
     if [ -f "$CONFIGURE_SELINUX_SCRIPT" ]; then
         . $CONFIGURE_SELINUX_SCRIPT

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -66,4 +66,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl
+    yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -77,4 +77,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl
+    yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -56,4 +56,4 @@
   version: "2023"
   vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
-    yum install -y --nobest nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl
+    yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

bails the installation if the installer detects that we have selinux rules to apply but the underlying system does not provide us with the semanage command (policycoreutils-python-utils).


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
