### PR TITLE
fix(velero): avoid broken pipe in cron-velero-update generate.sh

### DIFF
--- a/addons/velero/template/generate.sh
+++ b/addons/velero/template/generate.sh
@@ -17,10 +17,15 @@ function get_latest_release_version() {
 function get_latest_tag_version() {
     VAR_NAME=$1
     local url=$2
+    local response
     local version
 
-    version=$(curl -fsSL "$url" | \
-        grep -m1 '"name": "v' | \
+    # Fetch the full response before grepping.  Under set -o pipefail, piping
+    # curl directly to grep -m1 can fail with exit code 23 when grep exits
+    # after the first match and closes the pipe.  Using a here-string avoids
+    # the broken-pipe issue entirely.
+    response=$(curl -fsSL "$url")
+    version=$(grep -m1 '"name": "v' <<< "$response" | \
         grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
 
     export "$VAR_NAME=$version"


### PR DESCRIPTION
Fixes the recurring failure in the [cron-velero-update](https://github.com/replicatedhq/kURL/actions/workflows/update-velero.yaml) workflow (e.g. run https://github.com/replicatedhq/kURL/actions/runs/32679945073).

## Problem

The "Create Velero Update" step failed with exit code 23 because `generate.sh` runs with `set -euo pipefail` and used:

```bash
version=$(curl -fsSL "$url" | grep -m1 '"name": "v' | grep -Eo ...)
```

`grep -m1` exits after the first match, closing the pipe before `curl` is done writing. With `pipefail` enabled, `curl` exits with code 23 (failed writing body) and aborts the step.

## Fix

Fetch the full GitHub tags response into a variable first, then use a here-string to grep it, avoiding the broken pipe.

## Verification

Reproduced the failure in an Ubuntu 24.04 container (the same runner image) and confirmed the fixed `generate.sh` runs end-to-end, including the Docker/Skopeo tag lookup:

```
Found velero version 1.18.2
Found plugins AWS 1.14.2 AZURE 1.14.2 GCP 1.14.2
Found kurlsh/s3cmd tag 20260825-a9ea1c6
```
