### PR TITLE
fix: support for kernel 6.18 with nftables

### DIFF
--- a/scripts/common/kubernetes.sh
+++ b/scripts/common/kubernetes.sh
@@ -107,11 +107,22 @@ function kubernetes_load_ipv4_modules() {
         return 0
     fi
 
-    if ! lsmod | grep -q ^ip_tables ; then
+    # Prefer ip_tables (legacy); fall back to nf_tables on newer kernels
+    local iptables_module=
+    if lsmod | grep -q ^ip_tables ; then
+        iptables_module="ip_tables"
+    elif modprobe ip_tables 2>/dev/null ; then
         echo "Adding kernel module ip_tables"
-        modprobe ip_tables
+        iptables_module="ip_tables"
+    elif lsmod | grep -q ^nf_tables ; then
+        iptables_module="nf_tables"
+    elif modprobe nf_tables 2>/dev/null ; then
+        echo "Adding kernel module nf_tables"
+        iptables_module="nf_tables"
+    else
+        bail "Failed to load ip_tables or nf_tables kernel module"
     fi
-    echo "ip_tables" > /etc/modules-load.d/99-replicated-ipv4.conf
+    echo "$iptables_module" > /etc/modules-load.d/99-replicated-ipv4.conf
 
     echo "net.bridge.bridge-nf-call-iptables = 1" > /etc/sysctl.d/99-replicated-ipv4.conf
     echo "net.ipv4.conf.all.forwarding = 1" >> /etc/sysctl.d/99-replicated-ipv4.conf
@@ -128,11 +139,22 @@ function kubernetes_load_ipv6_modules() {
         return 0
     fi
 
-    if ! lsmod | grep -q ^ip6_tables ; then
+    # Prefer ip6_tables (legacy); fall back to nf_tables on newer kernels
+    local ip6tables_module=
+    if lsmod | grep -q ^ip6_tables ; then
+        ip6tables_module="ip6_tables"
+    elif modprobe ip6_tables 2>/dev/null ; then
         echo "Adding kernel module ip6_tables"
-        modprobe ip6_tables
+        ip6tables_module="ip6_tables"
+    elif lsmod | grep -q ^nf_tables ; then
+        ip6tables_module="nf_tables"
+    elif modprobe nf_tables 2>/dev/null ; then
+        echo "Adding kernel module nf_tables"
+        ip6tables_module="nf_tables"
+    else
+        bail "Failed to load ip6_tables or nf_tables kernel module"
     fi
-    echo "ip6_tables" > /etc/modules-load.d/99-replicated-ipv6.conf
+    echo "$ip6tables_module" > /etc/modules-load.d/99-replicated-ipv6.conf
 
     echo "net.bridge.bridge-nf-call-ip6tables = 1" > /etc/sysctl.d/99-replicated-ipv6.conf
     echo "net.ipv6.conf.all.forwarding = 1" >> /etc/sysctl.d/99-replicated-ipv6.conf

--- a/testgrid/specs/os-firstlast.yaml
+++ b/testgrid/specs/os-firstlast.yaml
@@ -70,6 +70,6 @@
 - id: amazon-2023
   name: Amazon Linux
   version: "2023"
-  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.11.20260406.2/kvm/al2023-kvm-2023.11.20260406.2-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
     yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-full.yaml
+++ b/testgrid/specs/os-full.yaml
@@ -81,6 +81,6 @@
 - id: amazon-2023
   name: Amazon Linux
   version: "2023"
-  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.11.20260406.2/kvm/al2023-kvm-2023.11.20260406.2-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
     yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd

--- a/testgrid/specs/os-latest.yaml
+++ b/testgrid/specs/os-latest.yaml
@@ -60,6 +60,6 @@
 - id: amazon-2023
   name: Amazon Linux
   version: "2023"
-  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.5.20240819.0/kvm/al2023-kvm-2023.5.20240819.0-kernel-6.1-x86_64.xfs.gpt.qcow2
+  vmimageuri: https://cdn.amazonlinux.com/al2023/os-images/2023.11.20260406.2/kvm/al2023-kvm-2023.11.20260406.2-kernel-6.1-x86_64.xfs.gpt.qcow2
   preinit: |
     yum install -y --nobest policycoreutils-python-utils nfs-utils fio container-selinux ebtables-legacy lvm2 conntrack-tools iptables-nft socat git iscsi-initiator-utils libcurl-minimal rrdtool yajl containerd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

Amazon Linux 2023, has kernel version option 6.18, where it no longer provides the legacy ip_tables kernel module that the kURL installer expects - the system has shifted to nftables.

Error during the install:

```
✔ Images loaded successfully
Checking if the kubelet service is enabled
docker.io/replicated/kurl util:v2026.02. saved
application/vnd.oci.image.manifest.v1+json sha256:4260c16a6e66bcfbf0aa9764b837e1ea69fca6d0649bb39e9c07f4daf816f4fd
Importing elapsed: 6.4 s total: 0.0 B (0.0 B/s)
Adding kernel module ip_tables
modprobe: FATAL: Module ip_tables not found in directory /lib/modules/6.18.15-14.217.amzn2023.x86_64
An error occurred on line 3439
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue installing on Amazon Linux 2023 with kernel 6.18 related to missing ip_tables kernel module
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
