### PR TITLE
remove automated Minio updates

### DIFF
--- a/.github/workflows/update-minio.yaml
+++ b/.github/workflows/update-minio.yaml
@@ -1,7 +1,5 @@
 name: cron-minio-update
 on:
-  schedule:
-  - cron: "0 1 * * 1" # “At 01:00 on Monday.”
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

The last official security/CVE release for the open-source MinIO Community Edition is RELEASE.2025-10-15T17-29-55Z, as the public repository is now archived and no longer maintained.

This removes the cron schedule for Minio updates since the PRs it creates are no longer useful.  The workflow itself is left in case there is some emergency patch released which can get an update using workflow_dispatch.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
