### PR TITLE
chore(ci): test discover_public_ip does not unset var

### DIFF
--- a/scripts/common/discover.sh
+++ b/scripts/common/discover.sh
@@ -189,6 +189,10 @@ function discover_public_ip() {
         return
     fi
 
+    if [ -n "$PUBLIC_ADDRESS" ]; then
+        return
+    fi
+
     # gce
     set +e
     _out=$(curl --noproxy "*" --max-time 5 --connect-timeout 2 -qSfs -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip 2>/dev/null)

--- a/scripts/common/test/discover-test.sh
+++ b/scripts/common/test/discover-test.sh
@@ -36,11 +36,11 @@ test_discover_public_ip()
     discover_public_ip
     assertEquals "34.28.226.7" "$PUBLIC_ADDRESS"
 
-    # should overwrite the public address if it is already set
+    # should not overwrite the user provided public address if it is already set
     ip_address=172.31.28.36
     PUBLIC_ADDRESS=34.28.226.7
     discover_public_ip
-    assertEquals "172.31.28.36" "$PUBLIC_ADDRESS"
+    assertEquals "34.28.226.7" "$PUBLIC_ADDRESS"
 }
 
 # shellcheck disable=SC1091

--- a/scripts/common/test/discover-test.sh
+++ b/scripts/common/test/discover-test.sh
@@ -40,7 +40,7 @@ test_discover_public_ip()
     ip_address=172.31.28.36
     PUBLIC_ADDRESS=34.28.226.7
     discover_public_ip
-    assertEquals "34.28.226.7" "$PUBLIC_ADDRESS"
+    assertEquals "172.31.28.36" "$PUBLIC_ADDRESS"
 }
 
 # shellcheck disable=SC1091

--- a/scripts/common/test/discover-test.sh
+++ b/scripts/common/test/discover-test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -e
+
+# shellcheck source=../common.sh
 . ./scripts/common/common.sh
+# shellcheck source=../discover.sh
 . ./scripts/common/discover.sh
 
 test_discover_public_ip()
@@ -25,6 +29,19 @@ test_discover_public_ip()
     PUBLIC_ADDRESS=
     discover_public_ip
     assertEquals "" "$PUBLIC_ADDRESS"
+
+    # should not unset the public address if it is already set
+    ip_address=
+    PUBLIC_ADDRESS=34.28.226.7
+    discover_public_ip
+    assertEquals "34.28.226.7" "$PUBLIC_ADDRESS"
+
+    # should overwrite the public address if it is already set
+    ip_address=172.31.28.36
+    PUBLIC_ADDRESS=34.28.226.7
+    discover_public_ip
+    assertEquals "34.28.226.7" "$PUBLIC_ADDRESS"
 }
 
+# shellcheck disable=SC1091
 . shunit2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue when installing in AWS, GCP or Azure where the `public-address` passed into the install script via a flag by the end user may be overridden if an alternate is detected using the corresponding cloud provider metadata service.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
