### PR TITLE
use rhel docker-containerd packages for rhel/containerd/rocky 8, not centos

### DIFF
--- a/addons/containerd/1.6.33/Manifest
+++ b/addons/containerd/1.6.33/Manifest
@@ -3,7 +3,7 @@ yum container-selinux
 asset runc https://github.com/opencontainers/runc/releases/download/v1.2.4/runc.amd64
 dockerout rhel-7 addons/containerd/template/Dockerfile.centos7 1.6.33
 dockerout rhel-7-force addons/containerd/template/Dockerfile.centos7-force 1.6.33
-dockerout rhel-8 addons/containerd/template/Dockerfile.centos8 1.6.32
+dockerout rhel-8 addons/containerd/template/Dockerfile.centos8 1.6.33
 dockerout rhel-9 addons/containerd/template/Dockerfile.rhel9 1.6.33
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.6.21
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.6.33

--- a/addons/containerd/1.7.25/Manifest
+++ b/addons/containerd/1.7.25/Manifest
@@ -3,7 +3,7 @@ yum container-selinux
 asset runc https://github.com/opencontainers/runc/releases/download/v1.2.4/runc.amd64
 dockerout rhel-7 addons/containerd/template/Dockerfile.centos7 1.6.33
 dockerout rhel-7-force addons/containerd/template/Dockerfile.centos7-force 1.6.33
-dockerout rhel-8 addons/containerd/template/Dockerfile.centos8 1.6.32
+dockerout rhel-8 addons/containerd/template/Dockerfile.centos8 1.7.25
 dockerout rhel-9 addons/containerd/template/Dockerfile.rhel9 1.7.25
 dockerout ubuntu-18.04 addons/containerd/template/Dockerfile.ubuntu18 1.6.21
 dockerout ubuntu-20.04 addons/containerd/template/Dockerfile.ubuntu20 1.7.25

--- a/addons/containerd/template/Dockerfile.centos8
+++ b/addons/containerd/template/Dockerfile.centos8
@@ -4,7 +4,7 @@ RUN echo -e "fastestmirror=1\nmax_parallel_downloads=8" >> /etc/dnf/dnf.conf
 
 RUN yum install -y yum-utils epel-release createrepo
 RUN yum install -y modulemd-tools
-RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+RUN yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 RUN mkdir -p /packages/archives
 
 ARG VERSION


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This changes the build for centos/rhel/rocky/oracle 8 packages to use docker's rhel upstream, not their centos repo. The rhel repo has newer versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
