### PR TITLE
feat(ci): add Slack release notification to deploy-prod workflow

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -304,6 +304,15 @@ jobs:
         AWS_DEFAULT_REGION: "us-east-1"
         DIST_FOLDER: "dist"
 
+  notify-release:
+    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@main
+    needs:
+    - github-release
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      slack_webhook: ${{ secrets.PRODUCTION_SYSTEMS_SLACK_WEBHOOK }}
+
   testgrid-run:
     runs-on: ubuntu-24.04
     needs:


### PR DESCRIPTION
## Summary
This PR adds a `notify-release` job to the production deployment workflow that sends a Slack notification via the reusable `replicatedhq/reusable-workflows` action whenever a new kURL release is published to GitHub.

## Changes
- Added `notify-release` job to `.github/workflows/deploy-prod.yaml`
- Uses `replicatedhq/reusable-workflows/.github/workflows/notify-release/notify-release.yml@main` reusable workflow
- Job depends on `github-release` and passes the release tag and production Slack webhook

## UAT
1. Merge this PR
2. On the next version tag push (`v*.*.*`), verify the `notify-release` job runs after `github-release` completes successfully
3. Confirm a release notification is posted to the production systems Slack channel