### PR TITLE
chore(ci): unsupported testgrid oses

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -267,6 +267,8 @@
       version: 2.8.3
   unsupportedOSIDs:
   - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
+  - centos-79 # Rook 1.13+ is not supported on centos-7
+  - ol-79 # Rook 1.13+ is not supported on centos-7
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     if is_ubuntu_2404 ; then

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -166,6 +166,7 @@
     - centos-9 # centos 9 was not supported on kurl v2024.07.02-0
     - amazon-2023 # amazon 2023 isn't supported on installer version v2024.07.02-0.
     - ubuntu-2404 # Ubuntu 24.04 isn't supported on installer version v2024.07.02-0.
+    - rocky-96 # Not supported on pinned kurl version v2024.07.02-0
 - name: "Upgrade from k8s 1.29 to 1.33 - Airgap"
   airgap: true
   installerSpec:

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -40,7 +40,8 @@
   vmimageuri: https://dl.rockylinux.org/vault/rocky/9.1/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2
   preinit: |
     yum install -y --nobest nfs-utils fio container-selinux lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl
-- name: Rocky Linux
+- id: rocky-96
+  name: Rocky Linux
   version: "9.6"
   vmimageuri: https://download.rockylinux.org/pub/rocky/9.6/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2
   preinit: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Marks tests as unsupported

```
2025-08-25 18:05:12+00:00 [FAIL] Host OS Info: Rook 1.17.7 does not support Oracle Linux 7
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
