### PR TITLE
mark centos-9 as unsupported in the same tests as rocky-9, update some containerd versions

### DIFF
--- a/testgrid/specs/full.yaml
+++ b/testgrid/specs/full.yaml
@@ -22,8 +22,9 @@
       version: 1.4.9
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s121x_containerd
@@ -54,8 +55,9 @@
       version: latest
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not available on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s1184_1202_containerd
@@ -79,8 +81,9 @@
       version: 1.6.x
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119x_containerd148
@@ -107,8 +110,9 @@
       version: 1.4.13
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119x_containerd139
@@ -135,8 +139,9 @@
       version: 1.4.9
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119_containerd1412
@@ -163,8 +168,9 @@
       version: 1.4.12
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119_containerd146-airgap
@@ -192,8 +198,9 @@
   airgap: true
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119_containerd_rook_block
@@ -225,6 +232,7 @@
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119_ctrd_longhorn
@@ -256,8 +264,9 @@
       uiBindPort: 30080
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s119_ctrd_longhorn-airgap
@@ -349,8 +358,9 @@
                   nodePort: 30443
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s120_minimal_containerd1411
@@ -367,8 +377,9 @@
       version: 1.4.11
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s129_selinux
@@ -419,6 +430,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s120-airgap
@@ -450,6 +462,7 @@
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - rocky-91 # containerd < 1.6 is not supported on rhel 9 variant4
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: k8s24x_rook_upgrade_17x_110x
@@ -583,8 +596,9 @@
       version: latest
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # Kubernetes versions < 1.24 are not supported on Amazon Linux.
   - ubuntu-2404 # Kubernetes versions < 1.24 are not supported on Ubuntu 24.04.
 - name: "K8s 1.22x Airgap"
@@ -712,8 +726,9 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # containerd < 1.5 is not supported on amazon linux 2023
   - ubuntu-2404 # containerd < 1.5 is not supported on ubuntu 24
 - name: "K8s 1.31x Rook, disableS3"
@@ -774,8 +789,9 @@
   unsupportedOSIDs:
   - ubuntu-2204 # containerd 1.4.x is not supported on ubuntu 22.04
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variantsl
+  - rocky-91 # containerd < 1.6 is not supported on rhel 9 variants
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - amazon-2023 # containerd < 1.5 is not supported on amazon linux 2023
   - ubuntu-2404 # containerd < 1.5 is not supported on ubuntu 24
 - name: "Upgrade to 1.24, disable s3, weave to flannel"
@@ -1249,6 +1265,7 @@
   unsupportedOSIDs:
   - rocky-91 # con:
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
 - name: "containerd upgrade from 1.2.x to 1.4.x"
   installerSpec:
@@ -1280,6 +1297,7 @@
   unsupportedOSIDs:
   - rocky-91 # con:
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   - centos-74 # containerd 1.2.x does not install on centos-7
   - centos-79 # containerd 1.2.x does not install on centos-7
@@ -1367,6 +1385,7 @@
   unsupportedOSIDs:
   - rocky-91 # con:
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   - amazon-2023 # containerd < 1.5 is not supported on amazon linux 2023
   - ubuntu-2404 # containerd < 1.5 is not supported on ubuntu 24
@@ -1409,6 +1428,7 @@
   unsupportedOSIDs:
   - rocky-91 # con:
   - rocky-9 # containerd < 1.6 is not supported on rhel 9 variants
+  - centos-9 # containerd < 1.6 is not supported on rhel 9 variants
   - ubuntu-2204 # containerd is not supported by ubuntu 22.04
   - amazon-2023 # containerd < 1.5 is not supported on amazon linux 2023
   - ubuntu-2404 # containerd < 1.5 is not supported on ubuntu 24
@@ -1519,7 +1539,7 @@
     kubernetes:
       version: 1.26.x
     containerd:
-      version: 1.6.19
+      version: 1.6.30
     flannel:
       version: latest
     ekco:
@@ -1550,7 +1570,7 @@
     kubernetes:
       version: 1.26.x
     containerd:
-      version: 1.6.19
+      version: 1.6.30
     flannel:
       version: latest
     ekco:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

These centos-9 tests fail for the same reasons that rocky-9 tests fail (very old containerd) and so we shouldn't run them.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
