### PR TITLE
feat(ci): opt-in pre-merge testgrid for core changes via label + RC-tagged staging build

### DIFF
--- a/.github/workflows/testgrid-pr.yaml
+++ b/.github/workflows/testgrid-pr.yaml
@@ -17,15 +17,36 @@ name: testgrid-pr
 #     OS matrix instead of the default first/last subset.
 #   * Or run it manually: Actions > testgrid-pr > Run workflow, choose a branch.
 #
+# ── What a label run builds ─────────────────────────────────────────────────
+#   * A LABEL run reuses the existing replicated/kurl-util:alpha image and
+#     rebuilds ONLY the core batch (install/join/upgrade/tasks.tmpl, common.tar.gz,
+#     kurl-bin-utils); everything else is copied from the last staging release.
+#   * To rebuild EXTRA packages (e.g. a specific kubernetes-<ver>.tar.gz) or to
+#     build a branch-specific kurl-util image, use workflow_dispatch and set the
+#     `extra-packages` / `build-kurl-util-image` inputs (not available on label
+#     runs, which are intentionally fast).
+#
 # ── Security model ──────────────────────────────────────────────────────────
 #   * Trigger is plain `pull_request` (NOT pull_request_target), so untrusted
 #     fork code never runs with repository secrets. Fork PRs are skipped (a
 #     maintainer must push the branch and use workflow_dispatch to test a fork).
 #   * The `run-testgrid` label gates execution; applying a label requires write
 #     access, so only maintainers can start a run.
-#   * Privileged jobs run in the `testgrid-pr` GitHub Environment. If that
-#     environment is configured with required reviewers, every run additionally
-#     pauses for manual approval before any secret is exposed (defense in depth).
+#
+# ── REQUIRED provisioning before enabling this workflow ─────────────────────
+#   These are hard prerequisites — the workflow is a security risk without them:
+#   1. Dedicated least-privilege S3 credential. The privileged jobs use the
+#      secrets AWS_STAGING_PR_ACCESS_KEY_ID / AWS_STAGING_PR_SECRET_ACCESS_KEY.
+#      This MUST be a NEW IAM user, NOT the prod credential (AWS_PROD_*). Its
+#      policy MUST allow writes only under s3://kurl-sh/staging/* and explicitly
+#      DENY s3://kurl-sh/dist/* and s3://kurl-sh/staging/VERSION. Because the
+#      credentialed jobs run PR-authored code (`make dist/*`, `make
+#      generate-addons`), the IAM policy — not the workflow text — is the real
+#      blast-radius boundary.
+#   2. The `testgrid-pr` GitHub Environment MUST be configured with required
+#      reviewers, so every run pauses for maintainer approval before any secret
+#      is exposed. (The `run-testgrid` label alone is addable by Triage-level
+#      access; the environment gate is what makes secret exposure write-gated.)
 #
 # ── Cost / expectations ─────────────────────────────────────────────────────
 #   * Core-only build: rebuilds a handful of core packages and copies the rest
@@ -33,6 +54,7 @@ name: testgrid-pr
 #   * Default OS subset (os-firstlast) keeps VM cost down; `testgrid-full` opts
 #     into the full matrix. RC artifacts land under staging/<rc-tag>/ and are
 #     auto-expired by bin/cleanup-staging-s3.sh (staging/v20* prefix, 30 days).
+#     RC builds are NEVER promoted to prod.
 
 on:
   pull_request:
@@ -177,7 +199,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         if: inputs.build-kurl-util-image
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
@@ -246,8 +268,8 @@ jobs:
       - id: set-matrix
         name: Build copy matrix from previous staging
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_PR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_PR_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
           S3_BUCKET: kurl-sh
           STAGING_RELEASE: ${{ needs.get-tag.outputs.prev_version }}
@@ -276,17 +298,37 @@ jobs:
       - name: copy packages from previous staging
         env:
           S3_BUCKET: kurl-sh
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_PR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_PR_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
           PREV_VERSION: ${{ needs.get-tag.outputs.prev_version }}
         run: |
           set -euo pipefail
+
+          # Exponential-backoff retry for flaky S3 calls (mirrors bin/upload-dist-staging.sh).
+          retry() {
+            local retries="$1"; shift
+            local count=0 exit wait
+            until "$@"; do
+              exit=$?
+              wait=$((2 ** count))
+              count=$((count + 1))
+              if [ "${count}" -lt "${retries}" ]; then
+                echo "Retry ${count}/${retries} exited ${exit}, retrying in ${wait}s..."
+                sleep "${wait}"
+              else
+                echo "Retry ${count}/${retries} exited ${exit}, no more retries left."
+                return "${exit}"
+              fi
+            done
+            return 0
+          }
+
           for package in ${{ matrix.batch }}; do
             echo "copying ${package} from staging/${PREV_VERSION} to staging/${VERSION_TAG}"
-            aws s3api copy-object \
+            retry 5 aws s3api copy-object \
               --copy-source "${S3_BUCKET}/staging/${PREV_VERSION}/${package}" \
               --bucket "${S3_BUCKET}" \
               --key "staging/${VERSION_TAG}/${package}"
@@ -328,8 +370,8 @@ jobs:
       - name: build and upload versioned packages
         env:
           S3_BUCKET: kurl-sh
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_PR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_PR_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
           AWS_DEFAULT_REGION: "us-east-1"
           VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
@@ -337,6 +379,26 @@ jobs:
           KURL_BIN_UTILS_FILE: kurl-bin-utils-${{ needs.get-tag.outputs.version_tag }}.tar.gz
         run: |
           set -euo pipefail
