### PR TITLE
fix(velero): include s3cmd image in Velero 1.18.2 manifest and sync Registry 3.0.0/3.1.0

### DIFF
--- a/addons/registry/3.0.0/Manifest
+++ b/addons/registry/3.0.0/Manifest
@@ -1,2 +1,2 @@
 image registry registry:3.0.0
-image s3cmd kurlsh/s3cmd:20260224-0d00dd0
+image s3cmd kurlsh/s3cmd:20260825-a9ea1c6

--- a/addons/registry/3.0.0/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/3.0.0/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/3.0.0/patch-deployment-velero.yaml
+++ b/addons/registry/3.0.0/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/registry/3.1.0/Manifest
+++ b/addons/registry/3.1.0/Manifest
@@ -1,2 +1,2 @@
 image registry registry:3.1.0
-image s3cmd kurlsh/s3cmd:20260224-0d00dd0
+image s3cmd kurlsh/s3cmd:20260825-a9ea1c6

--- a/addons/registry/3.1.0/patch-deployment-migrate-s3.yaml
+++ b/addons/registry/3.1.0/patch-deployment-migrate-s3.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/registry/3.1.0/patch-deployment-velero.yaml
+++ b/addons/registry/3.1.0/patch-deployment-velero.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: restore
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /restore.sh
@@ -48,7 +48,7 @@ spec:
               name: registry-s3-secret
       containers:
       - name: registry-backup
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/addons/velero/1.18.2/Manifest
+++ b/addons/velero/1.18.2/Manifest
@@ -2,6 +2,7 @@ image velero velero/velero:v1.18.2
 image velero-aws velero/velero-plugin-for-aws:v1.14.2
 image velero-gcp velero/velero-plugin-for-gcp:v1.14.2
 image velero-azure velero/velero-plugin-for-microsoft-azure:v1.14.2
+image s3cmd kurlsh/s3cmd:20260825-a9ea1c6
 
 asset velero.tar.gz https://github.com/velero-io/velero/releases/download/v1.18.2/velero-v1.18.2-linux-amd64.tar.gz
 

--- a/addons/velero/1.18.2/install.sh
+++ b/addons/velero/1.18.2/install.sh
@@ -203,7 +203,7 @@ function velero_install() {
 
     local plugins="velero/velero-plugin-for-aws:v1.14.2,velero/velero-plugin-for-gcp:v1.14.2,velero/velero-plugin-for-microsoft-azure:v1.14.2,${KURL_UTIL_IMAGE}"
     if ! velero_version_ge "1.17.0"; then
-        plugins="$plugins,replicated/local-volume-provider:0.6.14"
+        plugins="$plugins,replicated/local-volume-provider:0.6.15"
     fi
 
     "$src"/assets/velero-v"${VELERO_VERSION}"-linux-amd64/velero install \

--- a/addons/velero/1.18.2/tmpl-s3-migration-deployment-patch.yaml
+++ b/addons/velero/1.18.2/tmpl-s3-migration-deployment-patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
       - name: migrate-s3
-        image: kurlsh/s3cmd:20260224-0d00dd0
+        image: kurlsh/s3cmd:20260825-a9ea1c6
         imagePullPolicy: IfNotPresent
         command:
         - /migrate-s3.sh

--- a/addons/velero/template/base/Manifest.tmpl
+++ b/addons/velero/template/base/Manifest.tmpl
@@ -2,6 +2,7 @@ image velero velero/velero:v__VELERO_VERSION__
 image velero-aws velero/velero-plugin-for-aws:v__AWS_PLUGIN_VERSION__
 image velero-gcp velero/velero-plugin-for-gcp:v__GCP_PLUGIN_VERSION__
 image velero-azure velero/velero-plugin-for-microsoft-azure:v__AZURE_PLUGIN_VERSION__
+image s3cmd kurlsh/s3cmd:__S3CMD_TAG__
 
 asset velero.tar.gz https://github.com/velero-io/velero/releases/download/v__VELERO_VERSION__/velero-v__VELERO_VERSION__-linux-amd64.tar.gz
 


### PR DESCRIPTION
Addresses the review comment on the automated Velero update PR (#6114).

## Issue

The `cron-velero-update` PR bumps the `kurlsh/s3cmd` image used by the Velero S3-to-PVC migration patch, but the `kurlsh/s3cmd:20260825-a9ea1c6` image is missing from the Velero 1.18.2 `Manifest`. Because the manifest does not list it, the image is not packaged for air-gap installs, so the `migrate-s3` init container cannot start during the migration path.

## Changes

1. **Velero template & 1.18.2 add-on** – restore the `image s3cmd kurlsh/s3cmd:__S3CMD_TAG__` line to `addons/velero/template/base/Manifest.tmpl` and regenerate the 1.18.2 add-on. This also picks up the latest `local-volume-provider` tag (0.6.15) in the generated `install.sh`.
2. **Registry 3.0.0 & 3.1.0** – sync the `kurlsh/s3cmd` image tag to the latest `20260825-a9ea1c6` in both the manifests and the S3 migration/Velero backup patches, so the image is present in both selected add-on packages for the air-gap migration path.

## Verification

- Confirmed the generated `addons/velero/1.18.2/Manifest` now includes `image s3cmd kurlsh/s3cmd:20260825-a9ea1c6`.
- Confirmed Registry 3.0.0 and 3.1.0 manifests and patches reference the same tag.
- Confirmed the registry template base already includes the s3cmd placeholder; only the pinned 3.0.0 and 3.1.0 versions needed the sync.
