### PR TITLE
fix: /etc/kubernetes/super-admin.conf file perms for cis benchmark

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -240,6 +240,16 @@ function kubernetes_cis_chmod_kubelet_config_file() {
     fi
 }
 
+# kubernetes_cis_super_admin_credentials_file_permissions fixes the following CIS benchmark test:
+# [FAIL] 1.1.13 Ensure that the default administrative credential file permissions are set to 600 (Automated)
+# [FAIL] 1.1.14 Ensure that the default administrative credential file ownership is set to root:root (Automated)
+function kubernetes_cis_super_admin_credentials_file_permissions() {
+    if [ -f /etc/kubernetes/super-admin.conf ]; then
+        chmod 600 /etc/kubernetes/super-admin.conf
+        chown root:root /etc/kubernetes/super-admin.conf
+    fi
+}
+
 kubernetes_host_commands_ok() {
     local k8sVersion=$1
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -341,6 +341,7 @@ function init() {
     kubectl -n kurl apply -f "$DIR/manifests/troubleshoot.yaml"
 
     kubernetes_cis_chmod_kubelet_config_file
+    kubernetes_cis_super_admin_credentials_file_permissions
 }
 
 function kubeadm_post_init() {

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -131,6 +131,7 @@ function join() {
     fi
 
     kubernetes_cis_chmod_kubelet_config_file
+    kubernetes_cis_super_admin_credentials_file_permissions
 }
 
 outro() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

FIxes

[FAIL] 1.1.13 Ensure that the default administrative credential file permissions are set to 600 (Automated)
[FAIL] 1.1.14 Ensure that the default administrative credential file ownership is set to root:root (Automated)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes master CIS benchmark checks 1.1.13 and 1.1.14 for /etc/kubernetes/super-admin.conf file permissions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