+
+          # Exponential-backoff retry for flaky S3 calls (mirrors bin/upload-dist-staging.sh).
+          retry() {
+            local retries="$1"; shift
+            local count=0 exit wait
+            until "$@"; do
+              exit=$?
+              wait=$((2 ** count))
+              count=$((count + 1))
+              if [ "${count}" -lt "${retries}" ]; then
+                echo "Retry ${count}/${retries} exited ${exit}, retrying in ${wait}s..."
+                sleep "${wait}"
+              else
+                echo "Retry ${count}/${retries} exited ${exit}, no more retries left."
+                return "${exit}"
+              fi
+            done
+            return 0
+          }
+
           for package in ${{ matrix.batch }}; do
             echo "building package ${package}"
             make "dist/${package}"
@@ -345,7 +407,7 @@ jobs:
             GITSHA="$(git rev-parse HEAD)"
 
             echo "uploading package ${package} to s3://${S3_BUCKET}/staging/${VERSION_TAG}/${package}"
-            aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${VERSION_TAG}/${package}" \
+            retry 5 aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${VERSION_TAG}/${package}" \
               --metadata-directive REPLACE --metadata md5="${MD5}",gitsha="${GITSHA}"
 
             make clean
@@ -371,31 +433,20 @@ jobs:
       - run: npm install
 
       - name: generate addon metadata (versioned path only)
+        # VERSIONED_ONLY=1 makes generate-addons write ONLY the versioned
+        # staging/<rc-tag>/*-gen.json and skip the shared unversioned
+        # staging/*-gen.json that live staging installs consume. There is no
+        # write-then-restore race, and nothing to undo if the run is cancelled.
         env:
           S3_BUCKET: kurl-sh
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_STAGING_PR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_STAGING_PR_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
           DIST_FOLDER: "staging"
           VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          VERSIONED_ONLY: "1"
         run: |
           make generate-addons
-
-      - name: restore default staging metadata
-        # generate-addons also writes the unversioned staging/*-gen.json. This
-        # workflow must never disturb shared staging, so restore those files
-        # from the previous staging release.
-        env:
-          S3_BUCKET: kurl-sh
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: "us-east-1"
-          PREV_VERSION: ${{ needs.get-tag.outputs.prev_version }}
-        run: |
-          set -euo pipefail
-          echo "restoring default staging metadata from ${PREV_VERSION}"
-          aws s3 cp "s3://${S3_BUCKET}/staging/${PREV_VERSION}/addons-gen.json" "s3://${S3_BUCKET}/staging/addons-gen.json"
-          aws s3 cp "s3://${S3_BUCKET}/staging/${PREV_VERSION}/supported-versions-gen.json" "s3://${S3_BUCKET}/staging/supported-versions-gen.json"
 
   testgrid-run:
     runs-on: ubuntu-24.04
