### PR TITLE
Fix containerd 2.x registry TLS config via hosts.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,21 @@ packages/*/*/ubuntu-*
 sbom/
 
 
-# ide 
+# ide
 .vscode
+
+# ai/editor metadata
+.claude
+.opencode
+.cursor
+.aider*
+.continue
+.codeium
+CLAUDE.md
+AGENTS.md
+.repomixignore
+
+# local workflow
+plans/
+docs/
+release-manifest.json

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -171,6 +171,11 @@ function containerd_configure() {
     sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     # Ensure containerd reads per-registry hosts.toml files (required for 1.x; no-op on 2.x which already sets this)
     sed -i 's|config_path = ""|config_path = "/etc/containerd/certs.d"|' /etc/containerd/config.toml
+    # Strip the colon-separated suffix that containerd v2.x `config default` generates.
+    # io.containerd.transfer.v1.local (the pull path when use_local_image_pull=false) silently
+    # ignores colon-separated config_path values and never reads hosts.toml as a result.
+    # https://github.com/containerd/containerd/issues/12415
+    sed -i "s|config_path = '/etc/containerd/certs\.d:/etc/docker/certs\.d'|config_path = '/etc/containerd/certs.d'|" /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -169,6 +169,8 @@ function containerd_configure() {
     sed -i '/systemd_cgroup/d' /etc/containerd/config.toml
     sed -i '/containerd.runtimes.runc.options/d' /etc/containerd/config.toml
     sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
+    # Ensure containerd reads per-registry hosts.toml files (required for 1.x; no-op on 2.x which already sets this)
+    sed -i 's|config_path = ""|config_path = "/etc/containerd/certs.d"|' /etc/containerd/config.toml
     cat >> /etc/containerd/config.toml <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = true

--- a/addons/containerd/template/base/install.sh
+++ b/addons/containerd/template/base/install.sh
@@ -171,6 +171,10 @@ function containerd_configure() {
     sed -i 's/level = ""/level = "warn"/' /etc/containerd/config.toml
     # Ensure containerd reads per-registry hosts.toml files (required for 1.x; no-op on 2.x which already sets this)
     sed -i 's|config_path = ""|config_path = "/etc/containerd/certs.d"|' /etc/containerd/config.toml
+
+    # for local transfer service in 2.x
+    sed -i "s|config_path = ''|config_path = '/etc/containerd/certs.d'|" /etc/containerd/config.toml
+
     # Strip the colon-separated suffix that containerd v2.x `config default` generates.
     # io.containerd.transfer.v1.local (the pull path when use_local_image_pull=false) silently
     # ignores colon-separated config_path values and never reads hosts.toml as a result.

--- a/scripts/distro/kubeadm/distro.sh
+++ b/scripts/distro/kubeadm/distro.sh
@@ -180,14 +180,20 @@ function kubeadm_registry_containerd_configure() {
         echo "$registry_ip $server" >> /etc/hosts
     fi
 
-    if grep -Fq "plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"${server}\".tls" /etc/containerd/config.toml; then
+    local hosts_toml="/etc/containerd/certs.d/${server}/hosts.toml"
+    if [ -f "$hosts_toml" ]; then
         echo "Registry ${server} TLS already configured for containerd"
         return 0
     fi
 
-    cat >> /etc/containerd/config.toml <<EOF
-[plugins."io.containerd.grpc.v1.cri".registry.configs."${server}".tls]
-  ca_file = "/etc/kubernetes/pki/ca.crt"
+    # Use hosts.toml per-registry config — works for containerd 1.5+ and 2.x.
+    # The old inline registry.configs approach was removed in containerd 2.0.
+    mkdir -p "/etc/containerd/certs.d/${server}"
+    cat > "$hosts_toml" <<EOF
+server = "https://${server}"
+
+[host."https://${server}"]
+  ca = ["/etc/kubernetes/pki/ca.crt"]
 EOF
 
     CONTAINERD_NEEDS_RESTART=1


### PR DESCRIPTION
## Problem
Amazon Linux 2023 ships containerd 2.x by default. containerd 2.0 removed the `plugins."io.containerd.grpc.v1.cri".registry.configs` inline TOML approach from config.toml, breaking registry TLS configuration.

## Solution
Migrated to the `hosts.toml` per-registry approach under `/etc/containerd/certs.d/<server>/`. This is the official containerd 2.x registry configuration method and aligns with containerd's current architecture.

## Changes
- **scripts/distro/kubeadm/distro.sh** — Rewrote `kubeadm_registry_containerd_configure()` to write per-registry `hosts.toml` files instead of appending inline TOML to `config.toml`
- **addons/containerd/template/base/install.sh** — Added `sed` to set `config_path = "/etc/containerd/certs.d"` for containerd 1.x forward compatibility
- **.gitignore** — Added AI/editor metadata folders and local workflow directories

Fixes #5161