### PR TITLE
ci: validate GitHub Actions bundles are up-to-date

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -83,7 +83,7 @@ jobs:
             package_json="${action_dir}package.json"
             dist_dir="${action_dir}dist"
 
-            if [ ! -f "$action_yml" ] || [ ! -f "$package_json" ] || [ ! -d "$dist_dir" ]; then
+            if [ ! -f "$action_yml" ] || [ ! -f "$package_json" ]; then
               continue
             fi
 
@@ -98,10 +98,11 @@ jobs:
               npm run build
             )
 
-            if ! git diff --quiet -- "$dist_dir"; then
-              echo "ERROR: ${action_dir}dist/index.js is out of date."
+            if [ -n "$(git status --porcelain -- "$dist_dir")" ]; then
+              echo "ERROR: ${action_dir}dist/ has uncommitted changes."
               echo "Run 'npm run build' in ${action_dir} and commit the changes."
-              git diff -- "$dist_dir"
+              git status --porcelain -- "$dist_dir"
+              git diff -- "$dist_dir" || true
               failed=1
             fi
           done

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -65,6 +65,52 @@ jobs:
       - run: make docker-test-shell
       - run: make docker-test-containerd
 
+  validate-github-actions-bundles:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Verify GitHub Actions bundles are up-to-date
+        run: |
+          set -euo pipefail
+          failed=0
+          for action_dir in .github/actions/*/; do
+            action_yml="${action_dir}action.yml"
+            package_json="${action_dir}package.json"
+            dist_dir="${action_dir}dist"
+
+            if [ ! -f "$action_yml" ] || [ ! -f "$package_json" ] || [ ! -d "$dist_dir" ]; then
+              continue
+            fi
+
+            if ! grep -qE "main: ['\"]dist/index.js['\"]" "$action_yml"; then
+              continue
+            fi
+
+            echo "Checking ${action_dir}..."
+            (
+              cd "$action_dir"
+              npm ci
+              npm run build
+            )
+
+            if ! git diff --quiet -- "$dist_dir"; then
+              echo "ERROR: ${action_dir}dist/index.js is out of date."
+              echo "Run 'npm run build' in ${action_dir} and commit the changes."
+              git diff -- "$dist_dir"
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All GitHub Actions bundles are up-to-date."
+
   build-test-success:
     runs-on: ubuntu-latest
     if: ${{ always() }}
@@ -73,12 +119,14 @@ jobs:
       - build-kurl-utils
       - build-bin-kurl
       - test-shell
+      - validate-github-actions-bundles
     steps:
       - run: |
           if   [ "${{ needs.validate-go-mod.result }}" = "failure" ] \
             || [ "${{ needs.build-kurl-utils.result }}" = "failure" ] \
             || [ "${{ needs.build-bin-kurl.result }}" = "failure" ] \
-            || [ "${{ needs.test-shell.result }}" = "failure" ]
+            || [ "${{ needs.test-shell.result }}" = "failure" ] \
+            || [ "${{ needs.validate-github-actions-bundles.result }}" = "failure" ]
           then
             echo "build test failure"
             exit 1


### PR DESCRIPTION
Adds a check to the build-test workflow that rebuilds each bundled JavaScript GitHub Action under ".github/actions" and fails if the checked-in dist/index.js does not match the source/package-lock.json.

This prevents dependency update PRs (like #6094) from merging without regenerating the action bundle.