### PR TITLE
fix(deploy): replace deprecated actions in deploy-production workflow

### DIFF
--- a/.github/actions/import-external-addons/action.yml
+++ b/.github/actions/import-external-addons/action.yml
@@ -13,5 +13,5 @@ inputs:
     description: 'AWS secret access key'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/import-external-addons/action.yml
+++ b/.github/actions/import-external-addons/action.yml
@@ -13,5 +13,5 @@ inputs:
     description: 'AWS secret access key'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/testgrid-checker/action.yml
+++ b/.github/actions/testgrid-checker/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
     description: App Private Key for https://github.com/organizations/replicatedhq/settings/apps/kurl-testgrid-checker.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/testgrid-checker/action.yml
+++ b/.github/actions/testgrid-checker/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
     description: App Private Key for https://github.com/organizations/replicatedhq/settings/apps/kurl-testgrid-checker.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -250,28 +250,18 @@ jobs:
 
     - name: Read Changelog
       id: read-changelog
-      uses: juliangruber/read-file-action@v1
-      with:
-        path: ./CHANGELOG.md
-
-    - name: GitHub Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
-      with:
-        tag_name: ${{ env.GIT_TAG }}
-        release_name: Release ${{ env.GIT_TAG }}
-        body: ${{ steps.read-changelog.outputs.content }}
-        draft: false
-        prerelease: false
+      run: |
+        {
+          echo 'content<<EOF'
+          cat ./CHANGELOG.md
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
 
     - name: Get Cosign Key
-      run: | 
+      run: |
         echo $COSIGN_KEY | base64 -d > ./cosign.key
       env:
-        COSIGN_KEY: ${{secrets.COSIGN_KEY}}
+        COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
     - uses: sigstore/cosign-installer@v4.1.2
 
@@ -282,10 +272,15 @@ jobs:
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
-    - uses: shogo82148/actions-upload-release-asset@v1
+    - name: GitHub Release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: sbom/assets/*
+        tag_name: ${{ steps.get_tag.outputs.GIT_TAG }}
+        name: Release ${{ steps.get_tag.outputs.GIT_TAG }}
+        body: ${{ steps.read-changelog.outputs.content }}
+        files: sbom/assets/*
 
   set-current-version:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -251,10 +251,11 @@ jobs:
     - name: Read Changelog
       id: read-changelog
       run: |
+        delimiter="ghadelimiter_$(openssl rand -hex 16)"
         {
-          echo 'content<<EOF'
+          echo "content<<${delimiter}"
           cat ./CHANGELOG.md
-          echo 'EOF'
+          echo "${delimiter}"
         } >> "$GITHUB_OUTPUT"
 
     - name: Get Cosign Key

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -273,7 +273,7 @@ jobs:
         COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
     - name: GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
#### What this PR does / why we need it:
Replaces the deprecated `actions/create-release@v1` action (which triggers both the Node.js 20 and the `set-output` deprecation warnings) with `softprops/action-gh-release@v2`.

Also replaces `juliangruber/read-file-action@v1` with an inline shell step that reads the changelog into `$GITHUB_OUTPUT`, removing another potential source of deprecation warnings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
The SBOM generation steps are now moved before the release creation step, since `softprops/action-gh-release` creates the release and uploads assets in a single step.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Run the `deploy-production` workflow and verify no Node.js 20 or `set-output` deprecation warnings appear in the GitHub Actions logs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kurl.sh documentation PR:
-->
NONE
