### PR TITLE
fix: use modern kustomize patches format in flannel addon

### DIFF
--- a/addons/flannel/0.28.1/install.sh
+++ b/addons/flannel/0.28.1/install.sh
@@ -135,10 +135,6 @@ function flannel() {
        sed -i 's/  - path:/  -/' "$dst/kustomization.yaml"
     fi
 
-    # Kubernetes 1.27 uses kustomize v5 which dropped support for old, legacy style patches
-    # See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1270
-    kubernetes_kustomize_config_migrate "$dst"
-
     flannel_render_config
 
     if flannel_weave_conflict; then
@@ -207,12 +203,22 @@ function flannel_render_config() {
 
     if [ "$FLANNEL_ENABLE_IPV6" = "true" ] && [ -n "$POD_CIDR_IPV6" ]; then
         render_yaml_file_2 "$src/template/ipv6.patch.tmpl.yaml" > "$dst/ipv6.patch.yaml"
-        insert_patches_strategic_merge "$dst/kustomization.yaml" ipv6.patch.yaml
+        cat >> "$dst/kustomization.yaml" <<EOF
+  - path: ipv6.patch.yaml
+EOF
     fi
 
     if [ -n "$FLANNEL_IFACE" ]; then
         render_yaml_file_2 "$src/template/iface.patch.tmpl.yaml" > "$dst/iface.patch.yaml"
-        insert_patches_json_6902 "$dst/kustomization.yaml" iface.patch.yaml apps v1 DaemonSet kube-flannel-ds kube-flannel
+        cat >> "$dst/kustomization.yaml" <<EOF
+  - path: iface.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: kube-flannel-ds
+      namespace: kube-flannel
+EOF
     fi
 }
 

--- a/addons/flannel/template/base/install.sh
+++ b/addons/flannel/template/base/install.sh
@@ -135,10 +135,6 @@ function flannel() {
        sed -i 's/  - path:/  -/' "$dst/kustomization.yaml"
     fi
 
-    # Kubernetes 1.27 uses kustomize v5 which dropped support for old, legacy style patches
-    # See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1270
-    kubernetes_kustomize_config_migrate "$dst"
-
     flannel_render_config
 
     if flannel_weave_conflict; then
@@ -207,12 +203,22 @@ function flannel_render_config() {
 
     if [ "$FLANNEL_ENABLE_IPV6" = "true" ] && [ -n "$POD_CIDR_IPV6" ]; then
         render_yaml_file_2 "$src/template/ipv6.patch.tmpl.yaml" > "$dst/ipv6.patch.yaml"
-        insert_patches_strategic_merge "$dst/kustomization.yaml" ipv6.patch.yaml
+        cat >> "$dst/kustomization.yaml" <<EOF
+  - path: ipv6.patch.yaml
+EOF
     fi
 
     if [ -n "$FLANNEL_IFACE" ]; then
         render_yaml_file_2 "$src/template/iface.patch.tmpl.yaml" > "$dst/iface.patch.yaml"
-        insert_patches_json_6902 "$dst/kustomization.yaml" iface.patch.yaml apps v1 DaemonSet kube-flannel-ds kube-flannel
+        cat >> "$dst/kustomization.yaml" <<EOF
+  - path: iface.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: kube-flannel-ds
+      namespace: kube-flannel
+EOF
     fi
 }
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `patchesStrategicMerge` / `patchesJson6902` fields with the modern `patches:` format in `flannel_render_config`
- Removes the `kubernetes_kustomize_config_migrate` call from `flannel()`, which was running `kustomize edit fix` before patch files were generated — causing spurious warnings like:
  ```
  Fixed fields:
    patchesJson6902 -> patches
    patchesStrategicMerge -> patches
  Warning: 'Fixed' kustomization now produces the error when running kustomize build:
    failed to get the patch file from path(kube-flannel-cfg.patch.yaml): no such file or directory
  ```
- Changes applied to both `addons/flannel/0.28.1/install.sh` and `addons/flannel/template/base/install.sh`

## Test plan
- [ ] Install flannel without IPv6 or custom iface — verify no kustomize warnings
- [ ] Install flannel with `FLANNEL_ENABLE_IPV6=true` — verify `ipv6.patch.yaml` is applied correctly
- [ ] Install flannel with `FLANNEL_IFACE` set — verify `iface.patch.yaml` is applied with the correct target
- [ ] Upgrade flannel from a previous version — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)