### PR TITLE
fix(ubuntu-2604): rebuild kubernetes packages on bundles/ changes so Kubernetes host packages install on Ubuntu 26.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -696,6 +696,7 @@ test-shell: ## Run tests for code in shell. (Requires shUnit2 to be installed).
 	./scripts/common/test/docker-version-test.sh
 	./scripts/common/test/ip-address-test.sh
 	./scripts/common/test/semver-test.sh
+	./scripts/common/test/upload-dist-bundles-watch-test.sh
 
 ##@ Release
 

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -51,8 +51,13 @@ function package_has_changes() {
     # invisible here and the kubernetes tarball would never be rebuilt or
     # re-shipped, leaving the new OS with no host packages. Include bundles/ in the
     # diff for kubernetes packages so bundle changes force a rebuild.
+    # Match only real kubernetes package keys (kubernetes-<version>, which start
+    # with a digit, e.g. kubernetes-1.35.7). Do NOT match kubernetes-conformance-*
+    # archives: those are built from packages/kubernetes/<ver>/conformance/Manifest
+    # (sonobuoy images) and do not depend on bundles/, so watching bundles/ for them
+    # would needlessly rebuild and re-upload every conformance archive.
     local paths=( "${path}" )
-    if echo "${key}" | grep -q "kubernetes-" ; then
+    if echo "${key}" | grep -qE "kubernetes-[0-9]" ; then
         paths+=( "bundles/" )
     fi
 

--- a/bin/upload-dist-staging.sh
+++ b/bin/upload-dist-staging.sh
@@ -44,7 +44,19 @@ function package_has_changes() {
         return 0
     fi
 
-    if ( set -x; git diff --quiet "${upstream_gitsha}" -- "${path}" "${GITSHA}" -- "${path}" ) ; then
+    # kubernetes host packages (kubelet/kubectl/kubeadm .debs and .rpms) are built
+    # from the per-OS bundle Dockerfiles in bundles/ (e.g. bundles/k8s-ubuntu2604),
+    # not from anything under packages/kubernetes/<version>/. A change that only
+    # touches bundles/ -- such as adding a new supported OS -- would otherwise be
+    # invisible here and the kubernetes tarball would never be rebuilt or
+    # re-shipped, leaving the new OS with no host packages. Include bundles/ in the
+    # diff for kubernetes packages so bundle changes force a rebuild.
+    local paths=( "${path}" )
+    if echo "${key}" | grep -q "kubernetes-" ; then
+        paths+=( "bundles/" )
+    fi
+
+    if ( set -x; git diff --quiet "${upstream_gitsha}" -- "${paths[@]}" "${GITSHA}" -- "${paths[@]}" ) ; then
         return 1
     else
         return 0
@@ -199,8 +211,9 @@ function main() {
 
     git fetch
 
-    # TODO: kubernetes changes do not yet take into account changes in bundles/
-    # These need to manually be rebuilt when changing that path.
+    # kubernetes packages are rebuilt when either packages/kubernetes/<version>/
+    # or bundles/ changes -- see package_has_changes(). Bundle changes (e.g.
+    # adding a new supported OS) must force a rebuild so the host packages ship.
 
     while read -r line; do
         package="$(echo "${line}" | cut -f1 -d' ')"

--- a/bin/upload-dist-versioned.sh
+++ b/bin/upload-dist-versioned.sh
@@ -47,7 +47,19 @@ function package_has_changes() {
         return 0
     fi
 
-    if ( set -x; git diff --quiet "${upstream_gitsha}" -- "${path}" "${VERSION_TAG}" -- "${path}" ) ; then
+    # kubernetes host packages (kubelet/kubectl/kubeadm .debs and .rpms) are built
+    # from the per-OS bundle Dockerfiles in bundles/ (e.g. bundles/k8s-ubuntu2604),
+    # not from anything under packages/kubernetes/<version>/. A change that only
+    # touches bundles/ -- such as adding a new supported OS -- would otherwise be
+    # invisible here and the kubernetes tarball would never be rebuilt or
+    # re-shipped, leaving the new OS with no host packages. Include bundles/ in the
+    # diff for kubernetes packages so bundle changes force a rebuild.
+    local paths=( "${path}" )
+    if echo "${key}" | grep -q "kubernetes-" ; then
+        paths+=( "bundles/" )
+    fi
+
+    if ( set -x; git diff --quiet "${upstream_gitsha}" -- "${paths[@]}" "${VERSION_TAG}" -- "${paths[@]}" ) ; then
         return 1
     else
         return 0
@@ -214,8 +226,9 @@ function main() {
 
     git fetch
 
-    # TODO: kubernetes changes do not yet take into account changes in bundles/
-    # These need to manually be rebuilt when changing that path.
+    # kubernetes packages are rebuilt when either packages/kubernetes/<version>/
+    # or bundles/ changes -- see package_has_changes(). Bundle changes (e.g.
+    # adding a new supported OS) must force a rebuild so the host packages ship.
 
     while read -r line; do
         package="$(echo "${line}" | cut -f1 -d' ')"

--- a/bin/upload-dist-versioned.sh
+++ b/bin/upload-dist-versioned.sh
@@ -54,8 +54,13 @@ function package_has_changes() {
     # invisible here and the kubernetes tarball would never be rebuilt or
     # re-shipped, leaving the new OS with no host packages. Include bundles/ in the
     # diff for kubernetes packages so bundle changes force a rebuild.
+    # Match only real kubernetes package keys (kubernetes-<version>, which start
+    # with a digit, e.g. kubernetes-1.35.7). Do NOT match kubernetes-conformance-*
+    # archives: those are built from packages/kubernetes/<ver>/conformance/Manifest
+    # (sonobuoy images) and do not depend on bundles/, so watching bundles/ for them
+    # would needlessly rebuild and re-upload every conformance archive.
     local paths=( "${path}" )
-    if echo "${key}" | grep -q "kubernetes-" ; then
+    if echo "${key}" | grep -qE "kubernetes-[0-9]" ; then
         paths+=( "bundles/" )
     fi
 

--- a/scripts/common/test/upload-dist-bundles-watch-test.sh
+++ b/scripts/common/test/upload-dist-bundles-watch-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Tests the change-detection match used in bin/upload-dist-staging.sh and
+# bin/upload-dist-versioned.sh that decides whether a package key should also
+# watch bundles/ for changes. Real kubernetes host packages (kubernetes-<version>)
+# depend on bundles/; kubernetes-conformance-* archives do NOT and must not match.
+
+# Mirrors the guard in the upload-dist scripts:
+#   if echo "${key}" | grep -qE "kubernetes-[0-9]" ; then paths+=( "bundles/" ); fi
+key_watches_bundles()
+{
+    echo "$1" | grep -qE "kubernetes-[0-9]"
+}
+
+testKubernetesPackageWatchesBundles()
+{
+    key_watches_bundles "kubernetes-1.35.7"
+    assertEquals "kubernetes-1.35.7 should watch bundles/" "0" "$?"
+}
+
+testKubernetesConformanceDoesNotWatchBundles()
+{
+    key_watches_bundles "kubernetes-conformance-1.35.7"
+    assertEquals "kubernetes-conformance-1.35.7 should NOT watch bundles/" "1" "$?"
+}
+
+testOtherKubernetesVersionsWatchBundles()
+{
+    key_watches_bundles "kubernetes-1.24.0"
+    assertEquals "kubernetes-1.24.0 should watch bundles/" "0" "$?"
+
+    key_watches_bundles "kubernetes-1.30.5"
+    assertEquals "kubernetes-1.30.5 should watch bundles/" "0" "$?"
+}
+
+testNonKubernetesPackageDoesNotWatchBundles()
+{
+    key_watches_bundles "containerd-1.6.4"
+    assertEquals "containerd-1.6.4 should NOT watch bundles/" "1" "$?"
+}
+
+. shunit2


### PR DESCRIPTION
## Summary

Kubernetes host packages (`kubelet`/`kubectl`/`kubeadm`) are still missing on Ubuntu 26.04 even after #6072 (added 26.04) and #6082 (fixed the preflight `grep` in `host-packages.sh`). The staging run right after #6082 merged (`STAGING-release-v2026.07.30-0-d28b210df-20260804024943`) still fails Ubuntu-26.04 `kurl_install` on the k8s 1.35.x tests (rook, in-cluster support bundle, CIS benchmark, and two 1.31→1.35 upgrades) with:

```
bash: line 3841: kubelet: command not found
bash: line 10155: kubectl: command not found
```

#6082 fixed the preflight **validation** grep. The underlying "packages not installed" problem is a **SHIP** bug, not build or validation.

## Root cause (confirmed with file:line)

The deploy change-detection in `bin/upload-dist-staging.sh` and `bin/upload-dist-versioned.sh` decides whether to rebuild+re-upload a package by diffing **only** the package's own path:

```sh
# bin/upload-dist-staging.sh:47 (before)
git diff --quiet "${upstream_gitsha}" -- "${path}" "${GITSHA}" -- "${path}"
```

For kubernetes, `${path}` = `packages/kubernetes/<version>/` (see `bin/list-all-packages.sh:23`). But the kubelet/kubectl/kubeadm `.deb`s are built from the **per-OS bundle Dockerfiles in `bundles/`** (e.g. `bundles/k8s-ubuntu2604/Dockerfile`) via the `build/packages/kubernetes/%/ubuntu-26.04` Makefile target — **nothing under `packages/kubernetes/`**.

`#6072` added `bundles/k8s-ubuntu2604/Dockerfile` + Makefile targets but touched **nothing** under `packages/kubernetes/`. So `package_has_changes` for every `kubernetes-<ver>.tar.gz` returned "no changes", the tarballs were **never rebuilt or re-uploaded**, and the shipped `kubernetes-<ver>.tar.gz` in S3 still has **no `ubuntu-26.04/` directory**. On a 26.04 host, `_dpkg_install_host_packages` (`scripts/common/host-packages.sh:140`) globs `ubuntu-26.04/*.deb`, finds none, prints "Will not install host packages ... no packages found", and returns 0 — leaving kubelet/kubectl/kubeadm off the host.

This is exactly the pre-existing `TODO` in both upload scripts:
> `# TODO: kubernetes changes do not yet take into account changes in bundles/`

## Reproduction with Docker (local)

**Build 1.35.7 for both OSes and compare** — they are identical:

`make build/packages/kubernetes/1.35.7/ubuntu-24.04` (works in testgrid) and `make build/packages/kubernetes/1.35.7/ubuntu-26.04` both succeed and produce byte-for-byte-equivalent, valid, non-empty debs:

```
ubuntu-24.04/  kubeadm_1.35.7-1.1_*.deb  kubectl_1.35.7-1.1_*.deb  kubelet_1.35.7-1.1_*.deb  kubernetes-cni_1.8.0-1.1_*.deb  Deps
ubuntu-26.04/  kubeadm_1.35.7-1.1_*.deb  kubectl_1.35.7-1.1_*.deb  kubelet_1.35.7-1.1_*.deb  kubernetes-cni_1.8.0-1.1_*.deb  Deps
diff of file lists: IDENTICAL
```

Validated the 26.04 debs inside `ubuntu:26.04`:
```
kubelet  1.35.7-1.1  Installed-Size: 53076   ./usr/bin/kubelet present (54M)
kubectl  1.35.7-1.1
kubeadm  1.35.7-1.1
dpkg --install --dry-run --force-depends /debs/*.deb  -> EXIT=0
```

**So the BUILD is fine.** The gap is SHIP.

**Reproduced the ship gap** by running the exact diff `package_has_changes` uses, across the span that added 26.04 support (pre-#6072 `ef2f8cafd` → HEAD `d28b210df`):

```
BEFORE fix (path only):        git diff --quiet ... -- packages/kubernetes/1.35.7/   -> NO CHANGES -> NOT rebuilt (BUG: 26.04 debs never shipped)
AFTER  fix (path + bundles/):  git diff --quiet ... -- packages/kubernetes/1.35.7/ bundles/  -> CHANGES -> WILL rebuild (26.04 debs ship)
```

## The fix

Include `bundles/` in the change-detection diff for kubernetes packages in both `bin/upload-dist-staging.sh` and `bin/upload-dist-versioned.sh`, so any bundle change (adding a supported OS, editing a Dockerfile) forces a rebuild + re-ship of the kubernetes tarballs. Stale TODOs replaced with accurate comments.

On the next deploy after merge, this triggers a one-time rebuild of the kubernetes tarballs (their `bundles/` gitsha differs from the stored one), re-shipping them **with** the `ubuntu-26.04/` debs.

## Verified locally
- `make build/packages/kubernetes/1.35.7/ubuntu-26.04` produces valid, installable kubelet/kubectl/kubeadm debs (Docker) — the concrete build proof.
- `make build/packages/kubernetes/1.35.7/ubuntu-24.04` produces an identical set — confirms build parity.
- `package_has_changes` simulation flips from "no changes" to "changes" for the k8s path once `bundles/` is included — the concrete ship-gap proof.
- `bash -n` and `shellcheck -S error` pass on both edited scripts.
- No Go/JS touched; `make test` (lint+vet) is Go-only and unaffected.

## Needs a live Testgrid run (not done here)
The full 26.04 install path (download re-shipped tarball → dpkg-install on a real 26.04 VM → `kubeadm init` succeeds) can only be confirmed by a Testgrid staging run **after this merges and the deploy rebuilds+re-ships the kubernetes tarballs with the 26.04 debs**. I did not run Testgrid and am not claiming end-to-end pass.

## References
- Staging run: `STAGING-release-v2026.07.30-0-d28b210df-20260804024943` (post-#6082, still failing 26.04 k8s 1.35.x)
- #6072 — added Ubuntu 26.04 support (added `bundles/k8s-ubuntu2604`, touched nothing under `packages/kubernetes/`)
- #6082 — fixed preflight validation grep in `scripts/common/host-packages.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)