### PR TITLE
fix(goldpinger): make generate.sh sed commands portable between macOS and Linux

### DIFF
--- a/addons/goldpinger/template/generate.sh
+++ b/addons/goldpinger/template/generate.sh
@@ -5,9 +5,18 @@ set -euo pipefail
 VERSION=""
 CHARTVERSION=""
 
+function sed_i() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
 function add_as_latest() {
     if ! grep -q "\"${VERSION}-${CHARTVERSION}\"" ../../../web/src/installers/versions.js; then
-        sed -i '' "/cron-goldpinger-update/a\\    \"${VERSION}-${CHARTVERSION}\"," ../../../web/src/installers/versions.js
+        sed_i "/cron-goldpinger-update/a\\
+    \"${VERSION}-${CHARTVERSION}\"," ../../../web/src/installers/versions.js
     fi
 }
 
@@ -30,7 +39,7 @@ function generate_bloomberg_dynamic() {
     helm template goldpinger goldpinger/goldpinger --version "$CHARTVERSION" --values ./values-bloomberg.yaml -n kurl --include-crds > "../$VERSION-$CHARTVERSION/goldpinger.yaml"
     
     # Update version placeholders in install.sh (always use canonical template)
-    sed -i '' "s/__GOLDPINGER_VERSION__/$VERSION-$CHARTVERSION/g" "../$VERSION-$CHARTVERSION/install.sh"
+    sed_i "s/__GOLDPINGER_VERSION__/$VERSION-$CHARTVERSION/g" "../$VERSION-$CHARTVERSION/install.sh"
     
     # Generate manifest with Bloomberg image
     grep 'image: '  "../$VERSION-$CHARTVERSION/goldpinger.yaml" | sed 's/ *image: "*\(.*\)\/\(.*\):\([^"]*\)"*/image \2 \1\/\2:\3/' > "../$VERSION-$CHARTVERSION/Manifest"


### PR DESCRIPTION
The goldpinger generate.sh script used `sed -i ''` which works on BSD/macOS sed but not on GNU/Linux sed, causing the GitHub Actions update workflow to fail with:

```
sed: can't read /cron-goldpinger-update/a\    "3.11.2-1.1.2",: No such file or directory
```

Also, the BSD sed append command (`a\`) requires the appended text on a new line after the backslash, which caused a separate error on macOS:

```
sed: 1: "/cron-goldpinger-update ...": extra characters after \ at the end of a command
```

Changes:
- Add a `sed_i` helper that uses `sed -i ''` on macOS and `sed -i` on Linux.
- Split the append text across a newline so both BSD and GNU sed accept it.
- Replace both in-place sed calls in the script with `sed_i`.
