### PR TITLE
fix(rook): fix CSI image extraction and install helm in cron-rook-update workflow

### DIFF
--- a/.github/workflows/update-rook.yaml
+++ b/.github/workflows/update-rook.yaml
@@ -21,8 +21,8 @@ jobs:
 
     - name: Install Helm
       env:
-        HELM_VERSION: 4.2.4
-        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+        HELM_VERSION: 3.21.4
+        HELM_SHA256: 61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14
       run: |
         curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
         echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c

--- a/.github/workflows/update-rook.yaml
+++ b/.github/workflows/update-rook.yaml
@@ -23,6 +23,7 @@ jobs:
       id: update
       working-directory: ./addons/rook/template
       run: |
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         ./generate.sh --version=${{ github.event.inputs.version }} ${{ github.event.inputs.force == 'true' && '--force' || '' }}
 
     - name: Create Pull Request # creates a PR if there are differences

--- a/.github/workflows/update-rook.yaml
+++ b/.github/workflows/update-rook.yaml
@@ -19,12 +19,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install Helm
+      env:
+        HELM_VERSION: 4.2.4
+        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+      run: |
+        curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+
     - name: Create Rook Update
       id: update
       working-directory: ./addons/rook/template
-      run: |
-        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        ./generate.sh --version=${{ github.event.inputs.version }} ${{ github.event.inputs.force == 'true' && '--force' || '' }}
+      run: ./generate.sh --version=${{ github.event.inputs.version }} ${{ github.event.inputs.force == 'true' && '--force' || '' }}
 
     - name: Create Pull Request # creates a PR if there are differences
       uses: peter-evans/create-pull-request@v8.1.1

--- a/addons/rook/template/generate.sh
+++ b/addons/rook/template/generate.sh
@@ -64,7 +64,11 @@ function generate() {
     # get images in files
     {   grep ' image: '  "${dir}/operator/deployment.yaml" | sed -E 's/ *image: "*([^\/]+\/)?([^\/]+)\/([^:]+):([^" ]+).*/image \2-\3 \1\2\/\3:\4/' ; \
         grep ' image: '  "${dir}/cluster/cluster.yaml" | sed -E 's/ *image: "*([^\/]+\/)?([^\/]+)\/([^:]+):([^" ]+).*/image \2-\3 \1\2\/\3:\4/' ; \
-        curl -fsSL "${github_content_url}/deploy/examples/operator.yaml" | grep '_IMAGE: ' | sed -E 's/.*_IMAGE: "*([^\/]+\/)?([^\/]+)\/([^:]+):([^" ]+).*/image \2-\3 \1\2\/\3:\4/' ; \
+        # Newer Rook operator.yaml stores the CSI sidecar images in a ConfigMap as
+        # quoted image refs (e.g. provisioner: "registry.k8s.io/...:v1.2.3").
+        # Older versions kept them in commented _IMAGE: lines. Extract any quoted
+        # image reference so both formats work.
+        curl -fsSL "${github_content_url}/deploy/examples/operator.yaml" | grep -oE '"[^"]+/[^"]+:[^"]+"' | sed -E 's/"([^\/]+\/)?([^\/]+)\/([^:]+):([^" ]+)"/image \2-\3 \1\2\/\3:\4/' ; \
     } >> "${dir}/Manifest"
 }
 


### PR DESCRIPTION
Fixes the failure in the `cron-rook-update` workflow run https://github.com/replicatedhq/kURL/actions/runs/32680028352.

## Diagnosis

The `Create Rook Update` step exits with code 1 while generating the Rook add-on. The failing part is in `addons/rook/template/generate.sh`:

```bash
curl -fsSL "${github_content_url}/deploy/examples/operator.yaml" | grep '_IMAGE: ' | ...
```

This line expects Rook's `operator.yaml` to contain commented `ROOK_CSI_*_IMAGE:` lines that list the CSI sidecar images. Newer Rook versions (e.g. v1.20.x) moved those images into a ConfigMap as quoted image references and removed the old commented `_IMAGE:` lines, so `grep '_IMAGE: '` returns no matches and exits 1. With `set -euo pipefail`, that aborts the whole script.

## Fix

- Change the extraction to pull any quoted image reference from `operator.yaml`. This matches both the old commented `_IMAGE:` lines and the new ConfigMap values, so the generated `Manifest` includes the CSI sidecar images required for air-gap installs.
- Also add a Helm install step to the `update-rook.yaml` workflow, matching the `update-prometheus.yaml` and `update-goldpinger.yaml` workflows.

## Verification

I ran the fixed `generate.sh` in an Ubuntu 24.04 container (the same runner image). It successfully generated the latest Rook version with a complete `Manifest`:

```
image rook-ceph docker.io/rook/ceph:v1.20.6
image cephcsi-ceph-csi-operator quay.io/cephcsi/ceph-csi-operator:v1.0.4
image ceph-ceph quay.io/ceph/ceph:v20.2.4
image sig-storage-csi-provisioner registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
image sig-storage-csi-attacher registry.k8s.io/sig-storage/csi-attacher:v4.12.0
image sig-storage-csi-resizer registry.k8s.io/sig-storage/csi-resizer:v2.1.0
image sig-storage-csi-snapshotter registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
image sig-storage-csi-node-driver-registrar registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
image cephcsi-cephcsi quay.io/cephcsi/cephcsi:v3.17.0
image csiaddons-k8s-sidecar quay.io/csiaddons/k8s-sidecar:v0.14.0
```

I also tested regenerating Rook 1.18.11 with `--force` to confirm the new extraction still works for the older `operator.yaml` format.
