### PR TITLE
Add support for kubernetes 1.35

### DIFF
--- a/packages/kubernetes/template/Dockerfile.131
+++ b/packages/kubernetes/template/Dockerfile.131
@@ -1,6 +1,0 @@
-FROM ubuntu:22.04
-RUN apt-get update
-RUN apt-get -y install curl apt-transport-https gnupg ca-certificates
-RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update

--- a/packages/kubernetes/template/Dockerfile.135
+++ b/packages/kubernetes/template/Dockerfile.135
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+RUN apt-get update
+RUN apt-get -y install curl apt-transport-https gnupg ca-certificates
+RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.35/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update

--- a/packages/kubernetes/template/script.sh
+++ b/packages/kubernetes/template/script.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 # Populate VERSIONS array latest kURL-support versions (1.21, 1.22, 1.23, 1.24) available
 VERSIONS=()
 function find_available_versions() {
+    docker build -t k8s135 - < Dockerfile.135
+    local versions135=($(docker run k8s135 apt list -a kubelet 2>/dev/null | grep -Eo '1\.35\.[0-9]+' | sort -rV | uniq))
+    if [ ${#versions135[@]} -gt 0 ]; then
+        echo "Found latest version for Kubernetes 1.35: ${versions135[0]}"
+        VERSIONS+=("${versions135[0]}")
+    fi
+
     docker build -t k8s134 - < Dockerfile.134
     local versions134=($(docker run k8s134 apt list -a kubelet 2>/dev/null | grep -Eo '1\.34\.[0-9]+' | sort -rV | uniq))
     if [ ${#versions134[@]} -gt 0 ]; then
@@ -24,13 +31,6 @@ function find_available_versions() {
     if [ ${#versions132[@]} -gt 0 ]; then
         echo "Found latest version for Kubernetes 1.32: ${versions132[0]}"
         VERSIONS+=("${versions132[0]}")
-    fi
-
-    docker build -t k8s131 - < Dockerfile.131
-    local versions131=($(docker run k8s131 apt list -a kubelet 2>/dev/null | grep -Eo '1\.31\.[0-9]+' | sort -rV | uniq))
-    if [ ${#versions131[@]} -gt 0 ]; then
-        echo "Found latest version for Kubernetes 1.31: ${versions131[0]}"
-        VERSIONS+=("${versions131[0]}")
     fi
 
     echo "Found ${#VERSIONS[*]} versions for Kubernetes: ${VERSIONS[*]}"
@@ -126,6 +126,13 @@ function get_latest_sonobuoy_release_version() {
 }
 
 function update_available_versions() {
+    local version135=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.35' ) )
+    if [ ${#version135[@]} -gt 0 ]; then
+        if ! sed '0,/cron-kubernetes-update-135/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version135[0]}" ; then
+            sed -i "/cron-kubernetes-update-135/a\    \"${version135[0]}\"\," ../../../web/src/installers/versions.js
+        fi
+    fi
+
     local version134=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.34' ) )
     if [ ${#version134[@]} -gt 0 ]; then
         if ! sed '0,/cron-kubernetes-update-134/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version134[0]}" ; then
@@ -144,13 +151,6 @@ function update_available_versions() {
     if [ ${#version132[@]} -gt 0 ]; then
         if ! sed '0,/cron-kubernetes-update-132/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version132[0]}" ; then
             sed -i "/cron-kubernetes-update-132/a\    \"${version132[0]}\"\," ../../../web/src/installers/versions.js
-        fi
-    fi
-
-    local version131=( $( for i in "${VERSIONS[@]}" ; do echo $i ; done | grep '^1.31' ) )
-    if [ ${#version131[@]} -gt 0 ]; then
-        if ! sed '0,/cron-kubernetes-update-131/d' ../../../web/src/installers/versions.js | sed '/\],/,$d' | grep -q "${version131[0]}" ; then
-            sed -i "/cron-kubernetes-update-131/a\    \"${version131[0]}\"\," ../../../web/src/installers/versions.js
         fi
     fi
 }

--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -40,7 +40,7 @@
     - centos-9 # docker is not supported on rhel 9 variants
     - amazon-2023 # docker is not supported on amazon 2023
     - ubuntu-2404 # docker is not supported on Ubuntu 24.04
-- name: "Upgrade to 1.25 to 1.34, Migrate from Rook 1.12.x to OpenEBS + Minio"
+- name: "Upgrade to 1.25 to 1.35, Migrate from Rook 1.12.x to OpenEBS + Minio"
   flags: "yes"
   installerSpec:
     kubernetes:
@@ -59,7 +59,7 @@
       version: 1.12.x
   upgradeSpec:
     kubernetes:
-      version: 1.34.x
+      version: 1.35.x
     containerd:
       version: 1.6.x
     flannel:
@@ -167,11 +167,11 @@
     - amazon-2023 # amazon 2023 isn't supported on installer version v2024.07.02-0.
     - ubuntu-2404 # Ubuntu 24.04 isn't supported on installer version v2024.07.02-0.
     - rocky-96 # Not supported on pinned kurl version v2024.07.02-0
-- name: "Upgrade from k8s 1.30 to 1.34 - Airgap"
+- name: "Upgrade from k8s 1.31 to 1.35 - Airgap"
   airgap: true
   installerSpec:
     kubernetes:
-      version: 1.30.x
+      version: 1.31.x
     kurl:
       installerVersion: ""
     flannel:
@@ -190,7 +190,7 @@
       version: latest
   upgradeSpec:
     kubernetes:
-      version: 1.34.x
+      version: 1.35.x
     kurl:
       installerVersion: ""
     flannel:
@@ -219,10 +219,10 @@
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   unsupportedOSIDs:
     - centos-79
-- name: k8s134x_cis_benchmarks_checks
+- name: k8s135x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
-      version: "1.34.x"
+      version: "1.35.x"
       cisCompliance: true
     containerd:
       version: "latest"
@@ -238,10 +238,10 @@
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
-- name: "k8s_134x with kurl in-cluster support bundle spec"
+- name: "k8s_135x with kurl in-cluster support bundle spec"
   installerSpec:
     kubernetes:
-      version: "1.34.x"
+      version: "1.35.x"
     containerd:
       version: latest
     flannel:
@@ -254,10 +254,10 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
-- name: "k8s_134x with rook"
+- name: "k8s_135x with rook"
   installerSpec:
     kubernetes:
-      version: "1.34.x"
+      version: "1.35.x"
     containerd:
       version: latest
     flannel:

--- a/web/src/installers/versions.js
+++ b/web/src/installers/versions.js
@@ -23,6 +23,7 @@ module.exports.InstallerVersions = {
     "1.17.7",
     "1.17.3",
     "1.16.4",
+    // cron-kubernetes-update-135
     // cron-kubernetes-update-134
     "1.34.7",
     "1.34.6",


### PR DESCRIPTION
## Summary

Adds support for Kubernetes 1.35 to the kURL installer, mirroring the pattern used for the 1.34 support commit.

## Changes

- Added `packages/kubernetes/template/Dockerfile.135` with v1.35 apt repository configuration
- Removed `packages/kubernetes/template/Dockerfile.131` (oldest supported version, maintaining the 4-version sliding window)
- Updated `packages/kubernetes/template/script.sh` to discover and register 1.35 versions
- Updated `web/src/installers/versions.js` with `cron-kubernetes-update-135` marker
- Bumped testgrid `deploy.yaml` specs from 1.34 to 1.35

## Test Plan

- Automated Kubernetes version update workflow should pick up 1.35.x patch releases once available
- TestGrid deploy specs will validate fresh installs and upgrades on 1.35