### PR TITLE
chore: fix subnet util after deps update

### DIFF
--- a/kurl_util/cmd/subnet/main.go
+++ b/kurl_util/cmd/subnet/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/apparentlymart/go-cidr/cidr"
-	"github.com/vishvananda/netlink"
+	"github.com/replicatedhq/kurl/kurl_util/cmd/subnet/netlink"
 )
 
 const (
@@ -53,7 +53,7 @@ func main() {
 		}
 	}
 
-	routes, err := routeList()
+	routes, err := netlink.RouteList()
 	if err != nil {
 		fmt.Printf("failed to list routes: %s\n", err.Error())
 		os.Exit(1)

--- a/kurl_util/cmd/subnet/main_test.go
+++ b/kurl_util/cmd/subnet/main_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/vishvananda/netlink"
+	"github.com/replicatedhq/kurl/kurl_util/cmd/subnet/netlink"
 )
 
 func TestFindAvailableSubnet(t *testing.T) {

--- a/kurl_util/cmd/subnet/netlink/netlink.go
+++ b/kurl_util/cmd/subnet/netlink/netlink.go
@@ -1,0 +1,5 @@
+package netlink
+
+import "github.com/vishvananda/netlink"
+
+type Route = netlink.Route

--- a/kurl_util/cmd/subnet/netlink/netlink_linux.go
+++ b/kurl_util/cmd/subnet/netlink/netlink_linux.go
@@ -1,8 +1,8 @@
-package main
+package netlink
 
 import "github.com/vishvananda/netlink"
 
-func routeList() ([]netlink.Route, error) {
+func RouteList() ([]netlink.Route, error) {
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
 		return nil, err

--- a/kurl_util/cmd/subnet/netlink/netlink_other.go
+++ b/kurl_util/cmd/subnet/netlink/netlink_other.go
@@ -1,9 +1,9 @@
 //go:build !linux
 
-package main
+package netlink
 
 import "github.com/vishvananda/netlink"
 
-func routeList() ([]netlink.Route, error) {
+func RouteList() ([]netlink.Route, error) {
 	return []netlink.Route{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Kurl installs failing with error

https://testgrid.kurl.sh/run/pr-5704-d757a6f-ekco-0.28.9-k8s-docker-2025-07-08T12:57:22Z?kurlLogsInstanceId=vzknfsdbtxnegpxp&nodeId=vzknfsdbtxnegpxp-initialprimary

```
Failed to find an available /20 subnet for the pod network within either 10.32.0.0/16 or 10.0.0.0/8.
  Use Flannel's podCIDR parameter to set a pod network that is not already in use.
  https://kurl.sh/docs/add-ons/flannel#advanced-install-options
```

netlink now returning "0.0.0.0/0" rather than a nil route.Dst

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
