### PR TITLE
update install scripts for containerd 1.6.28+, fix preflights

### DIFF
--- a/addons/containerd/1.6.28/install.sh
+++ b/addons/containerd/1.6.28/install.sh
@@ -108,9 +108,10 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # is available before proceeding.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/1.6.31/install.sh
+++ b/addons/containerd/1.6.31/install.sh
@@ -108,9 +108,10 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # is available before proceeding.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/1.6.32/install.sh
+++ b/addons/containerd/1.6.32/install.sh
@@ -108,9 +108,10 @@ function containerd_install() {
             systemctl start kubelet
             # If using the internal load balancer the Kubernetes API server will be unavailable until
             # kubelet starts the HAProxy static pod. This check ensures the Kubernetes API server
-            # is available before proceeeding.
-            # "nodes.v1." is needed becasue addons can have a CRD names "nodes", like nodes.longhorn.io
-            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1.
+            # is available before proceeding.
+            # "nodes.v1." is needed because addons can have a CRD names "nodes", like nodes.longhorn.io
+            # we get the specific node name because as of kubernetes 1.32 the node kubeconfig only has permissions to get the current node
+            try_5m kubectl --kubeconfig=/etc/kubernetes/kubelet.conf get nodes.v1. "$(get_local_node_name)"
         fi
     fi
 }

--- a/addons/containerd/1.6.33/host-preflight.yaml
+++ b/addons/containerd/1.6.33/host-preflight.yaml
@@ -17,15 +17,15 @@ spec:
           - pass:
               when: "ol = 7"
               message: "containerd addon supports ol 7"
-          - warn:
+          - pass:
               when: "centos = 8"
-              message: "containerd addon supports centos 8, but only up to containerd 1.6.32, which will be installed instead of 1.6.33"
-          - warn:
+              message: "containerd addon supports centos 8"
+          - pass:
               when: "rhel = 8"
-              message: "containerd addon supports rhel 8, but only up to containerd 1.6.32, which will be installed instead of 1.6.33"
-          - warn:
+              message: "containerd addon supports rhel 8"
+          - pass:
               when: "ol = 8"
-              message: "containerd addon supports ol 8, but only up to containerd 1.6.32, which will be installed instead of 1.6.33"
+              message: "containerd addon supports ol 8"
           - pass:
               when: "centos = 9"
               message: "containerd addon supports centos 9"

--- a/addons/containerd/1.7.25/host-preflight.yaml
+++ b/addons/containerd/1.7.25/host-preflight.yaml
@@ -17,15 +17,15 @@ spec:
           - warn:
               when: "ol = 7"
               message: "containerd addon supports ol 7, but only up to containerd 1.6.33, which will be installed instead of 1.7.25"
-          - warn:
+          - pass:
               when: "centos = 8"
-              message: "containerd addon supports centos 8, but only up to containerd 1.6.32, which will be installed instead of 1.7.25"
-          - warn:
+              message: "containerd addon supports centos 8"
+          - pass:
               when: "rhel = 8"
-              message: "containerd addon supports rhel 8, but only up to containerd 1.6.32, which will be installed instead of 1.7.25"
-          - warn:
+              message: "containerd addon supports rhel 8"
+          - pass:
               when: "ol = 8"
-              message: "containerd addon supports ol 8, but only up to containerd 1.6.32, which will be installed instead of 1.7.25"
+              message: "containerd addon supports ol 8"
           - pass:
               when: "centos = 9"
               message: "containerd addon supports centos 9"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

This copies changes from https://github.com/replicatedhq/kURL/pull/5566, but only for containerd 1.6.28+ - older versions appear to have lost access to packages for rhel8 and that is causing issues.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