@@ -454,7 +505,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Post Testgrid run URL
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3
         with:
           message: ${{ needs.testgrid-run.outputs.msg }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testgrid-pr.yaml
+++ b/.github/workflows/testgrid-pr.yaml
@@ -30,23 +30,36 @@ name: testgrid-pr
 #   * Trigger is plain `pull_request` (NOT pull_request_target), so untrusted
 #     fork code never runs with repository secrets. Fork PRs are skipped (a
 #     maintainer must push the branch and use workflow_dispatch to test a fork).
-#   * The `run-testgrid` label gates execution; applying a label requires write
-#     access, so only maintainers can start a run.
+#   * The `run-testgrid` label starts a run, but a label is addable at
+#     Triage-level access — it is NOT a strong gate on its own. The real gate on
+#     secret exposure is the `testgrid-pr` Environment's required reviewers (see
+#     provisioning below). Do not treat the label as maintainer-only.
 #
 # ── REQUIRED provisioning before enabling this workflow ─────────────────────
 #   These are hard prerequisites — the workflow is a security risk without them:
 #   1. Dedicated least-privilege S3 credential. The privileged jobs use the
 #      secrets AWS_STAGING_PR_ACCESS_KEY_ID / AWS_STAGING_PR_SECRET_ACCESS_KEY.
-#      This MUST be a NEW IAM user, NOT the prod credential (AWS_PROD_*). Its
-#      policy MUST allow writes only under s3://kurl-sh/staging/* and explicitly
-#      DENY s3://kurl-sh/dist/* and s3://kurl-sh/staging/VERSION. Because the
-#      credentialed jobs run PR-authored code (`make dist/*`, `make
-#      generate-addons`), the IAM policy — not the workflow text — is the real
-#      blast-radius boundary.
+#      This MUST be a NEW IAM user, NOT the prod credential (AWS_PROD_*). Because
+#      the credentialed jobs run PR-authored code (`make dist/*`, `make
+#      generate-addons`), an exfiltrated credential is as powerful as its IAM
+#      policy — that policy, not the workflow text, is the blast-radius boundary.
+#      The workflow only ever WRITES under staging/<rc-tag>/ (the per-PR RC
+#      prefix, staging/*-rc-*), so scope the policy to exactly that:
+#        - Allow s3:ListBucket + s3:GetObject on staging/*  (READ, to copy
+#          packages from the previous staging release).
+#        - Allow s3:PutObject / s3:DeleteObject ONLY on staging/*-rc-*  (the RC
+#          prefix — NOT all of staging/*).
+#        - Explicit DENY on writes to: dist/*, staging/VERSION, and the shared
+#          unversioned metadata staging/addons-gen.json +
+#          staging/supported-versions-gen.json. (These keys lack the `-rc-`
+#          segment so the scoped write-allow already excludes them; deny them
+#          explicitly as belt-and-suspenders. Do NOT deny staging/*-gen.json
+#          broadly — that would also block the versioned
+#          staging/<rc-tag>/addons-gen.json this workflow must write.)
 #   2. The `testgrid-pr` GitHub Environment MUST be configured with required
 #      reviewers, so every run pauses for maintainer approval before any secret
-#      is exposed. (The `run-testgrid` label alone is addable by Triage-level
-#      access; the environment gate is what makes secret exposure write-gated.)
+#      is exposed. This — not the label — is the gate that limits who can start a
+#      credentialed run.
 #
 # ── Cost / expectations ─────────────────────────────────────────────────────
 #   * Core-only build: rebuilds a handful of core packages and copies the rest

--- a/.github/workflows/testgrid-pr.yaml
+++ b/.github/workflows/testgrid-pr.yaml
@@ -1,0 +1,462 @@
+name: testgrid-pr
+
+# Opt-in, PRE-MERGE Testgrid run for CORE kURL changes (scripts/, packages/,
+# staging metadata) that are not covered by the addon-only pre-merge tests.
+#
+# It builds the PR's kURL version with a fast core-only strategy, publishes it
+# under a unique release-candidate (RC) tag to a per-PR versioned staging path,
+# queues a Testgrid run against that version, and comments the run URL on the PR.
+#
+# It NEVER promotes the build to prod: it does NOT run set-current-version and
+# does NOT overwrite the shared s3://kurl-sh/staging/VERSION pointer or the
+# unversioned staging metadata.
+#
+# ── How to trigger ──────────────────────────────────────────────────────────
+#   * Label a PR with `run-testgrid` (only maintainers with write access can add
+#     labels — this is the security gate). Add `testgrid-full` to run the full
+#     OS matrix instead of the default first/last subset.
+#   * Or run it manually: Actions > testgrid-pr > Run workflow, choose a branch.
+#
+# ── Security model ──────────────────────────────────────────────────────────
+#   * Trigger is plain `pull_request` (NOT pull_request_target), so untrusted
+#     fork code never runs with repository secrets. Fork PRs are skipped (a
+#     maintainer must push the branch and use workflow_dispatch to test a fork).
+#   * The `run-testgrid` label gates execution; applying a label requires write
+#     access, so only maintainers can start a run.
+#   * Privileged jobs run in the `testgrid-pr` GitHub Environment. If that
+#     environment is configured with required reviewers, every run additionally
+#     pauses for manual approval before any secret is exposed (defense in depth).
+#
+# ── Cost / expectations ─────────────────────────────────────────────────────
+#   * Core-only build: rebuilds a handful of core packages and copies the rest
+#     from the last staging release, so it is much cheaper than a full build.
+#   * Default OS subset (os-firstlast) keeps VM cost down; `testgrid-full` opts
+#     into the full matrix. RC artifacts land under staging/<rc-tag>/ and are
+#     auto-expired by bin/cleanup-staging-s3.sh (staging/v20* prefix, 30 days).
+
+on:
+  pull_request:
+    types:
+      - labeled
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build and test'
+        required: true
+        type: string
+      testgrid-spec:
+        description: 'Testgrid test spec file (relative to repo root)'
+        required: true
+        default: 'testgrid/specs/deploy.yaml'
+        type: string
+      testgrid-os-spec:
+        description: 'Testgrid OS spec file (relative to repo root)'
+        required: true
+        default: 'testgrid/specs/os-firstlast.yaml'
+        type: string
+      extra-packages:
+        description: 'Extra core packages to build (space-separated), e.g. "kubernetes-1.32.13.tar.gz"'
+        required: false
+        default: ''
+        type: string
+      build-kurl-util-image:
+        description: 'Build and push a branch-specific replicated/kurl-util image (slow; default reuses :alpha)'
+        required: false
+        default: false
+        type: boolean
+      priority:
+        description: 'Testgrid run priority'
+        required: false
+        default: '0'
+        type: string
+
+# One run per PR (or per dispatched branch); newer commits cancel older runs.
+concurrency:
+  group: testgrid-pr-${{ github.event.pull_request.number || inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  get-tag:
+    # Only run for a manual dispatch, or for a PR that a maintainer has labeled
+    # `run-testgrid`. Fork PRs are skipped (they cannot access secrets and the
+    # label gate would otherwise produce confusing failures).
+    if: >-
+      ${{ github.repository_owner == 'replicatedhq' &&
+          github.actor != 'dependabot[bot]' &&
+          github.actor != 'replicated-ci-kurl' &&
+          (github.event_name == 'workflow_dispatch' ||
+           (github.event.label.name == 'run-testgrid' &&
+            github.event.pull_request.head.repo.full_name == github.repository)) }}
+    runs-on: ubuntu-24.04
+    outputs:
+      version_tag: ${{ steps.set-tag.outputs.version_tag }}
+      prev_version: ${{ steps.set-tag.outputs.prev_version }}
+      kurl_util_image: ${{ steps.set-tag.outputs.kurl_util_image }}
+      testgrid_ref: ${{ steps.set-tag.outputs.testgrid_ref }}
+      testgrid_os_spec: ${{ steps.set-tag.outputs.testgrid_os_spec }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+          fetch-depth: 0
+
+      - id: set-tag
+        env:
+          # Empty on workflow_dispatch, set on pull_request.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DISPATCH_BRANCH: ${{ inputs.branch }}
+          BUILD_UTIL_IMAGE: ${{ inputs.build-kurl-util-image }}
+        run: |
+          set -euo pipefail
+          git fetch --tags -f
+
+          LATEST_TAG=$(git tag | grep '^v20' | sort | tail -1)
+
+          if [ -n "${PR_NUMBER}" ]; then
+            SHORT_SHA="${PR_HEAD_SHA:0:7}"
+            VERSION_TAG="${LATEST_TAG}-rc-pr${PR_NUMBER}-${SHORT_SHA}"
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            SAFE_BRANCH="${DISPATCH_BRANCH//\//-}"
+            VERSION_TAG="${LATEST_TAG}-rc-${SAFE_BRANCH}-${SHORT_SHA}"
+          fi
+
+          if [ "${BUILD_UTIL_IMAGE}" = "true" ]; then
+            KURL_UTIL_IMAGE="replicated/kurl-util:${VERSION_TAG}"
+          else
+            KURL_UTIL_IMAGE="replicated/kurl-util:alpha"
+          fi
+
+          REF="PR-${VERSION_TAG}-$(date --utc +%FT%TZ)"
+
+          PREV_VERSION=$(curl -s "https://kurl-sh.s3.amazonaws.com/staging/VERSION")
+          if [ -z "${PREV_VERSION}" ]; then
+            echo "error: could not read current staging/VERSION"
+            exit 1
+          fi
+
+          {
+            echo "prev_version=${PREV_VERSION}"
+            echo "version_tag=${VERSION_TAG}"
+            echo "kurl_util_image=${KURL_UTIL_IMAGE}"
+            echo "testgrid_ref=${REF}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "prev_version=${PREV_VERSION}"
+          echo "version_tag=${VERSION_TAG}"
+          echo "kurl_util_image=${KURL_UTIL_IMAGE}"
+          echo "testgrid_ref=${REF}"
+
+      - id: os-spec
+        name: Select OS spec
+        env:
+          DISPATCH_OS_SPEC: ${{ inputs.testgrid-os-spec }}
+          FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'testgrid-full') }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            OS_SPEC="${DISPATCH_OS_SPEC}"
+          elif [ "${FULL_LABEL}" = "true" ]; then
+            OS_SPEC="testgrid/specs/os-full.yaml"
+          else
+            OS_SPEC="testgrid/specs/os-firstlast.yaml"
+          fi
+          echo "testgrid_os_spec=${OS_SPEC}" >> "$GITHUB_OUTPUT"
+          echo "using OS spec: ${OS_SPEC}"
+
+  kurl-util-image:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    needs:
+      - get-tag
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+
+      - uses: docker/login-action@v4
+        if: inputs.build-kurl-util-image
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: build and push kurl-util image
+        if: inputs.build-kurl-util-image
+        env:
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          KURL_UTIL_IMAGE: ${{ needs.get-tag.outputs.kurl_util_image }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make -C kurl_util build-and-push-kurl-util-image
+
+      - name: skip kurl-util image build
+        if: ${{ !inputs.build-kurl-util-image }}
+        run: |
+          echo "Using existing kurl-util image: ${{ needs.get-tag.outputs.kurl_util_image }}"
+
+  build-matrix:
+    runs-on: ubuntu-24.04
+    needs:
+      - get-tag
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+
+      - id: set-matrix
+        name: Build core package matrix
+        env:
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          EXTRA_PACKAGES: ${{ inputs.extra-packages }}
+        run: |
+          set -euo pipefail
+          # Core packages always rebuilt from the PR's source. Any additional
+          # packages a core change requires (e.g. a specific Kubernetes version)
+          # are supplied via the extra-packages input. Everything else is copied
+          # from the previous staging release by the copy-packages job.
+          CORE_BATCH="install.tmpl join.tmpl upgrade.tmpl tasks.tmpl common.tar.gz kurl-bin-utils-${VERSION_TAG}.tar.gz"
+          if [ -n "${EXTRA_PACKAGES}" ]; then
+            CORE_BATCH="${CORE_BATCH} ${EXTRA_PACKAGES}"
+          fi
+          OUTPUT=$(printf '{"include": [{"batch": "%s"}]}' "${CORE_BATCH}")
+          echo "matrix=${OUTPUT}" >> "$GITHUB_OUTPUT"
+          echo "core batch: ${CORE_BATCH}"
+
+  copy-packages-from-staging:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    needs:
+      - get-tag
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - id: set-matrix
+        name: Build copy matrix from previous staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+          S3_BUCKET: kurl-sh
+          STAGING_RELEASE: ${{ needs.get-tag.outputs.prev_version }}
+          KURL_UTIL_IMAGE: replicated/kurl-util:alpha
+          KURL_BIN_UTILS_FILE: kurl-bin-utils-latest.tar.gz
+        run: |
+          set -euo pipefail
+          if [ -z "${STAGING_RELEASE}" ]; then
+            echo "error: could not read current staging/VERSION"
+            exit 1
+          fi
+          echo "copying packages from previous staging release ${STAGING_RELEASE}"
+          LIST_FROM_STAGE_S3=1 ./bin/list-all-packages-actions-matrix.sh
+
+  copy-packages:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    needs:
+      - get-tag
+      - copy-packages-from-staging
+    strategy:
+      matrix: ${{ fromJSON(needs.copy-packages-from-staging.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 20
+    steps:
+      - name: copy packages from previous staging
+        env:
+          S3_BUCKET: kurl-sh
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+          AWS_DEFAULT_REGION: "us-east-1"
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          PREV_VERSION: ${{ needs.get-tag.outputs.prev_version }}
+        run: |
+          set -euo pipefail
+          for package in ${{ matrix.batch }}; do
+            echo "copying ${package} from staging/${PREV_VERSION} to staging/${VERSION_TAG}"
+            aws s3api copy-object \
+              --copy-source "${S3_BUCKET}/staging/${PREV_VERSION}/${package}" \
+              --bucket "${S3_BUCKET}" \
+              --key "staging/${VERSION_TAG}/${package}"
+          done
+
+  build-and-upload:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    # Depends on copy-packages so the freshly built core packages are uploaded
+    # AFTER the copies from the previous staging release. The copy set and the
+    # build set overlap on the *.tmpl files (and any extra-packages), so build
+    # must be the last writer — otherwise a stale copy could clobber the PR's
+    # own code and Testgrid would run the wrong build.
+    needs:
+      - get-tag
+      - build-matrix
+      - kurl-util-image
+      - copy-packages
+    strategy:
+      matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: setup env
+        id: env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: build and upload versioned packages
+        env:
+          S3_BUCKET: kurl-sh
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+          AWS_DEFAULT_REGION: "us-east-1"
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          KURL_UTIL_IMAGE: ${{ needs.get-tag.outputs.kurl_util_image }}
+          KURL_BIN_UTILS_FILE: kurl-bin-utils-${{ needs.get-tag.outputs.version_tag }}.tar.gz
+        run: |
+          set -euo pipefail
+          for package in ${{ matrix.batch }}; do
+            echo "building package ${package}"
+            make "dist/${package}"
+
+            MD5="$(openssl md5 -binary "dist/${package}" | base64)"
+            GITSHA="$(git rev-parse HEAD)"
+
+            echo "uploading package ${package} to s3://${S3_BUCKET}/staging/${VERSION_TAG}/${package}"
+            aws s3 cp "dist/${package}" "s3://${S3_BUCKET}/staging/${VERSION_TAG}/${package}" \
+              --metadata-directive REPLACE --metadata md5="${MD5}",gitsha="${GITSHA}"
+
+            make clean
+          done
+
+  generate-addons:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    needs:
+      - get-tag
+      - build-and-upload
+      - copy-packages
+    if: always() && needs.build-and-upload.result == 'success' && needs.copy-packages.result == 'success'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '18'
+
+      - run: npm install
+
+      - name: generate addon metadata (versioned path only)
+        env:
+          S3_BUCKET: kurl-sh
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+          DIST_FOLDER: "staging"
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+        run: |
+          make generate-addons
+
+      - name: restore default staging metadata
+        # generate-addons also writes the unversioned staging/*-gen.json. This
+        # workflow must never disturb shared staging, so restore those files
+        # from the previous staging release.
+        env:
+          S3_BUCKET: kurl-sh
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+          PREV_VERSION: ${{ needs.get-tag.outputs.prev_version }}
+        run: |
+          set -euo pipefail
+          echo "restoring default staging metadata from ${PREV_VERSION}"
+          aws s3 cp "s3://${S3_BUCKET}/staging/${PREV_VERSION}/addons-gen.json" "s3://${S3_BUCKET}/staging/addons-gen.json"
+          aws s3 cp "s3://${S3_BUCKET}/staging/${PREV_VERSION}/supported-versions-gen.json" "s3://${S3_BUCKET}/staging/supported-versions-gen.json"
+
+  testgrid-run:
+    runs-on: ubuntu-24.04
+    environment: testgrid-pr
+    needs:
+      - get-tag
+      - generate-addons
+    outputs:
+      msg: ${{ steps.queue.outputs.msg }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
+
+      - name: pin empty installerVersion values to RC version
+        env:
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          TESTGRID_SPEC: ${{ github.event_name == 'workflow_dispatch' && inputs.testgrid-spec || 'testgrid/specs/deploy.yaml' }}
+        run: |
+          set -euo pipefail
+          sed -i "s/installerVersion: \"\"/installerVersion: \"${VERSION_TAG}\"/g" "${TESTGRID_SPEC}"
+
+      - name: pull tgrun
+        run: |
+          docker pull replicated/tgrun:latest
+
+      - name: queue testgrid run
+        id: queue
+        env:
+          TESTGRID_API_TOKEN: ${{ secrets.TESTGRID_PROD_API_TOKEN }}
+          VERSION_TAG: ${{ needs.get-tag.outputs.version_tag }}
+          TESTGRID_REF: ${{ needs.get-tag.outputs.testgrid_ref }}
+          TESTGRID_SPEC: ${{ github.event_name == 'workflow_dispatch' && inputs.testgrid-spec || 'testgrid/specs/deploy.yaml' }}
+          TESTGRID_OS_SPEC: ${{ needs.get-tag.outputs.testgrid_os_spec }}
+          PRIORITY: ${{ github.event_name == 'workflow_dispatch' && inputs.priority || '0' }}
+        run: |
+          set -euo pipefail
+          docker run --rm -e TESTGRID_API_TOKEN -v "$(pwd)":/wrk -w /wrk \
+            replicated/tgrun:latest queue --staging \
+              --kurl-version "${VERSION_TAG}" \
+              --ref "${TESTGRID_REF}" \
+              --spec "${TESTGRID_SPEC}" \
+              --os-spec "${TESTGRID_OS_SPEC}" \
+              --priority "${PRIORITY}"
+
+          MSG="Testgrid Run(s) Executing @ https://testgrid.kurl.sh/run/${TESTGRID_REF}"
+          echo "msg=$MSG" >> "$GITHUB_OUTPUT"
+          echo "::notice ::${MSG}"
+
+  comment-pr:
+    runs-on: ubuntu-24.04
+    needs:
+      - get-tag
+      - testgrid-run
+    # Only PR-triggered runs have a PR to comment on.
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Post Testgrid run URL
+        uses: mshick/add-pr-comment@v3
+        with:
+          message: ${{ needs.testgrid-run.outputs.msg }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message-id: testgrid-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          allow-repeats: false

--- a/.github/workflows/testgrid-pr.yaml
+++ b/.github/workflows/testgrid-pr.yaml
@@ -130,7 +130,7 @@ jobs:
       prev_version: ${{ steps.set-tag.outputs.prev_version }}
       kurl_util_image: ${{ steps.set-tag.outputs.kurl_util_image }}
       testgrid_ref: ${{ steps.set-tag.outputs.testgrid_ref }}
-      testgrid_os_spec: ${{ steps.set-tag.outputs.testgrid_os_spec }}
+      testgrid_os_spec: ${{ steps.os-spec.outputs.testgrid_os_spec }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/bin/generate-addons.js
+++ b/bin/generate-addons.js
@@ -9,6 +9,11 @@ const SECRET = process.env.AWS_SECRET_ACCESS_KEY;
 const BUCKET_NAME = process.env.S3_BUCKET;
 const FOLDER = process.env.DIST_FOLDER;
 const VERSION_TAG = process.env.VERSION_TAG;
+// When VERSIONED_ONLY is set, only write the versioned copy
+// (<folder>/<version>/<file>) and skip the shared unversioned copy
+// (<folder>/<file>). Used by testgrid-pr.yaml so a pre-merge RC build never
+// touches the metadata that live staging installs consume.
+const VERSIONED_ONLY = process.env.VERSIONED_ONLY === "1";
 
 const s3Client = new S3Client({
   region: 'us-east-1',
@@ -26,6 +31,11 @@ const uploadFile = async (file) => {
   };
   await s3Client.send(new PutObjectCommand(params));
   console.log("\x1b[32m%s\x1b[0m", "Successfully uploaded " + fileName + " to " + params.Key);
+
+  if (VERSIONED_ONLY) {
+    console.log("\x1b[33m%s\x1b[0m", "VERSIONED_ONLY set; skipping unversioned upload of " + fileName);
+    return;
+  }
 
   params = {
     Bucket: BUCKET_NAME,

--- a/bin/list-packages-s3.sh
+++ b/bin/list-packages-s3.sh
@@ -20,6 +20,14 @@ require STAGING_RELEASE "${STAGING_RELEASE}"
 
 STAGING_PREFIX="${STAGING_PREFIX:-staging}"
 
+# Completeness note: `aws s3api list-objects-v2` auto-paginates in the AWS CLI —
+# it makes as many API calls as needed and aggregates all pages before `--query`
+# (a client-side JMESPath filter) is applied, so this returns every object in the
+# release even when there are more than 1000 (the per-call MaxKeys limit). Callers
+# (deploy-prod.yaml, testgrid-pr.yaml core-only copy) depend on this being the
+# complete set; if AWS CLI auto-paging is ever disabled, add an explicit
+# continuation-token loop like bin/cleanup-staging-s3.sh.
+#
 # Get list of packages associated with a staging release from s3:
 # Exclude common and kurl-bin-utils packages => grep -vE "/common.*" | grep -vE "/kurl-bin-utils-*"
 # Get raw strings NOT JSON encoded strings => jq -rc '.[]'

--- a/testgrid/specs/README.md
+++ b/testgrid/specs/README.md
@@ -124,9 +124,36 @@ This allows addon templates to reference the version and package under test dyna
 
 ---
 
+## Pre-merge Testgrid for core changes (`testgrid-pr.yaml`)
+
+Core kURL changes (`scripts/`, `packages/`, staging metadata) are not covered by
+the addon-only `test-addon-pr.yaml`. The **`.github/workflows/testgrid-pr.yaml`**
+workflow lets a maintainer run Testgrid against a PR's own build **before** merge,
+without touching the shared `staging/VERSION` pointer.
+
+- **Trigger:** add the **`run-testgrid`** label to a PR (label add requires write
+  access — this is the security gate), or run it manually via
+  Actions → **testgrid-pr** → Run workflow with a `branch` input.
+- **Build:** fast **core-only** strategy — rebuilds a small core batch from the
+  PR's source and copies the rest from the last staging release. Publishes under a
+  unique RC tag to `s3://kurl-sh/staging/<latest-tag>-rc-pr<num>-<sha>/`. Never
+  promoted to prod.
+- **OS pool:** defaults to the `os-firstlast.yaml` subset; add the **`testgrid-full`**
+  label to run the full `os-full.yaml` matrix.
+- **Report:** comments the Testgrid run URL back on the PR.
+- **Security:** plain `pull_request` (never `pull_request_target`), so fork code
+  never runs with secrets (fork PRs are skipped — use `workflow_dispatch`).
+  Privileged jobs run in the `testgrid-pr` GitHub Environment, which can be given
+  required reviewers for manual approval as defense in depth.
+- **Expiry:** RC artifacts live under `staging/v20…-rc-…/` and are swept by
+  `bin/cleanup-staging-s3.sh` (30-day `staging/v20*` cutoff). Optionally add an S3
+  lifecycle rule expiring `staging/*-rc-*` sooner.
+
+---
+
 ## Summary
 
 - **Testgrid does not auto-discover spec files.** Each workflow explicitly passes `--spec` and `--os-spec` to `tgrun`.
-- **Only `os-latest.yaml`, `os-firstlast.yaml`, and `os-customer-common.yaml` are actively used.** `os-full.yaml` and `os-removed.yaml` are not referenced by any CI workflow.
+- **`os-latest.yaml`, `os-firstlast.yaml`, and `os-customer-common.yaml` are actively used.** `os-firstlast.yaml` is also the default subset for `testgrid-pr.yaml`, which uses `os-full.yaml` when the `testgrid-full` label is applied. `os-removed.yaml` is not referenced by any CI workflow.
 - **OS filtering is opt-out via `unsupportedOSIDs`.** If an OS is not listed there, the test runs on it.
 - **Addons define their own test specs** and are submitted separately via the `addon-testgrid-tester` action.

--- a/testgrid/specs/README.md
+++ b/testgrid/specs/README.md
@@ -148,14 +148,23 @@ without touching the shared `staging/VERSION` pointer.
 - **Required before enabling (hard prerequisites):**
   1. A **dedicated least-privilege S3 credential** in the secrets
      `AWS_STAGING_PR_ACCESS_KEY_ID` / `AWS_STAGING_PR_SECRET_ACCESS_KEY`. This
-     **must not** be the prod credential (`AWS_PROD_*`); its IAM policy must allow
-     writes only under `s3://kurl-sh/staging/*` and explicitly **deny**
-     `s3://kurl-sh/dist/*` and `s3://kurl-sh/staging/VERSION`. The credentialed
-     jobs run PR-authored code, so the IAM policy — not the workflow text — is the
-     blast-radius boundary.
-  2. The **`testgrid-pr` GitHub Environment must have required reviewers**, so
-     every run pauses for maintainer approval before secrets are exposed (the
-     `run-testgrid` label alone is addable at Triage level).
+     **must not** be the prod credential (`AWS_PROD_*`). The credentialed jobs run
+     PR-authored code, so an exfiltrated credential is only as powerful as its IAM
+     policy — that policy, not the workflow text, is the blast-radius boundary.
+     The workflow only ever **writes** under `staging/<rc-tag>/` (the per-PR RC
+     prefix `staging/*-rc-*`), so scope the policy to exactly that:
+     - Allow `s3:ListBucket` + `s3:GetObject` on `staging/*` (read, to copy
+       packages from the previous staging release).
+     - Allow `s3:PutObject` / `s3:DeleteObject` **only** on `staging/*-rc-*` — not
+       all of `staging/*`.
+     - Explicitly **deny** writes to `dist/*`, `staging/VERSION`, and the shared
+       unversioned metadata `staging/addons-gen.json` +
+       `staging/supported-versions-gen.json`. (Do **not** deny `staging/*-gen.json`
+       broadly — that would also block the versioned
+       `staging/<rc-tag>/addons-gen.json` this workflow must write.)
+  2. The **`testgrid-pr` GitHub Environment must have required reviewers.** This —
+     not the `run-testgrid` label (which is addable at Triage level) — is the gate
+     that limits who can start a credentialed run.
 - **Expiry:** RC artifacts live under `staging/v20…-rc-…/` and are swept by
   `bin/cleanup-staging-s3.sh` (30-day `staging/v20*` cutoff). Optionally add an S3
   lifecycle rule expiring `staging/*-rc-*` sooner.

--- a/testgrid/specs/README.md
+++ b/testgrid/specs/README.md
@@ -131,20 +131,31 @@ the addon-only `test-addon-pr.yaml`. The **`.github/workflows/testgrid-pr.yaml`*
 workflow lets a maintainer run Testgrid against a PR's own build **before** merge,
 without touching the shared `staging/VERSION` pointer.
 
-- **Trigger:** add the **`run-testgrid`** label to a PR (label add requires write
-  access — this is the security gate), or run it manually via
+- **Trigger:** add the **`run-testgrid`** label to a PR, or run it manually via
   Actions → **testgrid-pr** → Run workflow with a `branch` input.
 - **Build:** fast **core-only** strategy — rebuilds a small core batch from the
   PR's source and copies the rest from the last staging release. Publishes under a
   unique RC tag to `s3://kurl-sh/staging/<latest-tag>-rc-pr<num>-<sha>/`. Never
-  promoted to prod.
+  promoted to prod. A **label run reuses `kurl-util:alpha` and rebuilds only the
+  core `.tmpl`/`common`/`kurl-bin-utils` batch**; to rebuild extra packages or a
+  branch-specific `kurl-util` image, use `workflow_dispatch` with the
+  `extra-packages` / `build-kurl-util-image` inputs.
 - **OS pool:** defaults to the `os-firstlast.yaml` subset; add the **`testgrid-full`**
   label to run the full `os-full.yaml` matrix.
 - **Report:** comments the Testgrid run URL back on the PR.
 - **Security:** plain `pull_request` (never `pull_request_target`), so fork code
   never runs with secrets (fork PRs are skipped — use `workflow_dispatch`).
-  Privileged jobs run in the `testgrid-pr` GitHub Environment, which can be given
-  required reviewers for manual approval as defense in depth.
+- **Required before enabling (hard prerequisites):**
+  1. A **dedicated least-privilege S3 credential** in the secrets
+     `AWS_STAGING_PR_ACCESS_KEY_ID` / `AWS_STAGING_PR_SECRET_ACCESS_KEY`. This
+     **must not** be the prod credential (`AWS_PROD_*`); its IAM policy must allow
+     writes only under `s3://kurl-sh/staging/*` and explicitly **deny**
+     `s3://kurl-sh/dist/*` and `s3://kurl-sh/staging/VERSION`. The credentialed
+     jobs run PR-authored code, so the IAM policy — not the workflow text — is the
+     blast-radius boundary.
+  2. The **`testgrid-pr` GitHub Environment must have required reviewers**, so
+     every run pauses for maintainer approval before secrets are exposed (the
+     `run-testgrid` label alone is addable at Triage level).
 - **Expiry:** RC artifacts live under `staging/v20…-rc-…/` and are swept by
   `bin/cleanup-staging-s3.sh` (30-day `staging/v20*` cutoff). Optionally add an S3
   lifecycle rule expiring `staging/*-rc-*` sooner.


### PR DESCRIPTION
Core kURL changes (`scripts/`, `packages/`, staging metadata) only get exercised in Testgrid **after** they land on `main`, when `deploy-staging.yaml` runs on push. So a core regression stays invisible until it's already merged. That's exactly how the Ubuntu 26.04 `kubelet: command not found` bug (#6072) slipped through and needed a follow-up fix (#6082).

This brings back a pre-merge Testgrid path for core changes. It existed once as `deploy-branch-staging.yaml` and got deleted right after 26.04 shipped, so I recovered it from git history and reworked it into a label-driven, PR-safe workflow.

## ⚠️ REQUIRED before enabling

This workflow hands repository secrets to jobs that build and run PR-authored code, so two things must be provisioned first. Without them it's a security risk, not a feature.

**1. A dedicated least-privilege IAM user for `AWS_STAGING_PR_ACCESS_KEY_ID` / `AWS_STAGING_PR_SECRET_ACCESS_KEY`.** This must NOT be the prod credential (`AWS_PROD_*`). The workflow only ever writes under the per-PR RC prefix, so scope the policy to exactly that:

- Allow `s3:ListBucket` + `s3:GetObject` on `staging/*` (read, to copy packages from the previous staging release).
- Allow `s3:PutObject` / `s3:DeleteObject` only on `staging/*-rc-*` (the RC prefix, not all of `staging/*`).
- Explicit DENY on writes to `dist/*`, `staging/VERSION`, `staging/addons-gen.json`, and `staging/supported-versions-gen.json`. (Don't deny `staging/*-gen.json` broadly, or you'll also block the versioned `staging/<rc-tag>/addons-gen.json` this workflow legitimately writes.)

Since the credentialed jobs run PR code, that IAM policy (not the workflow text) is the real blast-radius boundary. An exfiltrated credential is only as powerful as the policy lets it be.

**2. The `testgrid-pr` GitHub Environment configured with required reviewers.** The `run-testgrid` label is addable at Triage-level access, so it's not a strong gate on its own. The Environment's required reviewers is what actually gates who can start a credentialed run.

## How it works

Trigger: add the `run-testgrid` label to a PR, or run it manually via `workflow_dispatch` with a branch input.

- Builds the PR's kURL with a fast **core-only** strategy: rebuilds the core batch (`*.tmpl`, `common.tar.gz`, `kurl-bin-utils`) from the PR's source and copies everything else from the last staging release. A label run reuses `kurl-util:alpha`; to rebuild extra packages or a branch-specific util image, use `workflow_dispatch` with the `extra-packages` / `build-kurl-util-image` inputs.
- Publishes under a unique RC tag, `<latest-tag>-rc-pr<num>-<sha>`, to a per-PR path `s3://kurl-sh/staging/<rc-tag>/`. It never runs `set-current-version` and never touches the shared `staging/VERSION` pointer or the unversioned staging metadata (a `VERSIONED_ONLY` mode in `generate-addons.js` keeps the shared `*-gen.json` untouched).
- Queues `tgrun` against that RC version. OS pool defaults to the `os-firstlast` subset to keep cost down; add the `testgrid-full` label for the full matrix. Concurrency is capped to one run per PR.
- Comments the Testgrid run URL back on the PR.

RC builds are never promoted to prod. Artifacts land under `staging/v20...-rc-.../` and get swept by the existing `bin/cleanup-staging-s3.sh` (30-day cutoff); a tighter S3 lifecycle rule on `staging/*-rc-*` is a nice-to-have.

## Security model

Plain `pull_request`, not `pull_request_target`, so fork code never runs with secrets. Fork PRs are skipped; a maintainer pushes the branch and uses `workflow_dispatch` to test a fork. Third-party actions that receive tokens are SHA-pinned. Privileged jobs run in the `testgrid-pr` Environment (see prereq 2 above).

## What I verified

A GitHub Actions workflow can't really run locally, so I validated what I could: `actionlint` (which runs shellcheck on every embedded script), `shellcheck` on the edited shell, `node --check` on `generate-addons.js`, and a YAML parse. I traced the build, copy, publish, and queue chain against the existing scripts by hand.

What still needs a live run with CI + S3 + Testgrid creds: the actual build/upload to the versioned path, the `tgrun` queue, the PR comment, and the acceptance criterion of demonstrating it on a real core-change PR. That's why this stays a **draft**.

Fixes #6084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
