### PR TITLE
Revert "Remove npm from dependabot as there is no longer js code in this repo"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,13 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "type::chore"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 25
+


### PR DESCRIPTION
Reverts replicatedhq/kURL#5430

... we actually still use JS in the build process. I'm an idiot.