### PR TITLE
fix(testgrid): exclude cgroup v1 OSes from k8s 1.35 test matrix

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -103,6 +103,13 @@
        echo  Rook Data directories not removed.
        exit 1
     fi
+  unsupportedOSIDs:
+    - amzn-20 # Kubernetes 1.35 does not support cgroup v1
+    - centos-74 # Kubernetes 1.35 does not support cgroup v1
+    - centos-78 # Kubernetes 1.35 does not support cgroup v1
+    - centos-79 # Kubernetes 1.35 does not support cgroup v1
+    - ol-79 # Kubernetes 1.35 does not support cgroup v1
+    - ubuntu-1804 # Kubernetes 1.35 does not support cgroup v1
 - name: "Migrate from Longhorn + Minio to OpenEBS + Minio"
   flags: "yes"
   cpu: 6
@@ -218,7 +225,12 @@
     source /opt/kurl-testgrid/testhelpers.sh
     rhel_9_install_host_packages lvm2 conntrack-tools socat container-selinux git
   unsupportedOSIDs:
-    - centos-79
+    - amzn-20 # Kubernetes 1.35 does not support cgroup v1
+    - centos-74 # Kubernetes 1.35 does not support cgroup v1
+    - centos-78 # Kubernetes 1.35 does not support cgroup v1
+    - centos-79 # Kubernetes 1.35 does not support cgroup v1
+    - ol-79 # Kubernetes 1.35 does not support cgroup v1
+    - ubuntu-1804 # Kubernetes 1.35 does not support cgroup v1
 - name: k8s135x_cis_benchmarks_checks
   installerSpec:
     kubernetes:
@@ -238,6 +250,13 @@
     echo "Kubeconfig was $KUBECONFIG"
     unset KUBECONFIG
     kubectl get namespaces
+  unsupportedOSIDs:
+    - amzn-20 # Kubernetes 1.35 does not support cgroup v1
+    - centos-74 # Kubernetes 1.35 does not support cgroup v1
+    - centos-78 # Kubernetes 1.35 does not support cgroup v1
+    - centos-79 # Kubernetes 1.35 does not support cgroup v1
+    - ol-79 # Kubernetes 1.35 does not support cgroup v1
+    - ubuntu-1804 # Kubernetes 1.35 does not support cgroup v1
 - name: "k8s_135x with kurl in-cluster support bundle spec"
   installerSpec:
     kubernetes:
@@ -254,6 +273,13 @@
     echo $supportBundle | base64 -d | grep 'kind: SupportBundle'
     echo "test if the support bundle has 'troubleshoot.io/kind: support-bundle' label"
     kubectl get secrets -n kurl kurl-supportbundle-spec -oyaml | grep 'troubleshoot.io/kind: support-bundle'
+  unsupportedOSIDs:
+    - amzn-20 # Kubernetes 1.35 does not support cgroup v1
+    - centos-74 # Kubernetes 1.35 does not support cgroup v1
+    - centos-78 # Kubernetes 1.35 does not support cgroup v1
+    - centos-79 # Kubernetes 1.35 does not support cgroup v1
+    - ol-79 # Kubernetes 1.35 does not support cgroup v1
+    - ubuntu-1804 # Kubernetes 1.35 does not support cgroup v1
 - name: "k8s_135x with rook"
   installerSpec:
     kubernetes:
@@ -267,9 +293,12 @@
     registry:
       version: 2.8.3
   unsupportedOSIDs:
-    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel
-    - centos-79 # Rook 1.13+ is not supported on centos-7
-    - ol-79 # Rook 1.13+ is not supported on centos-7
+    - amzn-20 # Kubernetes 1.35 does not support cgroup v1
+    - centos-74 # Rook 1.8+ not supported on 3.10.0-693.el7.x86_64 kernel / Kubernetes 1.35 does not support cgroup v1
+    - centos-78 # Kubernetes 1.35 does not support cgroup v1
+    - centos-79 # Rook 1.13+ is not supported on centos-7 / Kubernetes 1.35 does not support cgroup v1
+    - ol-79 # Rook 1.13+ is not supported on centos-7 / Kubernetes 1.35 does not support cgroup v1
+    - ubuntu-1804 # Kubernetes 1.35 does not support cgroup v1
   preInstallScript: |
     source /opt/kurl-testgrid/testhelpers.sh
     if is_ubuntu_2404 ; then

--- a/testgrid/specs/latest.yaml
+++ b/testgrid/specs/latest.yaml
@@ -19,7 +19,13 @@
     kotsadm:
       version: latest
   unsupportedOSIDs:
-  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
+  - amazon-2023 # kubernetes latest (1.35) isnt supported on Amazon Linux 2023.
+  - amzn-20 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-74 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-78 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-79 # kubernetes latest (1.35) does not support cgroup v1
+  - ol-79 # kubernetes latest (1.35) does not support cgroup v1
+  - ubuntu-1804 # kubernetes latest (1.35) does not support cgroup v1
 - name: openebs
   installerSpec:
     contour:
@@ -45,4 +51,10 @@
     kotsadm:
       version: latest
   unsupportedOSIDs:
-  - amazon-2023 # kubernetes latest (1.19) isnt supported on Amazon Linux 2023.
+  - amazon-2023 # kubernetes latest (1.35) isnt supported on Amazon Linux 2023.
+  - amzn-20 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-74 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-78 # kubernetes latest (1.35) does not support cgroup v1
+  - centos-79 # kubernetes latest (1.35) does not support cgroup v1
+  - ol-79 # kubernetes latest (1.35) does not support cgroup v1
+  - ubuntu-1804 # kubernetes latest (1.35) does not support cgroup v1


### PR DESCRIPTION
## Problem

Kubernetes 1.35 dropped cgroup v1 support, but the TestGrid test specs still allow legacy OS distributions that exclusively use cgroup v1. This causes ~27 guaranteed failures per k8s 1.35 staging run, masking genuine kURL/product bugs.

## Affected OSes (cgroup v1)

-  Amazon Linux 2.0
- CentOS 7.x
-  Oracle Linux 7.9
-  Ubuntu 18.04

## Expected Impact

- Removes ~27 expected cgroup v1 failures from k8s 1.35 runs.
- Surfaces ~5 genuine issues (Rocky  missing, addon compatibility, registry/airgap flakes) immediately.

Current failing tests: https://testgrid.kurl.sh/run/STAGING-release-v2026.05.05-0-8d1140f20-20260511101915