### PR TITLE
fix(prometheus): increase grafana limits

### DIFF
--- a/addons/prometheus/template/values.yaml
+++ b/addons/prometheus/template/values.yaml
@@ -18,8 +18,8 @@ grafana:
   # added section (replicated)
   resources:
     limits:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
       cpu: 100m
       memory: 128Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Grafana pod killed by oom

```
    Last State:      Terminated
      Reason:        OOMKilled
      Exit Code:     137
      Started:       Sat, 08 Feb 2025 02:45:19 +1300
      Finished:      Sat, 08 Feb 2025 02:47:56 +1300
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Increased grafana pod limits to 200m cpu and 128Mi memory.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
