### PR TITLE
fix(ubuntu-2604): install Kubernetes host packages on Ubuntu 26.04

### DIFF
--- a/scripts/common/host-packages.sh
+++ b/scripts/common/host-packages.sh
@@ -502,7 +502,11 @@ function preflights_require_host_packages() {
                     fail=1
                     ;;
                 ubuntu)
-                    if ! echo "$deps_file" | grep -q "ubuntu-24"; then
+                    # Only inspect the Deps file that matches the running Ubuntu
+                    # release. host_packages_shipped() is false for Ubuntu 24.04
+                    # and 26.04, so both must be matched here or the required
+                    # host-package check is silently skipped.
+                    if ! echo "$deps_file" | grep -q "ubuntu-${DIST_VERSION}"; then
                         continue
                     fi
                     seen+=("$dep")


### PR DESCRIPTION
## Evidence

A Testgrid **staging** run for release `v2026.07.30-0` shows Ubuntu **26.04** `kurl_install` FAILS at the *Initialize Kubernetes* step. The host install log (Xav Paice) shows the Kubernetes host binaries are absent:

```
bash: line 3841: kubelet: command not found
bash: line 3841: kubelet: command not found
bash: line 10155: kubectl: command not found
```

Three tests fail **only** on 26.04, all with the same install failure:
- `k8s_135x` (with rook)
- `k8s_135x` + in-cluster support bundle
- `k8s135x_cis_benchmarks_checks`

The Kubernetes host packages (kubelet/kubectl/kubeadm) are not present on the node. This is Ubuntu-26.04-specific and traces back to [PR #6072](https://github.com/replicatedhq/kURL/pull/6072) (`ubuntu-2604`), which added initial 26.04 support.

## Root cause (link c — INSTALLED)

I traced the 26.04 path end-to-end against the working 24.04 path across the three links:

- **(a) BUILT** — `Makefile` `build/packages/kubernetes/%/ubuntu-26.04` and `bundles/k8s-ubuntu2604/Dockerfile` are byte-for-byte symmetric with the 24.04 equivalents (only the `FROM` line differs), wired into `dist/kubernetes-%.tar.gz`. Correct. (The hardcoded `v1.31` keyring URL is only the k8s apt GPG signing key — shared across minor versions — while the repo itself uses `KUBERNETES_MINOR_VERSION`; the 24.04 Dockerfile does the identical thing and works.)
- **(b) SHIPPED** — `bin/save-manifest-assets.sh` has a correct `apt26` case (writes `ubuntu-26.04/Deps`) mirroring `apt24`, and the containerd addon `Manifest` gained `apt26 containerd`. Correct.
- **(c) INSTALLED** — one distro-selection site was **not** given a 26.04 counterpart.

`scripts/common/host-packages.sh:505`, in `preflights_require_host_packages()`, selects which shipped `Deps` file to validate against the running Ubuntu release with a hardcoded substring:

```sh
ubuntu)
    if ! echo "$deps_file" | grep -q "ubuntu-24"; then
        continue
    fi
```

`host_packages_shipped()` is **false** for both Ubuntu 24.04 and 26.04 (rows added in #6072), which is exactly the branch that runs `preflights_require_host_packages()`. On 26.04 the shipped deps live under `ubuntu-26.04/Deps`, so `grep -q "ubuntu-24"` never matches — every dependency is skipped and the required-host-package preflight passes without validating anything on 26.04.

`grep -rniE 'ubuntu.?2404|apt24|is_ubuntu_2404'` vs the 2604/apt26 equivalents confirms this is the **only** install-flow site in `scripts/`/`bin/` where 24.04 is handled but 26.04 was missed. Every other reference (`host_packages_shipped`, `is_ubuntu_2604`, `bailIfUnsupportedOS`, `save-manifest-assets` `apt26`, containerd apparmor guards) already has a correct 26.04 counterpart.

## Fix

Match the Deps file by the actual running release, using the same `ubuntu-${DIST_VERSION}` directory convention already used by `_dpkg_install_host_packages()` (which globs `ubuntu-${DIST_VERSION}/*.deb`). This covers 24.04 and 26.04 and stays correct for future releases without another hardcoded edit:

```sh
ubuntu)
    if ! echo "$deps_file" | grep -q "ubuntu-${DIST_VERSION}"; then
        continue
    fi
```

## Verified locally

- `bash -n scripts/common/host-packages.sh` — passes
- `shellcheck -S error scripts/common/host-packages.sh` — clean
- Confirmed the k8s deb build/package pipeline (Makefile targets, Dockerfile, tar into `dist/kubernetes-*.tar.gz`) is symmetric between 24.04 and 26.04
- Confirmed via `grep` that this is the sole 24→26 install-flow asymmetry

## NOT verified — needs a Testgrid run

- **Could not run Docker in this environment**, so I could not build `bundles/k8s-ubuntu2604/Dockerfile` to empirically confirm it produces valid `kubelet`/`kubectl`/`kubeadm` debs for k8s 1.35 on an `ubuntu:26.04` base.
- A real **Testgrid run on an Ubuntu 26.04 VM** (the three `k8s_135x` specs above) is required to confirm the install now completes end-to-end. This fix removes a demonstrable 24→26 asymmetry in the required-host-package check; if the 26.04 k8s debs were additionally absent from the staging bundle due to a stale/failed package rebuild, that would need to be confirmed separately on Testgrid — I could not reproduce the bundle contents locally.

Do not merge until a 26.04 Testgrid run passes.

References: Testgrid staging run `v2026.07.30-0`; PR #6072 (`ubuntu-2604`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)