### PR TITLE
Deployment with clusteradmin group for kubeadm compatability

### DIFF
--- a/addons/ekco/0.28.9/rbac.yaml
+++ b/addons/ekco/0.28.9/rbac.yaml
@@ -193,3 +193,15 @@ rules:
       - list
       - update
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:cluster-admins
+subjects:
+- kind: Group
+  name: kubeadm:cluster-admins
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes an RBAC mismatch issue where ECKO's certificate renewal process updates the API server's kubelet client certificate to use the `kubeadm:cluster-admins` group on Kubernetes clusters prior to version 1.29, but fails to create the corresponding `kubeadm:cluster-admins` ClusterRoleBinding. This causes kubectl proxy operations (exec, logs, port-forward) to fail with 403 Forbidden errors after certificate renewal.

The fix adds the missing ClusterRoleBinding that binds the `kubeadm:cluster-admins` group to the `cluster-admin` ClusterRole, ensuring that the API server maintains its ability to authenticate with kubelets for proxy operations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/124900/ecko-api-server-cert-renewal-rbac-mismatch

#### Special notes for your reviewer:

This fix addresses a critical issue where ECKO applies Kubernetes 1.29+ certificate formats to pre-1.29 clusters without ensuring the required RBAC exists. The added ClusterRoleBinding is already present in Kubernetes 1.29+ clusters by default, so this change provides backward compatibility for older clusters.

The ClusterRoleBinding grants the same permissions that the API server had before certificate renewal (cluster-admin access), maintaining the security posture while fixing the authentication issue.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

**Before the fix:**
1. Install kURL with Kubernetes version < 1.29 (e.g., 1.28.15)
2. Force certificate renewal by advancing system clock: `sudo date -s "$(date -d '+11 months')"`
3. Restart ECKO to trigger renewal: `kubectl delete pod -n kurl <ecko-pod>`
4. Wait for certificate renewal to complete
5. Attempt proxy operations: `kubectl logs -n kube-system kube-apiserver-$(hostname)`
6. Observe 403 Forbidden errors

**After the fix:**
1. Deploy the updated EKCO addon with the new ClusterRoleBinding
2. Repeat steps 1-5 above
3. Verify that kubectl exec, logs, and port-forward commands work correctly

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed RBAC issue where ECKO certificate renewal would break kubectl proxy operations (exec, logs, port-forward) on Kubernetes clusters prior to version 1.29 by adding the missing kubeadm:cluster-admins ClusterRoleBinding.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE