### PR TITLE
fix: improve staging s3 cleanup time

### DIFF
--- a/bin/cleanup-staging-s3.sh
+++ b/bin/cleanup-staging-s3.sh
@@ -15,24 +15,121 @@ require S3_BUCKET "${S3_BUCKET}"
 
 monthAgo=$(date --date "-744 hour" "+%s")
 
-echo "cleaning up old staging releases"
-# get the objects inside versioned staging buckets
-# then filter it for objects with timestamps older than 31 days
-# and then delete those objects older than 31 days
-objects=$(aws s3api list-objects --bucket "$S3_BUCKET" --prefix 'staging/v20' --query 'Contents[].{Key: Key, LastModified: LastModified}' --output json)
-if [ "$objects" != "null" ]; then
-    echo "Found staging objects: $objects"
-    echo "$objects" | jq "map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo)) | .[].Key" | \
-        xargs -I {} aws s3api delete-object --bucket "$S3_BUCKET" --key "{}"
-fi
+function delete_objects_batch() {
+    local bucket="$1"
+    local keys_json="$2"
 
-echo "cleaning up old PR files"
-# get the objects inside the PR folder
-# then filter it for objects with timestamps older than 31 days
-# and then delete those objects older than 31 days
-objects=$(aws s3api list-objects --bucket "$S3_BUCKET" --prefix 'pr/' --query 'Contents[].{Key: Key, LastModified: LastModified}' --output json)
-if [ "$objects" != "null" ]; then
-    echo "Found PR objects: $objects"
-    echo "$objects" | jq "map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo)) | .[].Key" | { grep -v '"pr/"' || test $? = 1; } | \
-        xargs -I {} aws s3api delete-object --bucket "$S3_BUCKET" --key "{}"
-fi
+    if [ -z "$keys_json" ] || [ "$keys_json" = "[]" ]; then
+        return 0
+    fi
+
+    local delete_json
+    delete_json=$(echo "$keys_json" | jq '{Objects: map({Key: .})}')
+
+    local result
+    result=$(aws s3api delete-objects \
+        --bucket "$bucket" \
+        --delete "$delete_json")
+
+    # Log any errors from partial failures
+    local errors
+    errors=$(echo "$result" | jq -c '.Errors // empty')
+    if [ -n "$errors" ]; then
+        echo "WARNING: delete-objects reported errors:"
+        echo "$errors"
+    fi
+}
+
+function list_all_objects() {
+    local bucket="$1"
+    local prefix="$2"
+
+    local all_objects="[]"
+    local continuation_token=""
+
+    while true; do
+        local response
+        if [ -n "$continuation_token" ]; then
+            response=$(aws s3api list-objects-v2 \
+                --bucket "$bucket" \
+                --prefix "$prefix" \
+                --continuation-token "$continuation_token" \
+                --query '{Contents: Contents[].{Key: Key, LastModified: LastModified}, IsTruncated: IsTruncated, NextContinuationToken: NextContinuationToken}' \
+                --output json)
+        else
+            response=$(aws s3api list-objects-v2 \
+                --bucket "$bucket" \
+                --prefix "$prefix" \
+                --query '{Contents: Contents[].{Key: Key, LastModified: LastModified}, IsTruncated: IsTruncated, NextContinuationToken: NextContinuationToken}' \
+                --output json)
+        fi
+
+        local objects
+        objects=$(echo "$response" | jq '.Contents // []')
+        all_objects=$(echo "$all_objects $objects" | jq -s 'add')
+
+        local is_truncated
+        is_truncated=$(echo "$response" | jq -r '.IsTruncated // false')
+
+        if [ "$is_truncated" != "true" ]; then
+            break
+        fi
+
+        continuation_token=$(echo "$response" | jq -r '.NextContinuationToken // empty')
+
+        if [ -z "$continuation_token" ]; then
+            echo "WARNING: list-objects-v2 returned IsTruncated=true but no NextContinuationToken"
+            break
+        fi
+    done
+
+    echo "$all_objects"
+}
+
+function cleanup_prefix() {
+    local prefix="$1"
+    local description="$2"
+    local exclude_root="$3"
+
+    echo "cleaning up old $description"
+
+    local objects
+    objects=$(list_all_objects "$S3_BUCKET" "$prefix")
+
+    if [ "$objects" = "null" ] || [ -z "$objects" ] || [ "$objects" = "[]" ]; then
+        echo "no objects found for prefix $prefix"
+        return 0
+    fi
+
+    local count_all
+    count_all=$(echo "$objects" | jq 'length')
+    echo "found $count_all total objects for prefix $prefix"
+
+    local keys_to_delete
+    keys_to_delete=$(echo "$objects" | jq -r "
+        map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo))
+        | map(.Key)
+        $exclude_root
+    ")
+
+    if [ "$keys_to_delete" = "[]" ] || [ -z "$keys_to_delete" ]; then
+        echo "no old objects to delete for prefix $prefix"
+        return 0
+    fi
+
+    local count
+    count=$(echo "$keys_to_delete" | jq 'length')
+    echo "found $count objects to delete for prefix $prefix"
+
+    # Batch delete in chunks of 1000 (AWS limit for delete-objects)
+    echo "$keys_to_delete" | \
+        jq -c '. as $a | [range(0; length; 1000) | $a[.:.+1000]] | .[]' | \
+        while read -r batch; do
+            delete_objects_batch "$S3_BUCKET" "$batch" || exit 1
+        done
+
+    echo "finished deleting old $description"
+}
+
+cleanup_prefix "staging/v20" "staging releases"
+cleanup_prefix "pr/" "PR files" '| map(select(. != "pr/"))'

