### PR TITLE
fix error in containerd version in testgrid test

### DIFF
--- a/testgrid/specs/deploy.yaml
+++ b/testgrid/specs/deploy.yaml
@@ -121,7 +121,7 @@
     kubernetes:
       version: 1.22.x
     containerd:
-      version: 1.7.x
+      version: 1.6.x
     flannel:
       version: 0.21.x
     registry:
@@ -138,7 +138,7 @@
     kubernetes:
       version: 1.24.x
     containerd:
-      version: 1.7.x
+      version: 1.6.x
     flannel:
       version: latest
     registry:


### PR DESCRIPTION
#### What this PR does / why we need it:

Corrects an error in testgrid tests where containerd 1.7 is not available in the older version of kURL used for the test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE