### PR TITLE
fix an issue where the containerd health check failed on k8s 1.32

### DIFF
--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -108,6 +108,7 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+            # is available before proceeding.
             # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
             # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
             try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -110,7 +110,7 @@ function containerd_install() {
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
             # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
             # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/1.6.33/install.sh
+++ b/addons/containerd/1.6.33/install.sh
@@ -108,9 +108,9 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
         fi
     fi
 }

--- a/addons/containerd/1.7.25/install.sh
+++ b/addons/containerd/1.7.25/install.sh
@@ -108,6 +108,7 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
+            # is available before proceeding.
             # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
             # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
             try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"

--- a/addons/containerd/1.7.25/install.sh
+++ b/addons/containerd/1.7.25/install.sh
@@ -110,7 +110,7 @@ function containerd_install() {
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
             # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
             # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/1.7.25/install.sh
+++ b/addons/containerd/1.7.25/install.sh
@@ -108,9 +108,9 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
         fi
     fi
 }

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -111,7 +111,7 @@ function containerd_install() {
             # is available before proceeding.
             # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
             # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -108,9 +108,10 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # is available before proceeding.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(hostname)"
         fi
     fi
 }

--- a/addons/containerd/template/testgrid/k8s-ctrd.yaml
+++ b/addons/containerd/template/testgrid/k8s-ctrd.yaml
@@ -1,8 +1,8 @@
-- name: basic containerd and flannel, internal LB, airgap, 1.31
+- name: basic containerd and flannel, internal LB, airgap, 1.32
   airgap: true
   installerSpec:
     kubernetes:
-      version: "1.31.x"
+      version: "1.32.x"
     flannel:
       version: latest
     containerd:
@@ -345,7 +345,7 @@
 - name: "Upgrade Containerd from current to __testver__"
   installerSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.32.x"
     flannel:
       version: latest
     containerd:
@@ -362,7 +362,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: "1.25.x"
+      version: "1.32.x"
     flannel:
       version: latest
     containerd:
@@ -395,7 +395,7 @@
 - name: "flannel latest multinode"
   installerSpec:
     kubernetes:
-      version: "1.31.x"
+      version: "1.32.x"
     flannel:
       version: "latest"
     containerd:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

rerunning kurl installers in 1.32 failed with an error:
```
Error from server (Forbidden): nodes is forbidden: User "system:node:laverya-kurl-validation" cannot list resource "nodes" in API group "" at the cluster scope: node 'laverya-kurl-validation' cannot read all nodes, only its own Node object
spent 5m attempting to run "kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1." without success
```

This is because the role for the `/etc/kubernetes/kubelet.conf` user now only has access to its own node

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
