### PR TITLE
fix: bump node version to 18 in build-addons CI job

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -130,7 +130,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: '14'
+        node-version: '18'
     - run: npm install
     - run: make generate-addons
       env:


### PR DESCRIPTION
## Summary
- Bumps `node-version` from `'14'` to `'18'` in the `build-addons` job in `deploy-staging.yaml`
- `@aws-sdk/client-s3` v3 (migrated in #5941) requires Node 18+; running on Node 14 caused a `SyntaxError: Unexpected token '??='` from `@smithy/util-retry`

## Test plan
- [ ] Verify the `build-addons` job passes in the next staging deploy run

🤖 Generated with [Claude Code](https://claude.com/claude-code)