--- a/bin/cleanup-staging-s3.sh
+++ b/bin/cleanup-staging-s3.sh
@@ -88,10 +88,8 @@ function list_all_objects() {
 
 function cleanup_prefix() {
     local prefix="$1"
-    local description="$2"
-    local exclude_root="$3"
 
-    echo "cleaning up old $description"
+    echo "cleaning up old objects for prefix '$prefix'"
 
     local objects
     objects=$(list_all_objects "$S3_BUCKET" "$prefix")
@@ -106,11 +104,11 @@ function cleanup_prefix() {
     echo "found $count_all total objects for prefix $prefix"
 
     local keys_to_delete
-    keys_to_delete=$(echo "$objects" | jq -r "
-        map(select(.LastModified | .[0:19] + \"Z\" | fromdateiso8601 < $monthAgo))
+    keys_to_delete=$(echo "$objects" | jq -r --arg prefix "$prefix" '
+        map(select(.LastModified | .[0:19] + "Z" | fromdateiso8601 < '"$monthAgo"'))
         | map(.Key)
-        $exclude_root
-    ")
+        | map(select(. != $prefix))
+    ')
 
     if [ "$keys_to_delete" = "[]" ] || [ -z "$keys_to_delete" ]; then
         echo "no old objects to delete for prefix $prefix"
@@ -121,15 +119,17 @@ function cleanup_prefix() {
     count=$(echo "$keys_to_delete" | jq 'length')
     echo "found $count objects to delete for prefix $prefix"
 
-    # Batch delete in chunks of 1000 (AWS limit for delete-objects)
     echo "$keys_to_delete" | \
         jq -c '. as $a | [range(0; length; 1000) | $a[.:.+1000]] | .[]' | \
         while read -r batch; do
             delete_objects_batch "$S3_BUCKET" "$batch" || exit 1
         done
 
-    echo "finished deleting old $description"
+    echo "finished deleting old objects for prefix '$prefix'"
 }
 
-cleanup_prefix "staging/v20" "staging releases"
-cleanup_prefix "pr/" "PR files" '| map(select(. != "pr/"))'
+echo "cleaning up old staging releases"
+cleanup_prefix "staging/v20"
+
+echo "cleaning up old PR files"
+cleanup_prefix "pr/"


### PR DESCRIPTION
## Summary

Fixes the cleanup-s3 job in `deploy-staging.yaml` that took **4.5 hours** on recent runs (e.g. [run #4115](https://github.com/replicatedhq/kURL/actions/runs/25354290263/job/74344235100)).

## Changes

### 1. Batch delete objects (1000 per call)
The root cause of the multi-hour runtime: the old code made **one AWS API call per object** using `xargs -I {} aws s3api delete-object`. With thousands of staging objects, this ballooned to 4h 30m.

The new code batches deletions using `aws s3api delete-objects` (AWS limit: 1000 keys per call). If there are ~10,000 objects, this drops from ~10,000 API calls to ~10.

### 2. Handle pagination with `list-objects-v2`
The old `list-objects` call is hard-capped at **1,000 keys**. If `staging/v20` or `pr/` contain more than 1,000 objects, everything beyond the first page was silently ignored and never deleted.

The new code uses `list-objects-v2` with `NextContinuationToken` to iterate through all pages.

### 3. Fail fast on batch delete errors
The old `while read` loop fed by a pipe swallowed errors even with `set -e`. If a single `delete-object` failed, the script just continued to the next key.

The new loop uses `|| exit 1` so any batch delete failure aborts the job immediately and loudly.

### 4. Log partial delete failures
The old code passed `--quiet` to `delete-objects`, hiding per-key errors (e.g. access denied on a single object). The new code removes `--quiet` and explicitly logs any `Errors` returned by AWS.

## Testing
- `list-objects-v2` and `delete-objects` are available in AWS CLI v2 (pre-installed on `ubuntu-24.04` runners — currently v2.34.30).
- `jq` v1.7.1 is also pre-installed.