### PR TITLE
security(workflows): pin Helm install and verify checksum in prometheus and goldpinger update workflows

### DIFF
--- a/.github/workflows/update-goldpinger.yaml
+++ b/.github/workflows/update-goldpinger.yaml
@@ -14,8 +14,8 @@ jobs:
 
     - name: Install Helm
       env:
-        HELM_VERSION: 4.2.4
-        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+        HELM_VERSION: 3.21.4
+        HELM_SHA256: 61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14
       run: |
         curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
         echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c

--- a/.github/workflows/update-goldpinger.yaml
+++ b/.github/workflows/update-goldpinger.yaml
@@ -12,12 +12,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install Helm
+      env:
+        HELM_VERSION: 4.2.4
+        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+      run: |
+        curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+
     - name: Create Goldpinger Update
       id: update
       working-directory: ./addons/goldpinger/template
-      run: |
-        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        ./generate.sh
+      run: ./generate.sh
 
     - name: Create Pull Request # creates a PR if there are differences
       uses: peter-evans/create-pull-request@v8.1.1

--- a/.github/workflows/update-prometheus.yaml
+++ b/.github/workflows/update-prometheus.yaml
@@ -17,11 +17,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install Helm
+      env:
+        HELM_VERSION: 4.2.4
+        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+      run: |
+        curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+
     - name: Create Prometheus Update
       id: update
       working-directory: ./addons/prometheus/template
       run: |
-        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         if [ -n "${{ inputs.version }}" ]; then
           ./generate.sh --version=${{ inputs.version }}
         else

--- a/.github/workflows/update-prometheus.yaml
+++ b/.github/workflows/update-prometheus.yaml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Install Helm
       env:
-        HELM_VERSION: 4.2.4
-        HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+        HELM_VERSION: 3.21.4
+        HELM_SHA256: 61f88ab166748cb19604d7884cb100ae9ccb13804ddeb98e08af167eacbb6a14
       run: |
         curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
         echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c


### PR DESCRIPTION
Addresses the security review comment on the Rook update workflow PR (#6116) by applying the same fix to the Prometheus and Goldpinger update workflows.

## Problem

Both workflows were installing Helm by piping the upstream `get-helm-3` script directly to bash:

```yaml
curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
```

This executes a mutable, unverified third-party script in a job that later uses the repository automation PAT (`secrets.AUTOMATED_PR_GH_PAT`).

## Fix

Replace the pipe-to-bash install with a pinned Helm binary download and a hardcoded SHA-256 checksum verification:

```yaml
- name: Install Helm
  env:
    HELM_VERSION: 4.2.4
    HELM_SHA256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
  run: |
    curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
    echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c
    tar -xzf helm.tar.gz
    sudo mv linux-amd64/helm /usr/local/bin/helm
    rm -rf helm.tar.gz linux-amd64
```

This pins the installer source and verifies the archive integrity before executing any Helm binary.
